### PR TITLE
Delete stale AffectedCommits in impact task.

### DIFF
--- a/docker/worker/worker_test.py
+++ b/docker/worker/worker_test.py
@@ -119,6 +119,16 @@ class ImpactTest(unittest.TestCase):
         public=False)
     allocated_bug.put()
 
+    should_be_deleted = osv.AffectedCommit(
+        id='2020-1337-abcd',
+        bug_id='2020-1337',
+        commit='abcd',
+        confidence=100,
+        project='project',
+        ecosystem='ecosystem',
+        public=False)
+    should_be_deleted.put()
+
   def tearDown(self):
     self.clone_repository_patcher.stop()
 

--- a/lib/osv/impact.py
+++ b/lib/osv/impact.py
@@ -175,7 +175,7 @@ def get_affected_range(repo, regress_commits, fix_commits):
           get_commit_list(repo, equivalent_regress_commit,
                           last_affected_commit))
 
-  return list(commits), ranges
+  return commits, ranges
 
 
 def get_commit_range(repo, commit_or_range):


### PR DESCRIPTION
This can happen if a FixResult comes in later and we had previously
marked a commit before the fix commit as containing a vulnerability.