### PR TITLE
Implement Maven version parser and precedence.

### DIFF
--- a/lib/osv/maven/__init__.py
+++ b/lib/osv/maven/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Maven version support."""
+
+from .version import *

--- a/lib/osv/maven/version.py
+++ b/lib/osv/maven/version.py
@@ -1,0 +1,227 @@
+"""Maven version parser."""
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import collections
+import re
+
+# pylint: disable=line-too-long
+# Maven's very complicated spec:
+# http://maven.apache.org/pom.html#Dependency_Version_Requirement_Specification
+
+_TO_TRIM = ('0', '', 'final', 'ga')
+_KEYWORD_ORDER = ('alpha', 'beta', 'milestone', 'rc', 'snapshot', '', 'sp')
+
+
+def qualifier_order(token):
+  """Returns an integer representing a token's order."""
+  # ".qualifier" < "-qualifier" < "-number" < ".number"
+  if token.value.isdigit():
+    if token.prefix == '-':
+      return 2
+
+    assert token.prefix == '.'
+    return 3
+
+  if token.prefix == '-':
+    return 1
+
+  assert token.prefix == '.'
+  return 0
+
+
+class VersionToken(
+    collections.namedtuple(
+        'VersionToken', 'prefix value is_null', defaults=(False,))):
+  """Version token."""
+
+  __slots__ = ()
+
+  def __eq__(self, other):
+    return self.prefix == other.prefix and self.value == other.value
+
+  def __lt__(self, other):
+    if self.prefix == other.prefix:
+      # if the prefix is the same, then compare the token:
+      if self.value.isdigit() and other.value.isdigit():
+        # Numeric tokens have the natural order.
+        return int(self.value) < int(other.value)
+      # The spec is unclear, but according to Maven's implementation, numerics
+      # sort after non-numerics, **unless it's a null value**.
+      # https://github.com/apache/maven/blob/965aaa53da5c2d814e94a41d37142d0d6830375d/maven-artifact/src/main/java/org/apache/maven/artifact/versioning/ComparableVersion.java#L443
+      if self.value.isdigit() and not self.is_null:
+        return False
+
+      if other.value.isdigit() and not other.is_null:
+        return True
+
+      # Non-numeric tokens ("qualifiers") have the alphabetical order, except
+      # for the following tokens which come first in _KEYWORD_ORDER.
+      #
+      # The spec is unclear, but according to Maven's implementation, unknown
+      # qualifiers sort after known qualifiers:
+      # https://github.com/apache/maven/blob/965aaa53da5c2d814e94a41d37142d0d6830375d/maven-artifact/src/main/java/org/apache/maven/artifact/versioning/ComparableVersion.java#L423
+      try:
+        left_idx = _KEYWORD_ORDER.index(self.value)
+      except ValueError:
+        left_idx = len(_KEYWORD_ORDER)
+
+      try:
+        right_idx = _KEYWORD_ORDER.index(other.value)
+      except ValueError:
+        right_idx = len(_KEYWORD_ORDER)
+
+      if left_idx == len(_KEYWORD_ORDER) and right_idx == len(_KEYWORD_ORDER):
+        # Both are unknown qualifiers. Just do a lexical comparison.
+        return self.value < other.value
+
+      return left_idx < right_idx
+
+    # else ".qualifier" < "-qualifier" < "-number" < ".number"
+    return qualifier_order(self) < qualifier_order(other)
+
+
+class Version:
+  """Maven version."""
+
+  def __init__(self):
+    self.tokens = []
+
+  def __str__(self):
+    result = ''
+    for token in self.tokens:
+      result += token.prefix + token.value
+
+    return result
+
+  def __eq__(self, other):
+    return self.tokens == other.tokens
+
+  def __lt__(self, other):
+    for i in range(max(len(self.tokens), len(other.tokens))):
+      # the shorter one padded with enough "null" values with matching prefix to
+      # have the same length as the longer one. Padded "null" values depend on
+      # the prefix of the other version: 0 for '.', "" for '-'
+      if i >= len(self.tokens):
+        if other.tokens[i].prefix == '.':
+          left = VersionToken('.', '0', is_null=True)
+        else:
+          assert other.tokens[i].prefix == '-'
+          left = VersionToken('-', '', is_null=True)
+      else:
+        left = self.tokens[i]
+
+      if i >= len(other.tokens):
+        if self.tokens[i].prefix == '.':
+          right = VersionToken('.', '0', is_null=True)
+        else:
+          assert self.tokens[i].prefix == '-'
+          right = VersionToken('-', '', is_null=True)
+      else:
+        right = other.tokens[i]
+
+      if left == right:
+        continue
+
+      return left < right
+
+  @classmethod
+  def from_string(cls, str_version):
+    """Parse a version."""
+    version = Version()
+
+    # The Maven coordinate is split in tokens between dots ('.'), hyphens ('-')
+    # and transitions between digits and characters. The prefix is recorded
+    # and will have effect on the order.
+
+    # Split and keep the delimiter.
+    tokens = re.split(r'([-.])', str_version)
+    for i in range(0, len(tokens), 2):
+      if i == 0:
+        # First token has no preceding prefix.
+        prefix = ''
+      else:
+        # Preceding prefix.
+        prefix = tokens[i - 1]
+
+      # A transition between digits and characters is equivalent to a hyphen.
+      # According to Maven's implementation: any non-digit is a "character":
+      # https://github.com/apache/maven/blob/965aaa53da5c2d814e94a41d37142d0d6830375d/maven-artifact/src/main/java/org/apache/maven/artifact/versioning/ComparableVersion.java#L627
+
+      # Find instances of <digit><non-digit> or <non-digit><digit>.
+      # ?= makes the regex non-consuming (needed to catch overlapping
+      # transitions such as <digit><non-digit><digit>).
+      # This gives an array of indices where each index is where a hyphen should be.
+      transitions = [
+          m.span()[0] + 1
+          for m in re.finditer(r'(?=(\d[^\d]|[^\d]\d))', tokens[i])
+      ]
+      # Add the last index so that our algorithm to split up the current token works.
+      transitions.append(len(tokens[i]))
+
+      prev_index = 0
+      for j, transition in enumerate(transitions):
+        if j > 0:
+          prefix = '-'
+
+        # The spec doesn't say this, but all qualifiers are case insensitive.
+        current = tokens[i][prev_index:transition].lower()
+        if not current:
+          # Empty tokens are replaced with "0".
+          current = '0'
+
+        # Normalize "cr" to "rc" for easier comparison since they are equal in
+        # precedence.
+        if current == 'cr':
+          current = 'rc'
+
+        # Also do this for 'ga', 'final' which are equivalent to empty string.
+        # "release" is not part of the spec but is implemented by Maven.
+        if current in ('ga', 'final', 'release'):
+          current = ''
+
+        # the "alpha", "beta" and "milestone" qualifiers can respectively be
+        # shortened to "a", "b" and "m" when directly followed by a number.
+        if transition != len(tokens[i]):
+          if current == 'a':
+            current = 'alpha'
+
+          if current == 'b':
+            current = 'beta'
+
+          if current == 'm':
+            current = 'milestone'
+
+        if current.isdigit():
+          # Remove any leading zeros.
+          current = str(int(current))
+
+        version.tokens.append(VersionToken(prefix, current))
+        prev_index = transition
+
+    # Then, starting from the end of the version, the trailing "null" values
+    # (0, "", "final", "ga") are trimmed.
+    i = len(version.tokens) - 1
+    while i >= 0:
+      if version.tokens[i].value in _TO_TRIM:
+        version.tokens.pop(i)
+        i -= 1
+        continue
+
+      # This process is repeated at each remaining hyphen from end to start.
+      while i >= 0 and version.tokens[i].prefix != '-':
+        i -= 1
+
+      i -= 1
+
+    return version

--- a/lib/osv/maven/version_test.py
+++ b/lib/osv/maven/version_test.py
@@ -1,0 +1,250 @@
+"""Maven version parser tests."""
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# pylint: disable=line-too-long
+# Many tests are ported from
+# https://github.com/apache/maven/blob/c3cf29438e3d65d6ee5c5726f8611af99d9a649a/maven-artifact/src/test/java/org/apache/maven/artifact/versioning/ComparableVersionTest.java.
+import unittest
+
+import version
+
+
+class VersionTest(unittest.TestCase):
+  """Version tests."""
+
+  def setUp(self):
+    self.maxDiff = None  # pylint: disable=invalid-name
+
+  def check_versions_order(self, *versions):
+    """Check that our precedence logic matches the expected order."""
+    parsed_versions = [version.Version.from_string(v) for v in versions]
+
+    # pylint: disable=consider-using-enumerate
+    for i in range(len(parsed_versions)):
+      for j in range(i + 1, len(parsed_versions)):
+        self.assertLess(
+            parsed_versions[i],
+            parsed_versions[j],
+            msg=f'Expected {versions[i]} < {versions[j]}')
+        self.assertGreater(
+            parsed_versions[j],
+            parsed_versions[i],
+            msg=f'Expected {versions[j]} > {versions[i]}')
+
+  def check_versions_equal(self, *versions):
+    """Check that the provided versions are equivalent."""
+    parsed_versions = [version.Version.from_string(v) for v in versions]
+
+    # pylint: disable=consider-using-enumerate
+    for i in range(len(parsed_versions)):
+      for j in range(i + 1, len(parsed_versions)):
+        self.assertEqual(
+            parsed_versions[i],
+            parsed_versions[j],
+            msg=f'Expected {versions[i]} == {versions[j]}')
+
+  def test_normalize(self):
+    """Test version normalization."""
+    self.assertEqual('1', str(version.Version.from_string('1.0.0')))
+    self.assertEqual('1', str(version.Version.from_string('1.ga')))
+    self.assertEqual('1', str(version.Version.from_string('1.final')))
+    self.assertEqual('1', str(version.Version.from_string('1.0')))
+    self.assertEqual('1', str(version.Version.from_string('1.')))
+    self.assertEqual('1', str(version.Version.from_string('1-')))
+    self.assertEqual('1-foo', str(version.Version.from_string('1.0.0-foo.0.0')))
+    self.assertEqual('1', str(version.Version.from_string('1.0.0-0.0.0')))
+    self.assertEqual('1-1.foo-bar-1-baz-0.1',
+                     str(version.Version.from_string('1-1.foo-bar1baz-.1')))
+    self.assertEqual('1-rc', str(version.Version.from_string('1cr')))
+    self.assertEqual('1-a', str(version.Version.from_string('1a')))
+    self.assertEqual('1-alpha-1', str(version.Version.from_string('1a1')))
+    self.assertEqual('1-beta-1', str(version.Version.from_string('1b1')))
+    self.assertEqual('1-c-1', str(version.Version.from_string('1c1')))
+    self.assertEqual('1-milestone-1', str(version.Version.from_string('1m1')))
+    self.assertEqual('1-1', str(version.Version.from_string('1-ga-1')))
+
+  def test_sort(self):
+    """Basic sort tests."""
+    # These tests are taken from the spec.
+    unsorted = [
+        '1',
+        '1.1',
+        '1-snapshot',
+        '1',
+        '1-sp',
+        '1-foo2',
+        '1-foo10',
+        '1.foo',
+        '1-foo',
+        '1-1',
+        '1.1',
+        '1.ga',
+        '1-ga',
+        '1-0',
+        '1.0',
+        '1',
+        '1-sp',
+        '1-ga',
+        '1-sp.1',
+        '1-ga.1',
+        '1-sp-1',
+        '1-ga-1',
+        '1-1',
+        '1-a1',
+        '1-alpha-1',
+        '2',
+    ]
+
+    sorted_versions = [
+        str(v) for v in sorted(
+            version.Version.from_string(v) for v in unsorted)
+    ]
+
+    self.assertListEqual([
+        '1-alpha-1', '1-alpha-1', '1-snapshot', '1', '1', '1', '1', '1', '1',
+        '1', '1', '1.foo', '1-.1', '1-sp', '1-sp', '1-sp-1', '1-sp.1', '1-foo',
+        '1-foo-2', '1-foo-10', '1-1', '1-1', '1-1', '1.1', '1.1', '2'
+    ], sorted_versions)
+
+  def test_versions_qualifiers(self):
+    """Test qualifiers."""
+    expected = [
+        '1-alpha2snapshot', '1-alpha2', '1-alpha-123', '1-beta-2', '1-beta123',
+        '1-m2', '1-m11', '1-rc', '1-cr2', '1-rc123', '1-SNAPSHOT', '1', '1-sp',
+        '1-sp2', '1-sp123', '1-abc', '1-def', '1-pom-1', '1-1-snapshot', '1-1',
+        '1-2', '1-123'
+    ]
+    self.check_versions_order(*expected)
+
+  def test_versions_number(self):
+    """Test numbers."""
+    # Taken from Maven's tests.
+    expected = [
+        '2.0', '2-1', '2.0.a', '2.0.0.a', '2.0.2', '2.0.123', '2.1.0', '2.1-a',
+        '2.1b', '2.1-c', '2.1-1', '2.1.0.1', '2.2', '2.123', '11.a2', '11.a11',
+        '11.b2', '11.b11', '11.m2', '11.m11', '11', '11.a', '11b', '11c', '11m'
+    ]
+    self.check_versions_order(*expected)
+
+  def test_versions_order(self):
+    """More ordering tests."""
+    self.check_versions_order('1', '2')
+    self.check_versions_order('1.5', '2')
+    self.check_versions_order('1', '2.5')
+    self.check_versions_order('1.0', '1.1')
+    self.check_versions_order('1.1', '1.2')
+    self.check_versions_order('1.0.0', '1.1')
+    self.check_versions_order('1.0.1', '1.1')
+    self.check_versions_order('1.1', '1.2.0')
+
+    self.check_versions_order('1.0-alpha-1', '1.0')
+    self.check_versions_order('1.0-alpha-1', '1.0-alpha-2')
+    self.check_versions_order('1.0-alpha-1', '1.0-beta-1')
+
+    self.check_versions_order('1.0-beta-1', '1.0-SNAPSHOT')
+    self.check_versions_order('1.0-SNAPSHOT', '1.0')
+    self.check_versions_order('1.0-alpha-1-SNAPSHOT', '1.0-alpha-1')
+
+    self.check_versions_order('1.0', '1.0-1')
+    self.check_versions_order('1.0-1', '1.0-2')
+    self.check_versions_order('1.0.0', '1.0-1')
+
+    self.check_versions_order('2.0-1', '2.0.1')
+    self.check_versions_order('2.0.1-klm', '2.0.1-lmn')
+    self.check_versions_order('2.0.1', '2.0.1-xyz')
+
+    self.check_versions_order('2.0.1', '2.0.1-123')
+    self.check_versions_order('2.0.1-xyz', '2.0.1-123')
+
+  def test_versions_order_mng_5568(self):
+    """Regression test for MNG 5568."""
+    a = '6.1.0'
+    b = '6.1.0rc3'
+    c = '6.1H.5-beta'
+
+    self.check_versions_order(b, a)
+    self.check_versions_order(b, c)
+    self.check_versions_order(a, c)
+
+  def test_versions_order_mng_6572(self):
+    """Regression test for MNG 6572."""
+    a = '20190126.230843'
+    b = '1234567890.12345'
+    c = '123456789012345.1H.5-beta'
+    d = '12345678901234567890.1H.5-beta'
+
+    self.check_versions_order(a, b)
+    self.check_versions_order(b, c)
+    self.check_versions_order(a, c)
+    self.check_versions_order(c, d)
+    self.check_versions_order(b, d)
+    self.check_versions_order(a, d)
+
+  def test_versions_equal(self):
+    """Test versions that should be considered equal."""
+    self.check_versions_equal('1', '1')
+    self.check_versions_equal('1', '1.0')
+    self.check_versions_equal('1', '1.0.0')
+    self.check_versions_equal('1.0', '1.0.0')
+    self.check_versions_equal('1', '1-0')
+    self.check_versions_equal('1', '1.0-0')
+    self.check_versions_equal('1.0', '1.0-0')
+    # no separator between number and character
+    self.check_versions_equal('1a', '1-a')
+    self.check_versions_equal('1a', '1.0-a')
+    self.check_versions_equal('1a', '1.0.0-a')
+    self.check_versions_equal('1.0a', '1-a')
+    self.check_versions_equal('1.0.0a', '1-a')
+    self.check_versions_equal('1x', '1-x')
+    self.check_versions_equal('1x', '1.0-x')
+    self.check_versions_equal('1x', '1.0.0-x')
+    self.check_versions_equal('1.0x', '1-x')
+    self.check_versions_equal('1.0.0x', '1-x')
+
+    # aliases
+    self.check_versions_equal('1ga', '1')
+    self.check_versions_equal('1release', '1')
+    self.check_versions_equal('1final', '1')
+    self.check_versions_equal('1cr', '1rc')
+
+    # special 'aliases' a, b and m for alpha, beta and milestone
+    self.check_versions_equal('1a1', '1-alpha-1')
+    self.check_versions_equal('1b2', '1-beta-2')
+    self.check_versions_equal('1m3', '1-milestone-3')
+
+    # case insensitive
+    self.check_versions_equal('1X', '1x')
+    self.check_versions_equal('1A', '1a')
+    self.check_versions_equal('1B', '1b')
+    self.check_versions_equal('1M', '1m')
+    self.check_versions_equal('1Ga', '1')
+    self.check_versions_equal('1GA', '1')
+    self.check_versions_equal('1RELEASE', '1')
+    self.check_versions_equal('1release', '1')
+    self.check_versions_equal('1RELeaSE', '1')
+    self.check_versions_equal('1Final', '1')
+    self.check_versions_equal('1FinaL', '1')
+    self.check_versions_equal('1FINAL', '1')
+    self.check_versions_equal('1Cr', '1Rc')
+    self.check_versions_equal('1cR', '1rC')
+    self.check_versions_equal('1m3', '1Milestone3')
+    self.check_versions_equal('1m3', '1MileStone3')
+    self.check_versions_equal('1m3', '1MILESTONE3')
+
+    self.check_versions_equal('1', '01', '001')
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
This is a scheme with an ambiguous and complicated spec. This was
implemented based on both the spec and Maven's implementation in Java to
fill in the gaps.

There doesn't appear to be an existing good Python library.

This will be hooked up to the list of supported ecosystems in a future
PR to enable Maven vulnerability ingestion.