### PR TITLE
Docs: use lowercase "npm" ecosystem.

### DIFF
--- a/lib/osv/vulnerability.proto
+++ b/lib/osv/vulnerability.proto
@@ -61,7 +61,7 @@ message Package {
   // Other valid values are:
   //   - "Go" for Go modules.
   //   - "PyPI" for Python packages.
-  //   - "NPM" for NPM packages.
+  //   - "npm" for NPM packages.
   string ecosystem = 2;
   // Optional. The package URL for this package.
   string purl = 3;


### PR DESCRIPTION
To match https://github.com/google/osv/blob/4cd067c6adf640867ecbf91a0143a046a93f32af/lib/osv/ecosystems.py#L117

Tested with

```
curl -X POST -d \
          '{"version": "0.8.12", "package": {"name": "unzipper", "ecosystem": "NPM"}}' \
          "https://api.osv.dev/v1/query"

and

curl -X POST -d \
          '{"version": "0.8.12", "package": {"name": "unzipper", "ecosystem": "npm"}}' \
          "https://api.osv.dev/v1/query"
```