### PR TITLE
Fix App Engine and API deployment.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,9 +7,7 @@ name = "pypi"
 google-cloud-ndb = "*"
 semver = "*"
 pyyaml = "*"
-# Has to be locked to 1.5.0 because docker pulls down specific libgit2 version that only works with 1.5.0
-# TODO: Update Dockerfile to use newer libgit2 version
-pygit2 = "==1.5.0"
+pygit2 = "*"
 attrs = "*"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d077ae5ca7f0a84c6f132f850bd8e99c10c81e27560c93fd902d7b9f44b54c85"
+            "sha256": "44a23a785260a22255a035578f0c9dec7353bab991641c693d984ad51b40a1ab"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -29,13 +29,6 @@
             ],
             "index": "pypi",
             "version": "==21.4.0"
-        },
-        "cached-property": {
-            "hashes": [
-                "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130",
-                "sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0"
-            ],
-            "version": "==1.5.2"
         },
         "cachetools": {
             "hashes": [
@@ -151,11 +144,11 @@
         },
         "google-auth": {
             "hashes": [
-                "sha256:3b2f9d2f436cc7c3b363d0ac66470f42fede249c3bafcc504e9f0bcbe983cff0",
-                "sha256:75b3977e7e22784607e074800048f44d6a56df589fb2abe58a11d4d20c97c314"
+                "sha256:14292fa3429f2bb1e99862554cde1ee730d6840ebae067814d3d15d8549c0888",
+                "sha256:5a7eed0cb0e3a83989fad0b59fe1329dfc8c479543039cd6fd1e01e9adf39475"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==2.9.0"
+            "version": "==2.9.1"
         },
         "google-cloud-core": {
             "hashes": [
@@ -183,11 +176,11 @@
         },
         "googleapis-common-protos": {
             "hashes": [
-                "sha256:6f1369b58ed6cf3a4b7054a44ebe8d03b29c309257583a2bbdc064cd1e4a1442",
-                "sha256:87955d7b3a73e6e803f2572a33179de23989ebba725e05ea42f24838b792e461"
+                "sha256:8eb2cbc91b69feaf23e32452a7ae60e791e09967d81d4fcc7fc388182d1bd394",
+                "sha256:c25873c47279387cfdcbdafa36149887901d36202cb645a0e4f29686bf6e4417"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.56.3"
+            "markers": "python_version >= '3.7'",
+            "version": "==1.56.4"
         },
         "grpcio": {
             "hashes": [
@@ -338,26 +331,42 @@
         },
         "pygit2": {
             "hashes": [
-                "sha256:279ebf1560be0f563caab1584ff38169c757afdaf44ca7fc790b72bd14b6d1a6",
-                "sha256:320ec448bb37a02c620a3b2ed3355614198513093de6e1777783e826a030bcea",
-                "sha256:40c2a6f15f916fc5ff7be191daf1d0308eb081c8a7e24db1263f7d3e4fffbc65",
-                "sha256:5acd2a1c3b0949c9804a98ea7f447a9fc6e1f229b9bafa64bb71fa2500899914",
-                "sha256:6512e6f0f07affb97fef4b8733bee0953693de3d38e870d106092d6566ca91b2",
-                "sha256:711829b95c42f5db019f381647fe6e8f52f3ff349c9ed9c77722b1e7bfdca3cf",
-                "sha256:7a2a511ab8cde226a377bff1e1c517be52f1f3162c5bab2d37e3098a2e12e97e",
-                "sha256:89a095765337fa2c2100a840b21f1e9a9cbf931df6b0a8ef7ed046e27194b5f3",
-                "sha256:9711367bd05f96ad6fc9c91d88fa96126ba2d1f1c3ea6f23c11402c243d66a20",
-                "sha256:a5c64ec093523710a5849cc35d73878d0762aac6920d5b7bec949809fe7f2446",
-                "sha256:b59e0ab959b682ca0dbc2040f11eaed144b4963c91c97a815b076559ea0e6f24",
-                "sha256:b5f52c2d0bda69be8ded1f66c7e6c6c9e21fdeb6d76488edf63af466fb9273ce",
-                "sha256:b953b84871bf21581019c0b2b3c8c7613b1543c6b9b726d22d0d9838ed835a83",
-                "sha256:d3951d2ef3942c0377738189c307df002d8a2c19351b2cf6620cbe2229703c5f",
-                "sha256:ea9c540e2b87153707b16ddcc5853a27bcc6e60a3817b3ec7ca3dce09cc954fe",
-                "sha256:eb333e43024ba631e83c7500a9853f79feb5daf8b25e6faa8025021f3d83a51a",
-                "sha256:fda3f8dd30608475f24a531e6f968010662ed7b9d4e303525d945c8933d9528f"
+                "sha256:084bc622205b6f495a0c7e6d8dde9a2e42967bd6b8e16e28d21725dbcc837e1a",
+                "sha256:0a0aaadca823c2e6d1f6319190f53c55c8323a810a1d1117e378e907c98cf613",
+                "sha256:14b51a909debdfdaa7757a581a1c6f6d1a5b150870da68881d3bd9d5b94842c7",
+                "sha256:20894433df1146481aacae37e2b0f3bbbfdea026db2f55061170bd9823e40b19",
+                "sha256:3068375e81a473d01d23d86abc5e978bac7bd277a91538416d31e06d0e97402f",
+                "sha256:308ce00e8a1f8d8dc3858b3e21f0ea701cdde675966aea68fcccf559cb5e9577",
+                "sha256:3f737e8eb42a818de2e604bfca125e79e3f386e8b77cceb1fe881f7603c378c2",
+                "sha256:4625e8957b9e7e72a300d42e27e5392ac449517397fb22045b8c3e468f4b6f06",
+                "sha256:487ae81134b44b1e0173b3e9a478f93f18c1c22d53241d1fc8047e400094582b",
+                "sha256:490d6ba5ae4a539d147644e9ce20a2c5dd55dd3ea177cec78971b7422c0540d4",
+                "sha256:55593d734a30e824f9136e0afcd15b287125ef41dac7833f564da454ba0969d0",
+                "sha256:5f038afaeaf5cd1fa35ae02073f42558eb7daf6cbc57cdc41e5ee9dfdad6a653",
+                "sha256:6724885e4a31a843fd6d7d6cd90baef5c61a774d222fabbe39505c0b3dd2c55b",
+                "sha256:6a1ebd104105cc56ae2ba100090228a4db8cbeb7a480e8657a803d674331b82d",
+                "sha256:6e7f56bf5338ec79e7521204ddf4f6848cd2ccd1de4ea8b2c0af163ed4b08ade",
+                "sha256:75a95ddab5d256c35377a2892bd5f5f3121552c3ae9af9b06eaa7ac426220d22",
+                "sha256:7cef5b08544b895a75ed7908ca6c0d730b890ffeba7f2b46e5c8aec458786802",
+                "sha256:81e1d25b2a0be1a8cd7d4131fe5af8efddc7015f522638e2c53fe820800e4de6",
+                "sha256:871682c3a910d71cc8bf6f8be4474085bf3eb27864a090f2132f6fa50fe2eb30",
+                "sha256:8a5bf52fb75dc2d2da814996b8006559d0b57b573775f757a1997f89eabfdb0a",
+                "sha256:8b6d7b3613ef8358f24d32e4a1ef976218e351e84953c474d1fa1d29b28484db",
+                "sha256:8cdf963725b1f6bfad12a9238a421587af682164d90b3d5a81224d4a112ed4f6",
+                "sha256:9bfd9d089942482ca0b5f426396b76fb86b25ca3414546388d8cfa8824ab1188",
+                "sha256:bf160b3653168e5d11e6de9589018db55ef51a0859bf4a3719aa8cc0998c584e",
+                "sha256:c0c18ed4ce7f06e6885ab01f1b1f80468e09d1bd72265e14575be0b44a581ae7",
+                "sha256:c6198c1010af273d91c182997693d61b2d00edeecdef9c39beef711568bec984",
+                "sha256:d2cb8571cd02acf739b26d2c2bb4828f7cfb4e23b564d6c4442bffe8714ec8e5",
+                "sha256:d52113184c38455bbc9576003054311d8c283a547a12790baf0210ccfd0cc90f",
+                "sha256:da12d67bdb43736e3bd6464623e8aff06796527ea8525f65b76a776f26c7fa24",
+                "sha256:eb2d916ec03c1dda7ab04506d42ef2c0bac2590827c5d15fec49b67f39f02704",
+                "sha256:ebe0b2371fe4d91adc5014cc94dc85497bec6a5e1e557856bb45f586e31519bd",
+                "sha256:f84826586d5e7f32e560d0d55fd35484cebd49fefccfe8a3727bd4b7c4788b92",
+                "sha256:fe3eec281222c5778eed6a4185d0442a7d7aaac552039359d5ec4c5b8737baa3"
             ],
             "index": "pypi",
-            "version": "==1.5.0"
+            "version": "==1.9.2"
         },
         "pymemcache": {
             "hashes": [

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -71,6 +71,7 @@ VOLUME /var/lib/docker
 
 ENV PIP_NO_BINARY pygit2
 # Replicate project structure to make relative editable pipenv dependency work.
+# TODO(ochang): Just copy the entire project (needs a clean checkout).
 COPY docker/worker/Pipfile* /env/docker/worker/
 COPY setup.py Pipfile* README.md /env/
 COPY osv /env/osv

--- a/gcp/api/Dockerfile
+++ b/gcp/api/Dockerfile
@@ -14,6 +14,7 @@
 
 FROM python:3.8-slim
 
+# TODO(ochang): Just copy the entire project (needs a clean checkout).
 COPY setup.py Pipfile* README.md /osv/
 COPY gcp/api /osv/gcp/api
 

--- a/gcp/api/Dockerfile
+++ b/gcp/api/Dockerfile
@@ -12,16 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google_appengine/python
+FROM python:3.8-slim
 
-RUN virtualenv -p python3.7 /env
+COPY setup.py Pipfile* README.md /osv/
+COPY gcp/api /osv/gcp/api
 
-ENV VIRTUAL_ENV /env
-ENV PATH /env/bin:$PATH
+WORKDIR /osv/gcp/api
+RUN pip3 install -U pipenv && python3 -m pipenv install --deploy --system
 
-ADD . /osv/
-
-WORKDIR /osv
-RUN pip install -r requirements.txt
-
-ENTRYPOINT ["python", "/osv/server.py"]
+ENTRYPOINT ["python", "/osv/gcp/api/server.py"]

--- a/gcp/api/deploy_backend
+++ b/gcp/api/deploy_backend
@@ -8,12 +8,11 @@ fi
 tag=$1
 name=$2
 
-rm -rf osv
-cp -r ../../osv .
-docker build -t "gcr.io/oss-vdb/osv-server:$tag" . &&
+pushd ../../
+docker build -t "gcr.io/oss-vdb/osv-server:$tag" -f gcp/api/Dockerfile .
 docker push "gcr.io/oss-vdb/osv-server:$tag"
+popd
 
-pipenv lock -r > requirements.txt
 gcloud run deploy $name \
   --platform managed \
   --project=oss-vdb \

--- a/gcp/appengine/deploy.sh
+++ b/gcp/appengine/deploy.sh
@@ -4,5 +4,7 @@ pushd frontend3
 npm run build:prod
 popd
 
-python3 -m pipenv lock -r > requirements.txt
+# Skip the '-e' editable library install as we copy in the "osv" library
+# directly instead for deployment.
+python3 -m pipenv lock -r | grep -v '^-e '  > requirements.txt
 gcloud app deploy app.yaml cron.yaml cron-service.yaml --project=oss-vdb


### PR DESCRIPTION
API: Use pipenv to install dependnecies rather than generating
requirements.

App Engine: Exclude the '-e ' dependency from the generated
requirements.txt

Also,
- Update the API server to use Python 3.8 to be consistent with other
  environments.
- Unpin pygit2 in the root Pipfile.