### PR TITLE
Update prerequisites based on my experiences

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,10 @@ Install `protoc` for your platform:
 
 https://grpc.io/docs/protoc-installation/
 
+Install `clang` for your platform:
+
+https://releases.llvm.org/download.html
+
 In the root directory, update submodules:
 
 ```bash
@@ -13,7 +17,7 @@ git submodule update --init --recursive
 Install `protoc-gen-openapiv2`:
 
 ```bash
-go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2
+go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@latest
 ```
 
 To install the protobuf service converter, run:


### PR DESCRIPTION
* mention missing dependency on `clang` when running `go install`
* add `@latest` which is required by `go install` to work correctly