### PR TITLE
Update documentation and OpenAPI spec.

### DIFF
--- a/docs/build.py
+++ b/docs/build.py
@@ -49,7 +49,7 @@ def main():
   if os.path.exists(osv_path):
     shutil.rmtree(osv_path)
 
-  shutil.copytree(os.path.join(_ROOT_DIR, 'lib', 'osv'), osv_path)
+  shutil.copytree(os.path.join(_ROOT_DIR, 'osv'), osv_path)
 
   subprocess.run([
       'protoc',

--- a/docs/osv_service_v1.swagger.json
+++ b/docs/osv_service_v1.swagger.json
@@ -334,14 +334,6 @@
           },
           "description": "Optional. List of IDs of closely related vulnerabilities, such as the same\nproblem in alternate ecosystems."
         },
-        "package": {
-          "description": "Required. Package information.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/osvPackage"
-            }
-          ]
-        },
         "summary": {
           "type": "string",
           "description": "Required. One line human readable summary for the vulnerability. It is\nrecommended to keep this under 120 characters."

--- a/osv/models.py
+++ b/osv/models.py
@@ -528,7 +528,6 @@ class Bug(ndb.Model):
 
   def to_vulnerability(self, include_source=False):
     """Convert to Vulnerability proto."""
-    package = None
     affected = []
 
     source_link = None
@@ -618,7 +617,6 @@ class Bug(ndb.Model):
         withdrawn=withdrawn,
         summary=self.summary,
         details=details,
-        package=package,
         affected=affected,
         severity=severity,
         credits=credits_,

--- a/osv/vulnerability.proto
+++ b/osv/vulnerability.proto
@@ -194,8 +194,6 @@ message Vulnerability {
   // Optional. List of IDs of closely related vulnerabilities, such as the same
   // problem in alternate ecosystems.
   repeated string related = 13;
-  // Required. Package information.
-  Package package = 2;
   // Required. One line human readable summary for the vulnerability. It is
   // recommended to keep this under 120 characters.
   string summary = 3;

--- a/osv/vulnerability_pb2.py
+++ b/osv/vulnerability_pb2.py
@@ -21,7 +21,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto3',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x17osv/vulnerability.proto\x12\x03osv\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"y\n\x06\x43ommit\x12\'\n\trepo_type\x18\x01 \x01(\x0e\x32\x14.osv.Commit.RepoType\x12\x10\n\x08repo_url\x18\x02 \x01(\t\x12\x0e\n\x06\x63ommit\x18\x03 \x01(\t\"$\n\x08RepoType\x12\x0f\n\x0bUNSPECIFIED\x10\x00\x12\x07\n\x03GIT\x10\x01\"8\n\x07Package\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tecosystem\x18\x02 \x01(\t\x12\x0c\n\x04purl\x18\x03 \x01(\t\"\xa4\x01\n\rAffectedRange\x12%\n\x04type\x18\x01 \x01(\x0e\x32\x17.osv.AffectedRange.Type\x12\x0c\n\x04repo\x18\x02 \x01(\t\x12\x12\n\nintroduced\x18\x03 \x01(\t\x12\r\n\x05\x66ixed\x18\x04 \x01(\t\";\n\x04Type\x12\x0f\n\x0bUNSPECIFIED\x10\x00\x12\x07\n\x03GIT\x10\x01\x12\n\n\x06SEMVER\x10\x02\x12\r\n\tECOSYSTEM\x10\x03\"9\n\x05\x45vent\x12\x12\n\nintroduced\x18\x01 \x01(\t\x12\r\n\x05\x66ixed\x18\x02 \x01(\t\x12\r\n\x05limit\x18\x03 \x01(\t\"\x8d\x01\n\x05Range\x12\x1d\n\x04type\x18\x01 \x01(\x0e\x32\x0f.osv.Range.Type\x12\x0c\n\x04repo\x18\x02 \x01(\t\x12\x1a\n\x06\x65vents\x18\x03 \x03(\x0b\x32\n.osv.Event\";\n\x04Type\x12\x0f\n\x0bUNSPECIFIED\x10\x00\x12\x07\n\x03GIT\x10\x01\x12\n\n\x06SEMVER\x10\x02\x12\r\n\tECOSYSTEM\x10\x03\"\xc0\x01\n\x08\x41\x66\x66\x65\x63ted\x12\x1d\n\x07package\x18\x01 \x01(\x0b\x32\x0c.osv.Package\x12\x1a\n\x06ranges\x18\x02 \x03(\x0b\x32\n.osv.Range\x12\x10\n\x08versions\x18\x03 \x03(\t\x12\x33\n\x12\x65\x63osystem_specific\x18\x04 \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x32\n\x11\x64\x61tabase_specific\x18\x05 \x01(\x0b\x32\x17.google.protobuf.Struct\"a\n\x08Severity\x12 \n\x04type\x18\x01 \x01(\x0e\x32\x12.osv.Severity.Type\x12\r\n\x05score\x18\x02 \x01(\t\"$\n\x04Type\x12\x0f\n\x0bUNSPECIFIED\x10\x00\x12\x0b\n\x07\x43VSS_V3\x10\x01\"\'\n\x06\x43redit\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07\x63ontact\x18\x02 \x03(\t\"\x93\x01\n\tReference\x12!\n\x04type\x18\x01 \x01(\x0e\x32\x13.osv.Reference.Type\x12\x0b\n\x03url\x18\x02 \x01(\t\"V\n\x04Type\x12\x08\n\x04NONE\x10\x00\x12\x07\n\x03WEB\x10\x01\x12\x0c\n\x08\x41\x44VISORY\x10\x02\x12\n\n\x06REPORT\x10\x03\x12\x07\n\x03\x46IX\x10\x04\x12\x0b\n\x07PACKAGE\x10\x05\x12\x0b\n\x07\x41RTICLE\x10\x06\"\xda\x03\n\rVulnerability\x12\x16\n\x0eschema_version\x18\x12 \x01(\t\x12\n\n\x02id\x18\x01 \x01(\t\x12-\n\tpublished\x18\x0b \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08modified\x18\n \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12-\n\twithdrawn\x18\x0c \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x0f\n\x07\x61liases\x18\x08 \x03(\t\x12\x0f\n\x07related\x18\r \x03(\t\x12\x1d\n\x07package\x18\x02 \x01(\x0b\x32\x0c.osv.Package\x12\x0f\n\x07summary\x18\x03 \x01(\t\x12\x0f\n\x07\x64\x65tails\x18\x04 \x01(\t\x12\x1f\n\x08\x61\x66\x66\x65\x63ted\x18\x11 \x03(\x0b\x32\r.osv.Affected\x12\"\n\nreferences\x18\x10 \x03(\x0b\x32\x0e.osv.Reference\x12\x32\n\x11\x64\x61tabase_specific\x18\x0f \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x1f\n\x08severity\x18\x13 \x03(\x0b\x32\r.osv.Severity\x12\x1c\n\x07\x63redits\x18\x14 \x03(\x0b\x32\x0b.osv.Creditb\x06proto3'
+  serialized_pb=b'\n\x17osv/vulnerability.proto\x12\x03osv\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"y\n\x06\x43ommit\x12\'\n\trepo_type\x18\x01 \x01(\x0e\x32\x14.osv.Commit.RepoType\x12\x10\n\x08repo_url\x18\x02 \x01(\t\x12\x0e\n\x06\x63ommit\x18\x03 \x01(\t\"$\n\x08RepoType\x12\x0f\n\x0bUNSPECIFIED\x10\x00\x12\x07\n\x03GIT\x10\x01\"8\n\x07Package\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tecosystem\x18\x02 \x01(\t\x12\x0c\n\x04purl\x18\x03 \x01(\t\"\xa4\x01\n\rAffectedRange\x12%\n\x04type\x18\x01 \x01(\x0e\x32\x17.osv.AffectedRange.Type\x12\x0c\n\x04repo\x18\x02 \x01(\t\x12\x12\n\nintroduced\x18\x03 \x01(\t\x12\r\n\x05\x66ixed\x18\x04 \x01(\t\";\n\x04Type\x12\x0f\n\x0bUNSPECIFIED\x10\x00\x12\x07\n\x03GIT\x10\x01\x12\n\n\x06SEMVER\x10\x02\x12\r\n\tECOSYSTEM\x10\x03\"9\n\x05\x45vent\x12\x12\n\nintroduced\x18\x01 \x01(\t\x12\r\n\x05\x66ixed\x18\x02 \x01(\t\x12\r\n\x05limit\x18\x03 \x01(\t\"\x8d\x01\n\x05Range\x12\x1d\n\x04type\x18\x01 \x01(\x0e\x32\x0f.osv.Range.Type\x12\x0c\n\x04repo\x18\x02 \x01(\t\x12\x1a\n\x06\x65vents\x18\x03 \x03(\x0b\x32\n.osv.Event\";\n\x04Type\x12\x0f\n\x0bUNSPECIFIED\x10\x00\x12\x07\n\x03GIT\x10\x01\x12\n\n\x06SEMVER\x10\x02\x12\r\n\tECOSYSTEM\x10\x03\"\xc0\x01\n\x08\x41\x66\x66\x65\x63ted\x12\x1d\n\x07package\x18\x01 \x01(\x0b\x32\x0c.osv.Package\x12\x1a\n\x06ranges\x18\x02 \x03(\x0b\x32\n.osv.Range\x12\x10\n\x08versions\x18\x03 \x03(\t\x12\x33\n\x12\x65\x63osystem_specific\x18\x04 \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x32\n\x11\x64\x61tabase_specific\x18\x05 \x01(\x0b\x32\x17.google.protobuf.Struct\"a\n\x08Severity\x12 \n\x04type\x18\x01 \x01(\x0e\x32\x12.osv.Severity.Type\x12\r\n\x05score\x18\x02 \x01(\t\"$\n\x04Type\x12\x0f\n\x0bUNSPECIFIED\x10\x00\x12\x0b\n\x07\x43VSS_V3\x10\x01\"\'\n\x06\x43redit\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07\x63ontact\x18\x02 \x03(\t\"\x93\x01\n\tReference\x12!\n\x04type\x18\x01 \x01(\x0e\x32\x13.osv.Reference.Type\x12\x0b\n\x03url\x18\x02 \x01(\t\"V\n\x04Type\x12\x08\n\x04NONE\x10\x00\x12\x07\n\x03WEB\x10\x01\x12\x0c\n\x08\x41\x44VISORY\x10\x02\x12\n\n\x06REPORT\x10\x03\x12\x07\n\x03\x46IX\x10\x04\x12\x0b\n\x07PACKAGE\x10\x05\x12\x0b\n\x07\x41RTICLE\x10\x06\"\xbb\x03\n\rVulnerability\x12\x16\n\x0eschema_version\x18\x12 \x01(\t\x12\n\n\x02id\x18\x01 \x01(\t\x12-\n\tpublished\x18\x0b \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08modified\x18\n \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12-\n\twithdrawn\x18\x0c \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x0f\n\x07\x61liases\x18\x08 \x03(\t\x12\x0f\n\x07related\x18\r \x03(\t\x12\x0f\n\x07summary\x18\x03 \x01(\t\x12\x0f\n\x07\x64\x65tails\x18\x04 \x01(\t\x12\x1f\n\x08\x61\x66\x66\x65\x63ted\x18\x11 \x03(\x0b\x32\r.osv.Affected\x12\"\n\nreferences\x18\x10 \x03(\x0b\x32\x0e.osv.Reference\x12\x32\n\x11\x64\x61tabase_specific\x18\x0f \x01(\x0b\x32\x17.google.protobuf.Struct\x12\x1f\n\x08severity\x18\x13 \x03(\x0b\x32\r.osv.Severity\x12\x1c\n\x07\x63redits\x18\x14 \x03(\x0b\x32\x0b.osv.Creditb\x06proto3'
   ,
   dependencies=[google_dot_protobuf_dot_struct__pb2.DESCRIPTOR,google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,])
 
@@ -675,56 +675,49 @@ _VULNERABILITY = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='package', full_name='osv.Vulnerability.package', index=7,
-      number=2, type=11, cpp_type=10, label=1,
-      has_default_value=False, default_value=None,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='summary', full_name='osv.Vulnerability.summary', index=8,
+      name='summary', full_name='osv.Vulnerability.summary', index=7,
       number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='details', full_name='osv.Vulnerability.details', index=9,
+      name='details', full_name='osv.Vulnerability.details', index=8,
       number=4, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='affected', full_name='osv.Vulnerability.affected', index=10,
+      name='affected', full_name='osv.Vulnerability.affected', index=9,
       number=17, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='references', full_name='osv.Vulnerability.references', index=11,
+      name='references', full_name='osv.Vulnerability.references', index=10,
       number=16, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='database_specific', full_name='osv.Vulnerability.database_specific', index=12,
+      name='database_specific', full_name='osv.Vulnerability.database_specific', index=11,
       number=15, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='severity', full_name='osv.Vulnerability.severity', index=13,
+      name='severity', full_name='osv.Vulnerability.severity', index=12,
       number=19, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='credits', full_name='osv.Vulnerability.credits', index=14,
+      name='credits', full_name='osv.Vulnerability.credits', index=13,
       number=20, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -743,7 +736,7 @@ _VULNERABILITY = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=1132,
-  serialized_end=1606,
+  serialized_end=1575,
 )
 
 _COMMIT.fields_by_name['repo_type'].enum_type = _COMMIT_REPOTYPE
@@ -764,7 +757,6 @@ _REFERENCE_TYPE.containing_type = _REFERENCE
 _VULNERABILITY.fields_by_name['published'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
 _VULNERABILITY.fields_by_name['modified'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
 _VULNERABILITY.fields_by_name['withdrawn'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
-_VULNERABILITY.fields_by_name['package'].message_type = _PACKAGE
 _VULNERABILITY.fields_by_name['affected'].message_type = _AFFECTED
 _VULNERABILITY.fields_by_name['references'].message_type = _REFERENCE
 _VULNERABILITY.fields_by_name['database_specific'].message_type = google_dot_protobuf_dot_struct__pb2._STRUCT


### PR DESCRIPTION
Remove the previously deprecated top level `package` field from the
Vulnerability proto.

Fixes #542