### PR TITLE
Fix issues with pages on vulnerability list page

### DIFF
--- a/gcp/appengine/frontend3/package-lock.json
+++ b/gcp/appengine/frontend3/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "frontend3",
       "version": "0.0.0",
       "dependencies": {
         "@github/clipboard-copy-element": "^1.1.2",

--- a/gcp/appengine/frontend3/src/index.js
+++ b/gcp/appengine/frontend3/src/index.js
@@ -73,3 +73,21 @@ export class CodeBlock extends LitElement {
   }
 }
 customElements.define('code-block', CodeBlock);
+
+function checkVisible(elm) {
+  var rect = elm.getBoundingClientRect();
+  var viewHeight = Math.max(document.documentElement.clientHeight, window.innerHeight);
+  return !(rect.bottom < 0 || rect.top - viewHeight >= 0);
+}
+
+document.addEventListener('scroll', () => {
+  let next_pg_btn = document.querySelector('.next-page-button')
+
+  if (next_pg_btn && !next_pg_btn.getAttribute('already-clicked')) {
+    let vis = checkVisible(next_pg_btn);
+    if (vis) {
+      next_pg_btn.setAttribute('already-clicked', 'true')
+      next_pg_btn.click();
+    }
+  }
+})

--- a/gcp/appengine/frontend3/src/index.js
+++ b/gcp/appengine/frontend3/src/index.js
@@ -73,21 +73,3 @@ export class CodeBlock extends LitElement {
   }
 }
 customElements.define('code-block', CodeBlock);
-
-function checkVisible(elm) {
-  var rect = elm.getBoundingClientRect();
-  var viewHeight = Math.max(document.documentElement.clientHeight, window.innerHeight);
-  return !(rect.bottom < 0 || rect.top - viewHeight >= 0);
-}
-
-document.addEventListener('scroll', () => {
-  let next_pg_btn = document.querySelector('.next-page-button')
-
-  if (next_pg_btn && !next_pg_btn.getAttribute('already-clicked')) {
-    let vis = checkVisible(next_pg_btn);
-    if (vis) {
-      next_pg_btn.setAttribute('already-clicked', 'true')
-      next_pg_btn.click();
-    }
-  }
-})

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -395,6 +395,15 @@ mwc-icon-button.mdc-data-table__sort-icon-button {
       transform: translateX(-50%);
     }
   }
+
+  .no-results {
+    font-family: $osv-heading-font-family;
+    font-weight: bold;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 25px;
+  }
 }
 
 /** Vulnerability page */

--- a/gcp/appengine/frontend3/src/templates/list.html
+++ b/gcp/appengine/frontend3/src/templates/list.html
@@ -128,16 +128,25 @@ data-column-id="{{ column_id }}"
           </span>
         </div>
         {% endfor %}
-        <turbo-frame id="vulnerability-table-page{{ page + 1 }}" data-turbo-action="advance" target="_top"
-            class="next-page-frame">
+        {% if vulnerabilities | length == 0 %}
+          <span class="no-results">No results</span>
+        {% endif %}
+        {% if page < total_pages %}
+          <turbo-frame id="vulnerability-table-page{{ page + 1 }}" data-turbo-action="advance" target="_top"
+                       class="next-page-frame">
           <div class="next-page-container">
-            <a class="next-page-button link-button" data-turbo-frame="_self"
-                href="{{ url_for(request.endpoint) }}?page={{ page + 1 }}{% if selected_ecosystem %}&ecosystem={{ selected_ecosystem }}{% endif %}">
-              Load more...
-            </a>
-            <mwc-circular-progress class="next-page-indicator" indeterminate density="-4"></mwc-circular-progress>
+          <a class="next-page-button link-button" data-turbo-frame="_self"
+             href="{{ url_for(request.endpoint) }}?page={{ page + 1 }}{% if selected_ecosystem %}&ecosystem={{ selected_ecosystem }}{% endif %}">
+            Load more...
+            {% if total_pages - page <= 3 %}
+              &nbsp;&nbsp;&nbsp;
+              ({{ total_pages - page }} page{% if total_pages - page > 1 %}s{% endif %} left)
+            {% endif %}
+          </a>
+          <mwc-circular-progress class="next-page-indicator" indeterminate density="-4"></mwc-circular-progress>
           </div>
-        </turbo-frame>
+          </turbo-frame>
+        {% endif %}
       </turbo-frame>
     </div>
   </div>

--- a/gcp/appengine/frontend3/src/templates/list.html
+++ b/gcp/appengine/frontend3/src/templates/list.html
@@ -137,10 +137,9 @@ data-column-id="{{ column_id }}"
           <div class="next-page-container">
           <a class="next-page-button link-button" data-turbo-frame="_self"
              href="{{ url_for(request.endpoint) }}?page={{ page + 1 }}{% if selected_ecosystem %}&ecosystem={{ selected_ecosystem }}{% endif %}">
-            Load more...
+            <span>Load more...</span>
             {% if total_pages - page <= 3 %}
-              &nbsp;&nbsp;&nbsp;
-              ({{ total_pages - page }} page{% if total_pages - page > 1 %}s{% endif %} left)
+              <span style="margin-left: 5px">({{ total_pages - page }} page{% if total_pages - page > 1 %}s{% endif %} left)</span>
             {% endif %}
           </a>
           <mwc-circular-progress class="next-page-indicator" indeterminate density="-4"></mwc-circular-progress>

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -23,6 +23,7 @@ from flask import make_response
 from flask import redirect
 from flask import render_template
 from flask import request
+from flask import url_for
 import markdown2
 from urllib import parse
 
@@ -102,7 +103,8 @@ def list_vulnerabilities():
     if request.args.get('page', 1) != 1:
       q = parse.parse_qs(request.query_string)
       q.pop(b'page', None)
-      return redirect(request.path + '?' + parse.urlencode(q, True))
+      return redirect(
+          url_for(request.endpoint) + '?' + parse.urlencode(q, True))
 
   query = request.args.get('q', '')
   page = int(request.args.get('page', 1))


### PR DESCRIPTION
- Remove ability to go to pages directly after refresh, as it causes confusing scenario
- Removes load more button if there are no more results.
- Add message indicating there are no results
- Add indicator of how many pages left if there are less than 3 pages left. (Probably can refactor that number to a config file or something)

Fixes: #468 