### PR TITLE
Add instructions for running UI and API servers locally.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,3 +89,25 @@ To format your code, run
 ```shell
 $ yapf -i <file>.py
 ```
+
+### Running local UI and API instances (maintainers only)
+
+#### UI
+
+```shell
+$ gcloud auth login --update-adc
+$ make run-appengine
+```
+
+#### API
+
+Running a local instance of the API server requires service account
+credentials.
+
+You will need to download a service account key for `esp-test@oss-vdb.iam.gserviceaccount.com` from
+<https://cloud.google.com/console/iam-admin/serviceaccounts?project=oss-vdb>. Keep this safe.
+
+```shell
+$ gcloud auth login --update-adc
+$ make SERVICE_ACCOUNT=/path/to/service_account.json run-api-server
+```

--- a/Makefile
+++ b/Makefile
@@ -27,5 +27,13 @@ appengine-tests:
 lint:
 	tools/lint_and_format.sh
 
+run-appengine:
+	cd gcp/appengine/frontend3 && npm run build
+	cd gcp/appengine && GOOGLE_CLOUD_PROJECT=oss-vdb pipenv run python main.py
+
+run-api-server:
+	test $(SERVICE_ACCOUNT) || (echo "SERVICE_ACCOUNT variable not set"; exit 1)
+	cd gcp/api && GOOGLE_CLOUD_PROJECT=oss-vdb pipenv run python test_server.py $(SERVICE_ACCOUNT)
+
 # TODO: API integration tests.
 all-tests: lib-tests worker-tests importer-tests appengine-tests

--- a/gcp/api/test_server.py
+++ b/gcp/api/test_server.py
@@ -96,12 +96,14 @@ def start_esp(port, backend_port, service_account_path, log_path):
     network = '--network=host'
     host = 'localhost'
 
+  # Stop existing osv-esp processes that weren't killed properly.
+  subprocess.run(['docker', 'stop', 'osv-esp'])
   esp_proc = subprocess.Popen([
       'docker',
       'run',
       '--privileged',
       '--name',
-      'esp',
+      'osv-esp',
       network,
       '--rm',
       '-v',

--- a/gcp/api/test_server.py
+++ b/gcp/api/test_server.py
@@ -62,7 +62,7 @@ def start_backend(port, log_path):
 def get_cloudbuild_esp_host():
   """Get cloudbuild host."""
   result = subprocess.run([
-      'docker', 'inspect', 'esp',
+      'docker', 'inspect', 'osv-esp',
       '--format={{(index .NetworkSettings.Networks "cloudbuild").IPAddress}}'
   ],
                           capture_output=True,


### PR DESCRIPTION
Also:
- Add instructions to CONTRIBUTING.md for how to invoke the targets.
- Make the API test_server.py a bit more robust by killing existing
  ESPv2 instances prior to starting.
- Rename the ESPv2 docker containers to something less generic to avoid potential
  collisions.