### PR TITLE
Enhance architecture documentation with additional links

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,7 @@ All vulnerability data is stored in [Cloud Datastore], with the [models] defined
 
 [Cloud Datastore]: https://cloud.google.com/datastore
 [models]:
-https://cloudplatform.googleblog.com/2015/08/Introduction-to-data-models-in-Cloud-Datastore.html
+https://googleapis.dev/python/python-ndb/latest/index.html#defining-entities-keys-and-properties
 [here]: https://github.com/google/osv/blob/master/osv/models.py
 
 ## OSS-Fuzz

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,37 +8,47 @@ OSV runs on Google Cloud Platform, with the following main components:
 
 ## Cloud Datastore
 
-All vulnerability data is stored in Cloud Datastore, with the models defined
+All vulnerability data is stored in [Cloud Datastore], with the [models] defined
 [here].
+
+[Cloud Datastore]: https://cloud.google.com/datastore
+[models]:
+https://cloudplatform.googleblog.com/2015/08/Introduction-to-data-models-in-Cloud-Datastore.html
+[here]: https://github.com/google/osv/blob/master/osv/models.py
 
 ## OSS-Fuzz
 
-All of our data is currently sourced from
-[OSS-Fuzz](https://github.com/google/oss-fuzz), and we are working to extend
-this with other sources.
+All of our data is currently sourced from [OSS-Fuzz], and we are working to
+extend this with [other sources].
+
+[OSS-Fuzz]: https://github.com/google/oss-fuzz
+[other sources]: https://github.com/google/osv.dev/tree/master/vulnfeeds
 
 ## Google Kubernetes Engine (GKE)
 
-GKE is used for running [workers] to perform bisects and impact analysis. These
-workers consume tasks from a Cloud Pub/Sub topic.
+[GKE] is used for running [workers] to perform bisects and impact analysis.
+These workers consume tasks from a [Cloud Pub/Sub] topic.
 
-Workers are Docker containers which use [gVisor](https://gvisor.dev/) for
-sandboxing untrusted workloads.
+Workers are Docker containers, which use [gVisor] for sandboxing untrusted
+workloads.
 
+[GKE]: https://cloud.google.com/kubernetes-engine
 [workers]: https://github.com/google/osv/tree/master/docker/worker
-
-[here]: https://github.com/google/osv/blob/master/osv/models.py
+[gVisor]: https://gvisor.dev/
+[Cloud Pub/Sub]: https://cloud.google.com/pubsub
 
 ## Cloud Run / Cloud Endpoints
 
-The [API server] runs on Cloud Run, and is served by Cloud Endpoints.
+The [API server] runs on [Cloud Run], and is served by [Cloud Endpoints].
 
 [API server]: https://github.com/google/osv/tree/master/gcp/api
+[Cloud Run]: https://cloud.google.com/run
+[Cloud Endpoints]: https://cloud.google.com/endpoints
 
 ## App Engine
 
-The main web UI (https://osv.dev) runs on [App Engine]. App Engine [cron jobs] also
-schedule recurring tasks for the workers, allocate OSV IDs, and make
+The main web UI (https://osv.dev) runs on [App Engine]. App Engine [cron jobs]
+also schedule recurring tasks for the workers, allocate OSV IDs, and make
 vulnerabilities public at the appropriate times.
 
 [App Engine]: https://github.com/google/osv/tree/master/gcp/appengine

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@
 Our data is sourced from a variety of [sources], which we are looking to expand
 on over time.
 
-[sources]: https://github.com/google/osv.dev/tree/master/vulnfeeds
+[sources]: https://github.com/google/osv.dev#current-data-sources
 
 OSV runs on Google Cloud Platform, with the following main components:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,6 +4,13 @@
   <img src="images/architecture.png" width="800">
 </p>
 
+## Data source
+
+Our data is sourced from a variety of [sources], which we are looking to expand
+on over time.
+
+[sources]: https://github.com/google/osv.dev/tree/master/vulnfeeds
+
 OSV runs on Google Cloud Platform, with the following main components:
 
 ## Cloud Datastore
@@ -15,14 +22,6 @@ All vulnerability data is stored in [Cloud Datastore], with the [models] defined
 [models]:
 https://googleapis.dev/python/python-ndb/latest/index.html#defining-entities-keys-and-properties
 [here]: https://github.com/google/osv/blob/master/osv/models.py
-
-## OSS-Fuzz
-
-All of our data is currently sourced from [OSS-Fuzz], and we are working to
-extend this with [other sources].
-
-[OSS-Fuzz]: https://github.com/google/oss-fuzz
-[other sources]: https://github.com/google/osv.dev/tree/master/vulnfeeds
 
 ## Google Kubernetes Engine (GKE)
 


### PR DESCRIPTION
* Link out to various GCP technologies to make it easier for the
  unfamiliar to school themselves
* Consistently use and place reference-style links for better readability