### PR TITLE
Fix deploy script using deprecated method to generate requirement

### DIFF
--- a/gcp/appengine/deploy.sh
+++ b/gcp/appengine/deploy.sh
@@ -6,5 +6,5 @@ popd
 
 # Skip the '-e' editable library install as we copy in the "osv" library
 # directly instead for deployment.
-python3 -m pipenv lock -r | grep -v '^-e '  > requirements.txt
+python3 -m pipenv requirements | grep -v '^-e '  > requirements.txt
 gcloud app deploy app.yaml cron.yaml cron-service.yaml --project=oss-vdb


### PR DESCRIPTION
Fix how the deploy script generates the requirements.txt file.

There's also another problem where pipenv is not actually specified as a devDependency in appengine, causing the script to fail if pipenv hasn't been installed inside this appengine environment specifically.

 Because that will actually change the Pipfile.lock, I will put that #616 alongside other dependency changes