### PR TITLE
Stop enumerating debian end of life advisories

### DIFF
--- a/osv/ecosystems.py
+++ b/osv/ecosystems.py
@@ -388,6 +388,10 @@ class Debian(Ecosystem):
       introduced = debian_version_cache.get_first_package_version(
           package, self.debian_release_ver)
 
+    if fixed == "<end-of-life>":
+      # Special case for eol, we do not enumerate
+      versions = []
+
     return self._get_affected_versions(versions, introduced, fixed, limits)
 
 

--- a/osv/ecosystems.py
+++ b/osv/ecosystems.py
@@ -340,13 +340,14 @@ class Debian(Ecosystem):
   """Debian ecosystem"""
 
   _API_PACKAGE_URL = 'https://snapshot.debian.org/mr/package/{package}/'
+  _END_OF_LIFE_VER = '<end-of-life>'
   debian_release_ver: str
 
   def __init__(self, debian_release_ver: str):
     self.debian_release_ver = debian_release_ver
 
   def sort_key(self, version):
-    if version == '<end-of-life>':
+    if version == self._END_OF_LIFE_VER:
       # End of life advisory means all versions can be affected
       return DebianVersion(999999)
 
@@ -388,7 +389,7 @@ class Debian(Ecosystem):
       introduced = debian_version_cache.get_first_package_version(
           package, self.debian_release_ver)
 
-    if fixed == "<end-of-life>":
+    if fixed == self._END_OF_LIFE_VER:
       # Special case for eol, we do not enumerate
       versions = []
 

--- a/osv/ecosystems.py
+++ b/osv/ecosystems.py
@@ -391,7 +391,7 @@ class Debian(Ecosystem):
 
     if fixed == self._END_OF_LIFE_VER:
       # Special case for eol, we do not enumerate
-      versions = []
+      return []
 
     return self._get_affected_versions(versions, introduced, fixed, limits)
 

--- a/osv/ecosystems_test.py
+++ b/osv/ecosystems_test.py
@@ -116,11 +116,13 @@ class GetNextVersionTest(unittest.TestCase):
     self.assertGreater(
         ecosystem.sort_key('<end-of-life>'), ecosystem.sort_key('1.13.6-1'))
 
+    self.assertEqual(
+        ecosystem.enumerate_versions("nginx", "0", "<end-of-life>"), [])
     # Test Ecosystem remover
     ecosystem = ecosystems.get('Debian:10')
     # '0' as introduced version also tests the get_first_package_version func
     versions = ecosystem.enumerate_versions('cyrus-sasl2', '0', None)
-    self.assertEqual(requests_mock.call_count, 1)
+    self.assertEqual(requests_mock.call_count, 2)
     self.assertIn('2.1.27+dfsg-1+deb10u1', versions)
     self.assertNotIn('2.1.27~101-g0780600+dfsg-3+deb9u1', versions)
     self.assertNotIn('2.1.27~101-g0780600+dfsg-3+deb9u2', versions)
@@ -130,7 +132,7 @@ class GetNextVersionTest(unittest.TestCase):
 
     # This should now only call the cache, and not requests.get
     ecosystem.enumerate_versions('cyrus-sasl2', '0', None)
-    self.assertEqual(requests_mock.call_count, 1)
+    self.assertEqual(requests_mock.call_count, 2)
 
   def test_semver(self):
     """Test SemVer."""

--- a/osv/ecosystems_test.py
+++ b/osv/ecosystems_test.py
@@ -117,7 +117,7 @@ class GetNextVersionTest(unittest.TestCase):
         ecosystem.sort_key('<end-of-life>'), ecosystem.sort_key('1.13.6-1'))
 
     self.assertEqual(
-        ecosystem.enumerate_versions("nginx", "0", "<end-of-life>"), [])
+        ecosystem.enumerate_versions('nginx', '0', '<end-of-life>'), [])
     # Test Ecosystem remover
     ecosystem = ecosystems.get('Debian:10')
     # '0' as introduced version also tests the get_first_package_version func


### PR DESCRIPTION
Stop enumerating Debian end of life advisories, as they are quite rare (as of writing only 7 EOL advisory entries, and around 3 packages affected). If enumerated it is likely to cause false positives, since the EOL generally only affects the specific Debian release, not following releases. 