### PR TITLE
Logging fixes 2

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,19 +17,19 @@ steps:
   dir: docker/worker
   args: ['clone', 'https://source.developers.google.com/p/oss-vdb/r/osv-test']
 - name: 'gcr.io/oss-vdb/ci'
-  args: ['bash', '-x', 'run_tests.sh']
+  args: ['bash', '-ex', 'run_tests.sh']
 - name: 'gcr.io/oss-vdb/ci'
   dir: docker/worker
-  args: ['bash', '-x', 'run_tests.sh']
+  args: ['bash', '-ex', 'run_tests.sh']
 - name: 'gcr.io/oss-vdb/ci'
   dir: docker/importer
-  args: ['bash', '-x', 'run_tests.sh']
+  args: ['bash', '-ex', 'run_tests.sh']
 - name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: 'bash'
   args: [ '-c', "gcloud secrets versions access latest --secret=integration-test-account --format='get(payload.data)' | tr '_-' '/+' | base64 -d > /workspace/service_account.json" ]
 - name: 'gcr.io/oss-vdb/ci'
   dir: gcp/api
-  args: ['bash', '-x', 'run_tests.sh', '/workspace/service_account.json']
+  args: ['bash', '-ex', 'run_tests.sh', '/workspace/service_account.json']
   env:
     - CLOUDBUILD=1
 - name: 'gcr.io/cloud-builders/gcloud'

--- a/osv/ecosystems.py
+++ b/osv/ecosystems.py
@@ -340,13 +340,16 @@ class Debian(Ecosystem):
   """Debian ecosystem"""
 
   _API_PACKAGE_URL = 'https://snapshot.debian.org/mr/package/{package}/'
-  _END_OF_LIFE_VER = '<end-of-life>'
   debian_release_ver: str
 
   def __init__(self, debian_release_ver: str):
     self.debian_release_ver = debian_release_ver
 
   def sort_key(self, version):
+    if not DebianVersion.is_valid(version):
+      # If debian version is not valid, it is most likely an invalid fixed
+      # version then sort it to the last/largest element
+      return DebianVersion(999999, 999999)
     return DebianVersion.from_string(version)
 
   def enumerate_versions(self, package, introduced, fixed, limits=None):

--- a/osv/ecosystems.py
+++ b/osv/ecosystems.py
@@ -388,7 +388,7 @@ class Debian(Ecosystem):
       introduced = debian_version_cache.get_first_package_version(
           package, self.debian_release_ver)
 
-    if not DebianVersion.is_valid(fixed):
+    if fixed is not None and not DebianVersion.is_valid(fixed):
       logging.warning(
           'Package %s has invalid fixed version: %s. In debian release %s',
           package, fixed, self.debian_release_ver)


### PR DESCRIPTION
Cloud build testing should now exit and error on any tests failing. 

Also fix the issue breaking tests.