### PR TITLE
Fix grammatical error I noticed

### DIFF
--- a/gcp/appengine/frontend3/src/templates/about.html
+++ b/gcp/appengine/frontend3/src/templates/about.html
@@ -75,7 +75,7 @@
           <p><a href="https://github.com/google/osv/tree/master/tools/osv-scanner">Command line tooling</a> is currently being developed to enable easy
           vulnerability scanning of SBOMs, language manifests, and container images. Stay tuned!</p>
         </div>
-        <h3 class="question">How do I use OSV as an vulnerability database maintainer?</h3>
+        <h3 class="question">How do I use OSV as a vulnerability database maintainer?</h3>
         <div class="answer">
           <p>By making your vulnerability database available in the OSV format,
           open source users will have a consistent way to consume vulnerabilities across all


### PR DESCRIPTION
"an" should only preceed words starting with a vowel.