### PR TITLE
Add cloudbuild.yaml for deploying to staging. 

### DIFF
--- a/deployment/staging.yaml
+++ b/deployment/staging.yaml
@@ -15,20 +15,20 @@
 steps:
 - name: 'gcr.io/cloud-builders/git'
   args: ['submodule', 'update', '--init', '--recursive']
-- name: 'gcr.io/oss-vdb/ci'
-  args: ['make', 'all-tests']
-- name: 'gcr.io/cloud-builders/gcloud'
-  entrypoint: 'bash'
-  args: [ '-c', "gcloud secrets versions access latest --secret=integration-test-account --format='get(payload.data)' | tr '_-' '/+' | base64 -d > /workspace/service_account.json" ]
-- name: 'gcr.io/oss-vdb/ci'
-  dir: gcp/api
-  args: ['bash', '-ex', 'run_tests.sh', '/workspace/service_account.json']
-  env:
-  - CLOUDBUILD=1
-- name: 'gcr.io/cloud-builders/gcloud'
-  entrypoint: 'bash'
-  args: [ '-c', "rm /workspace/service_account.json" ]
-- name: 'gcr.io/oss-vdb/ci'
+    #- name: 'gcr.io/oss-vdb/ci'
+    #  args: ['make', 'all-tests']
+    #- name: 'gcr.io/cloud-builders/gcloud'
+    #  entrypoint: 'bash'
+    #  args: [ '-c', "gcloud secrets versions access latest --secret=integration-test-account --format='get(payload.data)' | tr '_-' '/+' | base64 -d > /workspace/service_account.json" ]
+    #- name: 'gcr.io/oss-vdb/ci'
+    #  dir: gcp/api
+    #  args: ['bash', '-ex', 'run_tests.sh', '/workspace/service_account.json']
+    #  env:
+    #  - CLOUDBUILD=1
+    #- name: 'gcr.io/cloud-builders/gcloud'
+    #  entrypoint: 'bash'
+    #  args: [ '-c', "rm /workspace/service_account.json" ]
+- name: 'gcr.io/oss-vdb/deployment'
   args: ['bash', '-ex', 'deploy-staging.sh']
   dir: gcp/appengine
 timeout: 7200s

--- a/deployment/staging.yaml
+++ b/deployment/staging.yaml
@@ -15,19 +15,19 @@
 steps:
 - name: 'gcr.io/cloud-builders/git'
   args: ['submodule', 'update', '--init', '--recursive']
-    #- name: 'gcr.io/oss-vdb/ci'
-    #  args: ['make', 'all-tests']
-    #- name: 'gcr.io/cloud-builders/gcloud'
-    #  entrypoint: 'bash'
-    #  args: [ '-c', "gcloud secrets versions access latest --secret=integration-test-account --format='get(payload.data)' | tr '_-' '/+' | base64 -d > /workspace/service_account.json" ]
-    #- name: 'gcr.io/oss-vdb/ci'
-    #  dir: gcp/api
-    #  args: ['bash', '-ex', 'run_tests.sh', '/workspace/service_account.json']
-    #  env:
-    #  - CLOUDBUILD=1
-    #- name: 'gcr.io/cloud-builders/gcloud'
-    #  entrypoint: 'bash'
-    #  args: [ '-c', "rm /workspace/service_account.json" ]
+- name: 'gcr.io/oss-vdb/ci'
+  args: ['make', 'all-tests']
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: 'bash'
+  args: [ '-c', "gcloud secrets versions access latest --secret=integration-test-account --format='get(payload.data)' | tr '_-' '/+' | base64 -d > /workspace/service_account.json" ]
+- name: 'gcr.io/oss-vdb/ci'
+  dir: gcp/api
+  args: ['bash', '-ex', 'run_tests.sh', '/workspace/service_account.json']
+  env:
+  - CLOUDBUILD=1
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: 'bash'
+  args: [ '-c', "rm /workspace/service_account.json" ]
 - name: 'gcr.io/oss-vdb/deployment'
   args: ['bash', '-ex', 'deploy-staging.sh']
   dir: gcp/appengine

--- a/deployment/staging.yaml
+++ b/deployment/staging.yaml
@@ -1,0 +1,38 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- name: 'gcr.io/cloud-builders/git'
+  args: ['submodule', 'update', '--init', '--recursive']
+- name: 'gcr.io/oss-vdb/ci'
+  args: ['make', 'all-tests']
+- name: 'gcr.io/oss-vdb/ci'
+  args: ['make', 'all-tests']
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: 'bash'
+  args: [ '-c', "gcloud secrets versions access latest --secret=integration-test-account --format='get(payload.data)' | tr '_-' '/+' | base64 -d > /workspace/service_account.json" ]
+- name: 'gcr.io/oss-vdb/ci'
+  dir: gcp/api
+  args: ['bash', '-ex', 'run_tests.sh', '/workspace/service_account.json']
+  env:
+    - CLOUDBUILD=1
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: 'bash'
+  args: [ '-c', "rm /workspace/service_account.json" ]
+- name: 'gcr.io/oss-vdb/ci'
+  args: ['bash', '-ex', 'deploy_staging.sh']
+  dir: gcp/appengine
+timeout: 7200s
+options:
+  machineType: N1_HIGHCPU_8

--- a/deployment/staging.yaml
+++ b/deployment/staging.yaml
@@ -17,8 +17,6 @@ steps:
   args: ['submodule', 'update', '--init', '--recursive']
 - name: 'gcr.io/oss-vdb/ci'
   args: ['make', 'all-tests']
-- name: 'gcr.io/oss-vdb/ci'
-  args: ['make', 'all-tests']
 - name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: 'bash'
   args: [ '-c', "gcloud secrets versions access latest --secret=integration-test-account --format='get(payload.data)' | tr '_-' '/+' | base64 -d > /workspace/service_account.json" ]
@@ -26,12 +24,12 @@ steps:
   dir: gcp/api
   args: ['bash', '-ex', 'run_tests.sh', '/workspace/service_account.json']
   env:
-    - CLOUDBUILD=1
+  - CLOUDBUILD=1
 - name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: 'bash'
   args: [ '-c', "rm /workspace/service_account.json" ]
 - name: 'gcr.io/oss-vdb/ci'
-  args: ['bash', '-ex', 'deploy_staging.sh']
+  args: ['bash', '-ex', 'deploy-staging.sh']
   dir: gcp/appengine
 timeout: 7200s
 options:

--- a/deployment/staging.yaml
+++ b/deployment/staging.yaml
@@ -36,3 +36,4 @@ steps:
 timeout: 7200s
 options:
   machineType: N1_HIGHCPU_8
+  logging: CLOUD_LOGGING_ONLY

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -17,6 +17,8 @@ FROM gcr.io/oss-vdb/worker
 RUN apt-get update && \
     apt-get install -y \
         google-cloud-sdk-datastore-emulator \
+        nodejs \
+        npm \
         openjdk-11-jre  # Needed for Datastore emulator.
 
 COPY daemon.json /etc/docker/daemon.json

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -17,8 +17,6 @@ FROM gcr.io/oss-vdb/worker
 RUN apt-get update && \
     apt-get install -y \
         google-cloud-sdk-datastore-emulator \
-        nodejs \
-        npm \
         openjdk-11-jre  # Needed for Datastore emulator.
 
 COPY daemon.json /etc/docker/daemon.json

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -16,7 +16,8 @@ FROM gcr.io/oss-vdb/worker
 
 RUN apt-get update && \
     apt-get install -y \
-        google-cloud-sdk-datastore-emulator
+        google-cloud-sdk-datastore-emulator \
+        openjdk-11-jre  # Needed for Datastore emulator.
 
 COPY daemon.json /etc/docker/daemon.json
 ENTRYPOINT []

--- a/docker/deployment/Dockerfile
+++ b/docker/deployment/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    apt-get install -y curl nodejs npm python3-pip
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - && \
+    apt-get update && apt-get install -y google-cloud-sdk
+
+RUN pip3 install pipenv
+

--- a/gcp/api/run_tests.sh
+++ b/gcp/api/run_tests.sh
@@ -23,7 +23,7 @@ cp -r ../../osv .
 
 pipenv requirements > requirements.txt
 virtualenv ENV
-source ENV/bin/activate
+. ENV/bin/activate
 pip install -r requirements.txt
 service docker start
 

--- a/gcp/api/run_tests.sh
+++ b/gcp/api/run_tests.sh
@@ -21,7 +21,7 @@ fi
 rm -rf osv
 cp -r ../../osv .
 
-pipenv lock -r > requirements.txt
+pipenv requirements > requirements.txt
 virtualenv ENV
 source ENV/bin/activate
 pip install -r requirements.txt

--- a/gcp/appengine/deploy-staging.sh
+++ b/gcp/appengine/deploy-staging.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -ex
 
 pushd frontend3
+npm install
 npm run build:prod
 popd
 

--- a/gcp/appengine/deploy.sh
+++ b/gcp/appengine/deploy.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -ex
 
 pushd frontend3
+npm install
 npm run build:prod
 popd
 


### PR DESCRIPTION
This will be triggered on every commit to master, after passing all tests.

Also:
- Update gcp/api/run_tests.sh to use `pipenv requirements` instead as `pipenv lock -r` is deprecated/removed.
- Add explicit Java dependency in CI image as latest gcloud datastore emulators seem to require (but not install)
  this.
- Add `npm install` to App Engine deployment scripts.
- Add a new Docker image for deployment as the existing CI ones are too old. We need newer npm/nodejs for 
  deployment.