### PR TITLE
indexer: Move noindex annotation.

### DIFF
--- a/docker/indexer/stages/processing/processing.go
+++ b/docker/indexer/stages/processing/processing.go
@@ -43,7 +43,7 @@ type Storer interface {
 
 // FileResult holds the per file hash and path information.
 type FileResult struct {
-	Path string `datastore:"path"`
+	Path string `datastore:"path,noindex"`
 	Hash []byte `datastore:"hash"`
 }
 

--- a/docker/indexer/storage/storage.go
+++ b/docker/indexer/storage/storage.go
@@ -54,7 +54,7 @@ type document struct {
 
 type result struct {
 	Page        int                      `datastore:"page"`
-	FileResults []*processing.FileResult `datastore:"file_results,noindex"`
+	FileResults []*processing.FileResult `datastore:"file_results"`
 }
 
 func newDoc(repoInfo *preparation.Result, hashType string, fileResults []*processing.FileResult) (*document, []*result) {


### PR DESCRIPTION
We need the hashes themselves to be indexed so we can quickly guess by making submitting a subset of hashes.

Don't do this for file paths yet, as it's not clear if those are required, and it could cause issues with index sizes.