### PR TITLE
indexer: Flatten FileResults

### DIFF
--- a/docker/indexer/storage/storage.go
+++ b/docker/indexer/storage/storage.go
@@ -54,7 +54,7 @@ type document struct {
 
 type result struct {
 	Page        int                      `datastore:"page"`
-	FileResults []*processing.FileResult `datastore:"file_results"`
+	FileResults []*processing.FileResult `datastore:"file_results,flatten"`
 }
 
 func newDoc(repoInfo *preparation.Result, hashType string, fileResults []*processing.FileResult) (*document, []*result) {


### PR DESCRIPTION
This makes the encoding consistent with Python's ndb.StructuredProperty.

See https://pkg.go.dev/cloud.google.com/go/datastore#hdr-Structured_Properties.