### PR TITLE
Strip v from versions when enumerating

### DIFF
--- a/osv/packagist_version.py
+++ b/osv/packagist_version.py
@@ -130,6 +130,8 @@ class PackagistVersion:
     Replaces special separators (`-`,`_`,`+`) with `.`, and inserts `.`
     between any digit and non-digit.
     """
+    if version.startswith('v'):
+      version = version[1:]
     replaced = re.sub('[-_+]', '.', version)
     replaced = re.sub(r'([^\d.])(\d)', r'\1.\2', replaced)
     replaced = re.sub(r'(\d)([^\d.])', r'\1.\2', replaced)

--- a/osv/testdata/packagist_test_cases.txt
+++ b/osv/testdata/packagist_test_cases.txt
@@ -53,6 +53,27 @@
 1.0pl1 > 1.0
 1.0pl1 = 1.0pl1
 
+v1.0pl1 > 1.0-dev
+v1.0pl1 > 1.0a1
+v1.0pl1 > 1.0b1
+v1.0pl1 > 1.0RC1
+v1.0pl1 > 1.0rc1
+v1.0pl1 > 1.0
+v1.0pl1 = 1.0pl1
+
+v1.0pl1 > v1.0-dev
+v1.0pl1 > v1.0a1
+v1.0pl1 > v1.0b1
+v1.0pl1 > v1.0RC1
+v1.0pl1 > v1.0rc1
+v1.0pl1 > v1.0
+v1.0pl1 = v1.0pl1
+
+v1 < 2
+v10 > 2
+v1.0 < 1.1
+v1.2 > 1.0.1
+
 // From https://github.com/composer/semver/blob/main/tests/ComparatorTest.php
 1.25.0 < 1.26.0
 1.0.0 < 1.2-dev


### PR DESCRIPTION
Potentially fixes #701. Source code for stripping the v can be found here, 
https://github.com/composer/semver/blob/main/src/VersionParser.php#L137

it seems like they try to coerce the tag version into a semver version, which is different to how php's `version_compare` function is implemented. Both achieve the same results (mostly, except for edge cases like having a v to start the tag)
 

