### PR TITLE
RepoIndexResult: Fix type of hash.

### DIFF
--- a/osv/models.py
+++ b/osv/models.py
@@ -653,7 +653,7 @@ class RepoIndex(ndb.Model):
 class FileResult(ndb.Model):
   """FileResult entry containing the path and hash"""
   # The hash value of the file
-  hash = ndb.BlobKeyProperty(indexed=True)
+  hash = ndb.BlobProperty(indexed=True)
   # The file path
   path = ndb.TextProperty()
 


### PR DESCRIPTION
This should be a BlobProperty, not BlobKeyProperty.

Since this is in the Python model where writing isn't done, we don't have to migrate
any existing entities.