### PR TITLE
Make it easier for someone to override the GCS bucket used

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
+++ b/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
@@ -8,6 +8,7 @@
 
 set -e
 
+BUCKET="${GCS_BUCKET:=cve-osv-conversion}"
 OSV_PARTS_ROOT="parts/"
 OSV_OUTPUT="osv_output/"
 CVE_OUTPUT="cve_jsons/"
@@ -17,9 +18,9 @@ rm -rf $OSV_PARTS_ROOT && mkdir -p $OSV_PARTS_ROOT
 rm -rf $OSV_OUTPUT && mkdir -p $OSV_OUTPUT
 rm -rf $CVE_OUTPUT && mkdir -p $CVE_OUTPUT
 
-echo "Begin syncing with cloud parts"
-gsutil -q -m rsync -r "gs://cve-osv-conversion/parts/" $OSV_PARTS_ROOT
-echo "Successfully synced with cloud parts"
+echo "Begin syncing from parts in GCS bucket ${BUCKET}"
+gsutil -q -m rsync -r "gs://${BUCKET}/parts/" $OSV_PARTS_ROOT
+echo "Successfully synced from GCS bucket"
 
 echo "Run download-cves"
 go run ./cmd/download-cves/ -cvePath $CVE_OUTPUT
@@ -27,6 +28,6 @@ go run ./cmd/download-cves/ -cvePath $CVE_OUTPUT
 echo "Run combine-to-osv"
 go run ./cmd/combine-to-osv/ -cvePath $CVE_OUTPUT -partsPath $OSV_PARTS_ROOT -osvOutputPath $OSV_OUTPUT
 
-echo "Begin syncing output with cloud"
-gsutil -q -m rsync $OSV_OUTPUT "gs://cve-osv-conversion/osv-output/"
-echo "Successfully synced with cloud"
+echo "Begin syncing output to GCS bucket ${BUCKET}"
+gsutil -q -m rsync $OSV_OUTPUT "gs://${BUCKET}/osv-output/"
+echo "Successfully synced to GCS bucket"

--- a/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
+++ b/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
@@ -8,7 +8,8 @@
 
 set -e
 
-BUCKET="${GCS_BUCKET:=cve-osv-conversion}"
+INPUT_BUCKET="${INPUT_GCS_BUCKET:=cve-osv-conversion}"
+OUTPUT_BUCKET="${OUTPUT_GCS_BUCKET:=cve-osv-conversion}"
 OSV_PARTS_ROOT="parts/"
 OSV_OUTPUT="osv_output/"
 CVE_OUTPUT="cve_jsons/"
@@ -19,7 +20,7 @@ rm -rf $OSV_OUTPUT && mkdir -p $OSV_OUTPUT
 rm -rf $CVE_OUTPUT && mkdir -p $CVE_OUTPUT
 
 echo "Begin syncing from parts in GCS bucket ${BUCKET}"
-gsutil -q -m rsync -r "gs://${BUCKET}/parts/" $OSV_PARTS_ROOT
+gsutil -q -m rsync -r "gs://${INPUT_BUCKET}/parts/" $OSV_PARTS_ROOT
 echo "Successfully synced from GCS bucket"
 
 echo "Run download-cves"
@@ -29,5 +30,5 @@ echo "Run combine-to-osv"
 go run ./cmd/combine-to-osv/ -cvePath $CVE_OUTPUT -partsPath $OSV_PARTS_ROOT -osvOutputPath $OSV_OUTPUT
 
 echo "Begin syncing output to GCS bucket ${BUCKET}"
-gsutil -q -m rsync $OSV_OUTPUT "gs://${BUCKET}/osv-output/"
+gsutil -q -m rsync $OSV_OUTPUT "gs://${OUTPUT_BUCKET}/osv-output/"
 echo "Successfully synced to GCS bucket"


### PR DESCRIPTION
Update the output to make it clearer to someone less familiar with GCP what is going on.

See #749

I think there's probably a little more needed, as nothing seems to be produced if there's no input successfully synced down (which there won't be with a new empty bucket).