### PR TITLE
Use the tags as the first port of call to infer the type of the link

### DIFF
--- a/vulnfeeds/cves/cve.go
+++ b/vulnfeeds/cves/cve.go
@@ -24,20 +24,23 @@ type CVE struct {
 	CVEDataMeta struct {
 		ID string
 	} `json:"CVE_data_meta"`
-	References struct {
-		ReferenceData []struct {
-			URL       string   `json:"url"`
-			Name      string   `json:"name"`
-			RefSource string   `json:"refsource"`
-			Tags      []string `json:"tags"`
-		} `json:"reference_data"`
-	} `json:"references"`
+	References  CVEReferences `json:"references"`
 	Description struct {
 		DescriptionData []struct {
 			Lang  string `json:"lang"`
 			Value string `json:"value"`
 		} `json:"description_data"`
 	} `json:"description"`
+}
+type CVEReferenceData struct {
+	URL       string   `json:"url"`
+	Name      string   `json:"name"`
+	RefSource string   `json:"refsource"`
+	Tags      []string `json:"tags"`
+}
+
+type CVEReferences struct {
+	ReferenceData []CVEReferenceData `json:"reference_data"`
 }
 
 type CVEItem struct {

--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v2"
 
 	"github.com/google/osv/vulnfeeds/cves"

--- a/vulnfeeds/vulns/vulns_test.go
+++ b/vulnfeeds/vulns/vulns_test.go
@@ -52,20 +52,20 @@ func TestClassifyReferences(t *testing.T) {
 		references []Reference
 	}{
 		{cves.CVEReferences{
-			[]cves.CVEReferenceData{
-				{"https://example.com", "https://example.com", "MISC", nil},
+			ReferenceData: []cves.CVEReferenceData{
+				{URL: "https://example.com", Name: "https://example.com", RefSource: "MISC", Tags: nil},
 			},
 		},
 			[]Reference{{URL: "https://example.com", Type: "WEB"}}},
 		{cves.CVEReferences{
-			[]cves.CVEReferenceData{
-				{"https://github.com/Netflix/lemur/issues/117", "https://github.com/Netflix/lemur/issues/117", "MISC", []string{"Issue Tracking"}},
+			ReferenceData: []cves.CVEReferenceData{
+				{URL: "https://github.com/Netflix/lemur/issues/117", Name: "https://github.com/Netflix/lemur/issues/117", RefSource: "MISC", Tags: []string{"Issue Tracking"}},
 			},
 		},
 			[]Reference{{URL: "https://github.com/Netflix/lemur/issues/117", Type: "REPORT"}}},
 		{cves.CVEReferences{
-			[]cves.CVEReferenceData{
-				{"https://github.com/curl/curl/issues/9271", "https://github.com/curl/curl/issues/9271", "MISC", []string{"Exploit", "Issue Tracking", "Third Party Advisory"}},
+			ReferenceData: []cves.CVEReferenceData{
+				{URL: "https://github.com/curl/curl/issues/9271", Name: "https://github.com/curl/curl/issues/9271", RefSource: "MISC", Tags: []string{"Exploit", "Issue Tracking", "Third Party Advisory"}},
 			},
 		},
 			[]Reference{{URL: "https://github.com/curl/curl/issues/9271", Type: "EVIDENCE"}, {URL: "https://github.com/curl/curl/issues/9271", Type: "REPORT"}}},

--- a/vulnfeeds/vulns/vulns_test.go
+++ b/vulnfeeds/vulns/vulns_test.go
@@ -2,10 +2,11 @@ package vulns
 
 import (
 	"encoding/json"
-	"github.com/google/osv/vulnfeeds/utility"
 	"log"
 	"os"
 	"testing"
+
+	"github.com/google/osv/vulnfeeds/utility"
 
 	"github.com/google/osv/vulnfeeds/cves"
 )
@@ -13,28 +14,30 @@ import (
 func TestClassifyReferenceLink(t *testing.T) {
 	tables := []struct {
 		refLink string
+		refTags []string
 		refType string
 	}{
-		{"https://example.com", "WEB"},
-		{"https://github.com/google/osv/commit/cd4e934d0527e5010e373e7fed54ef5daefba2f5", "FIX"},
-		{"https://github.com/advisories/GHSA-fr26-qjc8-mvjx", "ADVISORY"},
-		{"https://github.com/dpgaspar/Flask-AppBuilder/security/advisories/GHSA-624f-cqvr-3qw4", "ADVISORY"},
-		{"https://github.com/Netflix/lemur/issues/117", "REPORT"},
-		{"https://snyk.io/vuln/SNYK-PYTHON-TRYTOND-1730329", "ADVISORY"},
-		{"https://nvd.nist.gov/vuln/detail/CVE-2021-23336", "ADVISORY"},
-		{"https://www.debian.org/security/2021/dsa-4878", "ADVISORY"},
-		{"https://usn.ubuntu.com/usn/usn-4661-1", "ADVISORY"},
-		{"http://www.ubuntu.com/usn/USN-2915-2", "ADVISORY"},
-		{"https://ubuntu.com/security/notices/USN-5124-1", "ADVISORY"},
-		{"http://rhn.redhat.com/errata/RHSA-2016-0504.html", "ADVISORY"},
-		{"https://access.redhat.com/errata/RHSA-2017:1499", "ADVISORY"},
-		{"https://security.gentoo.org/glsa/202003-45", "ADVISORY"},
-		{"https://pypi.org/project/flask", "PACKAGE"},
-		{"https://bugzilla.redhat.com/show_bug.cgi?id=684877", "REPORT"},
+		{"https://example.com", nil, "WEB"},
+		{"https://github.com/google/osv/commit/cd4e934d0527e5010e373e7fed54ef5daefba2f5", nil, "FIX"},
+		{"https://github.com/advisories/GHSA-fr26-qjc8-mvjx", nil, "ADVISORY"},
+		{"https://github.com/dpgaspar/Flask-AppBuilder/security/advisories/GHSA-624f-cqvr-3qw4", nil, "ADVISORY"},
+		{"https://github.com/Netflix/lemur/issues/117", nil, "REPORT"},
+		{"https://snyk.io/vuln/SNYK-PYTHON-TRYTOND-1730329", nil, "ADVISORY"},
+		{"https://nvd.nist.gov/vuln/detail/CVE-2021-23336", nil, "ADVISORY"},
+		{"https://www.debian.org/security/2021/dsa-4878", nil, "ADVISORY"},
+		{"https://usn.ubuntu.com/usn/usn-4661-1", nil, "ADVISORY"},
+		{"http://www.ubuntu.com/usn/USN-2915-2", nil, "ADVISORY"},
+		{"https://ubuntu.com/security/notices/USN-5124-1", nil, "ADVISORY"},
+		{"http://rhn.redhat.com/errata/RHSA-2016-0504.html", nil, "ADVISORY"},
+		{"https://access.redhat.com/errata/RHSA-2017:1499", nil, "ADVISORY"},
+		{"https://security.gentoo.org/glsa/202003-45", nil, "ADVISORY"},
+		{"https://pypi.org/project/flask", nil, "PACKAGE"},
+		{"https://bugzilla.redhat.com/show_bug.cgi?id=684877", nil, "REPORT"},
+		{"https://github.com/log4js-node/log4js-node/pull/1141/commits/8042252861a1b65adb66931fdf702ead34fa9b76", []string{"Patch"}, "FIX"},
 	}
 
 	for _, table := range tables {
-		refType := ClassifyReferenceLink(table.refLink)
+		refType := ClassifyReferenceLink(table.refLink, table.refTags)
 		if refType != table.refType {
 			t.Errorf("ClassifyReferenceLink for %s was incorrect, got: %s, expected: %s.", table.refLink, refType, table.refType)
 		}


### PR DESCRIPTION
The lovely folks at the NVD are already giving us hints, so only resort to URL shape-based guesswork if we don't have a more explicit signal.