### PR TITLE
Git clone shallow to improve new importer instance performance

### DIFF
--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -313,6 +313,7 @@ class Importer:
           source_repo, original_sha256, deleted_entry, deleted=True)
 
     source_repo.last_synced_hash = str(repo.head.target)
+    source_repo.last_update_date = utcnow().date()
     source_repo.put()
 
     logging.info("Finish processing git: %s", source_repo.name)

--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -129,6 +129,7 @@ class Importer:
     return osv.ensure_updated_checkout(
         source_repo.repo_url,
         os.path.join(self._sources_dir, source_repo.name),
+        last_update_date=source_repo.last_update_date,
         git_callbacks=self._git_callbacks(source_repo),
         branch=source_repo.repo_branch)
 

--- a/osv/repos.py
+++ b/osv/repos.py
@@ -93,7 +93,6 @@ def clone(git_url: str,
     :param git_callbacks: TODO:
     :param last_update_date: Optional python datetime object used to specify
       the date of the shallow clone.
-
   """
   # Use 'git' CLI here as it's much faster than libgit2's clone.
   env = {}
@@ -119,7 +118,15 @@ def clone_with_retries(git_url: str,
                        last_update_date: Optional[datetime.datetime] = None,
                        git_callbacks: Optional = None,
                        branch: Optional[str] = None):
-  """Clone with retries."""
+  """Clone with retries.
+  Number of retries is defined in the CLONE_TRIES constant.
+  
+    :param git_url: git URL
+    :param checkout_dir: checkout directory
+    :param git_callbacks: TODO:
+    :param last_update_date: Optional python datetime object used to specify
+      the date of the shallow clone.
+  """
   logging.info('Cloning %s to %s', git_url, checkout_dir)
   for _ in range(CLONE_TRIES):
     try:
@@ -161,7 +168,14 @@ def ensure_updated_checkout(
     last_update_date: Optional[datetime.datetime] = None,
     git_callbacks=None,
     branch: Optional[str] = None):
-  """Ensure updated checkout."""
+  """Ensure updated checkout.
+    :param git_url: git URL
+    :param checkout_dir: checkout directory
+    :param git_callbacks: TODO:
+    :param last_update_date: Optional python datetime object used to specify
+      the date of the shallow clone. If the repository already exists, this
+      argument will be ignored, and new commits pulled down.
+    """
   if os.path.exists(checkout_dir):
     # Already exists, reset and checkout latest revision.
     try:

--- a/osv/repos.py
+++ b/osv/repos.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Repo functions."""
-
+import datetime
 import logging
 import os
 import shutil
@@ -81,7 +81,7 @@ def _checkout_branch(repo, branch):
   repo.reset(remote_branch.target, pygit2.GIT_RESET_HARD)
 
 
-def clone(git_url, checkout_dir, git_callbacks=None):
+def clone(git_url, checkout_dir, git_callbacks=None, last_update_date=None):
   """Perform a clone."""
   # Use 'git' CLI here as it's much faster than libgit2's clone.
   env = {}
@@ -91,19 +91,27 @@ def clone(git_url, checkout_dir, git_callbacks=None):
         f'-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null '
         f'-o User={git_callbacks.username} -o IdentitiesOnly=yes')
 
-  subprocess.check_call(
-      ['git', 'clone', _git_mirror(git_url), checkout_dir],
-      env=env,
-      stderr=subprocess.STDOUT)
+    call_args = ['git', 'clone', _git_mirror(git_url), checkout_dir]
+    if last_update_date:
+      # Clone from 1 day prior to be safe and avoid any off by 1 errors
+      shallow_since_date = (last_update_date -
+                            datetime.timedelta(days=1)).strftime('%Y-%m-%d')
+      call_args.extend(['--shallow-since=' + shallow_since_date])
+
+  subprocess.check_call(call_args, env=env, stderr=subprocess.STDOUT)
   return pygit2.Repository(checkout_dir)
 
 
-def clone_with_retries(git_url, checkout_dir, git_callbacks=None, branch=None):
+def clone_with_retries(git_url,
+                       checkout_dir,
+                       last_update_date=None,
+                       git_callbacks=None,
+                       branch=None):
   """Clone with retries."""
   logging.info('Cloning %s to %s', git_url, checkout_dir)
   for _ in range(CLONE_TRIES):
     try:
-      repo = clone(git_url, checkout_dir, git_callbacks)
+      repo = clone(git_url, checkout_dir, git_callbacks, last_update_date)
       repo.cache = {}
       if branch:
         _checkout_branch(repo, branch)
@@ -137,6 +145,7 @@ def _use_existing_checkout(git_url,
 
 def ensure_updated_checkout(git_url,
                             checkout_dir,
+                            last_update_date=None,
                             git_callbacks=None,
                             branch=None):
   """Ensure updated checkout."""
@@ -151,7 +160,12 @@ def ensure_updated_checkout(git_url,
       shutil.rmtree(checkout_dir)
 
   repo = clone_with_retries(
-      git_url, checkout_dir, git_callbacks=git_callbacks, branch=branch)
+      git_url,
+      checkout_dir,
+      last_update_date,
+      git_callbacks=git_callbacks,
+      branch=branch)
+
   logging.info('Repo now at: %s', repo.head.peel().message)
   return repo
 

--- a/osv/repos.py
+++ b/osv/repos.py
@@ -104,12 +104,12 @@ def clone(git_url: str,
         f'-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null '
         f'-o User={git_callbacks.username} -o IdentitiesOnly=yes')
 
-    call_args = ['git', 'clone', _git_mirror(git_url), checkout_dir]
-    if last_update_date:
-      # Clone from 1 day prior to be safe and avoid any off by 1 errors
-      shallow_since_date = (last_update_date -
-                            datetime.timedelta(days=1)).strftime('%Y-%m-%d')
-      call_args.extend(['--shallow-since=' + shallow_since_date])
+  call_args = ['git', 'clone', _git_mirror(git_url), checkout_dir]
+  if last_update_date:
+    # Clone from 1 day prior to be safe and avoid any off by 1 errors
+    shallow_since_date = (last_update_date -
+                          datetime.timedelta(days=1)).strftime('%Y-%m-%d')
+    call_args.extend(['--shallow-since=' + shallow_since_date])
 
   subprocess.check_call(call_args, env=env, stderr=subprocess.STDOUT)
   return pygit2.Repository(checkout_dir)

--- a/osv/repos.py
+++ b/osv/repos.py
@@ -84,13 +84,15 @@ def _checkout_branch(repo, branch):
 
 def clone(git_url: str,
           checkout_dir: str,
-          git_callbacks: Optional = None,
+          git_callbacks: Optional[datetime.datetime] = None,
           last_update_date: Optional[datetime.datetime] = None):
   """
   Perform a clone.
+  
     :param git_url: git URL
     :param checkout_dir: checkout directory
-    :param git_callbacks: TODO:
+    :param git_callbacks: Used for git to retrieve credentials when pulling.
+      See `GitRemoteCallback`
     :param last_update_date: Optional python datetime object used to specify
       the date of the shallow clone.
   """
@@ -116,14 +118,15 @@ def clone(git_url: str,
 def clone_with_retries(git_url: str,
                        checkout_dir: str,
                        last_update_date: Optional[datetime.datetime] = None,
-                       git_callbacks: Optional = None,
+                       git_callbacks: Optional[datetime.datetime] = None,
                        branch: Optional[str] = None):
   """Clone with retries.
   Number of retries is defined in the CLONE_TRIES constant.
-  
+
     :param git_url: git URL
     :param checkout_dir: checkout directory
-    :param git_callbacks: TODO:
+    :param git_callbacks: Used for git to retrieve credentials when pulling.
+      See `GitRemoteCallback`
     :param last_update_date: Optional python datetime object used to specify
       the date of the shallow clone.
   """
@@ -166,12 +169,14 @@ def ensure_updated_checkout(
     git_url: str,
     checkout_dir: str,
     last_update_date: Optional[datetime.datetime] = None,
-    git_callbacks=None,
+    git_callbacks: Optional[pygit2.RemoteCallbacks] = None,
     branch: Optional[str] = None):
   """Ensure updated checkout.
+
     :param git_url: git URL
     :param checkout_dir: checkout directory
-    :param git_callbacks: TODO:
+    :param git_callbacks: Used for git to retrieve credentials when pulling.
+      See `GitRemoteCallback`
     :param last_update_date: Optional python datetime object used to specify
       the date of the shallow clone. If the repository already exists, this
       argument will be ignored, and new commits pulled down.

--- a/osv/repos.py
+++ b/osv/repos.py
@@ -18,6 +18,7 @@ import os
 import shutil
 import subprocess
 import time
+from typing import Optional
 
 import pygit2
 
@@ -81,8 +82,19 @@ def _checkout_branch(repo, branch):
   repo.reset(remote_branch.target, pygit2.GIT_RESET_HARD)
 
 
-def clone(git_url, checkout_dir, git_callbacks=None, last_update_date=None):
-  """Perform a clone."""
+def clone(git_url: str,
+          checkout_dir: str,
+          git_callbacks: Optional = None,
+          last_update_date: Optional[datetime.datetime] = None):
+  """
+  Perform a clone.
+    :param git_url: git URL
+    :param checkout_dir: checkout directory
+    :param git_callbacks: TODO:
+    :param last_update_date: Optional python datetime object used to specify
+      the date of the shallow clone.
+
+  """
   # Use 'git' CLI here as it's much faster than libgit2's clone.
   env = {}
   if git_callbacks:
@@ -102,11 +114,11 @@ def clone(git_url, checkout_dir, git_callbacks=None, last_update_date=None):
   return pygit2.Repository(checkout_dir)
 
 
-def clone_with_retries(git_url,
-                       checkout_dir,
-                       last_update_date=None,
-                       git_callbacks=None,
-                       branch=None):
+def clone_with_retries(git_url: str,
+                       checkout_dir: str,
+                       last_update_date: Optional[datetime.datetime] = None,
+                       git_callbacks: Optional = None,
+                       branch: Optional[str] = None):
   """Clone with retries."""
   logging.info('Cloning %s to %s', git_url, checkout_dir)
   for _ in range(CLONE_TRIES):
@@ -143,11 +155,12 @@ def _use_existing_checkout(git_url,
   return repo
 
 
-def ensure_updated_checkout(git_url,
-                            checkout_dir,
-                            last_update_date=None,
-                            git_callbacks=None,
-                            branch=None):
+def ensure_updated_checkout(
+    git_url: str,
+    checkout_dir: str,
+    last_update_date: Optional[datetime.datetime] = None,
+    git_callbacks=None,
+    branch: Optional[str] = None):
   """Ensure updated checkout."""
   if os.path.exists(checkout_dir):
     # Already exists, reset and checkout latest revision.

--- a/osv/repos.py
+++ b/osv/repos.py
@@ -88,7 +88,7 @@ def clone(git_url: str,
           last_update_date: Optional[datetime.datetime] = None):
   """
   Perform a clone.
-  
+
     :param git_url: git URL
     :param checkout_dir: checkout directory
     :param git_callbacks: Used for git to retrieve credentials when pulling.


### PR DESCRIPTION
A shallow clone that only clones commits up to the previous synced date. This avoids having to clone the entire repository history when unneeded. A pull/fetch will only fetch future commits, without needing to fill up the entire history. 

A potential issue is if default branch changes to a completely different branch (not just renamed), this will mean potentially needing more history than what is available since the last sync time. This is very rare and I am not aware of any reason for doing this.

Fixes #576 