### PR TITLE
Revert git shallow clone

### DIFF
--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -375,6 +375,8 @@ class Importer:
       converted_vulns = executor.map(convert_blob_to_vuln, listed_blob_names)
       for cv in converted_vulns:
         if cv:
+          logging.info('Requesting analysis of bucket entry: %s/%s',
+                       source_repo.bucket, cv[1])
           self._request_analysis_external(source_repo, cv[0], cv[1])
 
     source_repo.last_update_date = utcnow().date()
@@ -439,7 +441,7 @@ class Importer:
 
 
 def main():
-  logging.getLogger().setLevel(logging.INFO)
+  logging.getLogger().setLevel(logging.DEBUG)
   logging.getLogger('google.api_core.bidi').setLevel(logging.ERROR)
   logging.getLogger('google.cloud.pubsub_v1.subscriber._protocol.'
                     'streaming_pull_manager').setLevel(logging.ERROR)

--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -134,7 +134,6 @@ class Importer:
     return osv.ensure_updated_checkout(
         source_repo.repo_url,
         os.path.join(self._sources_dir, source_repo.name),
-        last_update_date=source_repo.last_update_date,
         git_callbacks=self._git_callbacks(source_repo),
         branch=source_repo.repo_branch)
 
@@ -313,7 +312,6 @@ class Importer:
           source_repo, original_sha256, deleted_entry, deleted=True)
 
     source_repo.last_synced_hash = str(repo.head.target)
-    source_repo.last_update_date = utcnow().date()
     source_repo.put()
 
     logging.info("Finish processing git: %s", source_repo.name)

--- a/osv/repos.py
+++ b/osv/repos.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Repo functions."""
-import datetime
+
 import logging
 import os
 import shutil
 import subprocess
 import time
-from typing import Optional
 
 import pygit2
 
@@ -82,20 +81,8 @@ def _checkout_branch(repo, branch):
   repo.reset(remote_branch.target, pygit2.GIT_RESET_HARD)
 
 
-def clone(git_url: str,
-          checkout_dir: str,
-          git_callbacks: Optional[datetime.datetime] = None,
-          last_update_date: Optional[datetime.datetime] = None):
-  """
-  Perform a clone.
-
-    :param git_url: git URL
-    :param checkout_dir: checkout directory
-    :param git_callbacks: Used for git to retrieve credentials when pulling.
-      See `GitRemoteCallback`
-    :param last_update_date: Optional python datetime object used to specify
-      the date of the shallow clone.
-  """
+def clone(git_url, checkout_dir, git_callbacks=None):
+  """Perform a clone."""
   # Use 'git' CLI here as it's much faster than libgit2's clone.
   env = {}
   if git_callbacks:
@@ -104,36 +91,19 @@ def clone(git_url: str,
         f'-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null '
         f'-o User={git_callbacks.username} -o IdentitiesOnly=yes')
 
-  call_args = ['git', 'clone', _git_mirror(git_url), checkout_dir]
-  if last_update_date:
-    # Clone from 1 day prior to be safe and avoid any off by 1 errors
-    shallow_since_date = (last_update_date -
-                          datetime.timedelta(days=1)).strftime('%Y-%m-%d')
-    call_args.extend(['--shallow-since=' + shallow_since_date])
-
-  subprocess.check_call(call_args, env=env, stderr=subprocess.STDOUT)
+  subprocess.check_call(
+      ['git', 'clone', _git_mirror(git_url), checkout_dir],
+      env=env,
+      stderr=subprocess.STDOUT)
   return pygit2.Repository(checkout_dir)
 
 
-def clone_with_retries(git_url: str,
-                       checkout_dir: str,
-                       last_update_date: Optional[datetime.datetime] = None,
-                       git_callbacks: Optional[datetime.datetime] = None,
-                       branch: Optional[str] = None):
-  """Clone with retries.
-  Number of retries is defined in the CLONE_TRIES constant.
-
-    :param git_url: git URL
-    :param checkout_dir: checkout directory
-    :param git_callbacks: Used for git to retrieve credentials when pulling.
-      See `GitRemoteCallback`
-    :param last_update_date: Optional python datetime object used to specify
-      the date of the shallow clone.
-  """
+def clone_with_retries(git_url, checkout_dir, git_callbacks=None, branch=None):
+  """Clone with retries."""
   logging.info('Cloning %s to %s', git_url, checkout_dir)
   for _ in range(CLONE_TRIES):
     try:
-      repo = clone(git_url, checkout_dir, git_callbacks, last_update_date)
+      repo = clone(git_url, checkout_dir, git_callbacks)
       repo.cache = {}
       if branch:
         _checkout_branch(repo, branch)
@@ -165,22 +135,11 @@ def _use_existing_checkout(git_url,
   return repo
 
 
-def ensure_updated_checkout(
-    git_url: str,
-    checkout_dir: str,
-    last_update_date: Optional[datetime.datetime] = None,
-    git_callbacks: Optional[pygit2.RemoteCallbacks] = None,
-    branch: Optional[str] = None):
-  """Ensure updated checkout.
-
-    :param git_url: git URL
-    :param checkout_dir: checkout directory
-    :param git_callbacks: Used for git to retrieve credentials when pulling.
-      See `GitRemoteCallback`
-    :param last_update_date: Optional python datetime object used to specify
-      the date of the shallow clone. If the repository already exists, this
-      argument will be ignored, and new commits pulled down.
-    """
+def ensure_updated_checkout(git_url,
+                            checkout_dir,
+                            git_callbacks=None,
+                            branch=None):
+  """Ensure updated checkout."""
   if os.path.exists(checkout_dir):
     # Already exists, reset and checkout latest revision.
     try:
@@ -192,12 +151,7 @@ def ensure_updated_checkout(
       shutil.rmtree(checkout_dir)
 
   repo = clone_with_retries(
-      git_url,
-      checkout_dir,
-      last_update_date,
-      git_callbacks=git_callbacks,
-      branch=branch)
-
+      git_url, checkout_dir, git_callbacks=git_callbacks, branch=branch)
   logging.info('Repo now at: %s', repo.head.peel().message)
   return repo
 


### PR DESCRIPTION
pygit2 does not support shallow clones at the moment, causing an error when attempting to walk shallow clones. 

Also adds some minor logging improvements to provide better visibility of what is happening. 

This does also revert a bunch of helpful typing and documentation options. For now it might be better to leave them reverted, as it will make it much easier to reapply the shallow clone changes once support is added in pygit2. 