### PR TITLE
Forward-fix type hint issue

### DIFF
--- a/docker/exporter/exporter.py
+++ b/docker/exporter/exporter.py
@@ -19,6 +19,7 @@ import logging
 import os
 import tempfile
 import zipfile
+from typing import List
 
 from google.cloud import ndb
 from google.cloud import storage
@@ -61,7 +62,7 @@ class Exporter:
     except Exception as e:
       logging.error('Failed to export: %s', e)
 
-  def _export_ecosystem_list_to_bucket(self, ecosystems: list[str],
+  def _export_ecosystem_list_to_bucket(self, ecosystems: List[str],
                                        tmp_dir: str):
     """Export an ecosystems.txt file with all of the ecosystem names.
 


### PR DESCRIPTION
Fun finds:

* Local runtime environment (where I had manually tested efc3876) uses Python 3.10, whereas the GKE container is based of Ubuntu 20.04 and uses Python 3.8
* Python 3.8 dislikes `list[str]` as a type hint, but 3.10 does not.
* So everything is peachy with local testing, not so much in production

Moral of this story? Don't test locally :-/