### PR TITLE
Fixes appengine releases by ignoring testdata

### DIFF
--- a/deployment/staging.yaml
+++ b/deployment/staging.yaml
@@ -17,6 +17,8 @@ steps:
   args: ['submodule', 'update', '--init', '--recursive']
 - name: 'gcr.io/oss-vdb/ci'
   args: ['make', 'all-tests']
+- name: 'gcr.io/cloud-builders/git'
+  args: ['git', 'clean', '-fdx']
 - name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: 'bash'
   args: [ '-c', "gcloud secrets versions access latest --secret=integration-test-account --format='get(payload.data)' | tr '_-' '/+' | base64 -d > /workspace/service_account.json" ]

--- a/gcp/appengine/.gcloudignore
+++ b/gcp/appengine/.gcloudignore
@@ -20,3 +20,5 @@ __pycache__/
 frontend
 frontend3
 Pipfile*
+
+testdata/


### PR DESCRIPTION
When running tests it will pull down alpine repository into testdata folder, massively inflating file count beyond the 10000 file limit. This is not needed for appengine, so should be ignored.