### PR TITLE
Fix alpine enumeration

### DIFF
--- a/osv/ecosystems.py
+++ b/osv/ecosystems.py
@@ -431,7 +431,11 @@ class Alpine(Ecosystem):
       if len(x) == 0:
         current_ver = current_ver.split(' #')[0]  # Remove comment lines
         current_ver = current_ver.strip(' "\'')  # Remove (occasional) quotes
-        all_versions.add(current_ver)
+        # Ignore occasional version that is still not valid.
+        if AlpineLinuxVersion.is_valid(current_ver):
+          all_versions.add(current_ver)
+        else:
+          logging.warning('Alpine version "%s" is not valid', current_ver)
         continue
 
       x_split = x.split('=', 1)

--- a/osv/ecosystems.py
+++ b/osv/ecosystems.py
@@ -429,6 +429,8 @@ class Alpine(Ecosystem):
 
     for x in lines:
       if len(x) == 0:
+        current_ver = current_ver.split(' #')[0]  # Remove comment lines
+        current_ver = current_ver.strip(' "\'')  # Remove (occasional) quotes
         all_versions.add(current_ver)
         continue
 


### PR DESCRIPTION
Since version history is tracked by git, it is really hard to correct for errors in a package's history, so if a version is not valid, it will likely still keep showing up when enumerating history for a package. Because of this, we will ignore all invalid versions when enumerating versions.