### PR TITLE
feat: implement `--recursive` flag

### DIFF
--- a/tools/osv-scanner/README.md
+++ b/tools/osv-scanner/README.md
@@ -64,13 +64,14 @@ $ go run ./cmd/osv-scanner --docker image_name:latest
 
 ## Scanning a directory
 
-Given a list of directories, this tool will recursively walk through every file
-to find:
+This tool will walk through a list of directories to find:
 - Lockfiles
 - SBOMs
 - git directories for the latest commit hash
 
 and make requests to OSV to determine affected vulnerabilities.
+
+You can have it recursively walk through subdirectories with the `--recursive` flag.
 
 Searching for git commit hash is intended to work with projects that use
 git submodules or a similar mechanism where dependencies are checked out

--- a/tools/osv-scanner/cmd/osv-scanner/main.go
+++ b/tools/osv-scanner/cmd/osv-scanner/main.go
@@ -206,9 +206,10 @@ func main() {
 				Value: false,
 			},
 			&cli.BoolFlag{
-				Name:  "recursive",
-				Usage: "check subdirectories",
-				Value: false,
+				Name:    "recursive",
+				Aliases: []string{"r"},
+				Usage:   "check subdirectories",
+				Value:   false,
 			},
 		},
 		ArgsUsage: "[directory1 directory2...]",

--- a/tools/osv-scanner/cmd/osv-scanner/main.go
+++ b/tools/osv-scanner/cmd/osv-scanner/main.go
@@ -19,8 +19,9 @@ import (
 )
 
 // scanDir walks through the given directory to try to find any relevant files
-func scanDir(query *osv.BatchedQuery, dir string, skipGit bool) error {
+func scanDir(query *osv.BatchedQuery, dir string, skipGit bool, recursive bool) error {
 	log.Printf("Scanning dir %s\n", dir)
+	root := true
 	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			log.Printf("Failed to walk %s: %v", path, err)
@@ -49,6 +50,11 @@ func scanDir(query *osv.BatchedQuery, dir string, skipGit bool) error {
 			// so just move onto the next file
 			_ = scanSBOMFile(query, path)
 		}
+
+		if !root && !recursive && info.IsDir() {
+			return filepath.SkipDir
+		}
+		root = false
 
 		return nil
 	})
@@ -199,6 +205,11 @@ func main() {
 				Usage: "skip scanning git repositories",
 				Value: false,
 			},
+			&cli.BoolFlag{
+				Name:  "recursive",
+				Usage: "check subdirectories",
+				Value: false,
+			},
 		},
 		ArgsUsage: "[directory1 directory2...]",
 		Action: func(context *cli.Context) error {
@@ -226,9 +237,10 @@ func main() {
 			}
 
 			skipGit := context.Bool("skip-git")
+			recursive := context.Bool("recursive")
 			genericDirs := context.Args().Slice()
 			for _, dir := range genericDirs {
-				err := scanDir(&query, dir, skipGit)
+				err := scanDir(&query, dir, skipGit, recursive)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
As mentioned [here](https://github.com/google/osv.dev/pull/815#issuecomment-1311245059), I've made the default to be checking only the files in the target directories, as I think that is the better UX: generally easier to manage inclusion in userland (i.e. loops, globs, `tree`, etc) than exclusion (case and point, right now there is no way to exclude anything from the scanner).

I suspect it is probably going to be best to replace `filepath.Walk` with a recursive loop, at least if `recursive` is not passed because otherwise I believe you load the whole file tree into memory every time.

I have started writing some tests for this, but will do a seperate PR for that since it requires more unrelated work.