### PR TITLE
Fix API dependency issues.

### DIFF
--- a/gcp/api/Dockerfile
+++ b/gcp/api/Dockerfile
@@ -19,8 +19,6 @@ COPY setup.py Pipfile* README.md /osv/
 COPY osv /osv/osv
 COPY gcp/api /osv/gcp/api
 
-ENV PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION "python"
-
 WORKDIR /osv/gcp/api
 RUN pip3 install -U pipenv && python3 -m pipenv install --deploy --system
 

--- a/gcp/api/Pipfile
+++ b/gcp/api/Pipfile
@@ -4,13 +4,14 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-google-api-core = "==2.10.2"
-google-cloud-logging = "==3.2.5"
+google-cloud-logging = "==2.7.2"
 google-cloud-pubsub = "==2.13.10"
 grpcio = "==1.50.0"
-grpcio-tools = "==1.50.0"
 osv = {editable = true, path = "../../"}
 packageurl-python = "==0.10.4"
 packaging = "==20.9"
 requests = "==2.28.1"
-grpcio-reflection = "==1.50.0"
+grpcio-reflection = "*"
+
+[dev-packages]
+grpcio-tools = "*"

--- a/gcp/api/Pipfile.lock
+++ b/gcp/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7825da4a94098eafc813c990688c1dd30f0a3bdb1af504b468e9836b7d786576"
+            "sha256": "80eb77f649fe11f1ca22229043b5303ace1e5accfc4bdb739f61fb8641caa0ca"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -120,7 +120,7 @@
                 "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
                 "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6'",
             "version": "==2.1.1"
         },
         "deprecated": {
@@ -132,11 +132,14 @@
             "version": "==1.2.13"
         },
         "google-api-core": {
+            "extras": [
+                "grpc"
+            ],
             "hashes": [
                 "sha256:10c06f7739fe57781f87523375e8e1a3a4674bf6392cd6131a3222182b971320",
                 "sha256:34f24bd1d5f72a8c4519773d99ca6bf080a6c4e041b4e9f024fe230191dda62e"
             ],
-            "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==2.10.2"
         },
         "google-auth": {
@@ -173,19 +176,19 @@
         },
         "google-cloud-datastore": {
             "hashes": [
-                "sha256:0d9417a977b21d06d2eed2ff5c2e8874a7e2eb44eecdfc64ac81469f0375c55a",
-                "sha256:be2cc7eac38ec1ed658f39a8ffb374c161227abbfc848260acdfaa5f698710b2"
+                "sha256:cd072adeffab48a67291ccd3d3946814fe2dc814820008ba21662ad9b689f447",
+                "sha256:dadca1631088b7a737f311df87574a417f254ce71d6a98080f36f35bdc96b30f"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.15.4"
+            "version": "==1.15.5"
         },
         "google-cloud-logging": {
             "hashes": [
-                "sha256:bc6c185f47b272a72015cd7dc3c8e5d06a6959d68c6ae9e04e7dbf5815126ed1",
-                "sha256:c1b078003f8fc2c0864af04651e2be1213e5b738ea83291e5ff5652529bc5e58"
+                "sha256:1ecc36a5a232b5561ac067023ad27bdea83f40cada4190e141a8bb802644bd0a",
+                "sha256:a35707c44afb940fa6a1a07ba20014a0417257ff64a477e7d44abcb86b5b86a2"
             ],
             "index": "pypi",
-            "version": "==3.2.5"
+            "version": "==2.7.2"
         },
         "google-cloud-ndb": {
             "hashes": [
@@ -272,70 +275,19 @@
         },
         "grpcio-reflection": {
             "hashes": [
-                "sha256:92fea4a9527a8bcc52b615b6a7af655a5a118ab0f57227cc814dc2192f8a7455",
-                "sha256:d75ff6a12f70f28ba6465d5a29781cf2d9c740eb809711990f61699019af1f72"
+                "sha256:280bf4569149126050b587ff9177051a409ee98882028dcf0c9caa3c2d31f6fe",
+                "sha256:b687acc86c736ba8273523e1cdd5f31155dccabf7f9b2acfb62bf4e9c79d3b5a"
             ],
             "index": "pypi",
-            "version": "==1.50.0"
+            "version": "==1.48.2"
         },
         "grpcio-status": {
             "hashes": [
-                "sha256:69be81c4317ec77983fb0eab80221a01e86e833e0fcf2f6acea0a62597c84b93",
-                "sha256:6bcf86b1cb1a8929c9cb75c8593ea001a667f5167cf692627f4b3fc1ae0eded4"
+                "sha256:2c33bbdbe20188b2953f46f31af669263b6ee2a9b2d38fa0d36ee091532e21bf",
+                "sha256:53695f45da07437b7c344ee4ef60d370fd2850179f5a28bb26d8e2aa1102ec11"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.50.0"
-        },
-        "grpcio-tools": {
-            "hashes": [
-                "sha256:0fe40a66d3ccde959f7290b881c78e8c420fd54289fede5c9119d993703e1a49",
-                "sha256:1736defd9fc54f942f500dd71555816487e52f07d25b0a58ff4089c375f0b5c3",
-                "sha256:1891aca6042fc403c1d492d03ce1c4bac0053c26132063b7b0171665a0aa6086",
-                "sha256:2313c8c73a5003d789fe05f4d01112ccf8330d3d141f5b77b514200d742193f6",
-                "sha256:23381ac6a19de0d3cb470f4d1fb450267014234a3923e3c43abb858049f5caf4",
-                "sha256:27f734e44631d755481a179ffd5f2659eaf1e9755cf3539e291d7a28d8373cc8",
-                "sha256:2869fba92670d5be3730f1ad108cbacd3f9a7b7afa57187a3c39379513b3fde7",
-                "sha256:3995d96635d6decaf9d5d2e071677782b08ea3186d7cb8ad93f6c2dd97ec9097",
-                "sha256:4c928610ceda7890cf7ddd3cb4cc16fb81995063bf4fdb5171bba572d508079b",
-                "sha256:4fe1cd201f0e0f601551c20bea2a8c1e109767ce341ac263e88d5a0acd0a124c",
-                "sha256:54528cec27238761055b28a34ea29392c8e90ac8d8966ee3ccfc9f906eb26fd3",
-                "sha256:56c28f50b9c88cbfc62861de86a1f8b2454d3b48cff85a73d523ec22f130635d",
-                "sha256:578f9137ebca0f152136b47b4895a6b4dabcf17e41f957b03637d1ae096ff67b",
-                "sha256:66113bc60db8ccb15e2d7b79efd5757bba33b15e653f20f473c776857bd4415d",
-                "sha256:675634367846fc906e8b6016830b3d361f9e788bce7820b4e6432d914cb0e25d",
-                "sha256:6c40f918d1fe0cb094bfb09ab7567a92f5368fa0b9935235680fe205ddc37518",
-                "sha256:71e98662f76d3bcf031f36f727ffee594c57006d5dce7b6d031d030d194f054d",
-                "sha256:73ba21fe500e2476d391cc92aa05545fdc71bdeedb5b9ec2b22e9a3ccc298a2f",
-                "sha256:7f211a8a6f159b496097cabbf4bdbb6d01db0fd7a8d516dd0e577ee2ddccded0",
-                "sha256:86a9e9b2cc30797472bd421c75b42fe1062519ef5675243cb33d99de33af279c",
-                "sha256:88b75f2afd889c7c6939f58d76b58ab84de4723c7de882a1f8448af6632e256f",
-                "sha256:89010e8e0d158966af478d9b345d29d98e52d62464cb93ef192125e94fb904c1",
-                "sha256:8d74672162474e2592c50708408b4ee145994451ee5171c9b8f580504b987ad3",
-                "sha256:927c8cbbfbf3bca46cd05bbabfd8cb6c99f5dbaeb860f2786f9286ce6894ad3d",
-                "sha256:9bc97b52d577406c240b0d6acf68ab5100c67c903792f1f9ce04d871ca83de53",
-                "sha256:a9816a6c8d1b7adb65217d01624006704faf02b5daa15b6e145b63a5e559d791",
-                "sha256:b7eb7a84d9171c0ae1550833f4a6ca52372bed9db0fa10f8c9dbe6ca65f97a8c",
-                "sha256:c1646bfec6d707bcaafea69088770151ba291ede788f2cda5efdc09c1eac5c1c",
-                "sha256:c5dde47bae615554349dd09185eaaeffd9a28e961de347cf0b3b98a853b43a6c",
-                "sha256:c61730ae21533ef992a89df0321ebe59e344f9f0d1d54572b92d9468969c75b3",
-                "sha256:c876dbaa6897e45ed074df1562006ac9fdeb5c7235f623cda2c29894fe4f8fba",
-                "sha256:d8aaff094d94d2119fffe7e0d08ca59d42076971f9d85857e99288e500ab31f0",
-                "sha256:d9b8b59a76f67270ce8a4fd7af005732356d5b4ebaffa4598343ea63677bad63",
-                "sha256:dedfe2947ad4ccc8cb2f7d0cac5766dd623901f29e1953a2854126559c317885",
-                "sha256:e1a8f9a57bbcc2e633aaf327e39830527f3c1f7add18c7580f3058fe9a0fa780",
-                "sha256:e42ac5aa09debbf7b72444af7f390713e85b8808557e920d9d8071f14127c0eb",
-                "sha256:e51133b78b67bd4c06e99bea9c631f29acd52af2b2a254926d192f277f9067b5",
-                "sha256:e5adcbec235dce997efacb44cca5cde24db47ad9c432fcbca875185d2095c55a",
-                "sha256:e6baae6fa9a88c1895193f9610b54d483753ad3e3f91f5d5a10a506afe342a43",
-                "sha256:ead51910d83123648b1e36e2de8483b66e9ba358ca1d8965005ba7713cbcb7db",
-                "sha256:f6dbd9d86aa2fbeb8a104ae8edd23c55f182829db58cae3f28842024e08b1071",
-                "sha256:f8178a475de70e6ae0a7e3f6d7ec1415c9dd10680654dbea9a1caf79665b0ed4",
-                "sha256:fad4f44220847691605e4079ec67b6663064d5b1283bee5a89dd6f7726672d08",
-                "sha256:fec4336e067f2bdd45d74c2466dcd06f245e972d2139187d87cfccf847dbaf50",
-                "sha256:fecbc5e773c1c1971641227d8fcd5de97533dbbc0bd7854b436ceb57243f4b2a"
-            ],
-            "index": "pypi",
-            "version": "==1.50.0"
+            "version": "==1.48.2"
         },
         "idna": {
             "hashes": [
@@ -344,14 +296,6 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==3.4"
-        },
-        "jsonschema": {
-            "hashes": [
-                "sha256:5bfcf2bca16a087ade17e02b282d34af7ccd749ef76241e7f9bd7c0cb8a9424d",
-                "sha256:f660066c3966db7d6daeaea8a75e0b68237a48e51cf49882087757bb59916248"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==4.17.0"
         },
         "osv": {
             "editable": true,
@@ -383,23 +327,31 @@
         },
         "protobuf": {
             "hashes": [
-                "sha256:2c9c2ed7466ad565f18668aa4731c535511c5d9a40c6da39524bccf43e441719",
-                "sha256:48e2cd6b88c6ed3d5877a3ea40df79d08374088e89bedc32557348848dff250b",
-                "sha256:5b0834e61fb38f34ba8840d7dcb2e5a2f03de0c714e0293b3963b79db26de8ce",
-                "sha256:61f21493d96d2a77f9ca84fefa105872550ab5ef71d21c458eb80edcf4885a99",
-                "sha256:6e0be9f09bf9b6cf497b27425487706fa48c6d1632ddd94dab1a5fe11a422392",
-                "sha256:6e312e280fbe3c74ea9e080d9e6080b636798b5e3939242298b591064470b06b",
-                "sha256:7eb8f2cc41a34e9c956c256e3ac766cf4e1a4c9c925dc757a41a01be3e852965",
-                "sha256:84ea107016244dfc1eecae7684f7ce13c788b9a644cd3fca5b77871366556444",
-                "sha256:9227c14010acd9ae7702d6467b4625b6fe853175a6b150e539b21d2b2f2b409c",
-                "sha256:a419cc95fca8694804709b8c4f2326266d29659b126a93befe210f5bbc772536",
-                "sha256:a7d0ea43949d45b836234f4ebb5ba0b22e7432d065394b532cdca8f98415e3cf",
-                "sha256:b5ab0b8918c136345ff045d4b3d5f719b505b7c8af45092d7f45e304f55e50a1",
-                "sha256:e575c57dc8b5b2b2caa436c16d44ef6981f2235eb7179bfc847557886376d740",
-                "sha256:f9eae277dd240ae19bb06ff4e2346e771252b0e619421965504bd1b1bba7c5fa"
+                "sha256:03038ac1cfbc41aa21f6afcbcd357281d7521b4157926f30ebecc8d4ea59dcb7",
+                "sha256:28545383d61f55b57cf4df63eebd9827754fd2dc25f80c5253f9184235db242c",
+                "sha256:2e3427429c9cffebf259491be0af70189607f365c2f41c7c3764af6f337105f2",
+                "sha256:398a9e0c3eaceb34ec1aee71894ca3299605fa8e761544934378bbc6c97de23b",
+                "sha256:44246bab5dd4b7fbd3c0c80b6f16686808fab0e4aca819ade6e8d294a29c7050",
+                "sha256:447d43819997825d4e71bf5769d869b968ce96848b6479397e29fc24c4a5dfe9",
+                "sha256:67a3598f0a2dcbc58d02dd1928544e7d88f764b47d4a286202913f0b2801c2e7",
+                "sha256:74480f79a023f90dc6e18febbf7b8bac7508420f2006fabd512013c0c238f454",
+                "sha256:819559cafa1a373b7096a482b504ae8a857c89593cf3a25af743ac9ecbd23480",
+                "sha256:899dc660cd599d7352d6f10d83c95df430a38b410c1b66b407a6b29265d66469",
+                "sha256:8c0c984a1b8fef4086329ff8dd19ac77576b384079247c770f29cc8ce3afa06c",
+                "sha256:9aae4406ea63d825636cc11ffb34ad3379335803216ee3a856787bcf5ccc751e",
+                "sha256:a7ca6d488aa8ff7f329d4c545b2dbad8ac31464f1d8b1c87ad1346717731e4db",
+                "sha256:b6cc7ba72a8850621bfec987cb72623e703b7fe2b9127a161ce61e61558ad905",
+                "sha256:bf01b5720be110540be4286e791db73f84a2b721072a3711efff6c324cdf074b",
+                "sha256:c02ce36ec760252242a33967d51c289fd0e1c0e6e5cc9397e2279177716add86",
+                "sha256:d9e4432ff660d67d775c66ac42a67cf2453c27cb4d738fc22cb53b5d84c135d4",
+                "sha256:daa564862dd0d39c00f8086f88700fdbe8bc717e993a21e90711acfed02f2402",
+                "sha256:de78575669dddf6099a8a0f46a27e82a1783c557ccc38ee620ed8cc96d3be7d7",
+                "sha256:e64857f395505ebf3d2569935506ae0dfc4a15cb80dc25261176c784662cdcc4",
+                "sha256:f4bd856d702e5b0d96a00ec6b307b0f51c1982c2bf9c0052cf9019e9a544ba99",
+                "sha256:f4c42102bc82a51108e449cbb32b19b180022941c727bac0cfd50170341f16ee"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.21.9"
+            "version": "==3.20.3"
         },
         "pyasn1": {
             "hashes": [
@@ -446,46 +398,40 @@
         },
         "pygit2": {
             "hashes": [
-                "sha256:0097b6631ef05c837c4800fad559d0865a90c55475a18f38c6f2f5a12750e914",
-                "sha256:11225811194ae6b9dbb34c2e8900e0eba6eacc180d82766e3dbddcbd2c6e6454",
-                "sha256:1f4f507e5cd775f6d5d95ec65761af4cdb33b2f859af15bf10a06d11efd0d3b2",
-                "sha256:25e4905cbb87db598b1cb38800ff995c0ba1f58745e2f52af4d54dbc93b9bda8",
-                "sha256:33138c256ad0ff084f5d8a82ab7d280f9ed6706ebb000ac82e3d133e2d82b366",
-                "sha256:354651bf062c02d1f08041d6fbf1a9b4bf7a93afce65979bdc08bdc65653aa2e",
-                "sha256:38ceecd5d30583f9db56aadcd7238bb3c76a2934d8a932de47aed77fe3c188e7",
-                "sha256:3efd2a2ab2bb443e1b758525546d74a5a12fe27006194d3c02b3e6ecc1e101e6",
-                "sha256:411dc8af5f25c30a0c3d79ee1e22fb892d6fd6ccb54d4c1fb7746e6274e36426",
-                "sha256:43bb910272866eb822e930dbd0feecc340e0c24934143aab651fa180cc5ebfb0",
-                "sha256:564e832e750f889aea3bb3e82674e1c860c9b89a141404530271e1341723a258",
-                "sha256:73e251d0b73f1010ad28c20bcdcf33e312fb363f10b7268ad2bcfa09770f9ac2",
-                "sha256:752f844d5379081fae5ef78e3bf6f0f35ae9b11aafc37e5e03e1c3607b196806",
-                "sha256:7eb2cee54a1cb468b5502493ee4f3ec2f1f82db9c46fab7dacaa37afc4fcde8e",
-                "sha256:889ca83528c0649afd970da700cc6ed47dc340481f146a39ba5bfbeca1ddd6f8",
-                "sha256:9d23bb613f5692da78c09a79ae40d6ced57b772ae9153aed23a9aa1889a16c85",
-                "sha256:9d6e1270b91e7bf70185bb4c3686e04cca87a385c8a2d5c74eec8770091531be",
-                "sha256:9da53c6f5c08308450059d7dfb3067d59c45f14bee99743e536c5f9d9823f154",
-                "sha256:b115bef251af4daf18f2f967287b56da2eae2941d5389dc1666bd0160892d769",
-                "sha256:b31ffdbc87629613ae03a533e01eee79112a12f66faf375fa08934074044a664",
-                "sha256:b67ef30f3c022be1d6da9ef0188f60fc2d20639bff44693ef5653818e887001b",
-                "sha256:bb1f4689ce38cd62a7000d38602ba4d704df5cec708e5d98dadaffcf510f3317",
-                "sha256:bb49f9469a893f75f105cdf2c79254859aaf2fdce1078c38514ca12fe185a759",
-                "sha256:cb3eb2f1d437db6e115d5f56d122f2f3737fa2e6063aa42e4d856ca76d785ce6",
-                "sha256:cb73f7967207a9ac485722ef0e517e5ca482f3c1308a0ac934707cb267b0ac7a",
-                "sha256:d4251830276018c2346ddccad4b4ce06ed1d983b002a633c4d894b13669052d0",
-                "sha256:d5465db21c6fd481ec29aa7afcca9a85b1fdb19b2f2d09a31b4bdba2f1bd0e75",
-                "sha256:dcd849c44bd743d829dbd9dc9d7e13c14cf31a47c22e2e3f9e98fa845a8b8b28",
-                "sha256:ddb3b5bdcdfae205d9cc0c80bc53fad222a5ba67e66fd336ef223f86b0ac5835",
-                "sha256:dfd55a6cf7ad6276fb5772e5c60c51fca2d9a5e68ea3e7237847421c10080a68",
-                "sha256:e09386b71ad474f2c2c02b6b251fa904b1145dabfe9095955ab30a789aaf84c0",
-                "sha256:e3a3cc867fa6907bfc78d7d1322f3dabd4107b16238205df7e2dec9ee265f0c0",
-                "sha256:e3f60e47c6a7a87f18a112753eb98848f4c5333986bec1940558ce09cdaf53bf",
-                "sha256:e8bb9002924975271d64e8869b44ea97f068e85b5edd03e802e4917b770aaf2d",
-                "sha256:f0f69ea42231bebf08006c85cd5aa233c9c047c5a88b7fcfb4b639476b70e31b",
-                "sha256:fe41da630f4e7cb290dc7e97edf30a59d634426af52a89d4ab5c0fb1ea9ccfe4",
-                "sha256:ff838665d6410b5a605f53c1ccd2d2f87ca30de59e89773e7cb5e10211426f90"
+                "sha256:0170f31c2efb15f6779689df328c05a8005ecb2b92784a37ff967d713cdafe82",
+                "sha256:263e05ac655a4ce0a1083aaaedfd0a900b8dee2c3bb3ecf4f4e504a404467d1f",
+                "sha256:273878adeced2aec7885745b73fffb91a8e67868c105bf881b61008d42497ad6",
+                "sha256:29f89d96bbb404ca1566418463521039903094fad2f81a76d7083810d2ea3aad",
+                "sha256:3b091e7fd00dd2a2cd3a6b5e235b6cbfbc1c07f15ee83a5cb3f188e1d6d1bca1",
+                "sha256:3be4534180edd53e3e1da93c5b091975566bfdffdc73f21930d79fef096a25d2",
+                "sha256:3c5838e6516abc4384498f4b4c7f88578221596dc2ba8db2320ff2cfebe9787e",
+                "sha256:48cfd72283a08a9226aca115870799ee92898d692699f541a3b3f519805108ec",
+                "sha256:4d6209c703764ae0ba57b17038482f3e54f432f80f88ccd490d7f8b70b167db6",
+                "sha256:550aa503c86ef0061ce64d61c3672b15b500c2b1e4224c405acecfac2211b5d9",
+                "sha256:56b9deeab214653805214f05337f5e9552b47bf268c285551f20ea51a6056c3e",
+                "sha256:585daa3956f1dc10d08e3459c20b57be42c7f9c0fbde21e797b3a00b5948f061",
+                "sha256:6c3434b143e7570ec45cd1a0e344fe7a12e64b99e7155fa38b74f724c8fc243c",
+                "sha256:793f583fd33620f0ac38376db0f57768ef2922b89b459e75b1ac440377eb64ec",
+                "sha256:960a55ff78f48887a7aa8ece952aad0f52f0a2ba1ad7bddd7064fbbefd85dfbb",
+                "sha256:96ff745d3199909d06cab5e419a6b953be99992414a08ec4dddb682f395de8f1",
+                "sha256:9b44674e53efa9eca36e44f2f3d1a29e53e78649ba13105ae0b037d557f2c076",
+                "sha256:a886aab5aae8d8db572e20b9f56c13cd506775265222ea7f35b2c781e4fa3a5e",
+                "sha256:a9ca4cb2481d2df14d23c765facef325f717d9a3966a986b86e88d92eef11929",
+                "sha256:b3c8726f0c9a2b0e04aac37b18027c58c2697b9c021d3458b28bc250b9b6aecf",
+                "sha256:d1b5fcaac1f29337f2d1465fa095e2e375b76a06385bda9391cb418c7937fb54",
+                "sha256:d5c158b9430c5e76ca728b1a214bf21d355af6ac6e2da86ed17775b870b6c6eb",
+                "sha256:d5f64a424d9123b047458b0107c5dd33559184b56a1f58b10056ea5cbac74360",
+                "sha256:da040dc28800831bcbefef0850466739f103bfc769d952bd10c449646d52ce8f",
+                "sha256:ddb032fa71d4b4a64bf101e37eaa21f5369f20a862b5e34bbc33854a3a35f641",
+                "sha256:df722c90fb54a42fa019dcf8d8f82961c3099c3024f1fda46c53e0886ff8f0f3",
+                "sha256:ee6b4a0e181c576cdb64b1568bfbff3d1c2cd7e99808f578c8b08875c0f43739",
+                "sha256:f13e190cc080bde093138e12bcb609500276227e3e8e8bd8765a2fd49ae2efb8",
+                "sha256:f270f86a0185ca2064e1aa6b8db3bb677b1bf76ee35f48ca5ce28a921fad5632",
+                "sha256:f42409d25bbfc090fd1af1f5f47584d7e0c4212b037a7f86639a02c30420c6ee",
+                "sha256:f8de0091e5eeaea2004f63f7dcb4540780f2124f68c0bcb670ae0fa9ada8bf66"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==1.10.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.11.1"
         },
         "pymemcache": {
             "hashes": [
@@ -502,34 +448,6 @@
             ],
             "markers": "python_full_version >= '3.6.8'",
             "version": "==3.0.9"
-        },
-        "pyrsistent": {
-            "hashes": [
-                "sha256:055ab45d5911d7cae397dc418808d8802fb95262751872c841c170b0dbf51eed",
-                "sha256:111156137b2e71f3a9936baf27cb322e8024dac3dc54ec7fb9f0bcf3249e68bb",
-                "sha256:187d5730b0507d9285a96fca9716310d572e5464cadd19f22b63a6976254d77a",
-                "sha256:21455e2b16000440e896ab99e8304617151981ed40c29e9507ef1c2e4314ee95",
-                "sha256:2aede922a488861de0ad00c7630a6e2d57e8023e4be72d9d7147a9fcd2d30712",
-                "sha256:3ba4134a3ff0fc7ad225b6b457d1309f4698108fb6b35532d015dca8f5abed73",
-                "sha256:456cb30ca8bff00596519f2c53e42c245c09e1a4543945703acd4312949bfd41",
-                "sha256:71d332b0320642b3261e9fee47ab9e65872c2bd90260e5d225dabeed93cbd42b",
-                "sha256:879b4c2f4d41585c42df4d7654ddffff1239dc4065bc88b745f0341828b83e78",
-                "sha256:9cd3e9978d12b5d99cbdc727a3022da0430ad007dacf33d0bf554b96427f33ab",
-                "sha256:a178209e2df710e3f142cbd05313ba0c5ebed0a55d78d9945ac7a4e09d923308",
-                "sha256:b39725209e06759217d1ac5fcdb510e98670af9e37223985f330b611f62e7425",
-                "sha256:bfa0351be89c9fcbcb8c9879b826f4353be10f58f8a677efab0c017bf7137ec2",
-                "sha256:bfd880614c6237243ff53a0539f1cb26987a6dc8ac6e66e0c5a40617296a045e",
-                "sha256:c43bec251bbd10e3cb58ced80609c5c1eb238da9ca78b964aea410fb820d00d6",
-                "sha256:d690b18ac4b3e3cab73b0b7aa7dbe65978a172ff94970ff98d82f2031f8971c2",
-                "sha256:d6982b5a0237e1b7d876b60265564648a69b14017f3b5f908c5be2de3f9abb7a",
-                "sha256:dec3eac7549869365fe263831f576c8457f6c833937c68542d08fde73457d291",
-                "sha256:e371b844cec09d8dc424d940e54bba8f67a03ebea20ff7b7b0d56f526c71d584",
-                "sha256:e5d8f84d81e3729c3b506657dddfe46e8ba9c330bf1858ee33108f8bb2adb38a",
-                "sha256:ea6b79a02a28550c98b6ca9c35b9f492beaa54d7c5c9e9949555893c8a9234d0",
-                "sha256:f1258f4e6c42ad0b20f9cfcc3ada5bd6b83374516cd01c0960e3cb75fdca6770"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==0.19.2"
         },
         "pytz": {
             "hashes": [
@@ -615,14 +533,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.13.0"
-        },
-        "setuptools": {
-            "hashes": [
-                "sha256:d0b9a8433464d5800cbe05094acf5c6d52a91bfac9b52bcfc4d41382be5d5d31",
-                "sha256:e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==65.5.1"
         },
         "six": {
             "hashes": [
@@ -711,5 +621,152 @@
             "version": "==1.14.1"
         }
     },
-    "develop": {}
+    "develop": {
+        "grpcio": {
+            "hashes": [
+                "sha256:05f7c248e440f538aaad13eee78ef35f0541e73498dd6f832fe284542ac4b298",
+                "sha256:080b66253f29e1646ac53ef288c12944b131a2829488ac3bac8f52abb4413c0d",
+                "sha256:12b479839a5e753580b5e6053571de14006157f2ef9b71f38c56dc9b23b95ad6",
+                "sha256:156f8009e36780fab48c979c5605eda646065d4695deea4cfcbcfdd06627ddb6",
+                "sha256:15f9e6d7f564e8f0776770e6ef32dac172c6f9960c478616c366862933fa08b4",
+                "sha256:177afaa7dba3ab5bfc211a71b90da1b887d441df33732e94e26860b3321434d9",
+                "sha256:1a4cd8cb09d1bc70b3ea37802be484c5ae5a576108bad14728f2516279165dd7",
+                "sha256:1d8d02dbb616c0a9260ce587eb751c9c7dc689bc39efa6a88cc4fa3e9c138a7b",
+                "sha256:2b71916fa8f9eb2abd93151fafe12e18cebb302686b924bd4ec39266211da525",
+                "sha256:2d9fd6e38b16c4d286a01e1776fdf6c7a4123d99ae8d6b3f0b4a03a34bf6ce45",
+                "sha256:3b611b3de3dfd2c47549ca01abfa9bbb95937eb0ea546ea1d762a335739887be",
+                "sha256:3e4244c09cc1b65c286d709658c061f12c61c814be0b7030a2d9966ff02611e0",
+                "sha256:40838061e24f960b853d7bce85086c8e1b81c6342b1f4c47ff0edd44bbae2722",
+                "sha256:4b123fbb7a777a2fedec684ca0b723d85e1d2379b6032a9a9b7851829ed3ca9a",
+                "sha256:531f8b46f3d3db91d9ef285191825d108090856b3bc86a75b7c3930f16ce432f",
+                "sha256:67dd41a31f6fc5c7db097a5c14a3fa588af54736ffc174af4411d34c4f306f68",
+                "sha256:7489dbb901f4fdf7aec8d3753eadd40839c9085967737606d2c35b43074eea24",
+                "sha256:8d4c8e73bf20fb53fe5a7318e768b9734cf122fe671fcce75654b98ba12dfb75",
+                "sha256:8e69aa4e9b7f065f01d3fdcecbe0397895a772d99954bb82eefbb1682d274518",
+                "sha256:8e8999a097ad89b30d584c034929f7c0be280cd7851ac23e9067111167dcbf55",
+                "sha256:906f4d1beb83b3496be91684c47a5d870ee628715227d5d7c54b04a8de802974",
+                "sha256:92d7635d1059d40d2ec29c8bf5ec58900120b3ce5150ef7414119430a4b2dd5c",
+                "sha256:931e746d0f75b2a5cff0a1197d21827a3a2f400c06bace036762110f19d3d507",
+                "sha256:95ce51f7a09491fb3da8cf3935005bff19983b77c4e9437ef77235d787b06842",
+                "sha256:9eea18a878cffc804506d39c6682d71f6b42ec1c151d21865a95fae743fda500",
+                "sha256:a23d47f2fc7111869f0ff547f771733661ff2818562b04b9ed674fa208e261f4",
+                "sha256:a4c23e54f58e016761b576976da6a34d876420b993f45f66a2bfb00363ecc1f9",
+                "sha256:a50a1be449b9e238b9bd43d3857d40edf65df9416dea988929891d92a9f8a778",
+                "sha256:ab5d0e3590f0a16cb88de4a3fa78d10eb66a84ca80901eb2c17c1d2c308c230f",
+                "sha256:ae23daa7eda93c1c49a9ecc316e027ceb99adbad750fbd3a56fa9e4a2ffd5ae0",
+                "sha256:af98d49e56605a2912cf330b4627e5286243242706c3a9fa0bcec6e6f68646fc",
+                "sha256:b2f77a90ba7b85bfb31329f8eab9d9540da2cf8a302128fb1241d7ea239a5469",
+                "sha256:baab51dcc4f2aecabf4ed1e2f57bceab240987c8b03533f1cef90890e6502067",
+                "sha256:ca8a2254ab88482936ce941485c1c20cdeaef0efa71a61dbad171ab6758ec998",
+                "sha256:cb11464f480e6103c59d558a3875bd84eed6723f0921290325ebe97262ae1347",
+                "sha256:ce8513aee0af9c159319692bfbf488b718d1793d764798c3d5cff827a09e25ef",
+                "sha256:cf151f97f5f381163912e8952eb5b3afe89dec9ed723d1561d59cabf1e219a35",
+                "sha256:d144ad10eeca4c1d1ce930faa105899f86f5d99cecfe0d7224f3c4c76265c15e",
+                "sha256:d534d169673dd5e6e12fb57cc67664c2641361e1a0885545495e65a7b761b0f4",
+                "sha256:d75061367a69808ab2e84c960e9dce54749bcc1e44ad3f85deee3a6c75b4ede9",
+                "sha256:d84d04dec64cc4ed726d07c5d17b73c343c8ddcd6b59c7199c801d6bbb9d9ed1",
+                "sha256:de411d2b030134b642c092e986d21aefb9d26a28bf5a18c47dd08ded411a3bc5",
+                "sha256:e07fe0d7ae395897981d16be61f0db9791f482f03fee7d1851fe20ddb4f69c03",
+                "sha256:ea8ccf95e4c7e20419b7827aa5b6da6f02720270686ac63bd3493a651830235c",
+                "sha256:f7025930039a011ed7d7e7ef95a1cb5f516e23c5a6ecc7947259b67bea8e06ca"
+            ],
+            "index": "pypi",
+            "version": "==1.50.0"
+        },
+        "grpcio-tools": {
+            "hashes": [
+                "sha256:0fe40a66d3ccde959f7290b881c78e8c420fd54289fede5c9119d993703e1a49",
+                "sha256:1736defd9fc54f942f500dd71555816487e52f07d25b0a58ff4089c375f0b5c3",
+                "sha256:1891aca6042fc403c1d492d03ce1c4bac0053c26132063b7b0171665a0aa6086",
+                "sha256:2313c8c73a5003d789fe05f4d01112ccf8330d3d141f5b77b514200d742193f6",
+                "sha256:23381ac6a19de0d3cb470f4d1fb450267014234a3923e3c43abb858049f5caf4",
+                "sha256:27f734e44631d755481a179ffd5f2659eaf1e9755cf3539e291d7a28d8373cc8",
+                "sha256:2869fba92670d5be3730f1ad108cbacd3f9a7b7afa57187a3c39379513b3fde7",
+                "sha256:3995d96635d6decaf9d5d2e071677782b08ea3186d7cb8ad93f6c2dd97ec9097",
+                "sha256:4c928610ceda7890cf7ddd3cb4cc16fb81995063bf4fdb5171bba572d508079b",
+                "sha256:4fe1cd201f0e0f601551c20bea2a8c1e109767ce341ac263e88d5a0acd0a124c",
+                "sha256:54528cec27238761055b28a34ea29392c8e90ac8d8966ee3ccfc9f906eb26fd3",
+                "sha256:56c28f50b9c88cbfc62861de86a1f8b2454d3b48cff85a73d523ec22f130635d",
+                "sha256:578f9137ebca0f152136b47b4895a6b4dabcf17e41f957b03637d1ae096ff67b",
+                "sha256:66113bc60db8ccb15e2d7b79efd5757bba33b15e653f20f473c776857bd4415d",
+                "sha256:675634367846fc906e8b6016830b3d361f9e788bce7820b4e6432d914cb0e25d",
+                "sha256:6c40f918d1fe0cb094bfb09ab7567a92f5368fa0b9935235680fe205ddc37518",
+                "sha256:71e98662f76d3bcf031f36f727ffee594c57006d5dce7b6d031d030d194f054d",
+                "sha256:73ba21fe500e2476d391cc92aa05545fdc71bdeedb5b9ec2b22e9a3ccc298a2f",
+                "sha256:7f211a8a6f159b496097cabbf4bdbb6d01db0fd7a8d516dd0e577ee2ddccded0",
+                "sha256:86a9e9b2cc30797472bd421c75b42fe1062519ef5675243cb33d99de33af279c",
+                "sha256:88b75f2afd889c7c6939f58d76b58ab84de4723c7de882a1f8448af6632e256f",
+                "sha256:89010e8e0d158966af478d9b345d29d98e52d62464cb93ef192125e94fb904c1",
+                "sha256:8d74672162474e2592c50708408b4ee145994451ee5171c9b8f580504b987ad3",
+                "sha256:927c8cbbfbf3bca46cd05bbabfd8cb6c99f5dbaeb860f2786f9286ce6894ad3d",
+                "sha256:9bc97b52d577406c240b0d6acf68ab5100c67c903792f1f9ce04d871ca83de53",
+                "sha256:a9816a6c8d1b7adb65217d01624006704faf02b5daa15b6e145b63a5e559d791",
+                "sha256:b7eb7a84d9171c0ae1550833f4a6ca52372bed9db0fa10f8c9dbe6ca65f97a8c",
+                "sha256:c1646bfec6d707bcaafea69088770151ba291ede788f2cda5efdc09c1eac5c1c",
+                "sha256:c5dde47bae615554349dd09185eaaeffd9a28e961de347cf0b3b98a853b43a6c",
+                "sha256:c61730ae21533ef992a89df0321ebe59e344f9f0d1d54572b92d9468969c75b3",
+                "sha256:c876dbaa6897e45ed074df1562006ac9fdeb5c7235f623cda2c29894fe4f8fba",
+                "sha256:d8aaff094d94d2119fffe7e0d08ca59d42076971f9d85857e99288e500ab31f0",
+                "sha256:d9b8b59a76f67270ce8a4fd7af005732356d5b4ebaffa4598343ea63677bad63",
+                "sha256:dedfe2947ad4ccc8cb2f7d0cac5766dd623901f29e1953a2854126559c317885",
+                "sha256:e1a8f9a57bbcc2e633aaf327e39830527f3c1f7add18c7580f3058fe9a0fa780",
+                "sha256:e42ac5aa09debbf7b72444af7f390713e85b8808557e920d9d8071f14127c0eb",
+                "sha256:e51133b78b67bd4c06e99bea9c631f29acd52af2b2a254926d192f277f9067b5",
+                "sha256:e5adcbec235dce997efacb44cca5cde24db47ad9c432fcbca875185d2095c55a",
+                "sha256:e6baae6fa9a88c1895193f9610b54d483753ad3e3f91f5d5a10a506afe342a43",
+                "sha256:ead51910d83123648b1e36e2de8483b66e9ba358ca1d8965005ba7713cbcb7db",
+                "sha256:f6dbd9d86aa2fbeb8a104ae8edd23c55f182829db58cae3f28842024e08b1071",
+                "sha256:f8178a475de70e6ae0a7e3f6d7ec1415c9dd10680654dbea9a1caf79665b0ed4",
+                "sha256:fad4f44220847691605e4079ec67b6663064d5b1283bee5a89dd6f7726672d08",
+                "sha256:fec4336e067f2bdd45d74c2466dcd06f245e972d2139187d87cfccf847dbaf50",
+                "sha256:fecbc5e773c1c1971641227d8fcd5de97533dbbc0bd7854b436ceb57243f4b2a"
+            ],
+            "index": "pypi",
+            "version": "==1.50.0"
+        },
+        "protobuf": {
+            "hashes": [
+                "sha256:03038ac1cfbc41aa21f6afcbcd357281d7521b4157926f30ebecc8d4ea59dcb7",
+                "sha256:28545383d61f55b57cf4df63eebd9827754fd2dc25f80c5253f9184235db242c",
+                "sha256:2e3427429c9cffebf259491be0af70189607f365c2f41c7c3764af6f337105f2",
+                "sha256:398a9e0c3eaceb34ec1aee71894ca3299605fa8e761544934378bbc6c97de23b",
+                "sha256:44246bab5dd4b7fbd3c0c80b6f16686808fab0e4aca819ade6e8d294a29c7050",
+                "sha256:447d43819997825d4e71bf5769d869b968ce96848b6479397e29fc24c4a5dfe9",
+                "sha256:67a3598f0a2dcbc58d02dd1928544e7d88f764b47d4a286202913f0b2801c2e7",
+                "sha256:74480f79a023f90dc6e18febbf7b8bac7508420f2006fabd512013c0c238f454",
+                "sha256:819559cafa1a373b7096a482b504ae8a857c89593cf3a25af743ac9ecbd23480",
+                "sha256:899dc660cd599d7352d6f10d83c95df430a38b410c1b66b407a6b29265d66469",
+                "sha256:8c0c984a1b8fef4086329ff8dd19ac77576b384079247c770f29cc8ce3afa06c",
+                "sha256:9aae4406ea63d825636cc11ffb34ad3379335803216ee3a856787bcf5ccc751e",
+                "sha256:a7ca6d488aa8ff7f329d4c545b2dbad8ac31464f1d8b1c87ad1346717731e4db",
+                "sha256:b6cc7ba72a8850621bfec987cb72623e703b7fe2b9127a161ce61e61558ad905",
+                "sha256:bf01b5720be110540be4286e791db73f84a2b721072a3711efff6c324cdf074b",
+                "sha256:c02ce36ec760252242a33967d51c289fd0e1c0e6e5cc9397e2279177716add86",
+                "sha256:d9e4432ff660d67d775c66ac42a67cf2453c27cb4d738fc22cb53b5d84c135d4",
+                "sha256:daa564862dd0d39c00f8086f88700fdbe8bc717e993a21e90711acfed02f2402",
+                "sha256:de78575669dddf6099a8a0f46a27e82a1783c557ccc38ee620ed8cc96d3be7d7",
+                "sha256:e64857f395505ebf3d2569935506ae0dfc4a15cb80dc25261176c784662cdcc4",
+                "sha256:f4bd856d702e5b0d96a00ec6b307b0f51c1982c2bf9c0052cf9019e9a544ba99",
+                "sha256:f4c42102bc82a51108e449cbb32b19b180022941c727bac0cfd50170341f16ee"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.20.3"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:d0b9a8433464d5800cbe05094acf5c6d52a91bfac9b52bcfc4d41382be5d5d31",
+                "sha256:e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==65.5.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        }
+    }
 }

--- a/gcp/api/run_tests.sh
+++ b/gcp/api/run_tests.sh
@@ -29,5 +29,4 @@ service docker start
 
 export GOOGLE_CLOUD_PROJECT=oss-vdb
 export GOOGLE_APPLICATION_CREDENTIALS="$1"
-export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION="python"
 python integration_tests.py "$1"

--- a/gcp/appengine/frontend3/package-lock.json
+++ b/gcp/appengine/frontend3/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "frontend3",
       "version": "0.0.0",
       "dependencies": {
         "@github/clipboard-copy-element": "1.1.2",

--- a/gcp/appengine/frontend3/package-lock.json
+++ b/gcp/appengine/frontend3/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "frontend3",
       "version": "0.0.0",
       "dependencies": {
         "@github/clipboard-copy-element": "1.1.2",


### PR DESCRIPTION
Revert package updates to avoid protobuf version mismatches.

The root cause was grpcio-tools, but this is a dev dependency so move it there instead to avoid issues with our production image build.
So, we move this package into the dev-packages section.