### PR TITLE
Don't mark deleted git entries as invalid.

### DIFF
--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -265,12 +265,10 @@ class Importer:
 
     # Get list of changed files since last sync.
     changed_entries = set()
-    deleted_entries = set()
 
     if source_repo.last_synced_hash:
       # Syncing from a previous commit.
-      changed_entries, deleted_entries = self._sync_from_previous_commit(
-          source_repo, repo)
+      changed_entries, _ = self._sync_from_previous_commit(source_repo, repo)
 
     else:
       # First sync from scratch.
@@ -304,18 +302,6 @@ class Importer:
       original_sha256 = osv.sha256(path)
       self._request_analysis_external(source_repo, original_sha256,
                                       changed_entry)
-
-    # Mark deleted entries as invalid.
-    for deleted_entry in deleted_entries:
-      path = os.path.join(osv.repo_path(repo), deleted_entry)
-      if os.path.exists(path):
-        # Path still exists. It must have been added back in another commit.
-        continue
-
-      logging.info('Marking %s as invalid', deleted_entry)
-      original_sha256 = ''
-      self._request_analysis_external(
-          source_repo, original_sha256, deleted_entry, deleted=True)
 
     source_repo.last_synced_hash = str(repo.head.target)
     source_repo.put()

--- a/docker/importer/importer_test.py
+++ b/docker/importer/importer_test.py
@@ -192,36 +192,6 @@ class ImporterTest(unittest.TestCase, tests.ExpectationTest(TEST_DATA_DIR)):
     ])
 
   @mock.patch('google.cloud.pubsub_v1.PublisherClient.publish')
-  def test_delete(self, mock_publish):
-    """Test deletion."""
-    self.mock_repo.add_file('2021-111.yaml', _MIN_VALID_VULNERABILITY)
-    self.mock_repo.commit('User', 'user@email')
-
-    repo = pygit2.Repository(self.remote_source_repo_path)
-    synced_commit = repo.head.peel()
-
-    self.source_repo.last_synced_hash = str(synced_commit.id)
-    self.source_repo.put()
-
-    self.mock_repo.delete_file('2021-111.yaml')
-    self.mock_repo.commit('User', 'user@email')
-
-    imp = importer.Importer('fake_public_key', 'fake_private_key', self.tmp_dir,
-                            'bucket', True)
-    imp.run()
-
-    mock_publish.assert_has_calls([
-        mock.call(
-            'projects/oss-vdb/topics/tasks',
-            data=b'',
-            deleted='true',
-            original_sha256='',
-            path='2021-111.yaml',
-            source='oss-fuzz',
-            type='update')
-    ])
-
-  @mock.patch('google.cloud.pubsub_v1.PublisherClient.publish')
   def test_nop(self, mock_publish: mock.MagicMock):
     """Test deletion."""
     self.mock_repo.add_file('2021-111.yaml', _MIN_VALID_VULNERABILITY)


### PR DESCRIPTION
The supported way to handle making entries as invalid is to mark them as "withdrawn" and
leave the entry intact.

This also guards against availability issues from source feeds, such as when a bug in their
system causes their entries to be deleted (e.g. https://github.com/github/advisory-database/commit/06071dd8e490ed354657f8ee158880433cf04997)
