### PR TITLE
Fix bug with SemVer range evaluation in API.

### DIFF
--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -320,6 +320,22 @@ class IntegrationTests(unittest.TestCase):
     self.assertCountEqual(['GO-2021-0061', 'GO-2020-0036'],
                           [vuln['id'] for vuln in response_json['vulns']])
 
+    response = requests.post(
+        _api() + '/v1/query',
+        data=json.dumps({
+            'version': '7.1.1',
+            'package': {
+                'name': 'ws',
+                'ecosystem': 'npm',
+            }
+        }),
+        timeout=_TIMEOUT)
+
+    response_json = response.json()
+    self.assertEqual(1, len(response_json['vulns']))
+    self.assertCountEqual(['GHSA-6fc8-4gx4-v693'],
+                          [vuln['id'] for vuln in response_json['vulns']])
+
   def test_query_purl(self):
     """Test querying by PURL."""
     expected = [

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -363,6 +363,9 @@ def _is_semver_affected(affected_packages, package_name, ecosystem,
             event.value):
           affected = False
 
+      if affected:
+        return affected
+
   return affected
 
 


### PR DESCRIPTION
This didn't work properly if there are multiple packages/ranges in the relevant vulnerability, and the matching range
is not the last one.

This implementation now matches the OSV schema pseudocode at https://ossf.github.io/osv-schema/#evaluation.

Fixes #834.