### PR TITLE
Only add an ecosystem version range if there's package information

### DIFF
--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -369,38 +369,40 @@ func (affected *Affected) AttachExtractedVersionInfo(version cves.VersionInfo) {
 	}
 
 	// Adding an ECOSYSTEM version range only makes sense if we have package information.
-	if affected.Package != nil {
-		versionRange := AffectedRange{
-			Type: "ECOSYSTEM",
-		}
-		seenIntroduced := map[string]bool{}
-		seenFixed := map[string]bool{}
+	if affected.Package == nil {
+		return
+	}
 
-		for _, v := range version.AffectedVersions {
-			var introduced string
-			if v.Introduced == "" {
-				introduced = "0"
-			} else {
-				introduced = v.Introduced
-			}
+	versionRange := AffectedRange{
+		Type: "ECOSYSTEM",
+	}
+	seenIntroduced := map[string]bool{}
+	seenFixed := map[string]bool{}
 
-			if _, seen := seenIntroduced[introduced]; !seen {
-				versionRange.Events = append(versionRange.Events, Event{
-					Introduced: introduced,
-				})
-				seenIntroduced[introduced] = true
-			}
+	for _, v := range version.AffectedVersions {
+		var introduced string
+		if v.Introduced == "" {
+			introduced = "0"
+		} else {
+			introduced = v.Introduced
+		}
 
-			if _, seen := seenFixed[v.Fixed]; v.Fixed != "" && !seen {
-				versionRange.Events = append(versionRange.Events, Event{
-					Fixed: v.Fixed,
-				})
-				seenFixed[v.Fixed] = true
-			}
+		if _, seen := seenIntroduced[introduced]; !seen {
+			versionRange.Events = append(versionRange.Events, Event{
+				Introduced: introduced,
+			})
+			seenIntroduced[introduced] = true
 		}
-		if len(version.AffectedVersions) > 0 {
-			affected.Ranges = append(affected.Ranges, versionRange)
+
+		if _, seen := seenFixed[v.Fixed]; v.Fixed != "" && !seen {
+			versionRange.Events = append(versionRange.Events, Event{
+				Fixed: v.Fixed,
+			})
+			seenFixed[v.Fixed] = true
 		}
+	}
+	if len(version.AffectedVersions) > 0 {
+		affected.Ranges = append(affected.Ranges, versionRange)
 	}
 }
 

--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -318,9 +318,11 @@ func FromCVE(id string, cve cves.CVEItem) (*Vulnerability, []string) {
 // AddPkgInfo adds affected package information to the OSV vulnerability object
 func (v *Vulnerability) AddPkgInfo(pkgInfo PackageInfo) {
 	affected := Affected{}
-	affected.Package.Name = pkgInfo.PkgName
-	affected.Package.Ecosystem = pkgInfo.Ecosystem
-	affected.Package.Purl = pkgInfo.PURL
+	affected.Package = &AffectedPackage{
+		Name:      pkgInfo.PkgName,
+		Ecosystem: pkgInfo.Ecosystem,
+		Purl:      pkgInfo.PURL,
+	}
 	if pkgInfo.FixedVersion != "" {
 		versionRange := AffectedRange{
 			Type: "ECOSYSTEM",


### PR DESCRIPTION
ecosystem-specific version ranges are only meaningful in conjuction with package information, so only add them to the resulting vulnerability record if package information is present.

Break out the Package to its own struct so it doesn't get emitted when there is no package information.

Adjust AddPkgInfo accordingly