### PR TITLE
Make CPEs() deterministic

### DIFF
--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -376,17 +376,13 @@ func ExtractVersionInfo(cve CVEItem, validVersions []string) (VersionInfo, []str
 }
 
 func CPEs(cve CVEItem) []string {
-	cpesMap := map[string]bool{}
+	var cpes []string
 	for _, node := range cve.Configurations.Nodes {
 		for _, match := range node.CPEMatch {
-			cpesMap[match.CPE23URI] = true
+			cpes = append(cpes, match.CPE23URI)
 		}
 	}
 
-	var cpes []string
-	for cpe := range cpesMap {
-		cpes = append(cpes, cpe)
-	}
 	return cpes
 }
 


### PR DESCRIPTION
Storing the CPEs in an intermediate map was redundant and destroyed the ordering of them.