### PR TITLE
Handle scenarios where a product has differing repository values

### DIFF
--- a/vulnfeeds/cmd/cperepos/main.go
+++ b/vulnfeeds/cmd/cperepos/main.go
@@ -237,10 +237,11 @@ func analyzeCPEDictionary(d CPEDict) (ProductToRepo map[string][]string, Descrip
 				Logger.Infof("Disliking %q for %q (%s)", repo, CPE.Product, r.Description)
 				continue
 			}
-			if !slices.Contains(ProductToRepo[CPE.Product], repo) {
-				Logger.Infof("Liking %q for %q (%s)", repo, CPE.Product, r.Description)
-				ProductToRepo[CPE.Product] = append(ProductToRepo[CPE.Product], repo)
+			if slices.Contains(ProductToRepo[CPE.Product], repo) {
+				continue
 			}
+			Logger.Infof("Liking %q for %q (%s)", repo, CPE.Product, r.Description)
+			ProductToRepo[CPE.Product] = append(ProductToRepo[CPE.Product], repo)
 		}
 	}
 	return ProductToRepo, DescriptionFrequency, ProductToVendor

--- a/vulnfeeds/cmd/cperepos/main.go
+++ b/vulnfeeds/cmd/cperepos/main.go
@@ -220,14 +220,6 @@ func analyzeCPEDictionary(d CPEDict) (ProductToRepo map[string][]string, Descrip
 				ProductToVendor[CPE.Product] = []string{CPE.Vendor}
 			}
 		}
-		/*
-			if _, exists := ProductToRepo[CPE.Product]; !exists {
-				// This way every seen product will exist in the map,
-				// and ones we never determine a repo for will have a
-				// nil value.
-				ProductToRepo[CPE.Product] = nil
-			}
-		*/
 		for _, r := range c.References {
 			DescriptionFrequency[r.Description] += 1
 			repo, err := cves.Repo(r.URL)

--- a/vulnfeeds/cmd/cperepos/main.go
+++ b/vulnfeeds/cmd/cperepos/main.go
@@ -237,8 +237,8 @@ func analyzeCPEDictionary(d CPEDict) (ProductToRepo map[string][]string, Descrip
 				Logger.Infof("Disliking %q for %q (%s)", repo, CPE.Product, r.Description)
 				continue
 			}
-			Logger.Infof("Liking %q for %q (%s)", repo, CPE.Product, r.Description)
 			if !slices.Contains(ProductToRepo[CPE.Product], repo) {
+				Logger.Infof("Liking %q for %q (%s)", repo, CPE.Product, r.Description)
 				ProductToRepo[CPE.Product] = append(ProductToRepo[CPE.Product], repo)
 			}
 		}


### PR DESCRIPTION
Rather than have the first seen repository win and others get ignored, leave it to the consumer of the resulting data to decide what they want to do.

e.g.

```
jq . | to_entries | map(select(.value | length > 1)) | from_entries
jq . | to_entries | map(select(.value | length == 1)) | from_entries
```

Also identified another definitely invalid repository for the regex