### PR TITLE
Handle the special case of cgit.freedesktop.org

### DIFF
--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -95,13 +95,17 @@ func Repo(u string) (string, error) {
 		if strings.HasSuffix(parsedURL.Path, "commit/") &&
 			strings.HasPrefix(parsedURL.RawQuery, "id=") {
 			repo := strings.TrimSuffix(parsedURL.Path, "/commit/")
-			return fmt.Sprintf("%s://gitlab.freedesktop.org%s",
-				parsedURL.Scheme, repo), nil
+			return fmt.Sprintf("https://gitlab.freedesktop.org%s",
+				repo), nil
+		}
+		if strings.HasSuffix(parsedURL.Path, "refs/tags") {
+			repo := strings.TrimSuffix(parsedURL.Path, "/refs/tags")
+			return fmt.Sprintf("https://gitlab.freedesktop.org%s",
+				repo), nil
 		}
 		if len(strings.Split(parsedURL.Path, "/")) == 4 {
-			return fmt.Sprintf("%s://gitlab.freedesktop.org%s",
-					parsedURL.Scheme, parsedURL.Path),
-				nil
+			return fmt.Sprintf("https://gitlab.freedesktop.org%s",
+				parsedURL.Path), nil
 		}
 	}
 

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -91,6 +91,9 @@ func Repo(u string) (string, error) {
 
 	// cgit.freedesktop.org is a special snowflake with enough repos to warrant special handling
 	// it is a mirror of gitlab.freedesktop.org
+	// https://cgit.freedesktop.org/xorg/lib/libXRes/commit/?id=c05c6d918b0e2011d4bfa370c321482e34630b17
+	// https://cgit.freedesktop.org/xorg/lib/libXRes
+	// http://cgit.freedesktop.org/spice/spice/refs/tags
 	if parsedURL.Hostname() == "cgit.freedesktop.org" {
 		if strings.HasSuffix(parsedURL.Path, "commit/") &&
 			strings.HasPrefix(parsedURL.RawQuery, "id=") {

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -89,6 +89,22 @@ func Repo(u string) (string, error) {
 			parsedURL.Hostname(), repo), nil
 	}
 
+	// cgit.freedesktop.org is a special snowflake with enough repos to warrant special handling
+	// it is a mirror of gitlab.freedesktop.org
+	if parsedURL.Hostname() == "cgit.freedesktop.org" {
+		if strings.HasSuffix(parsedURL.Path, "commit/") &&
+			strings.HasPrefix(parsedURL.RawQuery, "id=") {
+			repo := strings.TrimSuffix(parsedURL.Path, "/commit/")
+			return fmt.Sprintf("%s://gitlab.freedesktop.org%s",
+				parsedURL.Scheme, repo), nil
+		}
+		if len(strings.Split(parsedURL.Path, "/")) == 4 {
+			return fmt.Sprintf("%s://gitlab.freedesktop.org%s",
+					parsedURL.Scheme, parsedURL.Path),
+				nil
+		}
+	}
+
 	// GitHub and GitLab commit and blob URLs are structured one way, e.g.
 	// https://github.com/MariaDB/server/commit/b1351c15946349f9daa7e5297fb2ac6f3139e4a8
 	// https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/ops/math_ops.cc

--- a/vulnfeeds/cves/versions_test.go
+++ b/vulnfeeds/cves/versions_test.go
@@ -174,6 +174,12 @@ func TestRepo(t *testing.T) {
 			expectedRepoURL: "https://gitlab.freedesktop.org/xorg/lib/libXRes",
 			expectedOk:      true,
 		},
+		{
+			description:     "Freedesktop cGit mirror refs/tags URL",
+			inputLink:       "http://cgit.freedesktop.org/spice/spice/refs/tags",
+			expectedRepoURL: "https://gitlab.freedesktop.org/spice/spice",
+			expectedOk:      true,
+		},
 	}
 
 	for _, tc := range tests {

--- a/vulnfeeds/cves/versions_test.go
+++ b/vulnfeeds/cves/versions_test.go
@@ -162,6 +162,18 @@ func TestRepo(t *testing.T) {
 			expectedRepoURL: "https://github.com/apache/activemq-artemis",
 			expectedOk:      true,
 		},
+		{
+			description:     "Freedesktop cGit mirror",
+			inputLink:       "https://cgit.freedesktop.org/xorg/lib/libXRes/commit/?id=c05c6d918b0e2011d4bfa370c321482e34630b17",
+			expectedRepoURL: "https://gitlab.freedesktop.org/xorg/lib/libXRes",
+			expectedOk:      true,
+		},
+		{
+			description:     "Exact Freedesktop cGit mirror",
+			inputLink:       "https://cgit.freedesktop.org/xorg/lib/libXRes",
+			expectedRepoURL: "https://gitlab.freedesktop.org/xorg/lib/libXRes",
+			expectedOk:      true,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
References to cgit.freedesktop.org have been discovered in the wild, and this is doesn't quite walk and talk like other cGit webservers. Furthermore, it's a mirror of gitlab.freedesktop.org, so canonicalise to this in case callers want to clone the repo returned