### PR TITLE
Move repo detection to CPE dictionary parser

### DIFF
--- a/vulnfeeds/cmd/cperepos/README.md
+++ b/vulnfeeds/cmd/cperepos/README.md
@@ -1,0 +1,44 @@
+# CPE Dictionary Analysis Tool
+
+This extracts likely repository URLs from the NVD CPE Dictionary.
+
+It can utilise Debian copyright metadata for additional inference. Populate that
+metadata mirror with:
+
+```
+wget \
+  --directory debian_copyright
+    --mirror \
+    -A debian_copyright \
+    -A index.html \
+    https://metadata.ftp-master.debian.org/changelogs/main`
+```
+
+```
+cperepos analyzes the NVD CPE Dictionary for Open Source repository information.
+It reads the NVD CPE Dictionary XML file and outputs a JSON map of CPE products
+to discovered repository URLs.
+
+It can also output on stdout additional data about colliding CPE package names.
+
+Usage:
+
+    go run cmd/cperepos/main.go [flags]
+
+The flags are:
+
+      --cpe_dictionary
+        The path to the uncompressed NVD CPE Dictionary XML file, see https://nvd.nist.gov/products/cpe
+
+      --debian_metadata_path
+            The path to a directory containing a local mirror of Debian copyright metadata, see README.md
+
+      --output_dir
+            The directory to output cpe_product_to_repo.json and cpe_reference_description_frequency.csv in
+
+      --gcp_logging_project
+        The GCP project ID to utilise for Cloud Logging. Set to the empty string to log to stdout
+
+      --verbose
+        Output additional telemetry to stdout
+```

--- a/vulnfeeds/cpp/README.md
+++ b/vulnfeeds/cpp/README.md
@@ -5,16 +5,6 @@ This can be invoked as:
 ```shell
 go run cpp/main.go \
   --nvd_json cve_jsons/nvdcve-1.1-2022.json \
-  --debian_metadata_path debian_copyright/metadata.ftp-master.debian.org
 ```
 
-Use `cmd/download-cves/main.go` for downloading the NVD JSON files and
-
-```shell
-wget \
-  --directory debian_copyright
-  --mirror \
-  -A debian_copyright \
-  -A index.html \
-  https://metadata.ftp-master.debian.org/changelogs/main`
-```
+Use `cmd/download-cves/main.go` for downloading the NVD JSON files

--- a/vulnfeeds/cpp/main.go
+++ b/vulnfeeds/cpp/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/url"
 	"os"
 	"path/filepath"
 
@@ -27,6 +28,22 @@ var Metrics struct {
 	CVEsForApplications int
 	CVEsForKnownRepos   int
 	OSVRecordsGenerated int
+}
+
+// Looks at what the repo to determine if it contains code using an in-scope language
+func InScopeRepo(repoURL string) bool {
+	parsedURL, err := url.Parse(repoURL)
+	if err != nil {
+		Logger.Infof("Warning: %s failed to parse, skipping", repoURL)
+		return false
+	}
+
+	switch parsedURL.Hostname() {
+	case "github.com":
+		return InScopeGitHubRepo(repoURL)
+	default:
+		return InScopeGitRepo(repoURL)
+	}
 }
 
 // Use the GitHub API to query the repository's language metadata to make the determination.

--- a/vulnfeeds/cpp/main.go
+++ b/vulnfeeds/cpp/main.go
@@ -99,7 +99,6 @@ func CVEToOSV(CVE cves.CVEItem, directory string) error {
 
 func main() {
 	jsonPath := flag.String("nvd_json", "", "Path to NVD CVE JSON to examine.")
-	// debianMetadataPath := flag.String("debian_metadata_path", "", "Path to Debian copyright metadata")
 	outDir := flag.String("out_dir", "", "Path to output results.")
 
 	flag.Parse()

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -70,10 +70,10 @@ func Repo(u string) (string, error) {
 
 	// Were we handed a base repository URL from the get go?
 	if slices.Contains(supportedHosts, parsedURL.Hostname()) {
-		if len(strings.Split(parsedURL.Path, "/")) == 3 {
+		if len(strings.Split(strings.TrimSuffix(parsedURL.Path, "/"), "/")) == 3 {
 			return fmt.Sprintf("%s://%s%s", parsedURL.Scheme,
 					parsedURL.Hostname(),
-					parsedURL.Path),
+					strings.TrimSuffix(parsedURL.Path, "/")),
 				nil
 		}
 	}

--- a/vulnfeeds/cves/versions_test.go
+++ b/vulnfeeds/cves/versions_test.go
@@ -180,6 +180,12 @@ func TestRepo(t *testing.T) {
 			expectedRepoURL: "https://gitlab.freedesktop.org/spice/spice",
 			expectedOk:      true,
 		},
+		{
+			description:     "Exact repo URL with a trailing slash",
+			inputLink:       "https://github.com/pyca/pyopenssl/",
+			expectedRepoURL: "https://github.com/pyca/pyopenssl",
+			expectedOk:      true,
+		},
 	}
 
 	for _, tc := range tests {

--- a/vulnfeeds/utility/utility.go
+++ b/vulnfeeds/utility/utility.go
@@ -1,5 +1,7 @@
 package utility
 
+import "regexp"
+
 // SliceEqual returns true if two slices have identical items in the same order
 func SliceEqual[K comparable](a []K, b []K) bool {
 	if len(a) != len(b) {
@@ -31,4 +33,11 @@ func SliceEqualUnordered[K comparable](a []K, b []K) bool {
 		}
 	}
 	return true
+}
+
+// Checks if a URL is to a supported repo.
+func IsRepoURL(url string) bool {
+	re := regexp.MustCompile(`http[s]?:\/\/(?:c?git(?:hub|lab)?)\.|\.git$`)
+
+	return re.MatchString(url)
 }


### PR DESCRIPTION
* Remove redundant code from PoC NVD to OSV converter
* Move repository inference functionality over to CPE Dictionary parser
* Cover an edge case where bare repository URLs have a trailing slash