### PR TITLE
Add filter for ecosystem count

### DIFF
--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -313,7 +313,8 @@ def osv_get_ecosystem_counts():
         osv.Bug.public == True,  # pylint: disable=singleton-comparison
         osv.Bug.status == osv.BugStatus.PROCESSED).count()
 
-  return counts
+  filtered_counts = {key: elem for key, elem in counts.items() if elem > 0}
+  return filtered_counts
 
 
 def osv_query(search_string, page, affected_only, ecosystem):


### PR DESCRIPTION
This removes the UVI and GSD ecosystem entries on the vulnerabilities list. They still show up in the ecosystem list because there are entries that are marked as invalid.

We would require adding an additional index to have the `osv_get_ecosystems` function return only ecosystems with non invalid bugs. 