### PR TITLE
Start terraform set up for App Engine.

### DIFF
--- a/deployment/staging.yaml
+++ b/deployment/staging.yaml
@@ -31,7 +31,7 @@ steps:
   entrypoint: 'bash'
   args: [ '-c', "rm /workspace/service_account.json" ]
 - name: 'gcr.io/oss-vdb/deployment'
-  args: ['bash', '-ex', 'deploy.sh', 'app.yaml', '--no-promote']
+  args: ['bash', '-ex', 'deploy.sh', 'oss-vdb', 'app.yaml', '--no-promote']
   dir: gcp/appengine
 - name: 'gcr.io/oss-vdb/deployment'
   args: ['bash', '-ex', '../deploy_service_proxy', 'api-staging.osv.dev', 'osv-grpc-v1-staging', 'api_config_staging.yaml']

--- a/gcp/appengine/deploy.sh
+++ b/gcp/appengine/deploy.sh
@@ -1,9 +1,12 @@
 #!/bin/bash -ex
 
 if [ $# -lt 1 ]; then
-  echo "Usage: $0 <path to app.yaml> ..args.."
+  echo "Usage: $0 <project-id> <path to app.yaml> ..args.."
   exit 1
 fi
+
+project_id=$1
+shift
 
 pushd frontend3
 npm install
@@ -17,4 +20,4 @@ popd
 # Skip the '-e' editable library install as we copy in the "osv" library
 # directly instead for deployment.
 python3 -m pipenv requirements | grep -v '^-e '  > requirements.txt
-gcloud app deploy --quiet --project=oss-vdb --version=$(git rev-parse HEAD) "$@"
+gcloud app deploy --quiet --project=$project_id --version=$(git rev-parse HEAD) "$@"


### PR DESCRIPTION
- Set up App Engine instance.
- Set up Cloud Redis instances.
- Set up VPC connector.
- Add App Engine default IAM permissions.
- Make App Engine deploy script take in a project ID rather than hardcoding "oss-vdb".

TODO:
- Make App Engine deployment work by sharing a base app.yaml.

The test instance is running at https://oss-vdb-test.wl.r.appspot.com/ now by deploying a manually edited (and uncommitted) app.yaml.