### PR TITLE
Fix `last_affected` enumeration for deps.dev

### DIFF
--- a/osv/ecosystems.py
+++ b/osv/ecosystems.py
@@ -334,7 +334,8 @@ class Maven(DepsDevMixin):
                          limits=None):
     """Enumerate versions."""
     if use_deps_dev:
-      return self._deps_dev_enumerate(package, introduced, fixed, limits=limits)
+      return self._deps_dev_enumerate(
+          package, introduced, fixed, last_affected, limits=limits)
 
     get_versions = self._get_versions
     if shared_cache:

--- a/osv/ecosystems_test.py
+++ b/osv/ecosystems_test.py
@@ -252,5 +252,23 @@ class GetNextVersionTest(unittest.TestCase):
     cache_mock.set.assert_called_once()
 
 
+class EnumerateTest(unittest.TestCase):
+  """Enumerate test."""
+
+  @unittest.skipUnless(os.getenv('DEPSDEV_API_KEY'), 'Requires API key')
+  def test_maven_deps_dev(self):
+    """Test Maven using deps.dev."""
+    ecosystems.use_deps_dev = True
+    ecosystems.deps_dev_api_key = os.getenv('DEPSDEV_API_KEY')
+
+    ecosystem = ecosystems.get('Maven')
+    self.assertEqual(['10.0', '10.0.1', '11.0-rc1', '11.0'],
+                     ecosystem.enumerate_versions(
+                         'com.google.guava:guava', '10.0',
+                         last_affected='11.0'))
+
+    ecosystems.use_deps_dev = False
+
+
 if __name__ == '__main__':
   unittest.main(failfast=True)


### PR DESCRIPTION
The `last_affected` value was not being propagated properly in the deps.dev path. This only affects Maven OSV entries with `last_affected` specified.

Fixes #908.