### PR TITLE
Fix the default CPE Dictionary filename

### DIFF
--- a/vulnfeeds/cmd/cperepos/main.go
+++ b/vulnfeeds/cmd/cperepos/main.go
@@ -89,7 +89,7 @@ func (vp VendorProduct) MarshalText() (text []byte, err error) {
 type VendorProductToRepoMap map[VendorProduct][]string
 
 const (
-	CPEDictionaryDefault = "cve_jsons/nvdcpematch-1.0.json"
+	CPEDictionaryDefault = "cve_jsons/official-cpe-dictionary_v2.3.xml"
 	OutputDirDefault     = "."
 	projectId            = "oss-vdb"
 )


### PR DESCRIPTION
I realised I'd been using this exclusively with the flag until today when I wasn't, and had the default filename wrong.