### PR TITLE
UI tweaks.

### DIFF
--- a/gcp/appengine/frontend3/src/templates/about.html
+++ b/gcp/appengine/frontend3/src/templates/about.html
@@ -72,8 +72,8 @@
         <div class="answer">
           <p>OSV provides an <a href="/docs/" data-turbo="false">easy-to-use API</a>
           for querying against the aggregated database of vulnerabilities.</p>
-          <p><a href="https://github.com/google/osv-scanner">Command line tooling</a> is currently being developed to enable easy
-          vulnerability scanning of SBOMs, language manifests, and container images. Stay tuned!</p>
+          <p><a href="https://github.com/google/osv-scanner">Command line tooling</a> is also available for
+          vulnerability scanning of SBOMs, language manifests, and container images.</p>
         </div>
         <h3 class="question">How do I use OSV as a vulnerability database maintainer?</h3>
         <div class="answer">

--- a/gcp/appengine/frontend3/src/templates/home.html
+++ b/gcp/appengine/frontend3/src/templates/home.html
@@ -12,6 +12,7 @@
       <div class="cta">
         <a class="cta-primary link-button" href="{{ url_for('frontend_handlers.list_vulnerabilities') }}">Search Vulnerability Database</a>
         <a class="cta-primary link-button" href="#use-the-api">Use the API</a>
+        <a class="cta-primary link-button" href="#use-the-cli">CLI Tools</a>
       </div>
     </div>
     <div class="mdc-layout-grid__cell--span-12 ecosystems-section">
@@ -175,8 +176,8 @@ go install github.com/google/osv-scanner/cmd/osv-scanner@v1
         <div class="code-card mdc-layout-grid__cell--span-6 mdc-layout-grid__cell--span-12-tablet">
           <h3 class="code-card-title">Scan SBOM or Lockfiles</h3>
           <pre class="code-card-content" id="example-sbom-scan">
-$GOPATH/bin/osv-scanner --sbom=cycloned-or-spdx-sbom.json
-$GOPATH/bin/osv-scanner --lockfile=package-lock.json
+osv-scanner --sbom=cycloned-or-spdx-sbom.json
+osv-scanner --lockfile=package-lock.json
           </pre>
           <clipboard-copy class="code-card-copy" for="example-sbom-scan">
             <mwc-icon-button class="icon" icon="content_copy"></mwc-icon-button>
@@ -185,7 +186,7 @@ $GOPATH/bin/osv-scanner --lockfile=package-lock.json
         <div class="code-card mdc-layout-grid__cell--span-6 mdc-layout-grid__cell--span-12-tablet">
           <h3 class="code-card-title">Scan directory recursively</h3>
           <pre class="code-card-content" id="example-dir-scan">
-$GOPATH/bin/osv-scanner -r path/to/your/project
+osv-scanner -r path/to/your/project
           </pre>
           <clipboard-copy class="code-card-copy" for="example-dir-scan">
             <mwc-icon-button class="icon" icon="content_copy"></mwc-icon-button>


### PR DESCRIPTION
- Add "CLI Tools" button to home page to scroll down to the relevant section. (Similar to "Use the API").
- Remove the $GOPATH/bin prefix to match https://github.com/google/osv-scanner/pull/77.
- Tweak wording for OSV-Scanner section on "About" page

### CLI Tools button (desktop)
![image](https://user-images.githubusercontent.com/759062/208351893-cab0bc9d-fdd8-4508-bb1c-e9e3104e1787.png)

### CLI Tools button (mobile)
![image](https://user-images.githubusercontent.com/759062/208351941-b4ccfca2-08ee-488a-a764-b52352584e7f.png)
