### PR TITLE
Fix semver integration test

### DIFF
--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -236,11 +236,12 @@ class IntegrationTests(unittest.TestCase):
     go_2021_0052 = self._get('GO-2021-0052')
     ghsa_6vm3_jj99_7229 = self._get('GHSA-6vm3-jj99-7229')
     ghsa_h395_qcrw_5vmq = self._get('GHSA-h395-qcrw-5vmq')
-    expected_vulns = [ghsa_6vm3_jj99_7229,
-                      go_2020_0001,
-                      ghsa_h395_qcrw_5vmq,
-                      go_2021_0052,
-                      ]
+    expected_vulns = [
+        ghsa_6vm3_jj99_7229,
+        go_2020_0001,
+        ghsa_h395_qcrw_5vmq,
+        go_2021_0052,
+    ]
 
     # Test that a SemVer (believed to be vulnerable) version and an ecosystem
     # returns expected vulnerabilities.

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -233,8 +233,14 @@ class IntegrationTests(unittest.TestCase):
     package = 'github.com/gin-gonic/gin'
     ecosystem = 'Go'
     go_2020_0001 = self._get('GO-2020-0001')
+    go_2021_0052 = self._get('GO-2021-0052')
     ghsa_6vm3_jj99_7229 = self._get('GHSA-6vm3-jj99-7229')
-    expected_vulns = [go_2020_0001, ghsa_6vm3_jj99_7229]
+    ghsa_h395_qcrw_5vmq = self._get('GHSA-h395-qcrw-5vmq')
+    expected_vulns = [ghsa_6vm3_jj99_7229,
+                      go_2020_0001,
+                      ghsa_h395_qcrw_5vmq,
+                      go_2021_0052,
+                      ]
 
     # Test that a SemVer (believed to be vulnerable) version and an ecosystem
     # returns expected vulnerabilities.

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -230,8 +230,8 @@ class IntegrationTests(unittest.TestCase):
   def test_query_semver(self):
     """Test queries by SemVer."""
 
-    PACKAGE = 'github.com/nanobox-io/golang-nanoauth'
-    ECOSYSTEM = 'Go'
+    package = 'github.com/nanobox-io/golang-nanoauth'
+    ecosystem = 'Go'
     go_2020_0004 = self._get('GO-2020-0004')
     ghsa_hrm3_3xm6_x33h = self._get('GHSA-hrm3-3xm6-x33h')
     expected_vulns = [go_2020_0004, ghsa_hrm3_3xm6_x33h]
@@ -243,8 +243,8 @@ class IntegrationTests(unittest.TestCase):
         data=json.dumps({
             'version': '0.0.0-2017a',
             'package': {
-                'name': PACKAGE,
-                'ecosystem': ECOSYSTEM,
+                'name': package,
+                'ecosystem': ecosystem,
             }
         }),
         timeout=_TIMEOUT)
@@ -257,7 +257,7 @@ class IntegrationTests(unittest.TestCase):
         data=json.dumps({
             'version': '0.0.0-2017a',
             'package': {
-                'name': PACKAGE,
+                'name': package,
             }
         }),
         timeout=_TIMEOUT)
@@ -270,8 +270,8 @@ class IntegrationTests(unittest.TestCase):
         data=json.dumps({
             'version': '0.0.0-20160722212129-ac0cc4484ad4',
             'package': {
-                'name': PACKAGE,
-                'ecosystem': ECOSYSTEM,
+                'name': package,
+                'ecosystem': ecosystem,
             }
         }),
         timeout=_TIMEOUT)
@@ -284,8 +284,8 @@ class IntegrationTests(unittest.TestCase):
         data=json.dumps({
             'version': '0.0.0-20200131131040-063a3fb69896',
             'package': {
-                'name': PACKAGE,
-                'ecosystem': ECOSYSTEM,
+                'name': package,
+                'ecosystem': ecosystem,
             }
         }),
         timeout=_TIMEOUT)
@@ -298,8 +298,8 @@ class IntegrationTests(unittest.TestCase):
         data=json.dumps({
             'version': '0.0.0',
             'package': {
-                'name': PACKAGE,
-                'ecosystem': ECOSYSTEM,
+                'name': package,
+                'ecosystem': ecosystem,
             }
         }),
         timeout=_TIMEOUT)

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -251,7 +251,8 @@ class IntegrationTests(unittest.TestCase):
     self.assert_results_equal({'vulns': expected_vulns}, response.json())
 
     # Test that a SemVer with a (believed to be vulnerable) version and no
-    # ecosystem returns expected vulnerabilities.
+    # ecosystem returns expected vulnerabilities to test the fallback logic to
+    # try semver matching in the case that an ecosystem isn't specified.
     response = requests.post(
         _api() + '/v1/query',
         data=json.dumps({

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -228,65 +228,78 @@ class IntegrationTests(unittest.TestCase):
     self.assert_results_equal({}, response.json())
 
   def test_query_semver(self):
-    """Test query by SemVer."""
+    """Test queries by SemVer."""
+
+    PACKAGE = 'github.com/nanobox-io/golang-nanoauth'
+    ECOSYSTEM = 'Go'
     go_2020_0004 = self._get('GO-2020-0004')
     ghsa_hrm3_3xm6_x33h = self._get('GHSA-hrm3-3xm6-x33h')
     expected_vulns = [go_2020_0004, ghsa_hrm3_3xm6_x33h]
 
+    # Test that a SemVer with a pre-release (believed to be vulnerable) version
+    # and an ecosystem returns expected vulnerabilities.
     response = requests.post(
         _api() + '/v1/query',
         data=json.dumps({
             'version': '0.0.0-2017a',
             'package': {
-                'name': 'github.com/nanobox-io/golang-nanoauth',
-                'ecosystem': 'Go',
+                'name': PACKAGE,
+                'ecosystem': ECOSYSTEM,
             }
         }),
         timeout=_TIMEOUT)
     self.assert_results_equal({'vulns': expected_vulns}, response.json())
 
+    # Test that a SemVer with a pre-release (believed to be vulnerable) version
+    # and no ecosystem returns expected vulnerabilities.
     response = requests.post(
         _api() + '/v1/query',
         data=json.dumps({
             'version': '0.0.0-2017a',
             'package': {
-                'name': 'github.com/nanobox-io/golang-nanoauth',
+                'name': PACKAGE,
             }
         }),
         timeout=_TIMEOUT)
     self.assert_results_equal({'vulns': expected_vulns}, response.json())
 
+    # Test that a SemVer with a pre-release (believed to be vulnerable) version
+    # and an ecosystem returns expected vulnerabilities.
     response = requests.post(
         _api() + '/v1/query',
         data=json.dumps({
             'version': '0.0.0-20160722212129-ac0cc4484ad4',
             'package': {
-                'name': 'github.com/nanobox-io/golang-nanoauth',
-                'ecosystem': 'Go',
+                'name': PACKAGE,
+                'ecosystem': ECOSYSTEM,
             }
         }),
         timeout=_TIMEOUT)
     self.assert_results_equal({'vulns': expected_vulns}, response.json())
 
+    # Test that a SemVer with a pre-release (believed to be non-vulnerable)
+    # version and an ecosystem returns no vulnerabilities.
     response = requests.post(
         _api() + '/v1/query',
         data=json.dumps({
             'version': '0.0.0-20200131131040-063a3fb69896',
             'package': {
-                'name': 'github.com/nanobox-io/golang-nanoauth',
-                'ecosystem': 'Go',
+                'name': PACKAGE,
+                'ecosystem': ECOSYSTEM,
             }
         }),
         timeout=_TIMEOUT)
     self.assert_results_equal({}, response.json())
 
+    # Test that a SemVer (believed to be non-vulnerable) version and an
+    # ecosystem returns no vulnerabilities.
     response = requests.post(
         _api() + '/v1/query',
         data=json.dumps({
             'version': '0.0.0',
             'package': {
-                'name': 'github.com/nanobox-io/golang-nanoauth',
-                'ecosystem': 'Go',
+                'name': PACKAGE,
+                'ecosystem': ECOSYSTEM,
             }
         }),
         timeout=_TIMEOUT)

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -276,7 +276,7 @@ class IntegrationTests(unittest.TestCase):
     response = requests.post(
         _api() + '/v1/query',
         data=json.dumps({
-            'version': '1.6.3',
+            'version': '1.7.8',
             'package': {
                 'name': package,
                 'ecosystem': ecosystem,

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -230,6 +230,9 @@ class IntegrationTests(unittest.TestCase):
   def test_query_semver(self):
     """Test query by SemVer."""
     go_2020_0004 = self._get('GO-2020-0004')
+    ghsa_hrm3_3xm6_x33h = self._get('GHSA-hrm3-3xm6-x33h')
+    expected_vulns = [go_2020_0004, ghsa_hrm3_3xm6_x33h]
+
     response = requests.post(
         _api() + '/v1/query',
         data=json.dumps({
@@ -240,7 +243,7 @@ class IntegrationTests(unittest.TestCase):
             }
         }),
         timeout=_TIMEOUT)
-    self.assert_results_equal({'vulns': [go_2020_0004]}, response.json())
+    self.assert_results_equal({'vulns': expected_vulns}, response.json())
 
     response = requests.post(
         _api() + '/v1/query',
@@ -251,7 +254,7 @@ class IntegrationTests(unittest.TestCase):
             }
         }),
         timeout=_TIMEOUT)
-    self.assert_results_equal({'vulns': [go_2020_0004]}, response.json())
+    self.assert_results_equal({'vulns': expected_vulns}, response.json())
 
     response = requests.post(
         _api() + '/v1/query',
@@ -263,7 +266,7 @@ class IntegrationTests(unittest.TestCase):
             }
         }),
         timeout=_TIMEOUT)
-    self.assert_results_equal({'vulns': [go_2020_0004]}, response.json())
+    self.assert_results_equal({'vulns': expected_vulns}, response.json())
 
     response = requests.post(
         _api() + '/v1/query',

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -230,18 +230,18 @@ class IntegrationTests(unittest.TestCase):
   def test_query_semver(self):
     """Test queries by SemVer."""
 
-    package = 'github.com/nanobox-io/golang-nanoauth'
+    package = 'github.com/gin-gonic/gin'
     ecosystem = 'Go'
-    go_2020_0004 = self._get('GO-2020-0004')
-    ghsa_hrm3_3xm6_x33h = self._get('GHSA-hrm3-3xm6-x33h')
-    expected_vulns = [go_2020_0004, ghsa_hrm3_3xm6_x33h]
+    go_2020_0001 = self._get('GO-2020-0001')
+    ghsa_6vm3_jj99_7229 = self._get('GHSA-6vm3-jj99-7229')
+    expected_vulns = [go_2020_0001, ghsa_6vm3_jj99_7229]
 
-    # Test that a SemVer with a pre-release (believed to be vulnerable) version
-    # and an ecosystem returns expected vulnerabilities.
+    # Test that a SemVer (believed to be vulnerable) version and an ecosystem
+    # returns expected vulnerabilities.
     response = requests.post(
         _api() + '/v1/query',
         data=json.dumps({
-            'version': '0.0.0-2017a',
+            'version': '1.1.4',
             'package': {
                 'name': package,
                 'ecosystem': ecosystem,
@@ -250,12 +250,12 @@ class IntegrationTests(unittest.TestCase):
         timeout=_TIMEOUT)
     self.assert_results_equal({'vulns': expected_vulns}, response.json())
 
-    # Test that a SemVer with a pre-release (believed to be vulnerable) version
-    # and no ecosystem returns expected vulnerabilities.
+    # Test that a SemVer with a (believed to be vulnerable) version and no
+    # ecosystem returns expected vulnerabilities.
     response = requests.post(
         _api() + '/v1/query',
         data=json.dumps({
-            'version': '0.0.0-2017a',
+            'version': '1.1.4',
             'package': {
                 'name': package,
             }
@@ -263,40 +263,12 @@ class IntegrationTests(unittest.TestCase):
         timeout=_TIMEOUT)
     self.assert_results_equal({'vulns': expected_vulns}, response.json())
 
-    # Test that a SemVer with a pre-release (believed to be vulnerable) version
-    # and an ecosystem returns expected vulnerabilities.
-    response = requests.post(
-        _api() + '/v1/query',
-        data=json.dumps({
-            'version': '0.0.0-20160722212129-ac0cc4484ad4',
-            'package': {
-                'name': package,
-                'ecosystem': ecosystem,
-            }
-        }),
-        timeout=_TIMEOUT)
-    self.assert_results_equal({'vulns': expected_vulns}, response.json())
-
-    # Test that a SemVer with a pre-release (believed to be non-vulnerable)
-    # version and an ecosystem returns no vulnerabilities.
-    response = requests.post(
-        _api() + '/v1/query',
-        data=json.dumps({
-            'version': '0.0.0-20200131131040-063a3fb69896',
-            'package': {
-                'name': package,
-                'ecosystem': ecosystem,
-            }
-        }),
-        timeout=_TIMEOUT)
-    self.assert_results_equal({}, response.json())
-
-    # Test that a SemVer (believed to be non-vulnerable) version and an
+    # Test that a SemVer with a (believed to be non-vulnerable) version and an
     # ecosystem returns no vulnerabilities.
     response = requests.post(
         _api() + '/v1/query',
         data=json.dumps({
-            'version': '0.0.0',
+            'version': '1.6.3',
             'package': {
                 'name': package,
                 'ecosystem': ecosystem,


### PR DESCRIPTION
The current state of https://github.com/advisories/GHSA-hrm3-3xm6-x33h breaks the test, so use a
different package altogether. Adjust for test scenarios accordingly.