### PR TITLE
Update alpine mirror

### DIFF
--- a/osv/ecosystems.py
+++ b/osv/ecosystems.py
@@ -431,7 +431,7 @@ class NuGet(Ecosystem):
 class Alpine(Ecosystem):
   """Alpine packages ecosystem"""
 
-  _APORTS_GIT_URL = 'https://gitlab.alpinelinux.org/alpine/aports.git'
+  _APORTS_GIT_URL = 'https://github.com/alpinelinux/aports.git'
   _BRANCH_SUFFIX = '-stable'
   alpine_release_ver: str
   _GIT_REPO_PATH = 'version_enum/aports/'

--- a/osv/repos.py
+++ b/osv/repos.py
@@ -131,7 +131,9 @@ def _use_existing_checkout(git_url,
   repo = pygit2.Repository(checkout_dir)
   repo.cache = {}
   if repo.remotes['origin'].url != _git_mirror(git_url):
-    raise RuntimeError('Repo URL changed.')
+    logging.warn('origin url updated:\nOld: %s\nNew: %s',
+                 repo.remotes['origin'].url, _git_mirror(git_url))
+    repo.remotes['origin'].url = _git_mirror(git_url)
 
   if branch:
     _checkout_branch(repo, branch)


### PR DESCRIPTION
Changed the alpine git url, and also update existing repo url instead of throwing an exception. 

Was there a specific reason for the original code to throw an exception instead of updating if the url does not match?