### PR TITLE
Add cve conversion and alpine k8s tasks to osv-vdb-test

### DIFF
--- a/deployment/oss-vdb-test/k8s/cloudbuild.yaml
+++ b/deployment/oss-vdb-test/k8s/cloudbuild.yaml
@@ -30,6 +30,12 @@ steps:
   args: ['build', '-t', 'gcr.io/$PROJECT_ID/exporter', '-t', 'gcr.io/$PROJECT_ID/exporter:$COMMIT_SHA', '--build-arg', 'PROJECT=$PROJECT_ID', '.']
   dir: 'osv.dev/docker/exporter'
 - name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/alpine-cve-convert', '-t', 'gcr.io/$PROJECT_ID/alpine-cve-convert:$COMMIT_SHA', '-f', 'cmd/alpine/Dockerfile', '--build-arg', 'PROJECT=$PROJECT_ID', '.']
+  dir: 'osv.dev/vulnfeeds'
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/combine-to-osv', '-t', 'gcr.io/$PROJECT_ID/combine-to-osv:$COMMIT_SHA', '-f', 'cmd/combine-to-osv/Dockerfile', '--build-arg', 'PROJECT=$PROJECT_ID', '.']
+  dir: 'osv.dev/vulnfeeds'
+- name: gcr.io/cloud-builders/docker
   args: ['push', 'gcr.io/$PROJECT_ID/worker:$COMMIT_SHA']
 - name: gcr.io/cloud-builders/docker
   args: ['push', 'gcr.io/$PROJECT_ID/worker']
@@ -50,6 +56,12 @@ steps:
   dir: 'gke'
 - name: gcr.io/cloud-builders/gke-deploy
   args: ['run', '--filename=exporter', '--image=gcr.io/$PROJECT_ID/exporter:$COMMIT_SHA', '--location=us-central1-f', '--cluster=workers', '--output=/tmp']
+  dir: 'gke'
+- name: gcr.io/cloud-builders/gke-deploy
+  args: ['run', '--filename=alpine-cve-convert', '--image=gcr.io/$PROJECT_ID/worker:$COMMIT_SHA', '--location=us-central1-f', '--cluster=workers', '--output=/tmp', '--timeout=10m0s']
+  dir: 'gke'
+- name: gcr.io/cloud-builders/gke-deploy
+  args: ['run', '--filename=combine-to-osv', '--image=gcr.io/$PROJECT_ID/worker:$COMMIT_SHA', '--location=us-central1-f', '--cluster=workers', '--output=/tmp', '--timeout=10m0s']
   dir: 'gke'
 # TODO(ochang): Debian, indexer.
 # TODO(ochang): API deployment

--- a/deployment/oss-vdb-test/k8s/gke/alpine-cve-convert/alpine-cve-convert.yaml
+++ b/deployment/oss-vdb-test/k8s/gke/alpine-cve-convert/alpine-cve-convert.yaml
@@ -12,7 +12,7 @@ spec:
         spec:
           containers:
           - name: alpine-cve-convert
-            image: gcr.io/oss-vdb/alpine-cve-convert
+            image: gcr.io/oss-vdb-test/alpine-cve-convert:latest
             imagePullPolicy: Always
             securityContext:
               privileged: true

--- a/deployment/oss-vdb-test/k8s/gke/alpine-cve-convert/alpine-cve-convert.yaml
+++ b/deployment/oss-vdb-test/k8s/gke/alpine-cve-convert/alpine-cve-convert.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: alpine-cve-convert
+spec:
+  schedule: "0 */1 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3600
+      template:
+        spec:
+          containers:
+          - name: alpine-cve-convert
+            image: gcr.io/oss-vdb/alpine-cve-convert
+            imagePullPolicy: Always
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: 1
+                memory: "1G"
+              limits:
+                cpu: 1
+                memory: "2G"
+          restartPolicy: OnFailure
+          volumes:
+            - name: "ssd"
+              hostPath:
+                path: "/mnt/disks/ssd0"

--- a/deployment/oss-vdb-test/k8s/gke/alpine-cve-convert/alpine-cve-convert.yaml
+++ b/deployment/oss-vdb-test/k8s/gke/alpine-cve-convert/alpine-cve-convert.yaml
@@ -14,6 +14,9 @@ spec:
           - name: alpine-cve-convert
             image: gcr.io/oss-vdb-test/alpine-cve-convert:latest
             imagePullPolicy: Always
+            env:
+            - name: OUTPUT_GCS_BUCKET
+              value: osv-test-cve-osv-conversion
             securityContext:
               privileged: true
             resources:

--- a/deployment/oss-vdb-test/k8s/gke/combine-to-osv/combine-to-osv.yaml
+++ b/deployment/oss-vdb-test/k8s/gke/combine-to-osv/combine-to-osv.yaml
@@ -14,6 +14,9 @@ spec:
           - name: combine-to-osv
             image: gcr.io/oss-vdb-test/combine-to-osv:latest
             imagePullPolicy: Always
+            env:
+            - name: OUTPUT_GCS_BUCKET
+              value: osv-test-cve-osv-conversion
             securityContext:
               privileged: true
             resources:

--- a/deployment/oss-vdb-test/k8s/gke/combine-to-osv/combine-to-osv.yaml
+++ b/deployment/oss-vdb-test/k8s/gke/combine-to-osv/combine-to-osv.yaml
@@ -12,7 +12,7 @@ spec:
         spec:
           containers:
           - name: combine-to-osv
-            image: gcr.io/oss-vdb/combine-to-osv
+            image: gcr.io/oss-vdb-test/combine-to-osv:latest
             imagePullPolicy: Always
             securityContext:
               privileged: true

--- a/deployment/oss-vdb-test/k8s/gke/combine-to-osv/combine-to-osv.yaml
+++ b/deployment/oss-vdb-test/k8s/gke/combine-to-osv/combine-to-osv.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: combine-to-osv
+spec:
+  schedule: "30 */1 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3600
+      template:
+        spec:
+          containers:
+          - name: combine-to-osv
+            image: gcr.io/oss-vdb/combine-to-osv
+            imagePullPolicy: Always
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: 1
+                memory: "1G"
+              limits:
+                cpu: 1
+                memory: "2G"
+          restartPolicy: OnFailure
+          volumes:
+            - name: "ssd"
+              hostPath:
+                path: "/mnt/disks/ssd0"

--- a/deployment/terraform/environments/oss-vdb-test/.terraform.lock.hcl
+++ b/deployment/terraform/environments/oss-vdb-test/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/external" {
   version = "2.2.3"
   hashes = [
     "h1:I4IeCpJczlm0dnz4s4yfvPsj37iaGL5dvJ6fzSvCAhY=",
+    "h1:uvOYRWcVIqOZSl8YjjaB18yZFz1AWIt2CnK7O45rckg=",
     "zh:184ecd339d764de845db0e5b8a9c87893dcd0c9d822167f73658f89d80ec31c9",
     "zh:2661eaca31d17d6bbb18a8f673bbfe3fe1b9b7326e60d0ceb302017003274e3c",
     "zh:2c0a180f6d1fc2ba6e03f7dfc5f73b617e45408681f75bca75aa82f3796df0e4",
@@ -24,6 +25,7 @@ provider "registry.terraform.io/hashicorp/google" {
   version = "4.47.0"
   hashes = [
     "h1:Bk8UT17VdUXFF0ZLi+M5uOohwEFu9O6+FcaAT/jbme0=",
+    "h1:JXAoKJbm79Uo19YVObJCJcKPtNYBGVF+tQ91PtVIvt0=",
     "zh:030359653ee8e3a7a0ec30f06f7ac0d2bf5cb8bf895d06155646114fa13766e5",
     "zh:14b18f549466eb99cac08fd2d89c8df3591cc3688c9e5ed12fb4a957482d0e2d",
     "zh:3a9b9d1878f4004a7fee0ab8f8dea600307ad75a872f591590f704bf504b25af",
@@ -42,6 +44,7 @@ provider "registry.terraform.io/hashicorp/google" {
 provider "registry.terraform.io/hashicorp/google-beta" {
   version = "4.47.0"
   hashes = [
+    "h1:NYfsaCxorPlsWbxSVmG5pYWNoNXYiwPtEjDlnVPqiEE=",
     "h1:TJNEeUKihcASmHa7r/vUPm06/RQPbncpJ9TzsXlC1BA=",
     "zh:16bfb45fa9dcbb22a2f698978c579289ec7caaac1d7fe77f3f8f7e7cbb113a86",
     "zh:22865f5897e6c8dea19e24833cac134dd628724f086185d0e61188e69f073593",
@@ -61,6 +64,7 @@ provider "registry.terraform.io/hashicorp/google-beta" {
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.2.1"
   hashes = [
+    "h1:FbGfc+muBsC17Ohy5g806iuI1hQc4SIexpYCrQHQd8w=",
     "h1:Ic5DQgKFGWjWvTXZl7FMIoJGlKOW75ZHweWPT6DWvXU=",
     "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
     "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",

--- a/deployment/terraform/environments/oss-vdb-test/main.tf
+++ b/deployment/terraform/environments/oss-vdb-test/main.tf
@@ -5,6 +5,7 @@ module "osv_test" {
 
   public_import_logs_bucket     = "osv-test-public-import-logs"
   vulnerabilities_export_bucket = "osv-test-vulnerabilities"
+  cve_osv_conversion_bucket = "cve-osv-conversion"
 
   api_url               = "api.test.osv.dev"
   api_backend_image_tag = "20230105"

--- a/deployment/terraform/environments/oss-vdb-test/main.tf
+++ b/deployment/terraform/environments/oss-vdb-test/main.tf
@@ -5,7 +5,7 @@ module "osv_test" {
 
   public_import_logs_bucket     = "osv-test-public-import-logs"
   vulnerabilities_export_bucket = "osv-test-vulnerabilities"
-  cve_osv_conversion_bucket     = "cve-osv-conversion"
+  cve_osv_conversion_bucket     = "osv-test-cve-osv-conversion"
 
   api_url               = "api.test.osv.dev"
   api_backend_image_tag = "20230105"

--- a/deployment/terraform/environments/oss-vdb-test/main.tf
+++ b/deployment/terraform/environments/oss-vdb-test/main.tf
@@ -5,7 +5,7 @@ module "osv_test" {
 
   public_import_logs_bucket     = "osv-test-public-import-logs"
   vulnerabilities_export_bucket = "osv-test-vulnerabilities"
-  cve_osv_conversion_bucket = "cve-osv-conversion"
+  cve_osv_conversion_bucket     = "cve-osv-conversion"
 
   api_url               = "api.test.osv.dev"
   api_backend_image_tag = "20230105"

--- a/deployment/terraform/modules/osv/main.tf
+++ b/deployment/terraform/modules/osv/main.tf
@@ -83,6 +83,17 @@ resource "google_storage_bucket" "osv_vulnerabilities_export" {
   }
 }
 
+resource "google_storage_bucket" "cve_osv_conversion" {
+  project                     = var.project_id
+  name                        = var.cve_osv_conversion_bucket
+  location                    = "US"
+  uniform_bucket_level_access = true
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 # Service account permissions
 resource "google_service_account" "deployment_service" {
   project      = var.project_id

--- a/deployment/terraform/modules/osv/variables.tf
+++ b/deployment/terraform/modules/osv/variables.tf
@@ -13,6 +13,11 @@ variable "vulnerabilities_export_bucket" {
   description = "Name of bucket to export vulnerabilities to."
 }
 
+variable "cve_osv_conversion_bucket" {
+  type        = string
+  description = "Name of bucket to store converted CVEs in."
+}
+
 variable "api_url" {
   type        = string
   description = "URL to serve the OSV API on. Domain ownership and DNS settings has to be set up manually."

--- a/vulnfeeds/cmd/alpine/run_alpine_convert.sh
+++ b/vulnfeeds/cmd/alpine/run_alpine_convert.sh
@@ -9,11 +9,12 @@
 set -e
 
 OSV_PARTS_OUTPUT="parts/alpine"
+OUTPUT_BUCKET="${OUTPUT_GCS_BUCKET:=cve-osv-conversion}"
 
 echo "Setup initial directories"
 rm -rf $OSV_PARTS_OUTPUT && mkdir -p $OSV_PARTS_OUTPUT
 
 go run ./cmd/alpine/
 echo "Begin Syncing with cloud"
-gsutil -q -m rsync -d $OSV_PARTS_OUTPUT "gs://cve-osv-conversion/parts/alpine"
+gsutil -q -m rsync -d $OSV_PARTS_OUTPUT "gs://$OUTPUT_BUCKET/$OSV_PARTS_OUTPUT"
 echo "Successfully synced with cloud"


### PR DESCRIPTION
Adds the cve conversion release configs and process into the cloudbuild for the test environment, also sets up the cloud bucket in terraform.