### PR TITLE
Make the Maven tests use deps.dev

### DIFF
--- a/osv/ecosystems_test.py
+++ b/osv/ecosystems_test.py
@@ -38,7 +38,7 @@ class GetNextVersionTest(unittest.TestCase):
     with self.assertRaises(ecosystems.EnumerateError):
       ecosystem.next_version('doesnotexist123456', '1')
 
-  @unittest.skipIf(os.getenv('DEPSDEV_API_KEY'), 'Requires API key')
+  @unittest.skipIf(os.getenv('DEPSDEV_API_KEY'), 'Unnecessary if using deps.dev')
   def test_maven(self):
     """Test Maven."""
     ecosystem = ecosystems.get('Maven')
@@ -48,7 +48,7 @@ class GetNextVersionTest(unittest.TestCase):
     with self.assertRaises(ecosystems.EnumerateError):
       ecosystem.next_version('blah:doesnotexist123456', '1')
 
-  @unittest.skipIf(os.getenv('DEPSDEV_API_KEY'), 'Requires API key')
+  @unittest.skipIf(os.getenv('DEPSDEV_API_KEY'), 'Unnecessary if using deps.dev')
   @mock.patch('requests.Session.get', side_effect=requests.get)
   def test_maven_with_cache(self, mock_get):
     """Test Maven."""

--- a/osv/ecosystems_test.py
+++ b/osv/ecosystems_test.py
@@ -38,7 +38,8 @@ class GetNextVersionTest(unittest.TestCase):
     with self.assertRaises(ecosystems.EnumerateError):
       ecosystem.next_version('doesnotexist123456', '1')
 
-  @unittest.skipIf(os.getenv('DEPSDEV_API_KEY'), 'Unnecessary if using deps.dev')
+  @unittest.skipIf(
+      os.getenv('DEPSDEV_API_KEY'), 'Unnecessary if using deps.dev')
   def test_maven(self):
     """Test Maven."""
     ecosystem = ecosystems.get('Maven')
@@ -48,7 +49,8 @@ class GetNextVersionTest(unittest.TestCase):
     with self.assertRaises(ecosystems.EnumerateError):
       ecosystem.next_version('blah:doesnotexist123456', '1')
 
-  @unittest.skipIf(os.getenv('DEPSDEV_API_KEY'), 'Unnecessary if using deps.dev')
+  @unittest.skipIf(
+      os.getenv('DEPSDEV_API_KEY'), 'Unnecessary if using deps.dev')
   @mock.patch('requests.Session.get', side_effect=requests.get)
   def test_maven_with_cache(self, mock_get):
     """Test Maven."""

--- a/osv/ecosystems_test.py
+++ b/osv/ecosystems_test.py
@@ -38,6 +38,7 @@ class GetNextVersionTest(unittest.TestCase):
     with self.assertRaises(ecosystems.EnumerateError):
       ecosystem.next_version('doesnotexist123456', '1')
 
+  @unittest.skipIf(os.getenv('DEPSDEV_API_KEY'), 'Requires API key')
   def test_maven(self):
     """Test Maven."""
     ecosystem = ecosystems.get('Maven')
@@ -47,6 +48,7 @@ class GetNextVersionTest(unittest.TestCase):
     with self.assertRaises(ecosystems.EnumerateError):
       ecosystem.next_version('blah:doesnotexist123456', '1')
 
+  @unittest.skipIf(os.getenv('DEPSDEV_API_KEY'), 'Requires API key')
   @mock.patch('requests.Session.get', side_effect=requests.get)
   def test_maven_with_cache(self, mock_get):
     """Test Maven."""

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,9 @@
 #!/bin/bash -ex
 
 export PIPENV_IGNORE_VIRTUALENVS=1
+set +x  # Keep the API key out of execution logs
+export DEPSDEV_API_KEY=$(kubectl get secret secrets -o jsonpath='{.data.deps\.dev}' | base64 --decode)
+set -x
 python3 -m pipenv sync
 python3 -m pipenv run python -m unittest osv.bug_test
 python3 -m pipenv run python -m unittest osv.ecosystems_test

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,12 +2,12 @@
 
 export PIPENV_IGNORE_VIRTUALENVS=1
 set +x  # Keep the API key out of execution logs
-export DEPSDEV_API_KEY="$(gcloud --project oss-vdb secrets versions access latest --secret depsdotdev-key)"
-test -z "$DEPSDEV_API_KEY" && echo "No API key for deps.dev" && exit 1
+export DEPSDEV_API_KEY="$(gcloud --project oss-vdb secrets versions access latest --secret depsdotdev-key || true)"
+test -z "$DEPSDEV_API_KEY" && echo "FYI no API key for deps.dev, tests needing it will be skipped"
 set -x
 python3 -m pipenv sync
 python3 -m pipenv run python -m unittest osv.bug_test
-python3 -m pipenv run python -m unittest -v osv.ecosystems_test
+python3 -m pipenv run python -m unittest osv.ecosystems_test
 python3 -m pipenv run python -m unittest osv.maven.version_test
 python3 -m pipenv run python -m unittest osv.nuget_test
 python3 -m pipenv run python -m unittest osv.purl_helpers_test

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,13 +2,12 @@
 
 export PIPENV_IGNORE_VIRTUALENVS=1
 set +x  # Keep the API key out of execution logs
-# Temporarily confirm that we're getting expected output
-kubectl get secret secrets
-export DEPSDEV_API_KEY=$(kubectl get secret secrets -o jsonpath='{.data.deps\.dev}' | base64 --decode)
+export DEPSDEV_API_KEY="$(gcloud --project oss-vdb secrets versions access latest --secret depsdotdev-key)"
+test -z "$DEPSDEV_API_KEY" && echo "No API key for deps.dev" && exit 1
 set -x
 python3 -m pipenv sync
 python3 -m pipenv run python -m unittest osv.bug_test
-python3 -m pipenv run python -m unittest osv.ecosystems_test
+python3 -m pipenv run python -m unittest -v osv.ecosystems_test
 python3 -m pipenv run python -m unittest osv.maven.version_test
 python3 -m pipenv run python -m unittest osv.nuget_test
 python3 -m pipenv run python -m unittest osv.purl_helpers_test

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,6 +2,8 @@
 
 export PIPENV_IGNORE_VIRTUALENVS=1
 set +x  # Keep the API key out of execution logs
+# Temporarily confirm that we're getting expected output
+kubectl get secret secrets
 export DEPSDEV_API_KEY=$(kubectl get secret secrets -o jsonpath='{.data.deps\.dev}' | base64 --decode)
 set -x
 python3 -m pipenv sync


### PR DESCRIPTION
This matches production behaviour.

Avoid leaking the API key for deps.dev in test output.

This is an interim measure to address Maven flakiness causing intermittent test failures and won't work when we move tests over to GitHub Workflows. The ultimate solution is to make the tests hermetic and mock out the network dependencies.