### PR TITLE
Explicitly set API ESP version in Terraform

### DIFF
--- a/deployment/terraform/environments/oss-vdb-test/main.tf
+++ b/deployment/terraform/environments/oss-vdb-test/main.tf
@@ -8,6 +8,7 @@ module "osv_test" {
   cve_osv_conversion_bucket     = "osv-test-cve-osv-conversion"
 
   api_url               = "api.test.osv.dev"
+  esp_version           = "2.40.0"
   api_backend_image_tag = "20230105"
 }
 

--- a/deployment/terraform/environments/oss-vdb-test/main.tf
+++ b/deployment/terraform/environments/oss-vdb-test/main.tf
@@ -8,7 +8,7 @@ module "osv_test" {
   cve_osv_conversion_bucket     = "osv-test-cve-osv-conversion"
 
   api_url               = "api.test.osv.dev"
-  esp_version           = "2.40.0"
+  esp_version           = "2.41.0"
   api_backend_image_tag = "20230105"
 }
 

--- a/deployment/terraform/modules/osv/osv_api.tf
+++ b/deployment/terraform/modules/osv/osv_api.tf
@@ -46,6 +46,7 @@ resource "google_project_service" "grpc_service_api" {
 
 data "external" "esp_version" {
   program = ["bash", "${path.module}/scripts/esp_full_version"]
+  query   = { esp_tag = var.esp_version }
 }
 
 resource "null_resource" "grpc_proxy_image" {
@@ -62,7 +63,8 @@ resource "null_resource" "grpc_proxy_image" {
       bash ${path.module}/scripts/gcloud_build_image \
         -s ${var.api_url} \
         -c ${google_endpoints_service.grpc_service.config_id} \
-        -p ${var.project_id}
+        -p ${var.project_id} \
+        -v ${var.esp_version}
     EOS
   }
 }

--- a/deployment/terraform/modules/osv/variables.tf
+++ b/deployment/terraform/modules/osv/variables.tf
@@ -23,6 +23,11 @@ variable "api_url" {
   description = "URL to serve the OSV API on. Domain ownership and DNS settings has to be set up manually."
 }
 
+variable "esp_version" {
+  type        = string
+  description = "ESP version to use for OSV API frontend image."
+}
+
 variable "api_backend_image_tag" {
   type        = string
   description = "Image tag of GRPC backend that should be deployed."


### PR DESCRIPTION
Adds a Terraform variable to set the API frontend base ESP image version.
Stops Terraform trying to recreate the image whenever there's a new version available.