### PR TITLE
Fix semver_index_test not being run

### DIFF
--- a/osv/semver_index_test.py
+++ b/osv/semver_index_test.py
@@ -17,7 +17,7 @@ import unittest
 
 import semver
 
-import semver_index
+from . import semver_index
 
 
 class SemverIndexTests(unittest.TestCase):
@@ -40,7 +40,7 @@ class SemverIndexTests(unittest.TestCase):
     self.assertEqual('a1.0.0', semver_index.coerce('a1.0.0'))
     self.assertEqual('1.0.0.0', semver_index.coerce('1.0.0.0'))
     self.assertEqual('1.0.0-foo', semver_index.coerce('1.0.0-foo'))
-    self.assertEqual('1-foo', semver_index.coerce('1-foo'))
+    self.assertEqual('1.0.0-foo', semver_index.coerce('1-foo'))
 
   def test_normalize(self):
     """Test version normalization."""

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -12,3 +12,4 @@ python3 -m pipenv run python -m unittest osv.maven.version_test
 python3 -m pipenv run python -m unittest osv.nuget_test
 python3 -m pipenv run python -m unittest osv.purl_helpers_test
 python3 -m pipenv run python -m unittest osv.request_helper_test
+python3 -m pipenv run python -m unittest osv.semver_index_test


### PR DESCRIPTION
`semver_index_test` was not in `run_tests.sh`.
A change from a while ago also seems to have broken the test, which hadn't been picked up.