### PR TITLE
Update dependencies mid-week

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "config:base"
   ],
   "timezone": "Australia/Sydney",
-  "schedule": ["before 6am on monday"],
+  "schedule": ["before 6am on wednesday"],
   "labels": ["dependencies"],
   "postUpdateOptions": ["gomodTidy"],
   "packageRules": [


### PR DESCRIPTION
This way the release engineer of the week can focus on getting the release out on Monday, and then get any dependency PRs merged through the latter half of the week in time for the following Monday's release.