### PR TITLE
Fix Maven handling of version 0

### DIFF
--- a/osv/ecosystems/maven.py
+++ b/osv/ecosystems/maven.py
@@ -221,7 +221,7 @@ class Version:
     # Then, starting from the end of the version, the trailing "null" values
     # (0, "", "final", "ga") are trimmed.
     i = len(version.tokens) - 1
-    while i >= 0:
+    while i > 0:  # We always want at least one token for comparison
       if version.tokens[i].value in _TO_TRIM:
         version.tokens.pop(i)
         i -= 1

--- a/osv/ecosystems/maven_test.py
+++ b/osv/ecosystems/maven_test.py
@@ -249,6 +249,15 @@ class MavenVersionTest(unittest.TestCase):
 
     self.check_versions_equal('1', '01', '001')
 
+  def test_version_zero(self):
+    """Test comparison and equality with versions 0.0.0"""
+    self.check_versions_equal('0.0.0', '0.0', '0')
+    self.check_versions_equal('0.0.0-0.0.0', '0-final-ga', '0')
+    self.check_versions_order('0', '1')
+
+    # actual case from com.graphql-java:graphql-java
+    self.check_versions_order('0.0.0-2021-05-17T01-01-51-5ec03a8b', '20.0.0')
+
 
 class MavenEcosystemTest(unittest.TestCase):
   """Maven ecosystem helper tests."""


### PR DESCRIPTION
Fixes #1020 

This should also fix some of the missing vulnerabilities in #1018 on reimport:
- GHSA-v62j-cxhh-fq22
- GHSA-g2qw-6vrr-v6pq
- GHSA-789v-h9hw-38pg