### PR TITLE
Add the OSV Schema's `last_affected` field to the Event struct

### DIFF
--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -28,9 +28,10 @@ import (
 )
 
 type Event struct {
-	Introduced string `json:"introduced,omitempty" yaml:"introduced,omitempty"`
-	Fixed      string `json:"fixed,omitempty" yaml:"fixed,omitempty"`
-	Limit      string `json:"limit,omitempty" yaml:"limit,omitempty"`
+	Introduced   string `json:"introduced,omitempty" yaml:"introduced,omitempty"`
+	Fixed        string `json:"fixed,omitempty" yaml:"fixed,omitempty"`
+	Limit        string `json:"limit,omitempty" yaml:"limit,omitempty"`
+	LastAffected string `json:"last_affected,omitempty" yaml:"last_affected,omitempty"`
 }
 
 type Affected struct {


### PR DESCRIPTION
We will be relying on this for records generated from CVEs where the vulnerability is not fixed.