### PR TITLE
Downgrade another Docker package.

### DIFF
--- a/docker/worker-base/Dockerfile
+++ b/docker/worker-base/Dockerfile
@@ -43,7 +43,7 @@ ARG DOCKER_VERSION=5:20.10.23~3-0~ubuntu-bionic
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
     add-apt-repository \
         "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" && \
-    apt-get install -y docker-ce=$DOCKER_VERSION
+    apt-get install -y docker-ce=$DOCKER_VERSION docker-ce-cli=$DOCKER_VERSION
 
 # Install gcloud
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \


### PR DESCRIPTION
Per https://docs.docker.com/engine/install/ubuntu/ both "docker-ce" and "docker-ce-cli" need to be pinned.