### PR TITLE
Downgrade Docker a bit more.

### DIFF
--- a/docker/worker-base/Dockerfile
+++ b/docker/worker-base/Dockerfile
@@ -39,7 +39,7 @@ RUN pip3 install pipenv
 # Install Docker.
 # Pin the version to an older one due to gVisor incompatibilities.
 # See https://github.com/google/osv.dev/issues/1019#issuecomment-1427418758
-ARG DOCKER_VERSION=5:20.10.23~3-0~ubuntu-bionic
+ARG DOCKER_VERSION=5:20.10.22~3-0~ubuntu-bionic
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
     add-apt-repository \
         "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" && \


### PR DESCRIPTION
20.10.23 was still broken. I verified on GKE that 20.10.22 does indeed work.

Part of #1019