### PR TITLE
Consolidate staging & production docker registry and build images on push to master.

### DIFF
--- a/deployment/build-and-stage.yaml
+++ b/deployment/build-and-stage.yaml
@@ -28,6 +28,26 @@ steps:
   args: ['submodule', 'update', '--init', '--recursive']
   id: 'setup'
 
+# Poll currently-running Cloud Builds until this is the earliest-started build from this trigger/tag.
+# This is to avoid potential misordering of docker images and staging deployments
+# in the case when multiple commits to master occur close to one another.
+- name: gcr.io/cloud-builders/gcloud
+  entrypoint: bash
+  args:
+    - "-c"
+    - |
+      read current_build _ <<< $(gcloud builds list --filter=tags="build-and-stage" --format="value(id,create_time)" --sort-by=create_time --ongoing)
+      if [ -z $current_build ]; then exit 1; fi
+      while [ $current_build != $BUILD_ID ]
+      do
+        echo "Waiting for build $current_build"
+        sleep 30
+        read current_build _ <<< $(gcloud builds list --filter=tags="build-and-stage" --format="value(id,create_time)" --sort-by=create_time  --ongoing)
+        if [ -z $current_build ]; then exit 1; fi
+      done
+  id: 'cloud-build-queue'
+  waitFor: ['-']
+
 # Docker Image creation and tagging
 # Build/push worker-base image if there's an update.
 - name: 'gcr.io/cloud-builders/docker'
@@ -41,7 +61,7 @@ steps:
   waitFor: ['pull-worker-base']
 - name: gcr.io/cloud-builders/docker
   args: ['push', '--all-tags', 'gcr.io/oss-vdb/worker-base']
-  waitFor: ['build-worker-base']
+  waitFor: ['build-worker-base', 'cloud-build-queue']
 # Build/push core worker/importer/exporter images.
 - name: gcr.io/cloud-builders/docker
   args: ['build', '-t', 'gcr.io/oss-vdb/worker:latest', '-t', 'gcr.io/oss-vdb/worker:$COMMIT_SHA', '-f', 'docker/worker/Dockerfile', '.']
@@ -49,7 +69,7 @@ steps:
   waitFor: ['build-worker-base']
 - name: gcr.io/cloud-builders/docker
   args: ['push', '--all-tags', 'gcr.io/oss-vdb/worker']
-  waitFor: ['build-worker']
+  waitFor: ['build-worker', 'cloud-build-queue']
 
 - name: gcr.io/cloud-builders/docker
   args: ['build', '-t', 'gcr.io/oss-vdb/importer:latest', '-t', 'gcr.io/oss-vdb/importer:$COMMIT_SHA', '.']
@@ -58,7 +78,7 @@ steps:
   waitFor: ['build-worker']
 - name: gcr.io/cloud-builders/docker
   args: ['push', '--all-tags', 'gcr.io/oss-vdb/importer']
-  waitFor: ['build-importer']
+  waitFor: ['build-importer', 'cloud-build-queue']
 
 - name: gcr.io/cloud-builders/docker
   args: ['build', '-t', 'gcr.io/oss-vdb/exporter:latest', '-t', 'gcr.io/oss-vdb/exporter:$COMMIT_SHA', '.']
@@ -67,7 +87,7 @@ steps:
   waitFor: ['build-worker']
 - name: gcr.io/cloud-builders/docker
   args: ['push', '--all-tags', 'gcr.io/oss-vdb/exporter']
-  waitFor: ['build-exporter']
+  waitFor: ['build-exporter', 'cloud-build-queue']
 
 # Build/push vulnfeeds images
 - name: gcr.io/cloud-builders/docker
@@ -77,7 +97,7 @@ steps:
   waitFor: ['setup']
 - name: gcr.io/cloud-builders/docker
   args: ['push', '--all-tags', 'gcr.io/oss-vdb/alpine-cve-convert']
-  waitFor: ['build-alpine-cve-convert']
+  waitFor: ['build-alpine-cve-convert', 'cloud-build-queue']
 
 - name: gcr.io/cloud-builders/docker
   args: ['build', '-t', 'gcr.io/oss-vdb/combine-to-osv:latest', '-t', 'gcr.io/oss-vdb/combine-to-osv:$COMMIT_SHA', '-f', 'cmd/combine-to-osv/Dockerfile', '.']
@@ -86,7 +106,7 @@ steps:
   waitFor: ['setup']
 - name: gcr.io/cloud-builders/docker
   args: ['push', '--all-tags', 'gcr.io/oss-vdb/combine-to-osv']
-  waitFor: ['build-combine-to-osv']
+  waitFor: ['build-combine-to-osv', 'cloud-build-queue']
 
 # Build/push debian converter image
 - name: gcr.io/cloud-builders/docker
@@ -96,13 +116,14 @@ steps:
   waitFor: ['setup']
 - name: gcr.io/cloud-builders/docker
   args: ['push', '--all-tags', 'gcr.io/oss-vdb/debian-convert']
-  waitFor: ['build-debian-convert']
+  waitFor: ['build-debian-convert', 'cloud-build-queue']
 
 # Apply Terraform config to staging environment
 # TODO(michaelkedar): regenerate the api protobufs?
 - name: gcr.io/oss-vdb/terraform
   args: ['init', '-no-color']
   dir:  deployment/terraform/environments/oss-vdb-test
+# no waitFor means wait for every previous step to complete
 - name: gcr.io/oss-vdb/terraform
   args: ['apply', '-no-color', '-auto-approve']
   dir:  deployment/terraform/environments/oss-vdb-test

--- a/deployment/build-and-stage.yaml
+++ b/deployment/build-and-stage.yaml
@@ -17,13 +17,6 @@
 # eventually, they can probably be combined
 
 steps:
-### TODO: REMOVE STEPS BEFORE PR
-- name: gcr.io/cloud-builders/git
-  args: ['clone', 'https://github.com/michaelkedar/osv.dev.git', '.']
-- name: gcr.io/cloud-builders/git
-  args: ['checkout', '$COMMIT_SHA']
-###############
-
 - name: gcr.io/cloud-builders/git
   args: ['submodule', 'update', '--init', '--recursive']
   id: 'setup'

--- a/deployment/build-and-stage.yaml
+++ b/deployment/build-and-stage.yaml
@@ -19,48 +19,77 @@
 steps:
 - name: gcr.io/cloud-builders/git
   args: ['submodule', 'update', '--init', '--recursive']
+  id: 'setup'
 
 # Docker Image creation and tagging
 # Build/push worker-base image if there's an update.
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'bash'
   args: ['-c', 'docker pull gcr.io/oss-vdb/worker-base:latest || exit 0']
+  id: 'pull-worker-base'
+  waitFor: ['setup']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'gcr.io/oss-vdb/worker-base:latest', '-t', 'gcr.io/oss-vdb/worker-base:$COMMIT_SHA', '-f', 'docker/worker-base/Dockerfile', '--cache-from', 'gcr.io/oss-vdb/worker-base:latest', '--pull', '.']
+  id: 'build-worker-base'
+  waitFor: ['pull-worker-base']
 - name: gcr.io/cloud-builders/docker
   args: ['push', '--all-tags', 'gcr.io/oss-vdb/worker-base']
+  waitFor: ['build-worker-base']
 # Build/push core worker/importer/exporter images.
 - name: gcr.io/cloud-builders/docker
   args: ['build', '-t', 'gcr.io/oss-vdb/worker:latest', '-t', 'gcr.io/oss-vdb/worker:$COMMIT_SHA', '-f', 'docker/worker/Dockerfile', '.']
+  id: 'build-worker'
+  waitFor: ['build-worker-base']
 - name: gcr.io/cloud-builders/docker
   args: ['push', '--all-tags', 'gcr.io/oss-vdb/worker']
+  waitFor: ['build-worker']
+
 - name: gcr.io/cloud-builders/docker
   args: ['build', '-t', 'gcr.io/oss-vdb/importer:latest', '-t', 'gcr.io/oss-vdb/importer:$COMMIT_SHA', '.']
   dir: 'docker/importer'
+  id: 'build-importer'
+  waitFor: ['build-worker']
 - name: gcr.io/cloud-builders/docker
   args: ['push', '--all-tags', 'gcr.io/oss-vdb/importer']
+  waitFor: ['build-importer']
+
 - name: gcr.io/cloud-builders/docker
   args: ['build', '-t', 'gcr.io/oss-vdb/exporter:latest', '-t', 'gcr.io/oss-vdb/exporter:$COMMIT_SHA', '.']
   dir: 'docker/exporter'
+  id: 'build-exporter'
+  waitFor: ['build-worker']
 - name: gcr.io/cloud-builders/docker
   args: ['push', '--all-tags', 'gcr.io/oss-vdb/exporter']
+  waitFor: ['build-exporter']
+
 # Build/push vulnfeeds images
 - name: gcr.io/cloud-builders/docker
   args: ['build', '-t', 'gcr.io/oss-vdb/alpine-cve-convert:latest', '-t', 'gcr.io/oss-vdb/alpine-cve-convert:$COMMIT_SHA', '-f', 'cmd/alpine/Dockerfile', '.']
   dir: 'vulnfeeds'
+  id: 'build-alpine-cve-convert'
+  waitFor: ['setup']
 - name: gcr.io/cloud-builders/docker
   args: ['push', '--all-tags', 'gcr.io/oss-vdb/alpine-cve-convert']
+  waitFor: ['build-alpine-cve-convert']
+
 - name: gcr.io/cloud-builders/docker
   args: ['build', '-t', 'gcr.io/oss-vdb/combine-to-osv:latest', '-t', 'gcr.io/oss-vdb/combine-to-osv:$COMMIT_SHA', '-f', 'cmd/combine-to-osv/Dockerfile', '.']
   dir: 'vulnfeeds'
+  id: 'build-combine-to-osv'
+  waitFor: ['setup']
 - name: gcr.io/cloud-builders/docker
   args: ['push', '--all-tags', 'gcr.io/oss-vdb/combine-to-osv']
+  waitFor: ['build-combine-to-osv']
+
 # Build/push debian converter image
 - name: gcr.io/cloud-builders/docker
   args: ['build', '-t', 'gcr.io/oss-vdb/debian-convert:latest', '-t', 'gcr.io/oss-vdb/debian-convert:$COMMIT_SHA', '.']
   dir: 'vulnfeeds/tools/debian'
+  id: 'build-debian-convert'
+  waitFor: ['setup']
 - name: gcr.io/cloud-builders/docker
   args: ['push', '--all-tags', 'gcr.io/oss-vdb/debian-convert']
+  wairFor: ['build-debian-convert']
 
 # Apply Terraform config to staging environment
 # TODO(michaelkedar): regenerate the api protobufs?
@@ -80,6 +109,8 @@ serviceAccount: 'projects/oss-vdb/serviceAccounts/deployment@oss-vdb.iam.gservic
 logsBucket: gs://oss-vdb-tf/apply-logs
 options:
   machineType: N1_HIGHCPU_8
+
+tags: ['build-and-stage']
 
 images:
   - 'gcr.io/oss-vdb/worker-base:$COMMIT_SHA'

--- a/deployment/build-and-stage.yaml
+++ b/deployment/build-and-stage.yaml
@@ -18,7 +18,7 @@
 
 steps:
 - name: gcr.io/cloud-builders/git
-  args: ['submodule', 'update', '--init']
+  args: ['submodule', 'update', '--init', '--recursive']
 
 # Docker Image creation and tagging
 # Build/push worker-base image if there's an update.

--- a/deployment/build-and-stage.yaml
+++ b/deployment/build-and-stage.yaml
@@ -17,7 +17,50 @@
 # eventually, they can probably be combined
 
 steps:
-# TODO(michaelkedar): Docker image creation & tagging
+- name: gcr.io/cloud-builders/git
+  args: ['submodule', 'update', '--init']
+
+# Docker Image creation and tagging
+# Build/push worker-base image if there's an update.
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', 'docker pull gcr.io/oss-vdb/worker-base:latest || exit 0']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/oss-vdb/worker-base:latest', '-t', 'gcr.io/oss-vdb/worker-base:$COMMIT_SHA', '-f', 'docker/worker-base/Dockerfile', '--cache-from', 'gcr.io/oss-vdb/worker-base:latest', '--pull', '.']
+- name: gcr.io/cloud-builders/docker
+  args: ['push', '--all-tags', 'gcr.io/oss-vdb/worker-base']
+# Build/push core worker/importer/exporter images.
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/oss-vdb/worker:latest', '-t', 'gcr.io/oss-vdb/worker:$COMMIT_SHA', '-f', 'docker/worker/Dockerfile', '.']
+- name: gcr.io/cloud-builders/docker
+  args: ['push', '--all-tags', 'gcr.io/oss-vdb/worker']
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/oss-vdb/importer:latest', '-t', 'gcr.io/oss-vdb/importer:$COMMIT_SHA', '.']
+  dir: 'docker/importer'
+- name: gcr.io/cloud-builders/docker
+  args: ['push', '--all-tags', 'gcr.io/oss-vdb/importer']
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/oss-vdb/exporter:latest', '-t', 'gcr.io/oss-vdb/exporter:$COMMIT_SHA', '.']
+  dir: 'docker/exporter'
+- name: gcr.io/cloud-builders/docker
+  args: ['push', '--all-tags', 'gcr.io/oss-vdb/exporter']
+# Build/push vulnfeeds images
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/oss-vdb/alpine-cve-convert:latest', '-t', 'gcr.io/oss-vdb/alpine-cve-convert:$COMMIT_SHA', '-f', 'cmd/alpine/Dockerfile', '.']
+  dir: 'vulnfeeds'
+- name: gcr.io/cloud-builders/docker
+  args: ['push', '--all-tags', 'gcr.io/oss-vdb/alpine-cve-convert']
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/oss-vdb/combine-to-osv:latest', '-t', 'gcr.io/oss-vdb/combine-to-osv:$COMMIT_SHA', '-f', 'cmd/combine-to-osv/Dockerfile', '.']
+  dir: 'vulnfeeds'
+- name: gcr.io/cloud-builders/docker
+  args: ['push', '--all-tags', 'gcr.io/oss-vdb/combine-to-osv']
+# Build/push debian converter image
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/oss-vdb/debian-convert:latest', '-t', 'gcr.io/oss-vdb/debian-convert:$COMMIT_SHA', '.']
+  dir: 'vulnfeeds/tools/debian'
+- name: gcr.io/cloud-builders/docker
+  args: ['push', '--all-tags', 'gcr.io/oss-vdb/debian-convert']
 
 # Apply Terraform config to staging environment
 # TODO(michaelkedar): regenerate the api protobufs?
@@ -35,7 +78,14 @@ timeout: 7200s
 # Also set in Cloud Build:
 serviceAccount: 'projects/oss-vdb/serviceAccounts/deployment@oss-vdb.iam.gserviceaccount.com'
 logsBucket: gs://oss-vdb-tf/apply-logs
+options:
+  machineType: N1_HIGHCPU_8
 
-# TODO(michaelkedar): uncomment when docker image building is implemented
-# options:
-  # machineType: N1_HIGHCPU_8
+images:
+  - 'gcr.io/oss-vdb/worker-base:$COMMIT_SHA'
+  - 'gcr.io/oss-vdb/worker:$COMMIT_SHA'
+  - 'gcr.io/oss-vdb/importer:$COMMIT_SHA'
+  - 'gcr.io/oss-vdb/exporter:$COMMIT_SHA'
+  - 'gcr.io/oss-vdb/alpine-cve-convert:$COMMIT_SHA'
+  - 'gcr.io/oss-vdb/combine-to-osv:$COMMIT_SHA'
+  - 'gcr.io/oss-vdb/debian-convert:$COMMIT_SHA'

--- a/deployment/build-and-stage.yaml
+++ b/deployment/build-and-stage.yaml
@@ -45,6 +45,7 @@ steps:
         read current_build _ <<< $(gcloud builds list --filter=tags="build-and-stage" --format="value(id,create_time)" --sort-by=create_time  --ongoing)
         if [ -z $current_build ]; then exit 1; fi
       done
+      echo "Done waiting!"
   id: 'cloud-build-queue'
   waitFor: ['-']
 
@@ -122,7 +123,7 @@ steps:
 # Build/push api backend
 # TODO(michaelkedar): This is also done in staging.yaml. They should end up pushing identical images.
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/oss-vdb/osv-server:latest', 'gcr.io/oss-vdb/osv-server:$COMMIT_SHA', '-f', 'gcp/api/Dockerfile', '.']
+  args: ['build', '-t', 'gcr.io/oss-vdb/osv-server:latest', '-t', 'gcr.io/oss-vdb/osv-server:$COMMIT_SHA', '-f', 'gcp/api/Dockerfile', '.']
   id: 'build-osv-server'
   waitFor: ['setup']
 - name: 'gcr.io/cloud-builders/docker'

--- a/deployment/build-and-stage.yaml
+++ b/deployment/build-and-stage.yaml
@@ -62,6 +62,7 @@ steps:
 - name: gcr.io/cloud-builders/docker
   args: ['push', '--all-tags', 'gcr.io/oss-vdb/worker-base']
   waitFor: ['build-worker-base', 'cloud-build-queue']
+
 # Build/push core worker/importer/exporter images.
 - name: gcr.io/cloud-builders/docker
   args: ['build', '-t', 'gcr.io/oss-vdb/worker:latest', '-t', 'gcr.io/oss-vdb/worker:$COMMIT_SHA', '-f', 'docker/worker/Dockerfile', '.']
@@ -118,6 +119,16 @@ steps:
   args: ['push', '--all-tags', 'gcr.io/oss-vdb/debian-convert']
   waitFor: ['build-debian-convert', 'cloud-build-queue']
 
+# Build/push api backend
+# TODO(michaelkedar): This is also done in staging.yaml. They should end up pushing identical images.
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/oss-vdb/osv-server:latest', 'gcr.io/oss-vdb/osv-server:$COMMIT_SHA', '-f', 'gcp/api/Dockerfile', '.']
+  id: 'build-osv-server'
+  waitFor: ['setup']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['push', '--all-tags', 'gcr.io/oss-vdb/osv-server']
+  waitFor: ['build-osv-server', 'cloud-build-queue']
+
 # Apply Terraform config to staging environment
 # TODO(michaelkedar): regenerate the api protobufs?
 - name: gcr.io/oss-vdb/terraform
@@ -148,3 +159,4 @@ images:
   - 'gcr.io/oss-vdb/alpine-cve-convert:$COMMIT_SHA'
   - 'gcr.io/oss-vdb/combine-to-osv:$COMMIT_SHA'
   - 'gcr.io/oss-vdb/debian-convert:$COMMIT_SHA'
+  - 'gcr.io/oss-vdb/osv-server:$COMMIT_SHA'

--- a/deployment/build-and-stage.yaml
+++ b/deployment/build-and-stage.yaml
@@ -17,6 +17,13 @@
 # eventually, they can probably be combined
 
 steps:
+### TODO: REMOVE STEPS BEFORE PR
+- name: gcr.io/cloud-builders/git
+  args: ['clone', 'https://github.com/michaelkedar/osv.dev.git', '.']
+- name: gcr.io/cloud-builders/git
+  args: ['checkout', '$COMMIT_SHA']
+###############
+
 - name: gcr.io/cloud-builders/git
   args: ['submodule', 'update', '--init', '--recursive']
   id: 'setup'
@@ -89,7 +96,7 @@ steps:
   waitFor: ['setup']
 - name: gcr.io/cloud-builders/docker
   args: ['push', '--all-tags', 'gcr.io/oss-vdb/debian-convert']
-  wairFor: ['build-debian-convert']
+  waitFor: ['build-debian-convert']
 
 # Apply Terraform config to staging environment
 # TODO(michaelkedar): regenerate the api protobufs?

--- a/deployment/build-and-stage.yaml
+++ b/deployment/build-and-stage.yaml
@@ -30,15 +30,20 @@ steps:
     - "-c"
     - |
       read current_build _ <<< $(gcloud builds list --filter=tags="build-and-stage" --format="value(id,create_time)" --sort-by=create_time --ongoing)
-      if [ -z $current_build ]; then exit 1; fi
-      while [ $current_build != $BUILD_ID ]
-      do
-        echo "Waiting for build $current_build"
+      if [[ -z "${current_build}" ]]; then
+        echo "Could not find any matching builds."
+        exit 1
+      fi
+      while [[ "${current_build}" != "${BUILD_ID}" ]]; do
+        echo "Waiting for build ${current_build}"
         sleep 30
         read current_build _ <<< $(gcloud builds list --filter=tags="build-and-stage" --format="value(id,create_time)" --sort-by=create_time  --ongoing)
-        if [ -z $current_build ]; then exit 1; fi
+        if [[ -z "${current_build}" ]]; then
+          echo "Could not find any matching builds."
+          exit 1;
+        fi
       done
-      echo "Done waiting!"
+      echo "Finished waiting for other builds."
   id: 'cloud-build-queue'
   waitFor: ['-']
 

--- a/deployment/oss-vdb-test/k8s/cloudbuild.yaml
+++ b/deployment/oss-vdb-test/k8s/cloudbuild.yaml
@@ -5,91 +5,32 @@ steps:
 - name: gcr.io/cloud-builders/git
   args: ['checkout', '$COMMIT_SHA']
   dir: 'osv.dev'
-- name: gcr.io/cloud-builders/git
-  args: ['submodule', 'update', '--init']
-  dir: 'osv.dev'
-# Build/push worker-base image if there's an update.
-- name: 'gcr.io/cloud-builders/docker'
-  entrypoint: 'bash'
-  args: ['-c', 'docker pull gcr.io/$PROJECT_ID/worker-base:latest || exit 0']
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/worker-base', '-t', 'gcr.io/$PROJECT_ID/worker-base:$COMMIT_SHA', '-f', 'docker/worker-base/Dockerfile', '--cache-from', 'gcr.io/$PROJECT_ID/worker-base:latest', '--pull', '.']
-  dir: 'osv.dev'
-- name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/worker-base:$COMMIT_SHA']
-- name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/worker-base']
-# Build/push core worker/importer/exporter images.
-- name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/worker', '-t', 'gcr.io/$PROJECT_ID/worker:$COMMIT_SHA', '-f', 'docker/worker/Dockerfile', '--build-arg', 'PROJECT=$PROJECT_ID', '.']
-  dir: 'osv.dev'
-- name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/importer', '-t', 'gcr.io/$PROJECT_ID/importer:$COMMIT_SHA', '--build-arg', 'PROJECT=$PROJECT_ID', '.']
-  dir: 'osv.dev/docker/importer'
-- name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/exporter', '-t', 'gcr.io/$PROJECT_ID/exporter:$COMMIT_SHA', '--build-arg', 'PROJECT=$PROJECT_ID', '.']
-  dir: 'osv.dev/docker/exporter'
-- name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/worker:$COMMIT_SHA']
-- name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/worker']
-- name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/importer:$COMMIT_SHA']
-- name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/importer']
-- name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/exporter:$COMMIT_SHA']
-- name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/exporter']
-# Build/push vulnfeeds images
-- name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/alpine-cve-convert', '-t', 'gcr.io/$PROJECT_ID/alpine-cve-convert:$COMMIT_SHA', '-f', 'cmd/alpine/Dockerfile', '--build-arg', 'PROJECT=$PROJECT_ID', '.']
-  dir: 'osv.dev/vulnfeeds'
-- name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/combine-to-osv', '-t', 'gcr.io/$PROJECT_ID/combine-to-osv:$COMMIT_SHA', '-f', 'cmd/combine-to-osv/Dockerfile', '--build-arg', 'PROJECT=$PROJECT_ID', '.']
-  dir: 'osv.dev/vulnfeeds'
-- name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/alpine-cve-convert:$COMMIT_SHA']
-- name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/alpine-cve-convert']
-- name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/combine-to-osv:$COMMIT_SHA']
-- name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/combine-to-osv']
-# Build/push debian converter images
-- name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/debian-convert', '-t', 'gcr.io/$PROJECT_ID/debian-convert:$COMMIT_SHA', '.']
-  dir: 'osv.dev/vulnfeeds/tools/debian'
-- name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/debian-convert']
-- name: gcr.io/cloud-builders/docker
-  args: ['push', 'gcr.io/$PROJECT_ID/debian-convert:$COMMIT_SHA']
 # Apply GKE configs.
 - name: gcr.io/cloud-builders/gke-deploy
-  args: ['run', '--filename=workers', '--image=gcr.io/$PROJECT_ID/worker:$COMMIT_SHA', '--location=us-central1-f', '--cluster=workers', '--output=/tmp', '--timeout=10m0s']
+  args: ['run', '--filename=workers', '--image=gcr.io/oss-vdb/worker:$COMMIT_SHA', '--location=us-central1-f', '--cluster=workers', '--output=/tmp', '--timeout=10m0s']
   dir: 'gke'
 - name: gcr.io/cloud-builders/gke-deploy
-  args: ['run', '--filename=importer', '--image=gcr.io/$PROJECT_ID/importer:$COMMIT_SHA', '--location=us-central1-f', '--cluster=workers', '--output=/tmp']
+  args: ['run', '--filename=importer', '--image=gcr.io/oss-vdb/importer:$COMMIT_SHA', '--location=us-central1-f', '--cluster=workers', '--output=/tmp']
   dir: 'gke'
 - name: gcr.io/cloud-builders/gke-deploy
-  args: ['run', '--filename=exporter', '--image=gcr.io/$PROJECT_ID/exporter:$COMMIT_SHA', '--location=us-central1-f', '--cluster=workers', '--output=/tmp']
+  args: ['run', '--filename=exporter', '--image=gcr.io/oss-vdb/exporter:$COMMIT_SHA', '--location=us-central1-f', '--cluster=workers', '--output=/tmp']
   dir: 'gke'
 - name: gcr.io/cloud-builders/gke-deploy
-  args: ['run', '--filename=alpine-cve-convert', '--image=gcr.io/$PROJECT_ID/alpine-cve-convert:$COMMIT_SHA', '--location=us-central1-f', '--cluster=workers', '--output=/tmp']
+  args: ['run', '--filename=alpine-cve-convert', '--image=gcr.io/oss-vdb/alpine-cve-convert:$COMMIT_SHA', '--location=us-central1-f', '--cluster=workers', '--output=/tmp']
   dir: 'gke'
 - name: gcr.io/cloud-builders/gke-deploy
-  args: ['run', '--filename=combine-to-osv', '--image=gcr.io/$PROJECT_ID/combine-to-osv:$COMMIT_SHA', '--location=us-central1-f', '--cluster=workers', '--output=/tmp']
+  args: ['run', '--filename=combine-to-osv', '--image=gcr.io/oss-vdb/combine-to-osv:$COMMIT_SHA', '--location=us-central1-f', '--cluster=workers', '--output=/tmp']
   dir: 'gke'
 - name: gcr.io/cloud-builders/gke-deploy
-  args: ['run', '--filename=debian/debian-convert.yaml', '--image=gcr.io/$PROJECT_ID/debian-convert:$COMMIT_SHA', '--location=us-central1-f', '--cluster=workers', '--output=/tmp']
+  args: ['run', '--filename=debian/debian-convert.yaml', '--image=gcr.io/oss-vdb/debian-convert:$COMMIT_SHA', '--location=us-central1-f', '--cluster=workers', '--output=/tmp']
   dir: 'gke'
 - name: gcr.io/cloud-builders/gke-deploy
-  args: ['run', '--filename=debian/debian-first-version.yaml', '--image=gcr.io/$PROJECT_ID/debian-convert:$COMMIT_SHA', '--location=us-central1-f', '--cluster=workers', '--output=/tmp']
+  args: ['run', '--filename=debian/debian-first-version.yaml', '--image=gcr.io/oss-vdb/debian-convert:$COMMIT_SHA', '--location=us-central1-f', '--cluster=workers', '--output=/tmp']
   dir: 'gke'
 # TODO(ochang): Debian, indexer.
 # TODO(ochang): API deployment
 timeout: 2400s
-serviceAccount: 'projects/$PROJECT_ID/serviceAccounts/deployment@$PROJECT_ID.iam.gserviceaccount.com'
+serviceAccount: 'projects/oss-vdb-test/serviceAccounts/deployment@oss-vdb-test.iam.gserviceaccount.com'
 options:
   logging: CLOUD_LOGGING_ONLY
   machineType: N1_HIGHCPU_8

--- a/deployment/oss-vdb-test/k8s/cloudbuild.yaml
+++ b/deployment/oss-vdb-test/k8s/cloudbuild.yaml
@@ -1,10 +1,4 @@
 steps:
-# Checkout at specified commit.
-- name: gcr.io/cloud-builders/git
-  args: ['clone', 'https://github.com/google/osv.dev.git']
-- name: gcr.io/cloud-builders/git
-  args: ['checkout', '$COMMIT_SHA']
-  dir: 'osv.dev'
 # Apply GKE configs.
 - name: gcr.io/cloud-builders/gke-deploy
   args: ['run', '--filename=workers', '--image=gcr.io/oss-vdb/worker:$COMMIT_SHA', '--location=us-central1-f', '--cluster=workers', '--output=/tmp', '--timeout=10m0s']
@@ -33,6 +27,5 @@ timeout: 2400s
 serviceAccount: 'projects/oss-vdb-test/serviceAccounts/deployment@oss-vdb-test.iam.gserviceaccount.com'
 options:
   logging: CLOUD_LOGGING_ONLY
-  machineType: N1_HIGHCPU_8
 tags:
-- prod-deploy
+- stage-deploy

--- a/deployment/oss-vdb-test/k8s/gke/exporter/exporter.yaml
+++ b/deployment/oss-vdb-test/k8s/gke/exporter/exporter.yaml
@@ -11,8 +11,11 @@ spec:
         spec:
           containers:
           - name: exporter
-            image: gcr.io/oss-vdb-test/exporter:latest
+            image: gcr.io/oss-vdb/exporter:latest
             imagePullPolicy: Always
+            env:
+            - name: GOOGLE_CLOUD_PROJECT
+              value: oss-vdb-test
             args:
               # TODO(michaelkedar): single source of truth w/ terraform config
               - "--bucket=osv-test-vulnerabilities"

--- a/deployment/oss-vdb-test/k8s/gke/importer/importer.yaml
+++ b/deployment/oss-vdb-test/k8s/gke/importer/importer.yaml
@@ -19,7 +19,7 @@ spec:
             args:
               # TODO(michaelkedar): single source of truth w/ terraform config
               - "--public_log_bucket=osv-test-public-import-logs"
-              # TODO(michaelkear): secrets
+              # TODO(michaelkedar): secrets
               # - "--ssh_key_public=/secrets/ssh.pub"
               # - "--ssh_key_private=/secrets/ssh"
             volumeMounts:

--- a/deployment/oss-vdb-test/k8s/gke/importer/importer.yaml
+++ b/deployment/oss-vdb-test/k8s/gke/importer/importer.yaml
@@ -11,14 +11,15 @@ spec:
         spec:
           containers:
           - name: importer
-          # gcr.io/<PROJECT_ID>/[...] must match the build project id.
-          # TODO(michaelkedar): Investigate dynamically setting this. [kustomize]
-            image: gcr.io/oss-vdb-test/importer:latest
+            image: gcr.io/oss-vdb/importer:latest
             imagePullPolicy: Always
-            # TODO(michaelkear): secrets
+            env:
+            - name: GOOGLE_CLOUD_PROJECT
+              value: oss-vdb-test
             args:
               # TODO(michaelkedar): single source of truth w/ terraform config
               - "--public_log_bucket=osv-test-public-import-logs"
+              # TODO(michaelkear): secrets
               # - "--ssh_key_public=/secrets/ssh.pub"
               # - "--ssh_key_private=/secrets/ssh"
             volumeMounts:

--- a/deployment/oss-vdb-test/k8s/gke/workers/workers.yaml
+++ b/deployment/oss-vdb-test/k8s/gke/workers/workers.yaml
@@ -28,23 +28,22 @@ spec:
     spec:
       containers:
       - name: worker-private
-        # gcr.io/<PROJECT_ID>/[...] must match the build project id.
-        # TODO(michaelkedar): Investigate dynamically setting this. [kustomize]
-        image: gcr.io/oss-vdb-test/worker:latest
+        image: gcr.io/oss-vdb/worker:latest
         imagePullPolicy: Always
-        # TODO(michaelkedar): secrets
-        # env:
-        #   - name: DEPS_DEV_API_KEY
-        #     valueFrom:
-        #        secretKeyRef:
-        #         name: secrets
-        #         key: deps.dev
+        env:
+          - name: GOOGLE_CLOUD_PROJECT
+            value: oss-vdb-test
+          # TODO(michaelkedar): secrets
+          # - name: DEPS_DEV_API_KEY
+          #   valueFrom:
+          #      secretKeyRef:
+          #       name: secrets
+          #       key: deps.dev
         args:
-        #   - "--ssh_key_public=/secrets/ssh.pub"
-        #   - "--ssh_key_private=/secrets/ssh"
-        # TODO(michaelkedar): Somehow grab or enforce redis endpoint from terraform
-          - "--redis_host=10.102.25.214"
-        # NB(michaelkedar): deps_dev is commented out in real deployment as well
+          # - "--ssh_key_public=/secrets/ssh.pub"
+          # - "--ssh_key_private=/secrets/ssh"
+          # TODO(michaelkedar): Somehow grab or enforce redis endpoint from terraform
+          - "--redis_host=10.102.25.213"
           # - "--deps_dev_api_key=$(DEPS_DEV_API_KEY)"
         volumeMounts:
           - mountPath: "/work"

--- a/deployment/oss-vdb-test/k8s/gke/workers/workers.yaml
+++ b/deployment/oss-vdb-test/k8s/gke/workers/workers.yaml
@@ -43,7 +43,7 @@ spec:
           # - "--ssh_key_public=/secrets/ssh.pub"
           # - "--ssh_key_private=/secrets/ssh"
           # TODO(michaelkedar): Somehow grab or enforce redis endpoint from terraform
-          - "--redis_host=10.102.25.213"
+          - "--redis_host=10.102.25.214"
           # - "--deps_dev_api_key=$(DEPS_DEV_API_KEY)"
         volumeMounts:
           - mountPath: "/work"

--- a/docker/exporter/Dockerfile
+++ b/docker/exporter/Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PROJECT=oss-vdb
-FROM gcr.io/${PROJECT}/worker
+FROM gcr.io/oss-vdb/worker
 
 COPY exporter.py /usr/local/bin
 RUN chmod 755 /usr/local/bin/exporter.py

--- a/docker/exporter/build.sh
+++ b/docker/exporter/build.sh
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PROJECT=${GOOGLE_CLOUD_PROJECT:-oss-vdb}
-
-docker build -t gcr.io/$PROJECT/exporter:$1 . && \
-docker build -t gcr.io/$PROJECT/exporter:latest . && \
-docker push gcr.io/$PROJECT/exporter:$1 && \
-docker push gcr.io/$PROJECT/exporter:latest
+docker build -t gcr.io/oss-vdb/exporter:$1 . && \
+docker build -t gcr.io/oss-vdb/exporter:latest . && \
+docker push gcr.io/oss-vdb/exporter:$1 && \
+docker push gcr.io/oss-vdb/exporter:latest

--- a/docker/importer/Dockerfile
+++ b/docker/importer/Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PROJECT=oss-vdb
-FROM gcr.io/${PROJECT}/worker
+FROM gcr.io/oss-vdb/worker
 
 COPY importer.py /usr/local/bin
 RUN chmod 755 /usr/local/bin/importer.py

--- a/docker/importer/build.sh
+++ b/docker/importer/build.sh
@@ -13,9 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PROJECT=${GOOGLE_CLOUD_PROJECT:-oss-vdb}
 
-docker build -t gcr.io/$PROJECT/importer:$1 . && \
-docker build -t gcr.io/$PROJECT/importer:latest . && \
-docker push gcr.io/$PROJECT/importer:$1 && \
-docker push gcr.io/$PROJECT/importer:latest
+docker build -t gcr.io/oss-vdb/importer:$1 . && \
+docker build -t gcr.io/oss-vdb/importer:latest . && \
+docker push gcr.io/oss-vdb/importer:$1 && \
+docker push gcr.io/oss-vdb/importer:latest

--- a/docker/worker-base/build.sh
+++ b/docker/worker-base/build.sh
@@ -16,8 +16,6 @@
 # Build from root context.
 cd ../../
 
-PROJECT=${GOOGLE_CLOUD_PROJECT:-oss-vdb}
-
-docker build -t gcr.io/$PROJECT/worker-base:$1 -t gcr.io/$PROJECT/worker-base:latest -f docker/worker-base/Dockerfile --pull . && \
-gcloud docker -- push gcr.io/$PROJECT/worker-base:$1 && \
-gcloud docker -- push gcr.io/$PROJECT/worker-base:latest
+docker build -t gcr.io/oss-vdb/worker-base:$1 -t gcr.io/oss-vdb/worker-base:latest -f docker/worker-base/Dockerfile --pull . && \
+gcloud docker -- push gcr.io/oss-vdb/worker-base:$1 && \
+gcloud docker -- push gcr.io/oss-vdb/worker-base:latest

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PROJECT=oss-vdb
-FROM gcr.io/${PROJECT}/worker-base
+FROM gcr.io/oss-vdb/worker-base
 
 RUN apt-get update && apt-get upgrade -y
 
@@ -30,8 +29,4 @@ RUN cd /env/docker/worker && pip3 install pipenv && pipenv install --deploy --sy
 COPY docker/worker/oss_fuzz.py docker/worker/worker.py /usr/local/bin/
 RUN chmod 755 /usr/local/bin/worker.py
 
-# ARGs after a FROM are unusable without redeclaring
-# See: https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
-ARG PROJECT
-ENV GOOGLE_CLOUD_PROJECT ${PROJECT}
 ENTRYPOINT ["worker.py"]

--- a/docker/worker/build.sh
+++ b/docker/worker/build.sh
@@ -16,8 +16,6 @@
 # Build from root context.
 cd ../../
 
-PROJECT=${GOOGLE_CLOUD_PROJECT:-oss-vdb}
-
-docker build -t gcr.io/$PROJECT/worker:$1 -t gcr.io/$PROJECT/worker:latest -f docker/worker/Dockerfile . --build-arg PROJECT=$PROJECT && \
-gcloud docker -- push gcr.io/$PROJECT/worker:$1 && \
-gcloud docker -- push gcr.io/$PROJECT/worker:latest
+docker build -t gcr.io/oss-vdb/worker:$1 -t gcr.io/oss-vdb/worker:latest -f docker/worker/Dockerfile . && \
+gcloud docker -- push gcr.io/oss-vdb/worker:$1 && \
+gcloud docker -- push gcr.io/oss-vdb/worker:latest

--- a/gcp/api/deploy_backend
+++ b/gcp/api/deploy_backend
@@ -11,8 +11,8 @@ name=$3
 
 if [ -z "$CLOUDBUILD" ]; then
   pushd ../../
-  docker build -t "gcr.io/$project_id/osv-server:$tag" -f gcp/api/Dockerfile .
-  docker push "gcr.io/$project_id/osv-server:$tag"
+  docker build -t "gcr.io/oss-vdb/osv-server:$tag" -f gcp/api/Dockerfile .
+  docker push "gcr.io/oss-vdb/osv-server:$tag"
   popd
 fi
 
@@ -20,4 +20,4 @@ gcloud run deploy $name \
   --platform managed \
   --project=$project_id \
   --region=us-central1 \
-  --image="gcr.io/$project_id/osv-server:$tag"
+  --image="gcr.io/oss-vdb/osv-server:$tag"


### PR DESCRIPTION
- Point the staging environments deployments to images in `oss-vdb`.
- Automatically build GKE and API backend images on push to master
- Modify GKE worker deployment for `oss-vdb-test` to no longer build images
  - Deployment to `oss-vdb` is currently unchanged - images are still rebuilt on deployment
- Parallelized `build_and_stage.yaml` docker image building to make it faster
- Added a check in `build_and_stage.yaml` to make sure triggers don't happen out-of-order if the Cloud Build is triggered multiple times close together