### PR TITLE
Populate a per-repository map of normalized version tags

### DIFF
--- a/docker/exporter/exporter.py
+++ b/docker/exporter/exporter.py
@@ -91,7 +91,7 @@ class Exporter:
     zip_path = os.path.join(tmp_dir, 'all.zip')
     with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zip_file:
       for bug in osv.Bug.query(osv.Bug.ecosystem == ecosystem):
-        if not bug.public or not bug.status == osv.BugStatus.PROCESSED:
+        if not bug.public or bug.status == osv.BugStatus.UNPROCESSED:
           continue
 
         file_path = os.path.join(tmp_dir, bug.id() + '.json')

--- a/vulnfeeds/git/repository.go
+++ b/vulnfeeds/git/repository.go
@@ -26,16 +26,16 @@ func (t Tags) Len() int           { return len(t) }
 func (t Tags) Less(i, j int) bool { return t[i].Tag < t[j].Tag }
 func (t Tags) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
 
+// NormalizedTag holds a normalized (as by NormalizeRepoTags) tag and corresponding commit hash.
 type NormalizedTag struct {
 	OriginalTag string
 	Commit      string
 }
 
-// RepoTagsMap acts as a cache for RepoTags results, keyed on the repo's URL.
-// repo URL -> Tag -> GitTag
+// RepoTagsMap holds all of the tags (naturally occurring and normalized) for a Git repo.
 type RepoTagsMap struct {
-	Tag           map[string]Tag
-	NormalizedTag map[string]NormalizedTag
+	Tag           map[string]Tag           // The key is the original tag as seen on the repo.
+	NormalizedTag map[string]NormalizedTag // The key is the normalized (as by NormalizeRepoTags) original tag.
 }
 
 // RepoTags acts as a cache for RepoTags results, keyed on the repo's URL.

--- a/vulnfeeds/git/repository.go
+++ b/vulnfeeds/git/repository.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/storage/memory"
+
 	"github.com/google/osv/vulnfeeds/cves"
 )
 

--- a/vulnfeeds/git/repository.go
+++ b/vulnfeeds/git/repository.go
@@ -70,11 +70,11 @@ func RepoTags(repoURL string, repoTagsCache *RepoTagsMap) (versions Versions, e 
 	return versions, nil
 }
 
-// NormalizeRepoTags populates a durable mapping of tags to Versions for lookup by normalized tag.
-func NormalizeRepoTags(repoURL string, normalizedRepoTags NormalizedRepoTagsMap, repoTagsCache *RepoTagsMap) (e error) {
+// NormalizeRepoTags add to a persistent mapping, tags to Versions for lookup by normalized tag.
+func NormalizeRepoTags(repoURL string, normalizedRepoTags NormalizedRepoTagsMap, repoTagsCache *RepoTagsMap) (NormalizedRepoTagsMap, error) {
 	versions, err := RepoTags(repoURL, repoTagsCache)
 	if err != nil {
-		return err
+		return normalizedRepoTags, err
 	}
 	repoVersion, ok := normalizedRepoTags[repoURL]
 	if !ok {
@@ -90,7 +90,7 @@ func NormalizeRepoTags(repoURL string, normalizedRepoTags NormalizedRepoTagsMap,
 		repoVersion, _ := normalizedRepoTags[repoURL]
 		repoVersion[normalizedVersion] = v
 	}
-	return nil
+	return normalizedRepoTags, nil
 }
 
 // Validate the repo by attempting to query it's references.

--- a/vulnfeeds/git/repository_test.go
+++ b/vulnfeeds/git/repository_test.go
@@ -162,7 +162,7 @@ func TestNormalizeRepoTags(t *testing.T) {
 	var repoVersions NormalizedRepoTagsMap
 	repoVersions = make(NormalizedRepoTagsMap)
 	for _, tc := range tests {
-		err := NormalizeRepoTags(tc.inputRepoURL, repoVersions, cache)
+		repoVersions, err := NormalizeRepoTags(tc.inputRepoURL, repoVersions, cache)
 		if err != nil && tc.expectedOk {
 			t.Errorf("test %q: NormalizeRepoTags(%q) unexpectedly failed: %+v", tc.description, tc.inputRepoURL, err)
 		}

--- a/vulnfeeds/git/repository_test.go
+++ b/vulnfeeds/git/repository_test.go
@@ -136,6 +136,47 @@ func TestRepoTags(t *testing.T) {
 	}
 }
 
+func TestNormalizeRepoTags(t *testing.T) {
+	tests := []struct {
+		description  string
+		inputRepoURL string
+		expectedOk   bool
+	}{
+		{
+			description:  "Valid repository, normalized versions exist",
+			inputRepoURL: "https://github.com/aide/aide",
+			expectedOk:   true,
+		},
+		{
+			description:  "Valid repository, no tags, normalized versions do not exist",
+			inputRepoURL: "https://github.com/andrewpollock/osv.dev.git",
+			expectedOk:   false,
+		},
+		{
+			description:  "Invalid repository",
+			inputRepoURL: "https://github.com/andrewpollock/mybogusrepo",
+			expectedOk:   false,
+		},
+	}
+	var cache *RepoTagsMap
+	var repoVersions NormalizedRepoTagsMap
+	repoVersions = make(NormalizedRepoTagsMap)
+	for _, tc := range tests {
+		err := NormalizeRepoTags(tc.inputRepoURL, repoVersions, cache)
+		if err != nil && tc.expectedOk {
+			t.Errorf("test %q: NormalizeRepoTags(%q) unexpectedly failed: %+v", tc.description, tc.inputRepoURL, err)
+		}
+		// Confirm a key for the repo exists
+		if _, ok := repoVersions[tc.inputRepoURL]; !ok && tc.expectedOk {
+			t.Errorf("test: %q: NormalizedRepoTags(%q): failed to find expected entry for repo in map: %#v", tc.description, tc.inputRepoURL, repoVersions)
+		}
+		// Confirm there are some normalized versions
+		if len(repoVersions[tc.inputRepoURL]) == 0 && tc.expectedOk {
+			t.Errorf("test %q: NormalizeRepoTags(%q): failed to find any normalized versions for repo in map: %#v", tc.description, tc.inputRepoURL, repoVersions)
+		}
+	}
+}
+
 func TestValidRepo(t *testing.T) {
 	tests := []struct {
 		description    string


### PR DESCRIPTION
This will facilitate exact and fuzzy matches on CPE versions in CVE records.