### PR TITLE
Bump memory for backend API instances.

### DIFF
--- a/gcp/api/deploy_backend
+++ b/gcp/api/deploy_backend
@@ -20,4 +20,5 @@ gcloud run deploy $name \
   --platform managed \
   --project=$project_id \
   --region=us-central1 \
+  --memory=4Gi \
   --image="gcr.io/$project_id/osv-server:$tag"


### PR DESCRIPTION
We will need to remember to do this for our Cloud Deploy setup as well. Terraform cannot manage this as this is part of the [ignored changes](https://github.com/google/osv.dev/blob/932929f0f31584734b94339ea9cacf3158fd9bed/deployment/terraform/modules/osv/osv_api.tf#L18)

We are seeing some occasional OOM issues -- this bump should hopefully resolve that. 