### PR TITLE
Bump PyPI package version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open('README.md', 'r') as fh:
 
 setuptools.setup(
     name='osv',
-    version='0.0.16',
+    version='0.0.17',
     author='OSV authors',
     author_email='osv-discuss@googlegroups.com',
     description='Open Source Vulnerabilities library',


### PR DESCRIPTION
This is required to update downstream consumers
(such as https://github.com/google/osv.dev/tree/master/gcp/functions/pypi) to uptake recent schema changes.