### PR TITLE
Updated bad link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,4 +181,4 @@ Feel free to send a PR to add your project here.
 
 Contributions are welcome! We also have a
 [mailing list](https://groups.google.com/g/osv-discuss) and a
-[FAQ](https://osv.dev/docs/#tag/faq).
+[FAQ](https://osv.dev/about).


### PR DESCRIPTION
The previous link went to the docs, with the faq tag. But nothing is tagged as faq in the docs. I updated the link to the osv.dev about page, which is presented as an faq. 