### PR TITLE
Make it clearer that Normalize is for versions

### DIFF
--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -508,7 +508,7 @@ func ParseCPE(formattedString string) (*CPE, error) {
 
 // Normalize version strings found in CVE CPE Match data or Git tags.
 // Use the same logic and behaviour as normalize_tag() osv/bug.py for consistency.
-func Normalize(version string) (normalizedVersion string, e error) {
+func NormalizeVersion(version string) (normalizedVersion string, e error) {
 	// Keep in sync with the intent of https://github.com/google/osv.dev/blob/26050deb42785bc5a4dc7d802eac8e7f95135509/osv/bug.py#L31
 	var validVersion = regexp.MustCompile(`(?i)(\d+|(?:rc|alpha|beta|preview)\d*)`)
 	var validVersionText = regexp.MustCompile(`(?i)(?:rc|alpha|beta|preview)\d*`)

--- a/vulnfeeds/cves/versions_test.go
+++ b/vulnfeeds/cves/versions_test.go
@@ -344,7 +344,7 @@ func TestExtractGitCommit(t *testing.T) {
 	}
 }
 
-func TestNormalize(t *testing.T) {
+func TestNormalizeVersion(t *testing.T) {
 	tests := []struct {
 		description               string
 		inputVersion              string
@@ -443,7 +443,7 @@ func TestNormalize(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		got, err := Normalize(tc.inputVersion)
+		got, err := NormalizeVersion(tc.inputVersion)
 		if err != nil && tc.expectedOk {
 			t.Errorf("test %q: Normalize(%q) unexpectedly errored: %#v", tc.description, tc.inputVersion, err)
 		}

--- a/vulnfeeds/git/repository.go
+++ b/vulnfeeds/git/repository.go
@@ -94,7 +94,7 @@ func NormalizeRepoTags(repoURL string, repoTagsCache RepoTagsCache) (NormalizedT
 	}
 	NormalizedTags = make(map[string]NormalizedTag)
 	for _, t := range tags {
-		normalizedTag, err := cves.Normalize(t.Tag)
+		normalizedTag, err := cves.NormalizeVersion(t.Tag)
 		if err != nil {
 			// It's conceivable that not all tags are normalizable or potentially versions.
 			continue


### PR DESCRIPTION
It's in the cves package, and just happens to be in a file named versions, but it's not so obvious outside of the package that it's for normalizing versions when it's just called Normalize