### PR TITLE
Fix Terraform Redis Issues

### DIFF
--- a/deployment/gae/oss-vdb-test/app.yaml
+++ b/deployment/gae/oss-vdb-test/app.yaml
@@ -48,7 +48,7 @@ automatic_scaling:
 instance_class: F4
 
 env_variables:
-  REDISHOST: 10.126.238.69
+  REDISHOST: 10.189.34.180
   REDISPORT: 6379
 
 vpc_access_connector:

--- a/deployment/gae/oss-vdb-test/cron-service.yaml
+++ b/deployment/gae/oss-vdb-test/cron-service.yaml
@@ -12,7 +12,7 @@ basic_scaling:
 instance_class: B4_1G
 
 env_variables:
-  REDISHOST: 10.126.238.69
+  REDISHOST: 10.189.34.180
   REDISPORT: 6379
 
 vpc_access_connector:

--- a/deployment/gae/oss-vdb/app.yaml
+++ b/deployment/gae/oss-vdb/app.yaml
@@ -48,7 +48,7 @@ automatic_scaling:
 instance_class: F4
 
 env_variables:
-  REDISHOST: 10.126.238.68
+  REDISHOST: 10.85.52.228
   REDISPORT: 6379
 
 vpc_access_connector:

--- a/deployment/gae/oss-vdb/cron-service.yaml
+++ b/deployment/gae/oss-vdb/cron-service.yaml
@@ -12,7 +12,7 @@ basic_scaling:
 instance_class: B4_1G
 
 env_variables:
-  REDISHOST: 10.126.238.68
+  REDISHOST: 10.85.52.228
   REDISPORT: 6379
 
 vpc_access_connector:

--- a/deployment/gae/oss-vdb/testing-app.yaml
+++ b/deployment/gae/oss-vdb/testing-app.yaml
@@ -48,7 +48,7 @@ automatic_scaling:
 instance_class: F4
 
 env_variables:
-  REDISHOST: 10.126.238.68
+  REDISHOST: 10.85.52.228
   REDISPORT: 6379
 
 vpc_access_connector:

--- a/deployment/terraform/modules/osv/main.tf
+++ b/deployment/terraform/modules/osv/main.tf
@@ -12,7 +12,14 @@ resource "google_app_engine_application" "app" {
 }
 
 # MemoryStore
+# TODO(michaelkedar): The way this was initially created on production is not (easily) reproducable in Terraform.
+# A replacement redis server has been created to fix this, but this needs stay around to allow for potential rollbacks.
+# Delete this resource after 2023/04/11
 resource "google_redis_instance" "west2" {
+  lifecycle {
+    ignore_changes = all
+  }
+
   project            = var.project_id
   memory_size_gb     = 5
   name               = "redis"
@@ -23,12 +30,22 @@ resource "google_redis_instance" "west2" {
   replica_count      = 1
   tier               = "STANDARD_HA"
   reserved_ip_range  = "10.126.238.64/29"
+  secondary_ip_range = "auto"
+}
 
-  # TODO(michaelkedar): This needs to be recreated on oss-vdb-test
-  # will uncomment this on a second PR after it's been applied
-  # lifecycle {
-  #   prevent_destroy = true
-  # }
+resource "google_redis_instance" "frontend" {
+  project            = var.project_id
+  memory_size_gb     = 5
+  name               = "redis-west2"
+  read_replicas_mode = "READ_REPLICAS_ENABLED"
+  redis_version      = "REDIS_6_X"
+  region             = "us-west2"
+  replica_count      = 1
+  tier               = "STANDARD_HA"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "google_redis_instance" "central1" {
@@ -40,7 +57,6 @@ resource "google_redis_instance" "central1" {
   region             = "us-central1"
   replica_count      = 2
   tier               = "STANDARD_HA"
-  reserved_ip_range  = "10.102.25.208/28"
 
   lifecycle {
     prevent_destroy = true

--- a/deployment/terraform/modules/osv/main.tf
+++ b/deployment/terraform/modules/osv/main.tf
@@ -12,7 +12,7 @@ resource "google_app_engine_application" "app" {
 }
 
 # MemoryStore
-# TODO(michaelkedar): The way this was initially created on production is not (easily) reproducable in Terraform.
+# TODO(michaelkedar): The way this was initially created on production is not (easily) reproducible in Terraform.
 # A replacement redis server has been created to fix this, but this needs stay around to allow for potential rollbacks.
 # Delete this resource after 2023/04/11
 resource "google_redis_instance" "west2" {


### PR DESCRIPTION
Make a new Redis resource for the frontend because Terraform can't reproduce the one on production.
To not break the existing website & allow for rollbacks, the old one will stay around for about a month.

I've already run `terraform apply` on production and staging to generate the IPs, so no changes will appear in the plan check.