### PR TITLE
Expand the VersionInfo struct to support Limit and LastAffected

### DIFF
--- a/vulnfeeds/cpp/main.go
+++ b/vulnfeeds/cpp/main.go
@@ -123,7 +123,7 @@ func GitVersionToCommit(versions cves.VersionInfo, repos []string, repobasedir s
 				Logger.Warnf("Failed to find a tag for %q in %s: %v", av.Fixed, repo, err)
 				continue
 			}
-			fc := cves.FixCommit{
+			fc := cves.GitCommit{
 				Repo:   repo,
 				Commit: ref.Hash().String(),
 			}

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -26,7 +26,7 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-type FixCommit struct {
+type GitCommit struct {
 	Repo   string
 	Commit string
 }
@@ -38,8 +38,10 @@ type AffectedVersion struct {
 }
 
 type VersionInfo struct {
-	FixCommits       []FixCommit
-	AffectedVersions []AffectedVersion
+	FixCommits          []GitCommit
+	LimitCommits        []GitCommit
+	LastAffectedCommits []GitCommit
+	AffectedVersions    []AffectedVersion
 }
 
 type CPE struct {
@@ -263,8 +265,8 @@ func Commit(u string) (string, error) {
 	return "", fmt.Errorf("Commit(): unsupported URL: %s", u)
 }
 
-// For URLs referencing commits in supported Git repository hosts, return a FixCommit.
-func extractGitCommit(link string) *FixCommit {
+// For URLs referencing commits in supported Git repository hosts, return a GitCommit.
+func extractGitCommit(link string) *GitCommit {
 	r, err := Repo(link)
 	if err != nil {
 		return nil
@@ -275,7 +277,7 @@ func extractGitCommit(link string) *FixCommit {
 		return nil
 	}
 
-	return &FixCommit{
+	return &GitCommit{
 		Repo:   r,
 		Commit: c,
 	}

--- a/vulnfeeds/cves/versions_test.go
+++ b/vulnfeeds/cves/versions_test.go
@@ -261,12 +261,12 @@ func TestExtractGitCommit(t *testing.T) {
 	tests := []struct {
 		description       string
 		inputLink         string
-		expectedFixCommit *FixCommit
+		expectedGitCommit *GitCommit
 	}{
 		{
 			description: "Valid GitHub commit URL",
 			inputLink:   "https://github.com/google/osv/commit/cd4e934d0527e5010e373e7fed54ef5daefba2f5",
-			expectedFixCommit: &FixCommit{
+			expectedGitCommit: &GitCommit{
 				Repo:   "https://github.com/google/osv",
 				Commit: "cd4e934d0527e5010e373e7fed54ef5daefba2f5",
 			},
@@ -274,7 +274,7 @@ func TestExtractGitCommit(t *testing.T) {
 		{
 			description: "Valid GitLab commit URL",
 			inputLink:   "https://gitlab.freedesktop.org/virgl/virglrenderer/-/commit/b05bb61f454eeb8a85164c8a31510aeb9d79129c",
-			expectedFixCommit: &FixCommit{
+			expectedGitCommit: &GitCommit{
 				Repo:   "https://gitlab.freedesktop.org/virgl/virglrenderer",
 				Commit: "b05bb61f454eeb8a85164c8a31510aeb9d79129c",
 			},
@@ -282,7 +282,7 @@ func TestExtractGitCommit(t *testing.T) {
 		{
 			description: "Valid GitLab.com commit URL",
 			inputLink:   "https://gitlab.com/mayan-edms/mayan-edms/commit/9ebe80595afe4fdd1e2c74358d6a9421f4ce130e",
-			expectedFixCommit: &FixCommit{
+			expectedGitCommit: &GitCommit{
 				Repo:   "https://gitlab.com/mayan-edms/mayan-edms",
 				Commit: "9ebe80595afe4fdd1e2c74358d6a9421f4ce130e",
 			},
@@ -290,7 +290,7 @@ func TestExtractGitCommit(t *testing.T) {
 		{
 			description: "Valid bitbucket.org commit URL",
 			inputLink:   "https://bitbucket.org/openpyxl/openpyxl/commits/3b4905f428e1",
-			expectedFixCommit: &FixCommit{
+			expectedGitCommit: &GitCommit{
 				Repo:   "https://bitbucket.org/openpyxl/openpyxl",
 				Commit: "3b4905f428e1",
 			},
@@ -298,7 +298,7 @@ func TestExtractGitCommit(t *testing.T) {
 		{
 			description: "Valid bitbucket.org commit URL with trailing slash",
 			inputLink:   "https://bitbucket.org/jespern/django-piston/commits/91bdaec89543/",
-			expectedFixCommit: &FixCommit{
+			expectedGitCommit: &GitCommit{
 				Repo:   "https://bitbucket.org/jespern/django-piston",
 				Commit: "91bdaec89543",
 			},
@@ -306,7 +306,7 @@ func TestExtractGitCommit(t *testing.T) {
 		{
 			description: "Valid cGit commit URL",
 			inputLink:   "https://git.dpkg.org/cgit/dpkg/dpkg.git/commit/?id=faa4c92debe45412bfcf8a44f26e827800bb24be",
-			expectedFixCommit: &FixCommit{
+			expectedGitCommit: &GitCommit{
 				Repo:   "https://git.dpkg.org/cgit/dpkg/dpkg.git",
 				Commit: "faa4c92debe45412bfcf8a44f26e827800bb24be",
 			},
@@ -314,7 +314,7 @@ func TestExtractGitCommit(t *testing.T) {
 		{
 			description: "Valid GitWeb commit URL",
 			inputLink:   "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libksba.git;a=commit;h=f61a5ea4e0f6a80fd4b28ef0174bee77793cf070",
-			expectedFixCommit: &FixCommit{
+			expectedGitCommit: &GitCommit{
 				Repo:   "https://git.gnupg.org/libksba.git",
 				Commit: "f61a5ea4e0f6a80fd4b28ef0174bee77793cf070",
 			},
@@ -322,24 +322,24 @@ func TestExtractGitCommit(t *testing.T) {
 		{
 			description:       "Unsupported GitHub PR URL",
 			inputLink:         "https://github.com/google/osv/pull/123",
-			expectedFixCommit: nil,
+			expectedGitCommit: nil,
 		},
 		{
 			description:       "Unsupported GitHub tag URL",
 			inputLink:         "https://github.com/google/osv.dev/releases/tag/v0.0.14",
-			expectedFixCommit: nil,
+			expectedGitCommit: nil,
 		},
 		{
 			description:       "Completely invalid input",
 			inputLink:         "",
-			expectedFixCommit: nil,
+			expectedGitCommit: nil,
 		},
 	}
 
 	for _, tc := range tests {
 		got := extractGitCommit(tc.inputLink)
-		if !reflect.DeepEqual(got, tc.expectedFixCommit) {
-			t.Errorf("test %q: extractGitCommit for %q was incorrect, got: %#v, expected: %#v", tc.description, tc.inputLink, got, tc.expectedFixCommit)
+		if !reflect.DeepEqual(got, tc.expectedGitCommit) {
+			t.Errorf("test %q: extractGitCommit for %q was incorrect, got: %#v, expected: %#v", tc.description, tc.inputLink, got, tc.expectedGitCommit)
 		}
 	}
 }

--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -352,53 +352,49 @@ func (v *Vulnerability) AddPkgInfo(pkgInfo PackageInfo) {
 // AttachExtractedVersionInfo adds version information extracted from CVEs onto
 // the affected field
 func (affected *Affected) AttachExtractedVersionInfo(version cves.VersionInfo) {
-	repoToFixCommits := map[string][]string{}
+	// Synthetic enum of supported commit types.
+	type CommitType int
+	const (
+		Fixed CommitType = iota
+		Limit
+		LastAffected
+	)
+	// commit holds a commit hash of one of the supported commit types.
+	type commit struct {
+		commitType CommitType
+		hash       string
+	}
+	// Collect the commits of the supported types for each repo.
+	repoToCommits := map[string][]commit{}
+
 	for _, fixCommit := range version.FixCommits {
-		repoToFixCommits[fixCommit.Repo] = append(repoToFixCommits[fixCommit.Repo], fixCommit.Commit)
+		repoToCommits[fixCommit.Repo] = append(repoToCommits[fixCommit.Repo], commit{commitType: Fixed, hash: fixCommit.Commit})
 	}
 
-	repoToLimitCommits := map[string][]string{}
 	for _, limitCommit := range version.LimitCommits {
-		repoToLimitCommits[limitCommit.Repo] = append(repoToLimitCommits[limitCommit.Repo], limitCommit.Commit)
+		repoToCommits[limitCommit.Repo] = append(repoToCommits[limitCommit.Repo], commit{commitType: Limit, hash: limitCommit.Commit})
 	}
 
-	repoToLastAffectedCommits := map[string][]string{}
 	for _, lastAffectedCommit := range version.LastAffectedCommits {
-		repoToLastAffectedCommits[lastAffectedCommit.Repo] = append(repoToLastAffectedCommits[lastAffectedCommit.Repo], lastAffectedCommit.Commit)
+		repoToCommits[lastAffectedCommit.Repo] = append(repoToCommits[lastAffectedCommit.Repo], commit{commitType: LastAffected, hash: lastAffectedCommit.Commit})
 	}
 
-	for repo, commits := range repoToFixCommits {
+	for repo, commits := range repoToCommits {
 		gitRange := AffectedRange{
 			Type: "GIT",
 			Repo: repo,
 		}
 		gitRange.Events = append(gitRange.Events, Event{Introduced: "0"})
 		for _, commit := range commits {
-			gitRange.Events = append(gitRange.Events, Event{Fixed: commit})
-		}
-		affected.Ranges = append(affected.Ranges, gitRange)
-	}
-
-	for repo, commits := range repoToLimitCommits {
-		gitRange := AffectedRange{
-			Type: "GIT",
-			Repo: repo,
-		}
-		gitRange.Events = append(gitRange.Events, Event{Introduced: "0"})
-		for _, commit := range commits {
-			gitRange.Events = append(gitRange.Events, Event{Limit: commit})
-		}
-		affected.Ranges = append(affected.Ranges, gitRange)
-	}
-
-	for repo, commits := range repoToLastAffectedCommits {
-		gitRange := AffectedRange{
-			Type: "GIT",
-			Repo: repo,
-		}
-		gitRange.Events = append(gitRange.Events, Event{Introduced: "0"})
-		for _, commit := range commits {
-			gitRange.Events = append(gitRange.Events, Event{LastAffected: commit})
+			if commit.commitType == Fixed {
+				gitRange.Events = append(gitRange.Events, Event{Fixed: commit.hash})
+			}
+			if commit.commitType == Limit {
+				gitRange.Events = append(gitRange.Events, Event{Limit: commit.hash})
+			}
+			if commit.commitType == LastAffected {
+				gitRange.Events = append(gitRange.Events, Event{LastAffected: commit.hash})
+			}
 		}
 		affected.Ranges = append(affected.Ranges, gitRange)
 	}


### PR DESCRIPTION
Also expand AttachExtractedVersionInfo to support these fields.

This way we can generate OSV records containing Limit or LastAffected if Fixed cannot be determined.