### PR TITLE
Batch operations

### DIFF
--- a/tools/datafix/delete_invalid.py
+++ b/tools/datafix/delete_invalid.py
@@ -9,8 +9,7 @@ from google.cloud import datastore
 import argparse
 import sys
 
-
-MAX_BATCH_SIZE=500
+MAX_BATCH_SIZE = 500
 
 
 def main() -> None:
@@ -72,7 +71,7 @@ def main() -> None:
   for batch in range(0, len(result_to_delete), MAX_BATCH_SIZE):
     try:
       with client.transaction() as xact:
-        for r in result_to_delete[batch:batch+MAX_BATCH_SIZE]:
+        for r in result_to_delete[batch:batch + MAX_BATCH_SIZE]:
           if args.verbose:
             print(f"Deleting {r}")
           xact.delete(r.key)

--- a/tools/datafix/delete_invalid.py
+++ b/tools/datafix/delete_invalid.py
@@ -77,7 +77,9 @@ def main() -> None:
           xact.delete(r.key)
         if args.dryrun:
           raise Exception("Dry run mode. Preventing transaction from commiting")  # pylint: disable=broad-exception-raised
-    except Exception as e:  # Don't have the first batch's transaction-aborting exception stop subsequent batches from being attempted.
+    except Exception as e:
+      # Don't have the first batch's transaction-aborting exception stop
+      # subsequent batches from being attempted.
       if args.dryrun and e.args[0].startswith("Dry run mode"):
         pass
   if len(result_to_delete) > 0 and not args.dryrun:

--- a/tools/datafix/withdraw_invalid.py
+++ b/tools/datafix/withdraw_invalid.py
@@ -57,7 +57,9 @@ def main() -> None:
           xact.put(r)
         if args.dryrun:
           raise Exception("Dry run mode. Preventing transaction from commiting")  # pylint: disable=broad-exception-raised
-    except Exception as e:  # Don't have the first batch's transaction-aborting exception stop subsequent batches from being attempted.
+    except Exception as e:
+      # Don't have the first batch's transaction-aborting exception stop
+      # subsequent batches from being attempted.
       if args.dryrun and e.args[0].startswith("Dry run mode"):
         pass
   if len(result_to_fix) > 0 and not args.dryrun:

--- a/tools/datafix/withdraw_invalid.py
+++ b/tools/datafix/withdraw_invalid.py
@@ -10,6 +10,9 @@ import argparse
 import datetime
 
 
+MAX_BATCH_SIZE=500
+
+
 def main() -> None:
   parser = argparse.ArgumentParser(
       description="Fix bugs that are invalid but not marked as withdrawn")
@@ -19,6 +22,12 @@ def main() -> None:
       dest="dryrun",
       default=True,
       help="Abort before making changes")
+  parser.add_argument(
+      "--verbose",
+      action=argparse.BooleanOptionalAction,
+      dest="verbose",
+      default=False,
+      help="Display records being operated on")
   parser.add_argument(
       "--project",
       action="store",
@@ -36,14 +45,23 @@ def main() -> None:
   print(f"Retrieved {len(result)} bugs to examine for fixing")
   result_to_fix = [r for r in result if not r['withdrawn']]
   print(f"There are {len(result_to_fix)} bugs to fix...")
-  with client.transaction() as xact:
-    for r in result_to_fix:
-      r['withdrawn'] = datetime.datetime.now(tz=datetime.timezone.utc)
-      r['last_modified'] = r['withdrawn']
-      xact.put(r)
-    if args.dryrun:
-      raise Exception("Dry run mode. Preventing transaction from commiting")  # pylint: disable=broad-exception-raised
-  if len(result_to_fix) > 0:
+
+  # Chunk the results to modify in acceptibly sized batches for the API.
+  for batch in range(0, len(result_to_fix), MAX_BATCH_SIZE):
+    try:
+      with client.transaction() as xact:
+        for r in result_to_fix[batch:batch+MAX_BATCH_SIZE]:
+          r['withdrawn'] = datetime.datetime.now(tz=datetime.timezone.utc)
+          r['last_modified'] = r['withdrawn']
+          if args.verbose:
+            print(f"Modifying {r}")
+          xact.put(r)
+        if args.dryrun:
+          raise Exception("Dry run mode. Preventing transaction from commiting")  # pylint: disable=broad-exception-raised
+    except Exception as e:  # Don't have the first batch's transaction-aborting exception stop subsequent batches from being attempted.
+      if args.dryrun and e.args[0].startswith("Dry run mode"):
+        pass
+  if len(result_to_fix) > 0 and not args.dryrun:
     print("Fixed!")
 
 

--- a/tools/datafix/withdraw_invalid.py
+++ b/tools/datafix/withdraw_invalid.py
@@ -9,8 +9,7 @@ from google.cloud import datastore
 import argparse
 import datetime
 
-
-MAX_BATCH_SIZE=500
+MAX_BATCH_SIZE = 500
 
 
 def main() -> None:
@@ -50,7 +49,7 @@ def main() -> None:
   for batch in range(0, len(result_to_fix), MAX_BATCH_SIZE):
     try:
       with client.transaction() as xact:
-        for r in result_to_fix[batch:batch+MAX_BATCH_SIZE]:
+        for r in result_to_fix[batch:batch + MAX_BATCH_SIZE]:
           r['withdrawn'] = datetime.datetime.now(tz=datetime.timezone.utc)
           r['last_modified'] = r['withdrawn']
           if args.verbose:


### PR DESCRIPTION
It turns out there's a maximum of 500 updates per transaction, so break
it into appropriately sized batches.

Also add verbosity so the records being acted on can be inspected
easily.

For #1098 