### PR TITLE
Add `--to-target` flag to Cloud Deploy promotion

### DIFF
--- a/deployment/deploy-prod.yaml
+++ b/deployment/deploy-prod.yaml
@@ -19,9 +19,9 @@ steps:
 
 # Promote Cloud Deploy
 - name: gcr.io/cloud-builders/gcloud
-  args: ['deploy', 'releases', 'promote', '--quiet', '--release=osv-$SHORT_SHA', '--region=us-central1', '--delivery-pipeline=gke-workers', '--annotations=tag=$TAG_NAME']
+  args: ['deploy', 'releases', 'promote', '--quiet', '--release=osv-$SHORT_SHA', '--region=us-central1', '--delivery-pipeline=gke-workers', '--to-target=production-workers', '--annotations=tag=$TAG_NAME']
 - name: gcr.io/cloud-builders/gcloud
-  args: ['deploy', 'releases', 'promote', '--quiet', '--release=osv-$SHORT_SHA', '--region=us-central1', '--delivery-pipeline=osv-api', '--annotations=tag=$TAG_NAME']
+  args: ['deploy', 'releases', 'promote', '--quiet', '--release=osv-$SHORT_SHA', '--region=us-central1', '--delivery-pipeline=osv-api', '--to-target=production-api', '--annotations=tag=$TAG_NAME']
 
 # Tag the deployed images with the git tag
 - name: gcr.io/cloud-builders/gcloud


### PR DESCRIPTION
Cloud Deploy doesn't automatically know where to promote a release if it's not currently deployed on staging (i.e. if it's not the most recent commit).
Explicitly telling which target to deploy to should fix this.