### PR TITLE
Downgrade some error logs to warnings.

### DIFF
--- a/docker/worker/oss_fuzz.py
+++ b/docker/worker/oss_fuzz.py
@@ -67,7 +67,7 @@ def find_oss_fuzz_fix_via_commit(repo, start_commit, end_commit, source_id,
   try:
     walker = repo.walk(end_commit, pygit2.GIT_SORT_TOPOLOGICAL)
   except KeyError:
-    logging.error('Failed to walk repo with invalid commit: %s', end_commit)
+    logging.warning('Failed to walk repo with invalid commit: %s', end_commit)
     return None
 
   walker.hide(start_commit)
@@ -129,7 +129,8 @@ def do_bisect(bisect_type, source_id, project_name, engine, sanitizer,
       result = bisector.bisect(bisect_type, old_commit, new_commit, f.name,
                                fuzz_target, build_data)
     except bisector.BisectError as e:
-      logging.error('Bisect failed with exception:\n%s', traceback.format_exc())
+      logging.warning('Bisect failed with exception:\n%s',
+                      traceback.format_exc())
       return bisector.Result(e.repo_url, None)
     except Exception:
       logging.error('Bisect failed with unexpected exception:\n%s',
@@ -137,8 +138,8 @@ def do_bisect(bisect_type, source_id, project_name, engine, sanitizer,
       return None
 
     if result.commit == old_commit:
-      logging.error('Bisect failed for testcase %s, bisected to old_commit',
-                    source_id)
+      logging.warning('Bisect failed for testcase %s, bisected to old_commit',
+                      source_id)
       result = None
 
     return result

--- a/docker/worker/worker.py
+++ b/docker/worker/worker.py
@@ -584,7 +584,7 @@ class TaskRunner:
     task_type = message.attributes['type']
     source_id = get_source_id(message)
 
-    logging.error('Task %s timed out (source_id=%s)', task_type, source_id)
+    logging.warning('Task %s timed out (source_id=%s)', task_type, source_id)
     if task_type in ('fixed', 'regressed'):
       oss_fuzz.handle_timeout(task_type, source_id, self._oss_fuzz_dir, message)
 
@@ -613,7 +613,7 @@ class TaskRunner:
       logging.info('Returned from task thread')
       if not done:
         self.handle_timeout(subscriber, subscription, ack_id, message)
-        logging.error('Timed out processing task')
+        logging.warning('Timed out processing task')
 
     while True:
       response = subscriber.pull(subscription=subscription, max_messages=1)


### PR DESCRIPTION
Some of the OSS-Fuzz errors are bisection errors that we do expect (and is not the fault of the OSV infrastructure).

Note this does not address some problematic error logging that lives in code in the OSS-Fuzz repo that we import.