### PR TITLE
Fix API integration tests

### DIFF
--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -312,8 +312,8 @@ class IntegrationTests(unittest.TestCase):
         timeout=_TIMEOUT)
 
     response_json = response.json()
-    self.assertEqual(2, len(response_json['vulns']))
-    self.assertCountEqual(['GO-2021-0061', 'GO-2020-0036'],
+    self.assertCountEqual(['GO-2021-0061', 'GO-2020-0036',
+                           'GHSA-r88r-gmrh-7j83', 'GHSA-wxc4-f4m6-wwqv'],
                           [vuln['id'] for vuln in response_json['vulns']])
 
     response = requests.post(

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -312,9 +312,10 @@ class IntegrationTests(unittest.TestCase):
         timeout=_TIMEOUT)
 
     response_json = response.json()
-    self.assertCountEqual(['GO-2021-0061', 'GO-2020-0036',
-                           'GHSA-r88r-gmrh-7j83', 'GHSA-wxc4-f4m6-wwqv'],
-                          [vuln['id'] for vuln in response_json['vulns']])
+    self.assertCountEqual([
+        'GO-2021-0061', 'GO-2020-0036', 'GHSA-r88r-gmrh-7j83',
+        'GHSA-wxc4-f4m6-wwqv'
+    ], [vuln['id'] for vuln in response_json['vulns']])
 
     response = requests.post(
         _api() + '/v1/query',


### PR DESCRIPTION
`test_query_semver_multiple_package` was failing because the query for
version 2.4.0 of github.com/go-yaml/yaml Go is now returning
https://github.com/advisories/GHSA-r88r-gmrh-7j83 and https://github.com/advisories/GHSA-wxc4-f4m6-wwqv in addition to GO-2020-0036
and GO-2021-0061

Remove the length test for what the API returns, as it is less detailed
and made redundant by the following `assertCountEqual` test.