### PR TITLE
Revert "Fix API integration tests"

### DIFF
--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -312,10 +312,9 @@ class IntegrationTests(unittest.TestCase):
         timeout=_TIMEOUT)
 
     response_json = response.json()
-    self.assertCountEqual([
-        'GO-2021-0061', 'GO-2020-0036', 'GHSA-r88r-gmrh-7j83',
-        'GHSA-wxc4-f4m6-wwqv'
-    ], [vuln['id'] for vuln in response_json['vulns']])
+    self.assertEqual(2, len(response_json['vulns']))
+    self.assertCountEqual(['GO-2021-0061', 'GO-2020-0036'],
+                          [vuln['id'] for vuln in response_json['vulns']])
 
     response = requests.post(
         _api() + '/v1/query',


### PR DESCRIPTION
Reverts google/osv.dev#1138
A bug on GHSA's end caused those records to be recreated without a `last_affected` date. It should now be fixed.