### PR TITLE
Productionizing Debian copyright metadata mirroring

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/debian-copyright-mirror.yaml
+++ b/deployment/clouddeploy/gke-workers/base/debian-copyright-mirror.yaml
@@ -7,7 +7,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
-      activeDeadlineSeconds: 3600
+      activeDeadlineSeconds: 86400
       template:
         spec:
           containers:

--- a/deployment/clouddeploy/gke-workers/base/debian-copyright-mirror.yaml
+++ b/deployment/clouddeploy/gke-workers/base/debian-copyright-mirror.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: debian-copyright-mirror
+spec:
+  schedule: "0 6 */1 * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3600
+      template:
+        spec:
+          containers:
+          - name: debian-copyright-mirror
+            image: debian-copyright-mirror
+            imagePullPolicy: Always
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: 1
+                memory: "1G"
+              limits:
+                cpu: 1
+                memory: "2G"
+          restartPolicy: OnFailure
+          volumes:
+            - name: "ssd"
+              hostPath:
+                path: "/mnt/disks/ssd0"

--- a/deployment/clouddeploy/gke-workers/base/debian-copyright-mirror.yaml
+++ b/deployment/clouddeploy/gke-workers/base/debian-copyright-mirror.yaml
@@ -23,6 +23,9 @@ spec:
               limits:
                 cpu: 1
                 memory: "2G"
+            env:
+              - name: WORK_DIR
+                value: /scratch
           restartPolicy: OnFailure
           volumes:
             - name: "ssd"

--- a/deployment/clouddeploy/gke-workers/base/kustomization.yaml
+++ b/deployment/clouddeploy/gke-workers/base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - combine-to-osv.yaml
 - debian-convert.yaml
 - debian-first-version.yaml
+- debian-copyright-mirror.yaml

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/debian-copyright-mirror.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/debian-copyright-mirror.yaml
@@ -12,7 +12,5 @@ spec:
             env:
             - name: GCS_PATH
               value: gs://osv-test-cve-osv-conversion/debian_copyright
-            - name: WORK_DIR
-              value: /scratch
             - name: BE_VERBOSE
               value:

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/debian-copyright-mirror.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/debian-copyright-mirror.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: debian-copyright-mirror
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: debian-copyright-mirror
+            env:
+            - name: GCS_PATH
+              value: gs://osv-test-cve-osv-conversion/debian_copyright
+            - name: WORK_DIR
+              value: /scratch
+            - name: BE_VERBOSE
+              value:

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/kustomization.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/kustomization.yaml
@@ -9,3 +9,4 @@ patches:
 - combine-to-osv.yaml
 - debian-convert.yaml
 - debian-first-version.yaml
+- debian-copyright-mirror.yaml

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/debian-copyright-mirror.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/debian-copyright-mirror.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: debian-copyright-mirror
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: debian-copyright-mirror
+            env:
+            - name: GCS_PATH
+              value: gs://osv-cve-osv-conversion/debian_copyright
+            - name: WORK_DIR
+              value: /scratch

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/debian-copyright-mirror.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/debian-copyright-mirror.yaml
@@ -12,5 +12,3 @@ spec:
             env:
             - name: GCS_PATH
               value: gs://osv-cve-osv-conversion/debian_copyright
-            - name: WORK_DIR
-              value: /scratch

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/kustomization.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/kustomization.yaml
@@ -8,3 +8,4 @@ patches:
 - combine-to-osv.yaml
 - debian-convert.yaml
 - debian-first-version.yaml
+- debian-copyright-mirror.yaml

--- a/deployment/deploy-prod.yaml
+++ b/deployment/deploy-prod.yaml
@@ -39,6 +39,8 @@ steps:
 - name: gcr.io/cloud-builders/gcloud
   args: ['container', 'images', 'add-tag', '--quiet', 'gcr.io/oss-vdb/debian-convert:$COMMIT_SHA', 'gcr.io/oss-vdb/debian-convert:$TAG_NAME']
 - name: gcr.io/cloud-builders/gcloud
+  args: ['container', 'images', 'add-tag', '--quiet', 'gcr.io/oss-vdb/debian-copyright-mirror:$COMMIT_SHA', 'gcr.io/oss-vdb/debian-copyright-mirror:$TAG_NAME']
+- name: gcr.io/cloud-builders/gcloud
   args: ['container', 'images', 'add-tag', '--quiet', 'gcr.io/oss-vdb/osv-server:$COMMIT_SHA', 'gcr.io/oss-vdb/osv-server:$TAG_NAME']
 
 serviceAccount: 'projects/oss-vdb/serviceAccounts/deployment@oss-vdb.iam.gserviceaccount.com'


### PR DESCRIPTION
This is my first attempt at setting up all the additional plumbing for the Debian copyright metadata mirroring.

The objective is to get this up and going in the staging environment, prior to a release getting it going in the production environment.