### PR TITLE
Initial commit of productionization of gen-cperepos-map

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/gen-cperepos-map.yaml
+++ b/deployment/clouddeploy/gke-workers/base/gen-cperepos-map.yaml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: gen-cperepos-map
+spec:
+  schedule: "0 6 */1 * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 86400
+      template:
+        spec:
+          containers:
+          - name: gen-cperepos-map
+            image: gen-cperepos-map
+            imagePullPolicy: Always
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: 1
+                memory: "1G"
+              limits:
+                cpu: 1
+                memory: "2G"
+            env:
+              - name: WORK_DIR
+                value: /scratch
+          restartPolicy: OnFailure
+          volumes:
+            - name: "ssd"
+              hostPath:
+                path: "/mnt/disks/ssd0"

--- a/deployment/clouddeploy/gke-workers/base/gen-cperepos-map.yaml
+++ b/deployment/clouddeploy/gke-workers/base/gen-cperepos-map.yaml
@@ -11,8 +11,8 @@ spec:
       template:
         spec:
           containers:
-          - name: gen-cperepos-map
-            image: gen-cperepos-map
+          - name: cpe-repo-gen
+            image: cpe-repo-gen
             imagePullPolicy: Always
             securityContext:
               privileged: true

--- a/deployment/clouddeploy/gke-workers/base/kustomization.yaml
+++ b/deployment/clouddeploy/gke-workers/base/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 - debian-convert.yaml
 - debian-first-version.yaml
 - debian-copyright-mirror.yaml
+- gen-cperepos-map.yaml

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/gen-cperepos-map.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/gen-cperepos-map.yaml
@@ -1,0 +1,18 @@
+
+kind: CronJob
+metadata:
+  name: gen-cperepos-map
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: gen-cperepos-map
+            env:
+            - name: DEBIAN_COPYRIGHT_GCS_PATH
+              value: gs://osv-test-cve-osv-conversion/debian_copyright
+            - name: CPEREPO_GCS_PATH
+              value: gs://osv-test-cve-osv-conversion/cpe_repos
+            - name: BE_VERBOSE
+              value:

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/gen-cperepos-map.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/gen-cperepos-map.yaml
@@ -1,0 +1,16 @@
+
+kind: CronJob
+metadata:
+  name: gen-cperepos-map
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: gen-cperepos-map
+            env:
+            - name: DEBIAN_COPYRIGHT_GCS_PATH
+              value: gs://cve-osv-conversion/debian_copyright
+            - name: CPEREPO_GCS_PATH
+              value: gs://cve-osv-conversion/cpe_repos

--- a/deployment/deploy-prod.yaml
+++ b/deployment/deploy-prod.yaml
@@ -40,6 +40,7 @@ steps:
   args: ['container', 'images', 'add-tag', '--quiet', 'gcr.io/oss-vdb/debian-convert:$COMMIT_SHA', 'gcr.io/oss-vdb/debian-convert:$TAG_NAME']
 - name: gcr.io/cloud-builders/gcloud
   args: ['container', 'images', 'add-tag', '--quiet', 'gcr.io/oss-vdb/debian-copyright-mirror:$COMMIT_SHA', 'gcr.io/oss-vdb/debian-copyright-mirror:$TAG_NAME']
+  args: ['container', 'images', 'add-tag', '--quiet', 'gcr.io/oss-vdb/cpe-repo-gen:$COMMIT_SHA', 'gcr.io/oss-vdb/cpe-repo-gen:$TAG_NAME']
 - name: gcr.io/cloud-builders/gcloud
   args: ['container', 'images', 'add-tag', '--quiet', 'gcr.io/oss-vdb/osv-server:$COMMIT_SHA', 'gcr.io/oss-vdb/osv-server:$TAG_NAME']
 


### PR DESCRIPTION
Set up all the additional plumbing for the CPE repo map generation.

The objective is to get this up and going in the staging environment, prior to a release getting it going in the production environment.