### PR TITLE
Use correct production bucket name

### DIFF
--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/debian-copyright-mirror.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/debian-copyright-mirror.yaml
@@ -11,4 +11,4 @@ spec:
           - name: debian-copyright-mirror
             env:
             - name: GCS_PATH
-              value: gs://osv-cve-osv-conversion/debian_copyright
+              value: gs://cve-osv-conversion/debian_copyright


### PR DESCRIPTION
When setting up the other cron job I realised I had the production bucket name wrong.