### PR TITLE
Fix API integration tests

### DIFF
--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -312,9 +312,8 @@ class IntegrationTests(unittest.TestCase):
         timeout=_TIMEOUT)
 
     response_json = response.json()
-    self.assertCountEqual(
-        ['GO-2021-0061', 'GO-2020-0036'],
-        [vuln['id'] for vuln in response_json['vulns']])
+    self.assertCountEqual(['GO-2021-0061', 'GO-2020-0036'],
+                          [vuln['id'] for vuln in response_json['vulns']])
 
     response = requests.post(
         _api() + '/v1/query',

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -313,7 +313,7 @@ class IntegrationTests(unittest.TestCase):
 
     response_json = response.json()
     self.assertCountEqual(
-        ['GO-2021-0061', 'GO-2020-0036', 'GHSA-r88r-gmrh-7j83'],
+        ['GO-2021-0061', 'GO-2020-0036'],
         [vuln['id'] for vuln in response_json['vulns']])
 
     response = requests.post(


### PR DESCRIPTION
Revert the final bits of #1138 from last week because the upstream aberrations that made it necessary have been corrected.