### PR TITLE
Refactor repo denylisting for reuse

### DIFF
--- a/vulnfeeds/cmd/cperepos/main.go
+++ b/vulnfeeds/cmd/cperepos/main.go
@@ -106,96 +106,7 @@ const (
 var (
 	Logger utility.LoggerWrapper
 	// These repos should never be considered authoritative for a product.
-	// TODO(apollock): read this from an external file
-	InvalidRepos = []string{
-		"https://github.com/abhiunix/goo-blog-App-CVE",
-		"https://github.com/Accenture/AARO-Bugs",
-		"https://github.com/active-labs/Advisories",
-		"https://github.com/afeng2016-s/CVE-Request",
-		"https://github.com/agadient/SERVEEZ-CVE",
-		"https://github.com/AlwaysHereFight/YZMCMSxss",
-		"https://github.com/alwentiu/COVIDSafe-CVE-2020-12856",
-		"https://github.com/ArianeBlow/Axelor_Stored_XSS",
-		"https://github.com/beicheng-maker/vulns",
-		"https://github.com/BigTiger2020/74CMS",
-		"https://github.com/BlackFan/client-side-prototype-pollution",
-		"https://github.com/blindkey/cve_like",
-		"https://github.com/ciph0x01/Simple-Exam-Reviewer-Management-System-CVE",
-		"https://github.com/cloudflare/advisories",
-		"https://github.com/CVEProject/cvelist", // Heavily in Advisory URLs, sometimes shows up elsewhere
-		"https://github.com/cve-vul/vul",
-		"https://github.com/daaaalllii/cve-s",
-		"https://github.com/DayiliWaseem/CVE-2022-39196-",
-		"https://github.com/eddietcc/CVEnotes",
-		"https://github.com/enesozeser/Vulnerabilities",
-		"https://github.com/Fadavvi/CVE-2018-17431-PoC",
-		"https://github.com/FCncdn/Appsmith-Js-Injection-POC",
-		"https://github.com/fireeye/Vulnerability-Disclosures",
-		"https://github.com/GitHubAssessments/CVE_Assessments_11_2019",
-		"https://github.com/github/cvelist",        // Fork of https://github.com/CVEProject/cvelist
-		"https://github.com/gitlabhq/gitlabhq",     // GitHub mirror, not canonical
-		"https://github.com/google/oss-fuzz-vulns", // 8^)
-		"https://github.com/Gr4y21/My-CVE-IDs",
-		"https://github.com/hashicorp/terraform-enterprise-release-notes",
-		"https://github.com/hemantsolo/CVE-Reference",
-		"https://github.com/huclilu/CVE_Add",
-		"https://github.com/i3umi3iei3ii/CentOS-Control-Web-Panel-CVE",
-		"https://github.com/ianxtianxt/gitbook-xss",
-		"https://github.com/itodaro/doorGets_cve",
-		"https://github.com/jvz/test-cvelist",
-		"https://github.com/Kenun99/CVE-batdappboomx",
-		"https://github.com/kyrie403/Vuln",
-		"https://github.com/lukaszstu/SmartAsset-CORS-CVE-2020-26527",
-		"https://github.com/MacherCS/CVE_Evoh_Contract",
-		"https://github.com/mandiant/Vulnerability-Disclosures",
-		"https://github.com/martinkubecka/CVE-References",
-		"https://github.com/mclab-hbrs/BBB-POC",
-		"https://github.com/metaredteam/external-disclosures",
-		"https://github.com/MrR3boot/CVE-Hunting",
-		"https://github.com/N1ce759/74cmsSE-Arbitrary-File-Reading",
-		"https://github.com/nepenthe0320/cve_poc",
-		"https://github.com/Netflix/security-bulletins",
-		"https://github.com/nextcloud/security-advisories",
-		"https://github.com/nikip72/CVE-2021-39273-CVE-2021-39274",
-		"https://github.com/nu11secur1ty/CVE-nu11secur1ty",
-		"https://github.com/orangecertcc/security-research",
-		"https://github.com/Orange-Cyberdefense/CVE-repository",
-		"https://github.com/passtheticket/vulnerability-research",
-		"https://github.com/post-cyberlabs/CVE-Advisory",
-		"https://github.com/rapid7/metasploit-framework",
-		"https://github.com/refi64/CVE-2020-25265-25266",
-		"https://github.com/riteshgohil/My_CVE_References",
-		"https://github.com/roughb8722/CVE-2021-3122-Details",
-		"https://github.com/Ryan0lb/EC-cloud-e-commerce-system-CVE-application",
-		"https://github.com/SaumyajeetDas/POC-of-CVE-2022-36271",
-		"https://github.com/seb1055/cve-2020-27358-27359",
-		"https://github.com/Security-AVS/-CVE-2021-26904",
-		"https://github.com/seqred-s-a/gxdlmsdirector-cve",
-		"https://github.com/sickcodes/security",
-		"https://github.com/Snakinya/Vuln",
-		"https://github.com/snyk/zip-slip-vulnerability",
-		"https://github.com/soheilsamanabadi/vulnerability",
-		"https://github.com/soheilsamanabadi/vulnerabilitys",
-		"https://github.com/theyiyibest/Reflected-XSS-on-SockJS",
-		"https://github.com/vQAQv/Request-CVE-ID-PoC",
-		"https://github.com/vulnerabilities-cve/vulnerabilities",
-		"https://github.com/wind-cyber/LJCMS-UserTraversal-Vulnerability",
-		"https://github.com/wsummerhill/BSA-Radar_CVE-Vulnerabilities",
-		"https://github.com/xiahao90/CVEproject",
-		"https://github.com/xxhzz1/74cmsSE-Arbitrary-file-upload-vulnerability",
-		"https://github.com/ycdxsb/Vuln",
-		"https://github.com/YLoiK/74cmsSE-Arbitrary-file-upload-vulnerability",
-		"https://github.com/z00z00z00/Safenet_SAC_CVE-2021-42056",
-		"https://github.com/zer0yu/CVE_Request",
-		"https://github.com/Zeyad-Azima/Issabel-stored-XSS",
-		"https://gitlab.com/gitlab-org/gitlab-ce",      // redirects to gitlab-foss
-		"https://gitlab.com/gitlab-org/gitlab-ee",      // redirects to gitlab
-		"https://gitlab.com/gitlab-org/gitlab-foss",    // not the canonical source
-		"https://gitlab.com/gitlab-org/omnibus-gitlab", // not the source
-		"https://gitlab.com/gitlab-org/release",        // not the source
-	}
 	// Match repos with "CVE", "CVEs" or a pure CVE number in their name, anything from GitHubAssessments
-	InvalidRepoRegex   = `(?i)/(?:(?:CVEs?)|(?:CVE-\d{4}-\d{4,})|GitHubAssessments/.*|advisories/GHSA.*)$`
 	CPEDictionaryFile  = flag.String("cpe_dictionary", CPEDictionaryDefault, "CPE Dictionary file to parse")
 	OutputDir          = flag.String("output_dir", OutputDirDefault, "Directory to output cpe_product_to_repo.json and cpe_reference_description_frequency.csv in")
 	GCPLoggingProject  = flag.String("gcp_logging_project", projectId, "GCP project ID to use for logging, set to an empty string to log locally only")
@@ -406,17 +317,6 @@ func analyzeCPEDictionary(d CPEDict) (ProductToRepo VendorProductToRepoMap, Desc
 			repo, err := cves.Repo(r.URL)
 			if err != nil {
 				Logger.Infof("Disregarding %q for %q/%q (%s) because %v", r.URL, CPE.Vendor, CPE.Product, r.Description, err)
-				continue
-			}
-			// Disregard the repos we know we don't like (by regex).
-			matched, _ := regexp.MatchString(InvalidRepoRegex, repo)
-			if matched {
-				Logger.Infof("Disliking %q for %q/%q (%s) (matched regexp)", repo, CPE.Vendor, CPE.Product, r.Description)
-				continue
-			}
-			// Disregard the repos we know we don't like (by denylist).
-			if slices.Contains(InvalidRepos, repo) {
-				Logger.Infof("Disliking %q for %q/%q (%s)", repo, CPE.Vendor, CPE.Product, r.Description)
 				continue
 			}
 			// If we already have an entry for this repo, don't add it again.

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -60,6 +60,98 @@ type CPE struct {
 	Other      string
 }
 
+var (
+	// TODO(apollock): read this from an external file
+	InvalidRepos = []string{
+		"https://github.com/abhiunix/goo-blog-App-CVE",
+		"https://github.com/Accenture/AARO-Bugs",
+		"https://github.com/active-labs/Advisories",
+		"https://github.com/afeng2016-s/CVE-Request",
+		"https://github.com/agadient/SERVEEZ-CVE",
+		"https://github.com/AlwaysHereFight/YZMCMSxss",
+		"https://github.com/alwentiu/COVIDSafe-CVE-2020-12856",
+		"https://github.com/ArianeBlow/Axelor_Stored_XSS",
+		"https://github.com/beicheng-maker/vulns",
+		"https://github.com/BigTiger2020/74CMS",
+		"https://github.com/BlackFan/client-side-prototype-pollution",
+		"https://github.com/blindkey/cve_like",
+		"https://github.com/ciph0x01/Simple-Exam-Reviewer-Management-System-CVE",
+		"https://github.com/cloudflare/advisories",
+		"https://github.com/CVEProject/cvelist", // Heavily in Advisory URLs, sometimes shows up elsewhere
+		"https://github.com/cve-vul/vul",
+		"https://github.com/daaaalllii/cve-s",
+		"https://github.com/DayiliWaseem/CVE-2022-39196-",
+		"https://github.com/eddietcc/CVEnotes",
+		"https://github.com/enesozeser/Vulnerabilities",
+		"https://github.com/Fadavvi/CVE-2018-17431-PoC",
+		"https://github.com/FCncdn/Appsmith-Js-Injection-POC",
+		"https://github.com/fireeye/Vulnerability-Disclosures",
+		"https://github.com/GitHubAssessments/CVE_Assessments_11_2019",
+		"https://github.com/github/cvelist",        // Fork of https://github.com/CVEProject/cvelist
+		"https://github.com/gitlabhq/gitlabhq",     // GitHub mirror, not canonical
+		"https://github.com/google/oss-fuzz-vulns", // 8^)
+		"https://github.com/Gr4y21/My-CVE-IDs",
+		"https://github.com/hashicorp/terraform-enterprise-release-notes",
+		"https://github.com/hemantsolo/CVE-Reference",
+		"https://github.com/huclilu/CVE_Add",
+		"https://github.com/i3umi3iei3ii/CentOS-Control-Web-Panel-CVE",
+		"https://github.com/ianxtianxt/gitbook-xss",
+		"https://github.com/itodaro/doorGets_cve",
+		"https://github.com/jvz/test-cvelist",
+		"https://github.com/Kenun99/CVE-batdappboomx",
+		"https://github.com/kyrie403/Vuln",
+		"https://github.com/lukaszstu/SmartAsset-CORS-CVE-2020-26527",
+		"https://github.com/MacherCS/CVE_Evoh_Contract",
+		"https://github.com/mandiant/Vulnerability-Disclosures",
+		"https://github.com/martinkubecka/CVE-References",
+		"https://github.com/mclab-hbrs/BBB-POC",
+		"https://github.com/metaredteam/external-disclosures",
+		"https://github.com/MrR3boot/CVE-Hunting",
+		"https://github.com/N1ce759/74cmsSE-Arbitrary-File-Reading",
+		"https://github.com/nepenthe0320/cve_poc",
+		"https://github.com/Netflix/security-bulletins",
+		"https://github.com/nextcloud/security-advisories",
+		"https://github.com/nikip72/CVE-2021-39273-CVE-2021-39274",
+		"https://github.com/nu11secur1ty/CVE-nu11secur1ty",
+		"https://github.com/orangecertcc/security-research",
+		"https://github.com/Orange-Cyberdefense/CVE-repository",
+		"https://github.com/passtheticket/vulnerability-research",
+		"https://github.com/post-cyberlabs/CVE-Advisory",
+		"https://github.com/rapid7/metasploit-framework",
+		"https://github.com/refi64/CVE-2020-25265-25266",
+		"https://github.com/riteshgohil/My_CVE_References",
+		"https://github.com/roughb8722/CVE-2021-3122-Details",
+		"https://github.com/Ryan0lb/EC-cloud-e-commerce-system-CVE-application",
+		"https://github.com/SaumyajeetDas/POC-of-CVE-2022-36271",
+		"https://github.com/seb1055/cve-2020-27358-27359",
+		"https://github.com/Security-AVS/-CVE-2021-26904",
+		"https://github.com/seqred-s-a/gxdlmsdirector-cve",
+		"https://github.com/sickcodes/security",
+		"https://github.com/Snakinya/Vuln",
+		"https://github.com/snyk/zip-slip-vulnerability",
+		"https://github.com/soheilsamanabadi/vulnerability",
+		"https://github.com/soheilsamanabadi/vulnerabilitys",
+		"https://github.com/theyiyibest/Reflected-XSS-on-SockJS",
+		"https://github.com/vQAQv/Request-CVE-ID-PoC",
+		"https://github.com/vulnerabilities-cve/vulnerabilities",
+		"https://github.com/wind-cyber/LJCMS-UserTraversal-Vulnerability",
+		"https://github.com/wsummerhill/BSA-Radar_CVE-Vulnerabilities",
+		"https://github.com/xiahao90/CVEproject",
+		"https://github.com/xxhzz1/74cmsSE-Arbitrary-file-upload-vulnerability",
+		"https://github.com/ycdxsb/Vuln",
+		"https://github.com/YLoiK/74cmsSE-Arbitrary-file-upload-vulnerability",
+		"https://github.com/z00z00z00/Safenet_SAC_CVE-2021-42056",
+		"https://github.com/zer0yu/CVE_Request",
+		"https://github.com/Zeyad-Azima/Issabel-stored-XSS",
+		"https://gitlab.com/gitlab-org/gitlab-ce",      // redirects to gitlab-foss
+		"https://gitlab.com/gitlab-org/gitlab-ee",      // redirects to gitlab
+		"https://gitlab.com/gitlab-org/gitlab-foss",    // not the canonical source
+		"https://gitlab.com/gitlab-org/omnibus-gitlab", // not the source
+		"https://gitlab.com/gitlab-org/release",        // not the source
+	}
+	InvalidRepoRegex = `(?i)/(?:(?:CVEs?)|(?:CVE-\d{4}-\d{4,})|GitHubAssessments/.*)$`
+)
+
 // Returns the base repository URL for supported repository hosts.
 func Repo(u string) (string, error) {
 	var supportedHosts = []string{
@@ -70,6 +162,19 @@ func Repo(u string) (string, error) {
 	parsedURL, err := url.Parse(u)
 	if err != nil {
 		return "", err
+	}
+
+	// Disregard the repos we know we don't like (by regex).
+	// NOTE TO SELF THIS MAY NOT MATCH UNNORMALIZED URLS
+	matched, _ := regexp.MatchString(InvalidRepoRegex, u)
+	if matched {
+		return "", fmt.Errorf("%q matched invalid repo regexp", u)
+	}
+
+	for _, dr := range InvalidRepos {
+		if strings.HasPrefix(u, dr) {
+			return "", fmt.Errorf("%q found in denylist", u)
+		}
 	}
 
 	// Were we handed a base repository URL from the get go?

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -165,7 +165,6 @@ func Repo(u string) (string, error) {
 	}
 
 	// Disregard the repos we know we don't like (by regex).
-	// NOTE TO SELF THIS MAY NOT MATCH UNNORMALIZED URLS
 	matched, _ := regexp.MatchString(InvalidRepoRegex, u)
 	if matched {
 		return "", fmt.Errorf("%q matched invalid repo regexp", u)

--- a/vulnfeeds/cves/versions_test.go
+++ b/vulnfeeds/cves/versions_test.go
@@ -266,6 +266,30 @@ func TestRepo(t *testing.T) {
 			expectedRepoURL: "https://bitbucket.org/snakeyaml/snakeyaml",
 			expectedOk:      true,
 		},
+		{
+			description:     "Valid URL but not wanted (by denylist)",
+			inputLink:       "https://github.com/orangecertcc/security-research/security/advisories/GHSA-px2c-q384-5wxc",
+			expectedRepoURL: "",
+			expectedOk:      false,
+		},
+		{
+			description:     "Valid URL but not wanted (by deny regexp)",
+			inputLink:       "https://github.com/Ko-kn3t/CVE-2020-29156",
+			expectedRepoURL: "",
+			expectedOk:      false,
+		},
+		{
+			description:     "Valid URL but not wanted (by deny regexp)",
+			inputLink:       "https://github.com/GitHubAssessments/CVE_Assessment_04_2018",
+			expectedRepoURL: "",
+			expectedOk:      false,
+		},
+		{
+			description:     "Valid URL but not wanted (by deny regexp)",
+			inputLink:       "https://github.com/jenaye/cve",
+			expectedRepoURL: "",
+			expectedOk:      false,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Interim move to allow the denylisting to be used more broadly by baking it into the repository URL extraction and normalization function.

Added benefit, better testing.

Unexpected bonus of that: discovered repositories hosting their own GHSA's were being incorrectly ruled out of scope, so that's a bit of a win...