### PR TITLE
Fix a couple of issues with containerizing cperepos

### DIFF
--- a/vulnfeeds/cmd/cperepos/Dockerfile
+++ b/vulnfeeds/cmd/cperepos/Dockerfile
@@ -22,7 +22,7 @@ COPY ./go.sum /src/go.sum
 RUN go mod download
 
 COPY ./ /src/
-RUN go build -o cperepos ./cmd/cperepos
+RUN CGO_ENABLED=0 go build -o cperepos ./cmd/cperepos
 
 FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
 

--- a/vulnfeeds/cmd/cperepos/gen_cperepos_map
+++ b/vulnfeeds/cmd/cperepos/gen_cperepos_map
@@ -29,7 +29,7 @@ mkdir -p "${WORK_DIR}" || true
 
 curl ${BE_VERBOSE="--silent"} \
   https://nvd.nist.gov/feeds/xml/cpe/dictionary/official-cpe-dictionary_v2.3.xml.gz \
-  | gzip --decompress --output "${WORK_DIR}/official-cpe-dictionary_v2.3.xml"
+  | gzip -dc "${WORK_DIR}/official-cpe-dictionary_v2.3.xml"
 
 MAYBE_USE_DEBIAN_COPYRIGHT_METADATA=""
 if [[ -n "${DEBIAN_COPYRIGHT_GCS_PATH}" ]]; then


### PR DESCRIPTION
1. The runtime image has a busybox gzip that doesn't support the more descriptive long-form flag names. Oh well. I tried.
2. The intermediate image used to build the cperepos Go binary appears to dynamically link against glibc, which isn't present in the runtime image. Built it static link it instead.