### PR TITLE
Update highend node type to much better fit indexer behavior

### DIFF
--- a/deployment/terraform/modules/osv/workers_gke.tf
+++ b/deployment/terraform/modules/osv/workers_gke.tf
@@ -91,7 +91,7 @@ resource "google_container_node_pool" "highend" {
 
 
   node_config {
-    machine_type    = "n1-standard-32"
+    machine_type    = "n2-highmem-32"
     disk_type       = "pd-standard"
     disk_size_gb    = 100
     local_ssd_count = 1


### PR DESCRIPTION
Each indexer pod needs a lot more memory than it needs CPUs. The current standard-32 leaves about 22 cores completely unused because there's not enough memory available to spin up more pods on each node.