### PR TITLE
Automate cleaning up excessive App Engine versions

### DIFF
--- a/deployment/build-and-stage.yaml
+++ b/deployment/build-and-stage.yaml
@@ -172,6 +172,10 @@ steps:
 - name: 'gcr.io/oss-vdb/deployment'
   args: ['bash', '-ex', 'gcp/appengine/deploy.sh', 'oss-vdb-test', 'deployment/gae/oss-vdb-test', 'app.yaml']
 
+# Clean up all but the last 5 App Engine versions to avoid hitting the ceiling on versions
+- name: 'gcr.io/cloud-builders/gcloud'
+  args: ['bash', '-ex', 'gcp/appengine/cleanup_versions.sh', 'oss-vdb-test']
+
 # Cloud Deploy
 # GKE Workers
 - name: 'gcr.io/cloud-builders/gcloud'

--- a/deployment/build-and-stage.yaml
+++ b/deployment/build-and-stage.yaml
@@ -172,7 +172,7 @@ steps:
 - name: 'gcr.io/oss-vdb/deployment'
   args: ['bash', '-ex', 'gcp/appengine/deploy.sh', 'oss-vdb-test', 'deployment/gae/oss-vdb-test', 'app.yaml']
 
-# Clean up all but the last 5 App Engine versions to avoid hitting the ceiling on versions
+# Clean up older, non-serving App Engine versions to avoid hitting the ceiling on versions
 - name: 'gcr.io/cloud-builders/gcloud'
   args: ['bash', '-ex', 'gcp/appengine/cleanup_versions.sh', 'oss-vdb-test']
 

--- a/gcp/appengine/cleanup_versions.sh
+++ b/gcp/appengine/cleanup_versions.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Helper to clean up all but the most recent 5 versions of the default service
+# in the given project
+
+# Inspiration: https://stackoverflow.com/questions/34499875/how-to-automatically-delete-old-google-app-engine-version-instances
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $(basename $0) project_id"
+  exit 1
+fi
+
+PROJECT_ID="$1"
+
+VERSIONS="$(gcloud \
+  --project=$PROJECT_ID \
+  app versions list --service=default \
+  --format="value(version.id)" --sort-by="~version.createTime" \
+  | tail -n +6)"
+
+gcloud --project=$PROJECT_ID app versions delete --service=default --quiet $VERSIONS

--- a/gcp/appengine/cleanup_versions.sh
+++ b/gcp/appengine/cleanup_versions.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Helper to clean up all but the most recent 5 versions of the default service
-# in the given project
+# Helper to clean up all but the most recent 105 versions of the default service
+# in the given project to avoid hitting the 210 maximum version ceiling.
 
 # Inspiration: https://stackoverflow.com/questions/34499875/how-to-automatically-delete-old-google-app-engine-version-instances
 

--- a/gcp/appengine/cleanup_versions.sh
+++ b/gcp/appengine/cleanup_versions.sh
@@ -15,6 +15,7 @@ PROJECT_ID="$1"
 VERSIONS="$(gcloud \
   --project=$PROJECT_ID \
   app versions list --service=default \
+  --filter="traffic_split=0" \
   --format="value(version.id)" --sort-by="~version.createTime" \
   | tail -n +6)"
 

--- a/gcp/appengine/cleanup_versions.sh
+++ b/gcp/appengine/cleanup_versions.sh
@@ -17,6 +17,6 @@ VERSIONS="$(gcloud \
   app versions list --service=default \
   --filter="traffic_split=0" \
   --format="value(version.id)" --sort-by="~version.createTime" \
-  | tail -n +6)"
+  | tail -n +106)"
 
 gcloud --project=$PROJECT_ID app versions delete --service=default --quiet $VERSIONS


### PR DESCRIPTION
Add a build stage that executes a new script that cleans up all but the last 5 App Engine versions.