### PR TITLE
Remove duplicate embedded directory name

### DIFF
--- a/vulnfeeds/cmd/debian-copyright-mirror/debian-copyright-mirror
+++ b/vulnfeeds/cmd/debian-copyright-mirror/debian-copyright-mirror
@@ -33,7 +33,7 @@ gsutil ${BE_VERBOSE="-q"} -m rsync -d -r "${GCS_PATH}" "${WORK_DIR}"
 
 wget \
   ${BE_VERBOSE="--quiet"} \
-  --directory "${WORK_DIR}/debian_copyright" \
+  --directory "${WORK_DIR}" \
   --mirror \
   --accept debian_copyright \
   --accept index.html \


### PR DESCRIPTION
This was resulting in paths like
`osv-test-cve-osv-conversion/debian_copyright/debian_copyright/metadata.ftp-master.debian.org` which is unnecessarily deep and doesn't match expectations on the consumption side.