### PR TITLE
Handle not having any versions to remove

### DIFF
--- a/gcp/appengine/cleanup_versions.sh
+++ b/gcp/appengine/cleanup_versions.sh
@@ -19,4 +19,6 @@ VERSIONS="$(gcloud \
   --format="value(version.id)" --sort-by="~version.createTime" \
   | tail -n +106)"
 
-gcloud --project=$PROJECT_ID app versions delete --service=default --quiet $VERSIONS
+if [[ -n "$VERSIONS" ]]; then
+  gcloud --project=$PROJECT_ID app versions delete --service=default --quiet $VERSIONS
+fi


### PR DESCRIPTION
With the increase to 106 versions, it's totally conceivable there won't be any versions to delete, so do it conditionally