### PR TITLE
Fix cperepos map generation

### DIFF
--- a/vulnfeeds/cmd/cperepos/gen_cperepos_map
+++ b/vulnfeeds/cmd/cperepos/gen_cperepos_map
@@ -33,7 +33,7 @@ curl ${BE_VERBOSE="--silent"} \
 
 MAYBE_USE_DEBIAN_COPYRIGHT_METADATA=""
 if [[ -n "${DEBIAN_COPYRIGHT_GCS_PATH}" ]]; then
-  gsutil ${BE_VERBOSE="-q"} -m rsync -d -r "${DEBIAN_COPYRIGHT_GCS_PATH}" "${WORK_DIR}"
+  gsutil ${BE_VERBOSE="-q"} -m rsync -r "${DEBIAN_COPYRIGHT_GCS_PATH}" "${WORK_DIR}"
   MAYBE_USE_DEBIAN_COPYRIGHT_METADATA="--debian_metadata_path ${WORK_DIR}/debian_copyright/metadata.ftp-master.debian.org"
 fi
 


### PR DESCRIPTION
I think I got too overzealous with rsync `-d`'s and this is unintentionally (by me) wiping out the CPE Dictionary XML file that is also copied to `$WORK_DIR`, from looking at the logs.