### PR TITLE
Update local ssd entry again

### DIFF
--- a/deployment/terraform/modules/osv/workers_gke.tf
+++ b/deployment/terraform/modules/osv/workers_gke.tf
@@ -91,9 +91,10 @@ resource "google_container_node_pool" "highend" {
 
 
   node_config {
-    machine_type = "n2-highmem-32"
-    disk_type    = "pd-ssd"
-    disk_size_gb = 100
+    machine_type    = "n2-highmem-32"
+    disk_type       = "pd-ssd"
+    disk_size_gb    = 100
+    local_ssd_count = 4
 
     oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
 


### PR DESCRIPTION
Add local ssd entries to the disk, minimum is 4. Each disk is 375 gb for 1.5tb of local storage per node.

This should fix the out of disk space errors.

It seems like by default if there are local ssd's attached, then emptyDir uses the local ssds. It's really hard to find solid documentation on this though. 