### PR TITLE
Fix failing tests.

### DIFF
--- a/vulnfeeds/cves/versions_test.go
+++ b/vulnfeeds/cves/versions_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/go-test/deep"
+	"github.com/google/go-cmp/cmp"
 )
 
 // Helper function to load in a specific CVE from sample data.
@@ -567,7 +567,7 @@ func TestExtractVersionInfo(t *testing.T) {
 
 	for _, tc := range tests {
 		gotVersionInfo, _ := ExtractVersionInfo(tc.inputCVEItem, tc.inputValidVersions)
-		if diff := deep.Equal(gotVersionInfo, tc.expectedVersionInfo); diff != nil {
+		if diff := cmp.Diff(gotVersionInfo, tc.expectedVersionInfo); diff != "" {
 			t.Errorf("test %q: VersionInfo for %#v was incorrect: %s", tc.description, tc.inputCVEItem, diff)
 		}
 	}

--- a/vulnfeeds/git/repository_test.go
+++ b/vulnfeeds/git/repository_test.go
@@ -1,11 +1,9 @@
 package git
 
 import (
-	"reflect"
 	"testing"
 
-	"github.com/go-test/deep"
-
+	"github.com/google/go-cmp/cmp"
 	"golang.org/x/exp/maps"
 )
 
@@ -113,6 +111,7 @@ func TestRepoTags(t *testing.T) {
 				{Tag: "v0.17.4", Commit: "49e8faad5e2ed9ab2de54f6858ee223f918abac4"},
 				{Tag: "v0.18", Commit: "8ed48ad5ba180cd3ce30a3c41d42bad3779d9f26"},
 				{Tag: "v0.18.1", Commit: "5ee3529c3014b4238231885b1403faa3e1affb5c"},
+				{Tag: "v0.18.2", Commit: "d5499cbd3bf4ce6183f5ae3ce18e6e153e48ac9b"},
 			},
 			expectedOk: true,
 		},
@@ -127,8 +126,8 @@ func TestRepoTags(t *testing.T) {
 		if err != nil && tc.expectedOk {
 			t.Errorf("test %q: RepoTags(%q) unexpectedly failed: %+v", tc.description, tc.inputRepoURL, err)
 		}
-		if diff := deep.Equal(got, tc.expectedResult); diff != nil {
-			t.Errorf("test %q: RepoTags(%q) incorrect result: %#v", tc.description, tc.inputRepoURL, diff)
+		if diff := cmp.Diff(got, tc.expectedResult); diff != "" {
+			t.Errorf("test %q: RepoTags(%q) incorrect result: %s", tc.description, tc.inputRepoURL, diff)
 		}
 		if tc.cache != nil {
 			cache_after = len(tc.cache)
@@ -199,8 +198,8 @@ func TestValidRepo(t *testing.T) {
 	}
 	for _, tc := range tests {
 		got := ValidRepo(tc.repoURL)
-		if !reflect.DeepEqual(got, tc.expectedResult) {
-			t.Errorf("test %q: ValidRepo(%q) was incorrect, got: %#v, expected: %#v", tc.description, tc.repoURL, got, tc.expectedResult)
+		if diff := cmp.Diff(got, tc.expectedResult); diff != "" {
+			t.Errorf("test %q: ValidRepo(%q) was incorrect: %s", tc.description, tc.repoURL, diff)
 		}
 	}
 }

--- a/vulnfeeds/go.mod
+++ b/vulnfeeds/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/logging v1.7.0
 	github.com/aquasecurity/go-pep440-version v0.0.0-20210121094942-22b2f8951d46
 	github.com/go-git/go-git/v5 v5.6.1
-	github.com/go-test/deep v1.1.0
+	github.com/google/go-cmp v0.5.9
 	github.com/knqyf263/go-cpe v0.0.0-20201213041631-54f6ab28673f
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 	gopkg.in/yaml.v2 v2.4.0
@@ -27,7 +27,6 @@ require (
 	github.com/go-git/go-billy/v5 v5.4.1 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect

--- a/vulnfeeds/go.sum
+++ b/vulnfeeds/go.sum
@@ -54,8 +54,6 @@ github.com/go-git/go-git-fixtures/v4 v4.3.1 h1:y5z6dd3qi8Hl+stezc8p3JxDkoTRqMAlK
 github.com/go-git/go-git-fixtures/v4 v4.3.1/go.mod h1:8LHG1a3SRW71ettAD/jW13h8c6AqjVSeL11RAdgaqpo=
 github.com/go-git/go-git/v5 v5.6.1 h1:q4ZRqQl4pR/ZJHc1L5CFjGA1a10u76aV1iC+nh+bHsk=
 github.com/go-git/go-git/v5 v5.6.1/go.mod h1:mvyoL6Unz0PiTQrGQfSfiLFhBH1c1e84ylC2MDs4ee8=
-github.com/go-test/deep v1.1.0 h1:WOcxcdHcvdgThNXjw0t76K42FXTU7HpNQWHpA2HHNlg=
-github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=


### PR DESCRIPTION
Also replace github.com/go-test/deep with github.com/google/go-cmp which generates more readable diffs.