### PR TITLE
Highend and importer pool terraform update

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/importer.yaml
+++ b/deployment/clouddeploy/gke-workers/base/importer.yaml
@@ -9,6 +9,10 @@ spec:
     spec:
       template:
         spec:
+          tolerations:
+          - key: workloadType
+            operator: Equal
+            value: importer-pool
           containers:
           - name: importer
             image: importer

--- a/deployment/terraform/modules/osv/workers_gke.tf
+++ b/deployment/terraform/modules/osv/workers_gke.tf
@@ -97,6 +97,7 @@ resource "google_container_node_pool" "highend" {
     disk_type    = "pd-ssd"
     disk_size_gb = 100
     ephemeral_storage_config {
+      // Minimum is 4 ssds for n2-highmem-32, for 375GB * 4 = 1.5TB of storage
       local_ssd_count = 4
     }
 

--- a/deployment/terraform/modules/osv/workers_gke.tf
+++ b/deployment/terraform/modules/osv/workers_gke.tf
@@ -93,13 +93,13 @@ resource "google_container_node_pool" "highend" {
 
 
   node_config {
-    machine_type    = "n2-highmem-32"
-    disk_type       = "pd-ssd"
-    disk_size_gb    = 100
+    machine_type = "n2-highmem-32"
+    disk_type    = "pd-ssd"
+    disk_size_gb = 100
     ephemeral_storage_config {
       local_ssd_count = 4
     }
-    
+
     oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
 
     labels = {
@@ -137,6 +137,12 @@ resource "google_container_node_pool" "importer_pool" {
     local_ssd_count = 1
 
     oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+
+    taint = [{
+      effect = "NO_EXECUTE"
+      key    = "workloadType"
+      value  = "importer-pool"
+    }]
   }
 }
 

--- a/deployment/terraform/modules/osv/workers_gke.tf
+++ b/deployment/terraform/modules/osv/workers_gke.tf
@@ -96,7 +96,7 @@ resource "google_container_node_pool" "highend" {
     machine_type = "n2-highmem-32"
     disk_type    = "pd-ssd"
     disk_size_gb = 100
-    ephemeral_storage_config {
+    ephemeral_storage_config { // This is used for emptyDir storage in kubernetes
       // Minimum is 4 ssds for n2-highmem-32, for 375GB * 4 = 1.5TB of storage
       local_ssd_count = 4
     }

--- a/deployment/terraform/modules/osv/workers_gke.tf
+++ b/deployment/terraform/modules/osv/workers_gke.tf
@@ -74,6 +74,8 @@ resource "google_container_node_pool" "highend" {
   name     = "highend"
   cluster  = google_container_cluster.workers.name
   location = google_container_cluster.workers.location
+  # For using the ephemeral storage local ssd config
+  provider = google-beta
 
   lifecycle {
     # Terraform doesn't automatically know to recreate node pools when the cluster is recreated.
@@ -94,8 +96,10 @@ resource "google_container_node_pool" "highend" {
     machine_type    = "n2-highmem-32"
     disk_type       = "pd-ssd"
     disk_size_gb    = 100
-    local_ssd_count = 4
-
+    ephemeral_storage_config {
+      local_ssd_count = 4
+    }
+    
     oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
 
     labels = {


### PR DESCRIPTION
Update highend for actual ephemeral storage, and importer pool for taint to stop other services crowding out the importer from running. 