### PR TITLE
Fix incorrect YAML

### DIFF
--- a/deployment/deploy-prod.yaml
+++ b/deployment/deploy-prod.yaml
@@ -40,6 +40,7 @@ steps:
   args: ['container', 'images', 'add-tag', '--quiet', 'gcr.io/oss-vdb/debian-convert:$COMMIT_SHA', 'gcr.io/oss-vdb/debian-convert:$TAG_NAME']
 - name: gcr.io/cloud-builders/gcloud
   args: ['container', 'images', 'add-tag', '--quiet', 'gcr.io/oss-vdb/debian-copyright-mirror:$COMMIT_SHA', 'gcr.io/oss-vdb/debian-copyright-mirror:$TAG_NAME']
+- name: gcr.io/cloud-builders/gcloud  
   args: ['container', 'images', 'add-tag', '--quiet', 'gcr.io/oss-vdb/cpe-repo-gen:$COMMIT_SHA', 'gcr.io/oss-vdb/cpe-repo-gen:$TAG_NAME']
 - name: gcr.io/cloud-builders/gcloud
   args: ['container', 'images', 'add-tag', '--quiet', 'gcr.io/oss-vdb/osv-server:$COMMIT_SHA', 'gcr.io/oss-vdb/osv-server:$TAG_NAME']


### PR DESCRIPTION
My previous change to this file seems to have been botched by the looks of it...

Fixes:

```
/usr/bin/../lib/google-cloud-sdk/lib/third_party/ruamel/yaml/constructor.py:283: DuplicateKeyFutureWarning: while constructing a mapping
  in "deploy-prod.yaml", line 41, column 3
found duplicate key "args" with value "[]" (original value: "[]")
  in "deploy-prod.yaml", line 43, column 3

To suppress this check see:
    http://yaml.readthedocs.io/en/latest/api.html#duplicate-keys

Duplicate keys will become an error in future releases, and are errors
by default when using the new API.

  warnings.warn(DuplicateKeyFutureWarning(*args))
Created [https://cloudbuild.googleapis.com/v1/projects/oss-vdb/locations/global/builds/603e0a12-c9d2-466b-b465-80abd8b6b99f].
Logs are available at [ https://console.cloud.google.com/cloud-build/builds/603e0a12-c9d2-466b-b465-80abd8b6b99f?project=651737493649 ].
```