### PR TITLE
Change logging target for vulnfeeds to be dynamic

### DIFF
--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/alpine-cve-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/alpine-cve-convert.yaml
@@ -10,5 +10,7 @@ spec:
           containers:
           - name: alpine-cve-convert
             env:
+            - name: GOOGLE_CLOUD_PROJECT
+              value: oss-vdb-test
             - name: OUTPUT_GCS_BUCKET
               value: osv-test-cve-osv-conversion

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/combine-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/combine-to-osv.yaml
@@ -10,5 +10,7 @@ spec:
           containers:
           - name: combine-to-osv
             env:
+            - name: GOOGLE_CLOUD_PROJECT
+              value: oss-vdb-test
             - name: OUTPUT_GCS_BUCKET
               value: osv-test-cve-osv-conversion

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/debian-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/debian-convert.yaml
@@ -10,5 +10,7 @@ spec:
           containers:
           - name: debian-convert
             env:
+            - name: GOOGLE_CLOUD_PROJECT
+              value: oss-vdb-test
             - name: OUTPUT_GCS_BUCKET
               value: osv-test-debian-osv

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/debian-copyright-mirror.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/debian-copyright-mirror.yaml
@@ -10,6 +10,8 @@ spec:
           containers:
           - name: debian-copyright-mirror
             env:
+            - name: GOOGLE_CLOUD_PROJECT
+              value: oss-vdb-test
             - name: GCS_PATH
               value: gs://osv-test-cve-osv-conversion/debian_copyright/debian_copyright.tar
             - name: BE_VERBOSE

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/debian-first-version.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/debian-first-version.yaml
@@ -10,5 +10,7 @@ spec:
           containers:
           - name: debian-first-version
             env:
+            - name: GOOGLE_CLOUD_PROJECT
+              value: oss-vdb-test
             - name: OUTPUT_GCS_BUCKET
               value: osv-test-debian-osv

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/gen-cperepos-map.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/gen-cperepos-map.yaml
@@ -10,6 +10,8 @@ spec:
           containers:
           - name: gen-cperepos-map
             env:
+            - name: GOOGLE_CLOUD_PROJECT
+              value: oss-vdb
             - name: DEBIAN_COPYRIGHT_GCS_PATH
               value: gs://osv-test-cve-osv-conversion/debian_copyright/debian_copyright.tar
             - name: CPEREPO_GCS_PATH

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/alpine-cve-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/alpine-cve-convert.yaml
@@ -10,5 +10,7 @@ spec:
           containers:
           - name: alpine-cve-convert
             env:
+            - name: GOOGLE_CLOUD_PROJECT
+              value: oss-vdb
             - name: OUTPUT_GCS_BUCKET
               value: cve-osv-conversion

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/combine-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/combine-to-osv.yaml
@@ -10,5 +10,7 @@ spec:
           containers:
           - name: combine-to-osv
             env:
+            - name: GOOGLE_CLOUD_PROJECT
+              value: oss-vdb
             - name: OUTPUT_GCS_BUCKET
               value: cve-osv-conversion

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/debian-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/debian-convert.yaml
@@ -10,5 +10,7 @@ spec:
           containers:
           - name: debian-convert
             env:
+            - name: GOOGLE_CLOUD_PROJECT
+              value: oss-vdb
             - name: OUTPUT_GCS_BUCKET
               value: debian-osv

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/debian-copyright-mirror.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/debian-copyright-mirror.yaml
@@ -10,5 +10,7 @@ spec:
           containers:
           - name: debian-copyright-mirror
             env:
+            - name: GOOGLE_CLOUD_PROJECT
+              value: oss-vdb
             - name: GCS_PATH
               value: gs://cve-osv-conversion/debian_copyright/debian_copyright.tar

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/debian-first-version.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/debian-first-version.yaml
@@ -10,5 +10,7 @@ spec:
           containers:
           - name: debian-first-version
             env:
+            - name: GOOGLE_CLOUD_PROJECT
+              value: oss-vdb
             - name: OUTPUT_GCS_BUCKET
               value: debian-osv

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/gen-cperepos-map.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/gen-cperepos-map.yaml
@@ -10,6 +10,8 @@ spec:
           containers:
           - name: gen-cperepos-map
             env:
+            - name: GOOGLE_CLOUD_PROJECT
+              value: oss-vdb
             - name: DEBIAN_COPYRIGHT_GCS_PATH
               value: gs://cve-osv-conversion/debian_copyright/debian_copyright.tar
             - name: CPEREPO_GCS_PATH

--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"flag"
-	"log"
 	"os"
 	"path"
 	"strings"
@@ -12,33 +10,27 @@ import (
 	"github.com/google/osv/vulnfeeds/cves"
 	"github.com/google/osv/vulnfeeds/utility"
 	"github.com/google/osv/vulnfeeds/vulns"
-
-	"cloud.google.com/go/logging"
 )
 
 const (
 	defaultCvePath        = "cve_jsons"
 	defaultPartsInputPath = "parts"
 	defaultOSVOutputPath  = "osv_output"
-	projectId             = "oss-vdb"
 )
 
 var Logger utility.LoggerWrapper
 
 func main() {
-	client, err := logging.NewClient(context.Background(), projectId)
-	if err != nil {
-		log.Fatalf("Failed to create client: %v", err)
-	}
-	defer client.Close()
-	Logger.GCloudLogger = client.Logger("combine-to-osv")
+	var logCleanup func()
+	Logger, logCleanup = utility.CreateLoggerWrapper("combine-to-osv")
+	defer logCleanup()
 
 	cvePath := flag.String("cvePath", defaultCvePath, "Path to CVE file")
 	partsInputPath := flag.String("partsPath", defaultPartsInputPath, "Path to CVE file")
 	osvOutputPath := flag.String("osvOutputPath", defaultOSVOutputPath, "Path to CVE file")
 	flag.Parse()
 
-	err = os.MkdirAll(*cvePath, 0755)
+	err := os.MkdirAll(*cvePath, 0755)
 	if err != nil {
 		Logger.Fatalf("Can't create output path: %s", err)
 	}

--- a/vulnfeeds/cmd/download-cves/main.go
+++ b/vulnfeeds/cmd/download-cves/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"compress/gzip"
-	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -17,8 +16,6 @@ import (
 
 	"github.com/google/osv/vulnfeeds/cves"
 	"github.com/google/osv/vulnfeeds/utility"
-
-	"cloud.google.com/go/logging"
 )
 
 const (
@@ -28,7 +25,6 @@ const (
 	fileNameBase   = "nvdcve-1.1-"
 	startingYear   = 2002
 	CVEPathDefault = "cve_jsons"
-	projectId      = "oss-vdb"
 )
 
 var Logger utility.LoggerWrapper
@@ -36,12 +32,10 @@ var apiKey = flag.String("api_key", "", "API key for accessing NVD API 2.0")
 var CVEPath = flag.String("cvePath", CVEPathDefault, "Where to download CVEs to")
 
 func main() {
-	client, err := logging.NewClient(context.Background(), projectId)
-	if err != nil {
-		log.Fatalf("Failed to create client: %v", err)
-	}
-	defer client.Close()
-	Logger.GCloudLogger = client.Logger("download-cves")
+	var logCleanup func()
+	Logger, logCleanup = utility.CreateLoggerWrapper("download-cves")
+	defer logCleanup()
+
 	flag.Parse()
 	if *apiKey != "" {
 		downloadCVE2(*apiKey, *CVEPath)


### PR DESCRIPTION
Change logging target for vulnfeeds depending on what environment it's running in.

This changes:
- alpine
- cve-downloader
- combine-to-osv

to get their project from the environment instead of hard coding. (Added a extra utility function to create the Logger wrapper and retrieve the project from the env).

This does not change cperepos to avoid merge conflicts.

Then changes almost all of the yaml configs to include the GOOGLE_CLOUD_PROJECT environment variable (this includes the cperepos yaml files, can undo that if it causes merge conflicts @andrewpollock )


Also fixes alpine converter not using the logger wrapper for invalid versions.