### PR TITLE
Add a denylist for known non-OSS that is also known problematic

### DIFF
--- a/vulnfeeds/cpp/main.go
+++ b/vulnfeeds/cpp/main.go
@@ -77,6 +77,13 @@ var RefTagDenyList = []string{
 	// "Third Party Advisory",
 }
 
+// VendorProducts known not to be Open Source software and causing
+// cross-contamination of repo derivation between CVEs.
+var VendorProductDenyList = []VendorProduct{
+	// Causes a chain reaction of incorrect associations from CVE-2022-2068
+	VendorProduct{"netapp", "ontap_select_deploy_administration_utility"},
+}
+
 // Looks at what the repo to determine if it contains code using an in-scope language
 func InScopeRepo(repoURL string) bool {
 	parsedURL, err := url.Parse(repoURL)
@@ -393,6 +400,9 @@ func main() {
 				}
 				// Continue to only focus on application CPEs.
 				if CPE.Part != "a" {
+					continue
+				}
+				if slices.Contains(VendorProductDenyList, VendorProduct{CPE.Vendor, CPE.Product}) {
 					continue
 				}
 				repos := ReposForCPE(cve.CVE.CVEDataMeta.ID, VPRepoCache, VendorProduct{CPE.Vendor, CPE.Product}, refs, RefTagDenyList)


### PR DESCRIPTION
Instigated by CVE-2022-1664, which is ostensibly for dpkg (debian:dpkg) but netapp:ontap_select_deploy_administration_utility also uses dpkg, so the dpkg source repo gets (incorrectly) attributed to this CPE as well.

That then flows onto future CVEs that reference the netapp software (plus other CPEs) cross-contaminating them with the incorrect repo. This is one (rare) scenario where reusing precomputed repos for CPEs causes a domino effect of incorrect associations in later CVEs.