### PR TITLE
Add netapp:active_iq_unified_manager to bad CPE denylist

### DIFF
--- a/vulnfeeds/cpp/main.go
+++ b/vulnfeeds/cpp/main.go
@@ -83,6 +83,8 @@ var RefTagDenyList = []string{
 var VendorProductDenyList = []VendorProduct{
 	// Causes a chain reaction of incorrect associations from CVE-2022-2068
 	VendorProduct{"netapp", "ontap_select_deploy_administration_utility"},
+	// Causes misattribution for Python, e.g. CVE-2022-26488
+	VendorProduct{"netapp", "active_iq_unified_manager"},
 }
 
 // Looks at what the repo to determine if it contains code using an in-scope language


### PR DESCRIPTION
This was causing misattribution for Python on the likes of CVE-2022-26488