### PR TITLE
Fix integration tests

### DIFF
--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -274,12 +274,17 @@ class IntegrationTests(unittest.TestCase):
         timeout=_TIMEOUT)
     self.assert_results_equal({'vulns': expected_vulns}, response.json())
 
+  def test_no_vulns(self):
+    package = 'github.com/justinas/nosurf'
+    ecosystem = 'Go'
+
     # Test that a SemVer with a (believed to be non-vulnerable) version and an
     # ecosystem returns no vulnerabilities.
+    # (This version does not exist)
     response = requests.post(
         _api() + '/v1/query',
         data=json.dumps({
-            'version': '2.7.8',
+            'version': '1.1.1',
             'package': {
                 'name': package,
                 'ecosystem': ecosystem,

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -274,7 +274,8 @@ class IntegrationTests(unittest.TestCase):
         timeout=_TIMEOUT)
     self.assert_results_equal({'vulns': expected_vulns}, response.json())
 
-  def test_no_vulns(self):
+  def test_query_semver_no_vulns(self):
+    """Test queries by SemVer with no vulnerabilities."""
     package = 'github.com/justinas/nosurf'
     ecosystem = 'Go'
 


### PR DESCRIPTION
Our integration tests broke because of this: https://osv.dev/vulnerability/GO-2023-1737, which is an unfixed vulnerability that was just published on Friday, and we have a test that's expecting no vulnerabilities.

Moved that test to a separate simple package that only ever had 1 vuln in 2020, so it's less likely to break in the future.
