### PR TITLE
Add some additional instrumentation for troubleshooting

### DIFF
--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""API server implementation."""
+"""OSV API server implementation."""
 
 import argparse
 import codecs
@@ -632,7 +632,7 @@ def query_by_package(project, ecosystem, purl: PackageURL, page_token,
 
 
 def serve(port: int, local: bool):
-  """Configures and runs the bookstore API server."""
+  """Configures and runs the OSV API server."""
   server = grpc.server(concurrent.futures.ThreadPoolExecutor(max_workers=10))
   osv_service_v1_pb2_grpc.add_OSVServicer_to_server(OSVServicer(), server)
   if local:
@@ -649,6 +649,7 @@ def serve(port: int, local: bool):
     while True:
       time.sleep(3600)
   except KeyboardInterrupt:
+    print('Shutting down with {} grace period'.format(_SHUTDOWN_GRACE_DURATION))
     server.stop(_SHUTDOWN_GRACE_DURATION)
 
 


### PR DESCRIPTION
Python treats a SIGINT as a KeyboardInterrupt exception by default, so in the event of the container getting a SIGINT in production, log this explicitly.