### PR TITLE
Add typing, add timeout, add kernel quick fail

### DIFF
--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -91,7 +91,7 @@ class OSVServicer(osv_service_v1_pb2_grpc.OSVServicer):
 
     version.
     """
-    logging.info("Request time remaining: " + context.time_remaining())
+    logging.info(f"Request time remaining: {context.time_remaining()}")
     results, next_page_token = do_query(request.query, context).result()
     if results is not None:
       return osv_service_v1_pb2.VulnerabilityList(
@@ -348,7 +348,12 @@ def do_query(query, context: grpc.ServicerContext, include_details=True):
   elif (package_name != '' and ecosystem != '') or (purl and not purl_version):
     # Package specified without version.
     bugs, next_page_token = yield query_by_package(
-        package_name, ecosystem, purl, page_token, to_response=to_response)
+        context,
+        package_name,
+        ecosystem,
+        purl,
+        page_token,
+        to_response=to_response)
   else:
     context.abort(grpc.StatusCode.INVALID_ARGUMENT, 'Invalid query.')
     return None
@@ -576,8 +581,8 @@ def query_by_version(context: grpc.ServicerContext,
     context.abort(
         grpc.StatusCode.UNAVAILABLE,
         "Linux Kernel queries are currently unavailable: " +
-        "See https://google.github.io/osv.dev/faq/#why-am-i-getting-an-error-message-for-my-linux-kernel-query"
-    )
+        "See https://google.github.io/osv.dev/faq/" +
+        "#why-am-i-getting-an-error-message-for-my-linux-kernel-query")
 
   if package_name:
     query = osv.Bug.query(

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -38,7 +38,6 @@ from osv import semver_index
 import osv_service_v1_pb2
 import osv_service_v1_pb2_grpc
 
-_MAX_TIMEOUT_SECONDS = 60
 _SHUTDOWN_GRACE_DURATION = 5
 
 _MAX_BATCH_QUERY = 1000

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -91,7 +91,7 @@ class OSVServicer(osv_service_v1_pb2_grpc.OSVServicer):
 
     version.
     """
-    logging.info(f"Request time remaining: {context.time_remaining()}")
+    logging.info("Request time remaining: %s", context.time_remaining())
     results, next_page_token = do_query(request.query, context).result()
     if results is not None:
       return osv_service_v1_pb2.VulnerabilityList(


### PR DESCRIPTION
Added the quick fail for Kernel queries, and tried matching the ndb query timeout with the GRPC time_remaining function. Added a log to check if that function does what I think it does and matches what we set in cloud run. 

Also added a bunch of type hints just to make development more efficient. 