### PR TITLE
Make api backend timeout match frontend, reduce container concurrency

### DIFF
--- a/deployment/clouddeploy/osv-api/run.yaml
+++ b/deployment/clouddeploy/osv-api/run.yaml
@@ -10,3 +10,5 @@ spec:
         resources:
           limits:
             memory: 4Gi
+      timeoutSeconds: 60
+      containerConcurrency: 20

--- a/deployment/terraform/environments/oss-vdb-test/api/api_config.tftpl
+++ b/deployment/terraform/environments/oss-vdb-test/api/api_config.tftpl
@@ -30,3 +30,4 @@ backend:
   rules:
     - selector: "*"
       address: ${backend_url}
+      deadline: 60


### PR DESCRIPTION
- Set `timeoutSeconds` to 60, instead of the default 300, for the backend api to match what is on the frontend
  - Also set the staging instance's frontend timeout to 60 to match prod
- Reduce the backend's `containerConcurrency` to 20 (from default 80). This is 2x the number of threads in the thread pool for the server. May reduce further in future.