### PR TITLE
Updated frontend_handlers.py to handle negative page offsets

### DIFF
--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -388,9 +388,11 @@ def osv_query(search_string, page, affected_only, ecosystem):
     total_future = query.count_async()
 
   result_items = []
+  
+  offset = max((page - 1) * _PAGE_SIZE, 0)  # Ensure non-negative offset value
 
   bugs, _, _ = query.fetch_page(
-      page_size=_PAGE_SIZE, offset=(page - 1) * _PAGE_SIZE)
+      page_size=_PAGE_SIZE, offset=offset
   for bug in bugs:
     result_items.append(bug_to_response(bug, detailed=False))
 


### PR DESCRIPTION
In the modified code, I've added a line to calculate the offset value, ensuring it is a non-negative integer. The max() function is used to make sure that if the calculated offset is negative, it is set to 0. This prevents the "Offset must be non-negative" error.

Fixes #1117 