### PR TITLE
Only log the clone failure on the final attempt

### DIFF
--- a/osv/repos.py
+++ b/osv/repos.py
@@ -115,7 +115,7 @@ def clone_with_retries(git_url, checkout_dir, git_callbacks=None, branch=None):
         _checkout_branch(repo, branch)
       return repo
     except (pygit2.GitError, subprocess.CalledProcessError) as e:
-      if attempt == range(CLONE_TRIES)[-1]:
+      if attempt == CLONE_TRIES - 1:
         logging.error('Clone failed on attempt %d of %d: %s', attempt + 1,
                       CLONE_TRIES, str(e))
       shutil.rmtree(checkout_dir, ignore_errors=True)

--- a/osv/repos.py
+++ b/osv/repos.py
@@ -116,8 +116,8 @@ def clone_with_retries(git_url, checkout_dir, git_callbacks=None, branch=None):
       return repo
     except (pygit2.GitError, subprocess.CalledProcessError) as e:
       if attempt == CLONE_TRIES - 1:
-        logging.error('Clone failed on attempt %d of %d: %s', attempt + 1,
-                      CLONE_TRIES, str(e))
+        logging.error('Clone failed after %d attempts: %s', CLONE_TRIES,
+                      str(e))
       shutil.rmtree(checkout_dir, ignore_errors=True)
       time.sleep(RETRY_SLEEP_SECONDS)
       continue

--- a/osv/repos.py
+++ b/osv/repos.py
@@ -107,7 +107,7 @@ def clone(git_url, checkout_dir, git_callbacks=None):
 def clone_with_retries(git_url, checkout_dir, git_callbacks=None, branch=None):
   """Clone with retries."""
   logging.info('Cloning %s to %s', git_url, checkout_dir)
-  for _ in range(CLONE_TRIES):
+  for attempt in range(CLONE_TRIES):
     try:
       repo = clone(git_url, checkout_dir, git_callbacks)
       repo.cache = {}
@@ -115,7 +115,9 @@ def clone_with_retries(git_url, checkout_dir, git_callbacks=None, branch=None):
         _checkout_branch(repo, branch)
       return repo
     except (pygit2.GitError, subprocess.CalledProcessError) as e:
-      logging.error('Clone failed: %s', str(e))
+      if attempt == range(CLONE_TRIES)[-1]:
+        logging.error('Clone failed on attempt %d of %d: %s', attempt + 1,
+                      CLONE_TRIES, str(e))
       shutil.rmtree(checkout_dir, ignore_errors=True)
       time.sleep(RETRY_SLEEP_SECONDS)
       continue

--- a/osv/repos.py
+++ b/osv/repos.py
@@ -116,8 +116,7 @@ def clone_with_retries(git_url, checkout_dir, git_callbacks=None, branch=None):
       return repo
     except (pygit2.GitError, subprocess.CalledProcessError) as e:
       if attempt == CLONE_TRIES - 1:
-        logging.error('Clone failed after %d attempts: %s', CLONE_TRIES,
-                      str(e))
+        logging.error('Clone failed after %d attempts: %s', CLONE_TRIES, str(e))
       shutil.rmtree(checkout_dir, ignore_errors=True)
       time.sleep(RETRY_SLEEP_SECONDS)
       continue


### PR DESCRIPTION
Reasoning:

* it gets retried, so a first (or second) failure + successful reattempt is just noise

Reduces non-actionable instances of the likes of:

```
Clone failed: Command '['git', 'clone', 'https://github.com/github/advisory-database.git', '/work/sources/ghsa']' returned non-zero exit status 128.
```

in the error logs.