### PR TITLE
Fix timeout argument

### DIFF
--- a/vulnfeeds/git/repository_test.go
+++ b/vulnfeeds/git/repository_test.go
@@ -112,6 +112,7 @@ func TestRepoTags(t *testing.T) {
 				{Tag: "v0.18", Commit: "73078765396b99ac1ce9004d35a1ee5db2fbb6e5"},
 				{Tag: "v0.18.1", Commit: "de5bb24b9b24df7598161a1ce19dc2ce15afa9c6"},
 				{Tag: "v0.18.2", Commit: "3d5b18b9e5e1c51533ac01d8acd3499b2f9fcc2e"},
+				{Tag: "v0.18.3", Commit: "1cf7764293aebb473baee3ff82298d83593943e8"},
 			},
 			expectedOk: true,
 		},


### PR DESCRIPTION
Remove the deprecated default option and pass it in directly.

By filling out default options, every query now prints a warning log because of this line in the implementation code:

        if default_options is not None:
            _log.warning(
                "Deprecation warning: passing default_options to the Query"
                "constructor is deprecated. Please directly pass any "
                "arguments you want to use to the Query constructor or its "
                "methods."
            )
https://github.com/googleapis/python-ndb/blob/a3a181a427cc292882691d963b30bc78c05c6592/google/cloud/ndb/query.py#L1339

Though looking at the git blame has been "deprecated" since 4 years ago in version v0.0.1