### PR TITLE
Fix IN_SCOPE_YEARS in nvd-cve-osv

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/nvd-cve-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/nvd-cve-osv.yaml
@@ -28,7 +28,7 @@ spec:
               - name: WORK_DIR
                 value: /tmp
               - name: IN_SCOPE_YEARS
-                value: 2022
+                value: (2022)
           restartPolicy: OnFailure
           volumes:
             - name: "ssd"

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/base_nvd-cve-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/base_nvd-cve-osv.yaml
@@ -30,7 +30,7 @@ spec:
               - name: WORK_DIR
                 value: /tmp
               - name: IN_SCOPE_YEARS
-                value: 2022
+                value: (2022)
           restartPolicy: OnFailure
           volumes:
             - name: "ssd"


### PR DESCRIPTION
Looks like env vars need to be strings in kubernetes manifests.
Used parentheses instead of quotes since `IN_SCOPE_YEARS` is meant to be an array.