### PR TITLE
Try and fix handling of environment variable

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/nvd-cve-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/nvd-cve-osv.yaml
@@ -28,7 +28,7 @@ spec:
               - name: WORK_DIR
                 value: /tmp
               - name: IN_SCOPE_YEARS
-                value: (2022)
+                value: "2022"
           restartPolicy: OnFailure
           volumes:
             - name: "ssd"


### PR DESCRIPTION
This seemed to go through verbatim with parenthesis, when what's going to be needed is a quoted string, as it'll wind up being multiple space-separated values.

Saw a log run like this, which was not what's intended:

```
Commencing conversion run
Downloading NVD CVE dumps
Downloading latest CPE Git repository map
Converting NVD CVE records from (2022) to OSV
Copying NVD CVE records from (2022) successfully converted to OSV to GCS
find: /tmp/nvd2osv/(2022): No such file or directory
CommandException: No URLs matched. Do the files you're operating on exist?
CommandException: No URLs matched: /tmp/nvd2osv/(2022)/outcomes.csv
Results summary available at gs://osv-test-cve-osv-conversion/nvd-poc/nvd-conversion-outcomes-(2022)-2023-05-23T06:01+00:00.csv
Conversion run complete
```