### PR TITLE
Fix scorecard action by pinning `github/codeql-action` to 2.3.3

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -50,6 +50,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v2 # v1.0.26
+        uses: github/codeql-action/upload-sarif@29b1f65c5e92e24fe6b6647da1eaabe529cec70f # v2.3.3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Newest version (2.3.4) does allow scorecard's "no file" URI to be parsed correctly https://github.com/ossf/scorecard/issues/3063

Also, the version comment was pretty outdated.