### PR TITLE
Better logging redirection

### DIFF
--- a/vulnfeeds/utility/logginghelpers.go
+++ b/vulnfeeds/utility/logginghelpers.go
@@ -13,23 +13,21 @@ import (
 // CreateLoggerWrapper creates and initializes the LoggerWrapper,
 // and also returns a cleanup function to be deferred
 func CreateLoggerWrapper(name string) (LoggerWrapper, func()) {
-	projectId, ok := os.LookupEnv("GOOGLE_CLOUD_PROJECT")
-	var loggerOptions []logging.LoggerOption
-	if !ok {
-		log.Println("GOOGLE_CLOUD_PROJECT not set, routing logs to stdout")
-		loggerOptions = append(loggerOptions, logging.RedirectAsJSON(os.Stdout))
+	projectId, projectIdSet := os.LookupEnv("GOOGLE_CLOUD_PROJECT")
+	if !projectIdSet {
+		return LoggerWrapper{}, func() {}
 	}
-	client, err := logging.NewClient(context.Background(), projectId)
 
+	log.Println("Logging to project id: " + projectId)
+	client, err := logging.NewClient(context.Background(), projectId)
 	if err != nil {
 		log.Fatalf("Failed to create client: %v", err)
 	}
-
 	wrapper := LoggerWrapper{
-		GCloudLogger: client.Logger(name, loggerOptions...),
+		GCloudLogger: client.Logger(name),
 	}
-
 	return wrapper, func() { client.Close() }
+
 }
 
 // LoggerWrapper wraps the Logger provided by google cloud

--- a/vulnfeeds/utility/logginghelpers.go
+++ b/vulnfeeds/utility/logginghelpers.go
@@ -27,7 +27,6 @@ func CreateLoggerWrapper(logID string) (LoggerWrapper, func()) {
 		GCloudLogger: client.Logger(name),
 	}
 	return wrapper, func() { client.Close() }
-
 }
 
 // LoggerWrapper wraps the Logger provided by google cloud

--- a/vulnfeeds/utility/logginghelpers.go
+++ b/vulnfeeds/utility/logginghelpers.go
@@ -24,7 +24,7 @@ func CreateLoggerWrapper(logID string) (LoggerWrapper, func()) {
 		log.Fatalf("Failed to create client: %v", err)
 	}
 	wrapper := LoggerWrapper{
-		GCloudLogger: client.Logger(name),
+		GCloudLogger: client.Logger(logID),
 	}
 	return wrapper, func() { client.Close() }
 }

--- a/vulnfeeds/utility/logginghelpers.go
+++ b/vulnfeeds/utility/logginghelpers.go
@@ -12,7 +12,7 @@ import (
 
 // CreateLoggerWrapper creates and initializes the LoggerWrapper,
 // and also returns a cleanup function to be deferred
-func CreateLoggerWrapper(name string) (LoggerWrapper, func()) {
+func CreateLoggerWrapper(logID string) (LoggerWrapper, func()) {
 	projectId, projectIdSet := os.LookupEnv("GOOGLE_CLOUD_PROJECT")
 	if !projectIdSet {
 		return LoggerWrapper{}, func() {}


### PR DESCRIPTION
LoggingHelper already had the functionality to redirect to stdout (when cloud logger is nil), so undo the JSON redirect and set the gcloud logger to nil instead. 