### PR TITLE
Update `worker-base` image to Python 3.11.1

### DIFF
--- a/docker/worker-base/Dockerfile
+++ b/docker/worker-base/Dockerfile
@@ -28,12 +28,12 @@ RUN apt-get update && apt-get upgrade -y && \
         libssl-dev \
         software-properties-common
 
-RUN curl -sS https://www.python.org/ftp/python/3.11.0/Python-3.11.0.tgz | tar -C /tmp -xzv && \
-    cd /tmp/Python-3.11.0 && \
+RUN curl -sS https://www.python.org/ftp/python/3.11.0/Python-3.11.1.tgz | tar -C /tmp -xzv && \
+    cd /tmp/Python-3.11.1 && \
     ./configure --enable-optimizations --with-lto --enable-loadable-sqlite-extensions && \
     make -j && \
     make install && \
-    rm -rf /tmp/Python-3.11.0
+    rm -rf /tmp/Python-3.11.1
 RUN pip3 install pipenv
 
 # Install Docker.


### PR DESCRIPTION
Need to do this before #1338 (which enforces Python 3.11.1) because the PR test runner image `gcr.io/oss-vdb/ci` uses the worker image.

`gcr.io/oss-vdb/ci` should probably be automatically rebuilt for PRs if the worker image changes...