### PR TITLE
index-api-caller: Add a "-dir" flag.

### DIFF
--- a/tools/indexer-api-caller/caller.go
+++ b/tools/indexer-api-caller/caller.go
@@ -37,7 +37,7 @@ func main() {
 	if *searchDir != "" {
 		entries, err := os.ReadDir(*searchDir)
 		if err != nil {
-			log.Panicf("Failed to read dir: %w", err)
+			log.Panicf("Failed to read dir: %v", err)
 		}
 		for _, entry := range entries {
 			if entry.IsDir() {


### PR DESCRIPTION
This adds a convenience flag to scan all the (top level) subdirectories within a given directory.