### PR TITLE
Unpin Python patch version

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11.1'
+          python-version: '3.11'
       - name: Install pipenv
         run: pip install pipenv
       - name: Set up pipenv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ This project follows
 You must install:
 
 1.  Git
-1.  Python 3.11.1
+1.  Python 3.11
 1.  [Make](https://www.gnu.org/software/make/)
 1.  [Pipenv](https://pipenv.pypa.io/en/latest/)
 1.  [Google Cloud SDK](https://cloud.google.com/sdk)

--- a/Pipfile
+++ b/Pipfile
@@ -21,4 +21,4 @@ pipenv = ">=2022.9.4"
 grpcio-tools = "*"
 
 [requires]
-python_version = "3.11.1"
+python_version = "3.11"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8722c1325d1955b63a272da4b58492699d0ac2913680bcc25d2f7a9605525ced"
+            "sha256": "9fa21dbda79946affcd8f03838c37b057737a1a18fe64c779e10e6a8c1c06830"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.11.1"
+            "python_version": "3.11"
         },
         "sources": [
             {
@@ -368,7 +368,7 @@
                 "sha256:0e8cda3d5a634d9895b75c573c9352c16486cb75deb0e078b5fda34db4243165",
                 "sha256:de34e52d6c9c6fcd704192f09767cb561bb4ee64e70eede20b0834d841f0be4d"
             ],
-            "markers": "python_version >= '3.11'",
+            "markers": "python_version >= '3.6'",
             "version": "==1.22.2"
         },
         "protobuf": {

--- a/docker/worker-base/Dockerfile
+++ b/docker/worker-base/Dockerfile
@@ -28,12 +28,13 @@ RUN apt-get update && apt-get upgrade -y && \
         libssl-dev \
         software-properties-common
 
-RUN curl -sS https://www.python.org/ftp/python/3.11.1/Python-3.11.1.tgz | tar -C /tmp -xzv && \
-    cd /tmp/Python-3.11.1 && \
+ARG PYTHON_VERSION=3.11.3
+RUN curl -sS https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz | tar -C /tmp -xzv && \
+    cd /tmp/Python-${PYTHON_VERSION} && \
     ./configure --enable-optimizations --with-lto --enable-loadable-sqlite-extensions && \
     make -j && \
     make install && \
-    rm -rf /tmp/Python-3.11.1
+    rm -rf /tmp/Python-${PYTHON_VERSION}
 RUN pip3 install pipenv
 
 # Install Docker.

--- a/docker/worker/Pipfile
+++ b/docker/worker/Pipfile
@@ -17,4 +17,4 @@ yapf = "*"
 pylint = "*"
 
 [requires]
-python_version = "3.11.1"
+python_version = "3.11"

--- a/docker/worker/Pipfile.lock
+++ b/docker/worker/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "573e61fb4f1b487520a2ee7016f62079cbf6d03184a0dfca33888bc00e3c6a9e"
+            "sha256": "0546875e6320e70bf489212bae78643d4e463ed316f26f8a676bfa553057e9ad"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.11.1"
+            "python_version": "3.11"
         },
         "sources": [
             {
@@ -471,7 +471,7 @@
                 "sha256:0e8cda3d5a634d9895b75c573c9352c16486cb75deb0e078b5fda34db4243165",
                 "sha256:de34e52d6c9c6fcd704192f09767cb561bb4ee64e70eede20b0834d841f0be4d"
             ],
-            "markers": "python_version >= '3.11'",
+            "markers": "python_version >= '3.6'",
             "version": "==1.22.2"
         },
         "protobuf": {

--- a/gcp/api/Dockerfile
+++ b/gcp/api/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.11.1-slim
+FROM python:3.11-slim
 
 # TODO(ochang): Just copy the entire project (needs a clean checkout).
 COPY setup.py Pipfile* README.md /osv/

--- a/gcp/api/Pipfile
+++ b/gcp/api/Pipfile
@@ -18,4 +18,4 @@ grpcio-reflection = "*"
 grpcio-tools = "*"
 
 [requires]
-python_version = "3.11.1"
+python_version = "3.11"

--- a/gcp/api/Pipfile.lock
+++ b/gcp/api/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "429a2d6f4ded40abc953d2cce5e30b82def995dcc7a4288c1a8e722fbfaa944b"
+            "sha256": "70996bce45341a920e2216db0f80c911f17c61f36403625a6b532ed863384e66"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.11.1"
+            "python_version": "3.11"
         },
         "sources": [
             {

--- a/gcp/appengine/Pipfile
+++ b/gcp/appengine/Pipfile
@@ -24,5 +24,4 @@ grpcio-status = "==1.54.2"
 pipenv = "==2022.12.19"
 
 [requires]
-# We can't control what patch version App Engine uses - it always uses the latest stable.
 python_version = "3.11"


### PR DESCRIPTION
Since our local environments have now just upgraded Python 3.11.2, our Pipfiles need to be changed. Having the patch version pinned makes maintaining/upgrading everything difficult, so I've just unpinned them.

This should mean that dependabot/renovate-bot will use the latest version, 3.11.3 when checking updates, so I've bumped our worker-base to 3.11.3 also.

We have a transient dependency, `async-timeout` that has the marker `python_full_version <= '3.11.2'`:
https://github.com/google/osv.dev/blob/e756517994e3f250c5426e765a1287608b4e6174/Pipfile.lock#L19-L25
[It's brought in by `redis` and it's just removed and replaced by anything in for Python 3.11.3](https://github.com/redis/redis-py/blob/d95d8a24ed2af3eae80b7b0f14cbccc9dbe86e96/setup.py#L37).
This shouldn't impact us locally if removed by one of the bots, and keeping the workers/appengine on 3.11.3 should mean they don't actually need it anyway.