### PR TITLE
Improve CPE version extraction

### DIFF
--- a/vulnfeeds/cmd/cperepos/main.go
+++ b/vulnfeeds/cmd/cperepos/main.go
@@ -80,17 +80,17 @@ type CPE23Item struct {
 // product names, which cause undesired and incorrect repository attribution
 // when resolved via Debian copyright metadata.
 var DebianCopyrightDenylist = []cves.VendorProduct{
-	cves.VendorProduct{"apple", "pdfkit"},
-	cves.VendorProduct{"f-secure", "safe"},
-	cves.VendorProduct{"ibm", "workflow"},
-	cves.VendorProduct{"inductiveautomation", "ignition"},
-	cves.VendorProduct{"jetbrains", "hub"},
-	cves.VendorProduct{"microsoft", "onedrive"},
-	cves.VendorProduct{"mirametrix", "glance"},
-	cves.VendorProduct{"nintext", "workflow"},
-	cves.VendorProduct{"oracle", "workflow"},
-	cves.VendorProduct{"thrivethemes", "ignition"},
-	cves.VendorProduct{"vmware", "horizon"},
+	cves.VendorProduct{Vendor: "apple", Product: "pdfkit"},
+	cves.VendorProduct{Vendor: "f-secure", Product: "safe"},
+	cves.VendorProduct{Vendor: "ibm", Product: "workflow"},
+	cves.VendorProduct{Vendor: "inductiveautomation", Product: "ignition"},
+	cves.VendorProduct{Vendor: "jetbrains", Product: "hub"},
+	cves.VendorProduct{Vendor: "microsoft", Product: "onedrive"},
+	cves.VendorProduct{Vendor: "mirametrix", Product: "glance"},
+	cves.VendorProduct{Vendor: "nintext", Product: "workflow"},
+	cves.VendorProduct{Vendor: "oracle", Product: "workflow"},
+	cves.VendorProduct{Vendor: "thrivethemes", Product: "ignition"},
+	cves.VendorProduct{Vendor: "vmware", Product: "horizon"},
 }
 
 // VendorProductToRepoMap maps a VendorProduct to a repo URL.
@@ -319,26 +319,26 @@ func analyzeCPEDictionary(d CPEDict) (ProductToRepo VendorProductToRepoMap, Desc
 				continue
 			}
 			// If we already have an entry for this repo, don't add it again.
-			if slices.Contains(ProductToRepo[cves.VendorProduct{CPE.Vendor, CPE.Product}], repo) {
+			if slices.Contains(ProductToRepo[cves.VendorProduct{Vendor: CPE.Vendor, Product: CPE.Product}], repo) {
 				continue
 			}
 			Logger.Infof("Liking %q for %s:%s (%s)", repo, CPE.Vendor, CPE.Product, r.Description)
-			ProductToRepo[cves.VendorProduct{CPE.Vendor, CPE.Product}] = append(ProductToRepo[cves.VendorProduct{CPE.Vendor, CPE.Product}], repo)
+			ProductToRepo[cves.VendorProduct{Vendor: CPE.Vendor, Product: CPE.Product}] = append(ProductToRepo[cves.VendorProduct{Vendor: CPE.Vendor, Product: CPE.Product}], repo)
 			// If this was queued for trying to find via Debian, and subsequently found, dequeue it.
 			if *DebianMetadataPath != "" {
-				delete(MaybeTryDebian, cves.VendorProduct{CPE.Vendor, CPE.Product})
+				delete(MaybeTryDebian, cves.VendorProduct{Vendor: CPE.Vendor, Product: CPE.Product})
 			}
 		}
 		// If we've arrived to this point, we've exhausted the
 		// references and not calculated any repos for the product,
 		// flag for trying Debian afterwards.
 		// We may encounter another CPE item that *does* have a viable reference in the meantime.
-		if len(ProductToRepo[cves.VendorProduct{CPE.Vendor, CPE.Product}]) == 0 && *DebianMetadataPath != "" {
+		if len(ProductToRepo[cves.VendorProduct{Vendor: CPE.Vendor, Product: CPE.Product}]) == 0 && *DebianMetadataPath != "" {
 			// Check the denylist though.
-			if slices.Contains(DebianCopyrightDenylist, cves.VendorProduct{CPE.Vendor, CPE.Product}) {
+			if slices.Contains(DebianCopyrightDenylist, cves.VendorProduct{Vendor: CPE.Vendor, Product: CPE.Product}) {
 				continue
 			}
-			MaybeTryDebian[cves.VendorProduct{CPE.Vendor, CPE.Product}] = true
+			MaybeTryDebian[cves.VendorProduct{Vendor: CPE.Vendor, Product: CPE.Product}] = true
 		}
 	}
 	// Try any Debian possible ones as a last resort.
@@ -358,7 +358,7 @@ func analyzeCPEDictionary(d CPEDict) (ProductToRepo VendorProductToRepoMap, Desc
 					Logger.Infof("Disregarding derived repo %s for %s:%s because %v", repo, vp.Vendor, vp.Product, err)
 					continue
 				}
-				ProductToRepo[cves.VendorProduct{vp.Vendor, vp.Product}] = append(ProductToRepo[cves.VendorProduct{vp.Vendor, vp.Product}], repo)
+				ProductToRepo[cves.VendorProduct{Vendor: vp.Vendor, Product: vp.Product}] = append(ProductToRepo[cves.VendorProduct{Vendor: vp.Vendor, Product: vp.Product}], repo)
 			}
 		}
 	}

--- a/vulnfeeds/cpp/main.go
+++ b/vulnfeeds/cpp/main.go
@@ -70,9 +70,9 @@ var RefTagDenyList = []string{
 // cross-contamination of repo derivation between CVEs.
 var VendorProductDenyList = []cves.VendorProduct{
 	// Causes a chain reaction of incorrect associations from CVE-2022-2068
-	cves.VendorProduct{"netapp", "ontap_select_deploy_administration_utility"},
+	cves.VendorProduct{Vendor: "netapp", Product: "ontap_select_deploy_administration_utility"},
 	// Causes misattribution for Python, e.g. CVE-2022-26488
-	cves.VendorProduct{"netapp", "active_iq_unified_manager"},
+	cves.VendorProduct{Vendor: "netapp", Product: "active_iq_unified_manager"},
 }
 
 // Looks at what the repo to determine if it contains code using an in-scope language
@@ -366,8 +366,8 @@ func main() {
 			if CPE.Part == "a" {
 				appCPECount += 1
 			}
-			if _, ok := VPRepoCache[cves.VendorProduct{CPE.Vendor, CPE.Product}]; ok {
-				Logger.Infof("[%s]: Pre-references, derived %q for %q %q using cache", cve.CVE.CVEDataMeta.ID, VPRepoCache[cves.VendorProduct{CPE.Vendor, CPE.Product}], CPE.Vendor, CPE.Product)
+			if _, ok := VPRepoCache[cves.VendorProduct{Vendor: CPE.Vendor, Product: CPE.Product}]; ok {
+				Logger.Infof("[%s]: Pre-references, derived %q for %q %q using cache", cve.CVE.CVEDataMeta.ID, VPRepoCache[cves.VendorProduct{Vendor: CPE.Vendor, Product: CPE.Product}], CPE.Vendor, CPE.Product)
 				ReposForCVE[cve.CVE.CVEDataMeta.ID] = VPRepoCache[cves.VendorProduct{CPE.Vendor, CPE.Product}]
 			}
 		}
@@ -392,10 +392,10 @@ func main() {
 				if CPE.Part != "a" {
 					continue
 				}
-				if slices.Contains(VendorProductDenyList, cves.VendorProduct{CPE.Vendor, CPE.Product}) {
+				if slices.Contains(VendorProductDenyList, cves.VendorProduct{Vendor: CPE.Vendor, Product: CPE.Product}) {
 					continue
 				}
-				repos := ReposForCPE(cve.CVE.CVEDataMeta.ID, VPRepoCache, cves.VendorProduct{CPE.Vendor, CPE.Product}, refs, RefTagDenyList)
+				repos := ReposForCPE(cve.CVE.CVEDataMeta.ID, VPRepoCache, cves.VendorProduct{Vendor: CPE.Vendor, Product: CPE.Product}, refs, RefTagDenyList)
 				if len(repos) == 0 {
 					Logger.Warnf("[%s]: Failed to derive any repos for %q %q", cve.CVE.CVEDataMeta.ID, CPE.Vendor, CPE.Product)
 					continue

--- a/vulnfeeds/cpp/main.go
+++ b/vulnfeeds/cpp/main.go
@@ -368,7 +368,7 @@ func main() {
 			}
 			if _, ok := VPRepoCache[cves.VendorProduct{Vendor: CPE.Vendor, Product: CPE.Product}]; ok {
 				Logger.Infof("[%s]: Pre-references, derived %q for %q %q using cache", cve.CVE.CVEDataMeta.ID, VPRepoCache[cves.VendorProduct{Vendor: CPE.Vendor, Product: CPE.Product}], CPE.Vendor, CPE.Product)
-				ReposForCVE[cve.CVE.CVEDataMeta.ID] = VPRepoCache[cves.VendorProduct{CPE.Vendor, CPE.Product}]
+				ReposForCVE[cve.CVE.CVEDataMeta.ID] = VPRepoCache[cves.VendorProduct{Vendor: CPE.Vendor, Product: CPE.Product}]
 			}
 		}
 

--- a/vulnfeeds/cves/versions_test.go
+++ b/vulnfeeds/cves/versions_test.go
@@ -683,6 +683,22 @@ func TestExtractVersionInfo(t *testing.T) {
 			},
 			expectedNotes: []string{},
 		},
+		{
+			description:        "A CVE with multiple unrelated CPEs",
+			inputCVEItem:       loadTestData("CVE-2022-27778"),
+			inputValidVersions: []string{},
+			expectedVersionInfo: VersionInfo{
+				FixCommits:          []GitCommit(nil),
+				LimitCommits:        []GitCommit(nil),
+				LastAffectedCommits: []GitCommit(nil),
+				AffectedVersions: []AffectedVersion{
+					AffectedVersion{
+						LastAffected: "7.83.0",
+					},
+				},
+			},
+			expectedNotes: []string{},
+		},
 	}
 
 	for _, tc := range tests {

--- a/vulnfeeds/test_data/nvdcve-1.1-test-data.json
+++ b/vulnfeeds/test_data/nvdcve-1.1-test-data.json
@@ -41335,8 +41335,334 @@
     },
     "publishedDate" : "2022-08-23T04:15Z",
     "lastModifiedDate" : "2022-08-24T14:26Z"
-  },
-  {
+  }, {
+    "cve": {
+      "data_type": "CVE",
+      "data_format": "MITRE",
+      "data_version": "4.0",
+      "CVE_data_meta": {
+	"ID": "CVE-2022-27778",
+	"ASSIGNER": "support@hackerone.com"
+      },
+      "problemtype": {
+	"problemtype_data": [
+	  {
+	    "description": [
+	      {
+		"lang": "en",
+		"value": "CWE-706"
+	      }
+	    ]
+	  }
+	]
+      },
+      "references": {
+	"reference_data": [
+	  {
+	    "url": "https://hackerone.com/reports/1553598",
+	    "name": "https://hackerone.com/reports/1553598",
+	    "refsource": "MISC",
+	    "tags": [
+	      "Exploit",
+	      "Third Party Advisory"
+	    ]
+	  },
+	  {
+	    "url": "https://security.netapp.com/advisory/ntap-20220609-0009/",
+	    "name": "https://security.netapp.com/advisory/ntap-20220609-0009/",
+	    "refsource": "CONFIRM",
+	    "tags": [
+	      "Third Party Advisory"
+	    ]
+	  },
+	  {
+	    "url": "https://www.oracle.com/security-alerts/cpujul2022.html",
+	    "name": "N/A",
+	    "refsource": "N/A",
+	    "tags": [
+	      "Patch",
+	      "Third Party Advisory"
+	    ]
+	  },
+	  {
+	    "url": "https://security.netapp.com/advisory/ntap-20220729-0004/",
+	    "name": "https://security.netapp.com/advisory/ntap-20220729-0004/",
+	    "refsource": "CONFIRM",
+	    "tags": [
+	      "Third Party Advisory"
+	    ]
+	  }
+	]
+      },
+      "description": {
+	"description_data": [
+	  {
+	    "lang": "en",
+	    "value": "A use of incorrectly resolved name vulnerability fixed in 7.83.1 might remove the wrong file when `--no-clobber` is used together with `--remove-on-error`."
+	  }
+	]
+      }
+    },
+    "configurations": {
+      "CVE_data_version": "4.0",
+      "nodes": [
+	{
+	  "operator": "OR",
+	  "children": [],
+	  "cpe_match": [
+	    {
+	      "vulnerable": true,
+	      "cpe23Uri": "cpe:2.3:a:haxx:curl:7.83.0:*:*:*:*:*:*:*",
+	      "cpe_name": []
+	    }
+	  ]
+	},
+	{
+	  "operator": "OR",
+	  "children": [],
+	  "cpe_match": [
+	    {
+	      "vulnerable": true,
+	      "cpe23Uri": "cpe:2.3:a:netapp:snapcenter:-:*:*:*:*:*:*:*",
+	      "cpe_name": []
+	    },
+	    {
+	      "vulnerable": true,
+	      "cpe23Uri": "cpe:2.3:a:netapp:oncommand_workflow_automation:-:*:*:*:*:*:*:*",
+	      "cpe_name": []
+	    },
+	    {
+	      "vulnerable": true,
+	      "cpe23Uri": "cpe:2.3:a:netapp:oncommand_insight:-:*:*:*:*:*:*:*",
+	      "cpe_name": []
+	    },
+	    {
+	      "vulnerable": true,
+	      "cpe23Uri": "cpe:2.3:a:netapp:clustered_data_ontap:-:*:*:*:*:*:*:*",
+	      "cpe_name": []
+	    },
+	    {
+	      "vulnerable": true,
+	      "cpe23Uri": "cpe:2.3:a:netapp:solidfire_\\&_hci_management_node:-:*:*:*:*:*:*:*",
+	      "cpe_name": []
+	    },
+	    {
+	      "vulnerable": true,
+	      "cpe23Uri": "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:vmware_vsphere:*:*",
+	      "cpe_name": []
+	    },
+	    {
+	      "vulnerable": true,
+	      "cpe23Uri": "cpe:2.3:a:netapp:active_iq_unified_manager:-:*:*:*:*:windows:*:*",
+	      "cpe_name": []
+	    }
+	  ]
+	},
+	{
+	  "operator": "AND",
+	  "children": [
+	    {
+	      "operator": "OR",
+	      "children": [],
+	      "cpe_match": [
+		{
+		  "vulnerable": true,
+		  "cpe23Uri": "cpe:2.3:o:netapp:h300s_firmware:-:*:*:*:*:*:*:*",
+		  "cpe_name": []
+		}
+	      ]
+	    },
+	    {
+	      "operator": "OR",
+	      "children": [],
+	      "cpe_match": [
+		{
+		  "vulnerable": false,
+		  "cpe23Uri": "cpe:2.3:h:netapp:h300s:-:*:*:*:*:*:*:*",
+		  "cpe_name": []
+		}
+	      ]
+	    }
+	  ],
+	  "cpe_match": []
+	},
+	{
+	  "operator": "AND",
+	  "children": [
+	    {
+	      "operator": "OR",
+	      "children": [],
+	      "cpe_match": [
+		{
+		  "vulnerable": true,
+		  "cpe23Uri": "cpe:2.3:o:netapp:bh500s_firmware:-:*:*:*:*:*:*:*",
+		  "cpe_name": []
+		}
+	      ]
+	    },
+	    {
+	      "operator": "OR",
+	      "children": [],
+	      "cpe_match": [
+		{
+		  "vulnerable": false,
+		  "cpe23Uri": "cpe:2.3:h:netapp:h500s:-:*:*:*:*:*:*:*",
+		  "cpe_name": []
+		}
+	      ]
+	    }
+	  ],
+	  "cpe_match": []
+	},
+	{
+	  "operator": "AND",
+	  "children": [
+	    {
+	      "operator": "OR",
+	      "children": [],
+	      "cpe_match": [
+		{
+		  "vulnerable": true,
+		  "cpe23Uri": "cpe:2.3:o:netapp:h700s_firmware:-:*:*:*:*:*:*:*",
+		  "cpe_name": []
+		}
+	      ]
+	    },
+	    {
+	      "operator": "OR",
+	      "children": [],
+	      "cpe_match": [
+		{
+		  "vulnerable": false,
+		  "cpe23Uri": "cpe:2.3:h:netapp:h700s:-:*:*:*:*:*:*:*",
+		  "cpe_name": []
+		}
+	      ]
+	    }
+	  ],
+	  "cpe_match": []
+	},
+	{
+	  "operator": "AND",
+	  "children": [
+	    {
+	      "operator": "OR",
+	      "children": [],
+	      "cpe_match": [
+		{
+		  "vulnerable": true,
+		  "cpe23Uri": "cpe:2.3:o:netapp:h410s_firmware:-:*:*:*:*:*:*:*",
+		  "cpe_name": []
+		}
+	      ]
+	    },
+	    {
+	      "operator": "OR",
+	      "children": [],
+	      "cpe_match": [
+		{
+		  "vulnerable": false,
+		  "cpe23Uri": "cpe:2.3:h:netapp:h410s:-:*:*:*:*:*:*:*",
+		  "cpe_name": []
+		}
+	      ]
+	    }
+	  ],
+	  "cpe_match": []
+	},
+	{
+	  "operator": "AND",
+	  "children": [
+	    {
+	      "operator": "OR",
+	      "children": [],
+	      "cpe_match": [
+		{
+		  "vulnerable": true,
+		  "cpe23Uri": "cpe:2.3:o:netapp:hci_compute_node_firmware:-:*:*:*:*:*:*:*",
+		  "cpe_name": []
+		}
+	      ]
+	    },
+	    {
+	      "operator": "OR",
+	      "children": [],
+	      "cpe_match": [
+		{
+		  "vulnerable": false,
+		  "cpe23Uri": "cpe:2.3:h:netapp:hci_compute_node:-:*:*:*:*:*:*:*",
+		  "cpe_name": []
+		}
+	      ]
+	    }
+	  ],
+	  "cpe_match": []
+	},
+	{
+	  "operator": "OR",
+	  "children": [],
+	  "cpe_match": [
+	    {
+	      "vulnerable": true,
+	      "cpe23Uri": "cpe:2.3:a:oracle:mysql_server:*:*:*:*:*:*:*:*",
+	      "versionStartIncluding": "8.0.0",
+	      "versionEndIncluding": "8.0.29",
+	      "cpe_name": []
+	    },
+	    {
+	      "vulnerable": true,
+	      "cpe23Uri": "cpe:2.3:a:oracle:mysql_server:*:*:*:*:*:*:*:*",
+	      "versionEndIncluding": "5.7.38",
+	      "cpe_name": []
+	    }
+	  ]
+	}
+      ]
+    },
+    "impact": {
+      "baseMetricV3": {
+	"cvssV3": {
+	  "version": "3.1",
+	  "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:H",
+	  "attackVector": "NETWORK",
+	  "attackComplexity": "LOW",
+	  "privilegesRequired": "NONE",
+	  "userInteraction": "REQUIRED",
+	  "scope": "UNCHANGED",
+	  "confidentialityImpact": "NONE",
+	  "integrityImpact": "HIGH",
+	  "availabilityImpact": "HIGH",
+	  "baseScore": 8.1,
+	  "baseSeverity": "HIGH"
+	},
+	"exploitabilityScore": 2.8,
+	"impactScore": 5.2
+      },
+      "baseMetricV2": {
+	"cvssV2": {
+	  "version": "2.0",
+	  "vectorString": "AV:N/AC:M/Au:N/C:N/I:P/A:P",
+	  "accessVector": "NETWORK",
+	  "accessComplexity": "MEDIUM",
+	  "authentication": "NONE",
+	  "confidentialityImpact": "NONE",
+	  "integrityImpact": "PARTIAL",
+	  "availabilityImpact": "PARTIAL",
+	  "baseScore": 5.8
+	},
+	"severity": "MEDIUM",
+	"exploitabilityScore": 8.6,
+	"impactScore": 4.9,
+	"acInsufInfo": false,
+	"obtainAllPrivilege": false,
+	"obtainUserPrivilege": false,
+	"obtainOtherPrivilege": false,
+	"userInteractionRequired": true
+      }
+    },
+    "publishedDate": "2022-06-02T14:15Z",
+    "lastModifiedDate": "2023-02-28T15:42Z"
+  }, {
     "cve": {
       "data_type": "CVE",
       "data_format": "MITRE",


### PR DESCRIPTION
I'm not convinced this approach is sound, so I'm running some test conversions to see how it changes the results...

Problem: sometimes a CVE can have multiple unrelated CPEs on it, a
pathological example being [CVE-2022-27778](https://nvd.nist.gov/vuln/detail/CVE-2022-27778), which is for a curl
vulnerability, but also affects MySQL.

This changes the behaviour to effectively only focus on the first CPE in
the configurations of the CVE.

An alternative treatment of CVEs like [CVE-2022-27778](https://nvd.nist.gov/vuln/detail/CVE-2022-27778) would be to emit
multiple `affected[].ranges[]` entries.

This also refactors the `VendorProduct` struct into the `cves` package for centralised use.