### PR TITLE
Improve performance of affectedcommits 

### DIFF
--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -399,7 +399,7 @@ def _get_bugs(bug_ids, to_response=bug_to_response):
   """Get bugs from bug ids."""
   bugs = ndb.get_multi_async([ndb.Key(osv.Bug, bug_id) for bug_id in bug_ids])
 
-  responses = list()
+  responses = []
   for future_bug in bugs:
     bug: osv.Bug = future_bug.result()
     if bug and bug.status == osv.BugStatus.PROCESSED and bug.public:

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -397,12 +397,15 @@ def bug_to_response(bug, include_details=True):
 
 def _get_bugs(bug_ids, to_response=bug_to_response):
   """Get bugs from bug ids."""
-  bugs = ndb.get_multi([ndb.Key(osv.Bug, bug_id) for bug_id in bug_ids])
-  return [
-      to_response(bug)
-      for bug in bugs
-      if bug and bug.status == osv.BugStatus.PROCESSED
-  ]
+  bugs = ndb.get_multi_async([ndb.Key(osv.Bug, bug_id) for bug_id in bug_ids])
+
+  responses = list()
+  for future_bug in bugs:
+    bug: osv.Bug = future_bug.result()
+    if bug and bug.status == osv.BugStatus.PROCESSED and bug.public:
+      responses.append(to_response(bug))
+
+  return responses
 
 
 def _clean_purl(purl):
@@ -429,25 +432,24 @@ def query_by_commit(context: grpc.ServicerContext,
   """Query by commit."""
   query = osv.AffectedCommits.query(osv.AffectedCommits.commits == commit)
   bug_ids = []
-  it = query.iter()
+  it: ndb.QueryIterator = query.iter(keys_only=True)
   gsd_count = 0
 
   while (yield it.has_next_async()):
-    affected_commits = it.next()
-    # Avoid requiring a separate index to include this in the initial Datastore
-    # query. The number of these should be very little to just iterate through.
-    if not affected_commits.public:
-      continue
-
+    # Affect commits key follows this format: 
+    # <BugID>-<PageNumber>
+    affected_commit_key: ndb.Key = it.next()
+    bug_id: str = affected_commit_key.id().rsplit("-", 1)[0]
+    
     # Temporary mitigation.
-    if affected_commits.bug_id.startswith('GSD-'):
+    if bug_id.startswith('GSD-'):
       gsd_count += 1
       if gsd_count >= 10:
         context.abort(grpc.StatusCode.UNAVAILABLE, _LINUX_ERROR)
 
       continue
 
-    bug_ids.append(affected_commits.bug_id)
+    bug_ids.append(bug_id)
 
   return _get_bugs(bug_ids, to_response=to_response)
 
@@ -650,6 +652,7 @@ def query_by_version(context: grpc.ServicerContext,
       bugs.extend((yield _query_by_generic_version(context, query, package_name,
                                                    ecosystem, purl, version)))
   else:
+    logging.warning("Package query without ecosystem specified")
     # Unspecified ecosystem. Try both.
     bugs.extend((yield _query_by_semver(context, query, package_name, ecosystem,
                                         purl, version)))

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -436,11 +436,11 @@ def query_by_commit(context: grpc.ServicerContext,
   gsd_count = 0
 
   while (yield it.has_next_async()):
-    # Affect commits key follows this format: 
+    # Affect commits key follows this format:
     # <BugID>-<PageNumber>
     affected_commit_key: ndb.Key = it.next()
     bug_id: str = affected_commit_key.id().rsplit("-", 1)[0]
-    
+
     # Temporary mitigation.
     if bug_id.startswith('GSD-'):
       gsd_count += 1


### PR DESCRIPTION
- Improve performance of affected commits queries by making it keys_only.
- Adds logging to  package queries that don't have ecosystems.