### PR TITLE
Remove unavailable package

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ tools and unsupported by the core OSV maintainers.
 -   [Dependency-Track](https://github.com/DependencyTrack/dependency-track)
 -   [dep-scan](https://github.com/AppThreat/dep-scan)
 -   [EZE-CLI: The one stop shop for security testing in modern development](https://github.com/RiverSafeUK/eze-cli)
--   [Golang support for the schema](https://pkg.go.dev/golang.org/x/vuln/osv)
 -   [G-Rath/osv-detector](https://github.com/G-Rath/osv-detector): A scanner
     that uses the OSV database.
 -   [it-depends](https://github.com/trailofbits/it-depends)

--- a/docs/third-party.md
+++ b/docs/third-party.md
@@ -16,7 +16,6 @@ tools and unsupported by the core OSV maintainers.
 -   [Dependency-Track](https://github.com/DependencyTrack/dependency-track)
 -   [dep-scan](https://github.com/AppThreat/dep-scan)
 -   [EZE-CLI: The one stop shop for security testing in modern development](https://github.com/RiverSafeUK/eze-cli)
--   [Golang support for the schema](https://pkg.go.dev/golang.org/x/vuln/osv)
 -   [G-Rath/osv-detector](https://github.com/G-Rath/osv-detector): A scanner
     that uses the OSV database.
 -   [it-depends](https://github.com/trailofbits/it-depends)


### PR DESCRIPTION
The link checker caught another dead link. The previously linked go package was recently deprecated and is no longer available. 

If we wanted to, we could replace this link with a link to the [Go vuln database](https://go.dev/security/vuln/database) but I don't think that is the intention of this section. I am inclined to just delete the link. 