### PR TITLE
Change aliases for debian to related instead

### DIFF
--- a/vulnfeeds/tools/debian/debian_converter/convert_debian.py
+++ b/vulnfeeds/tools/debian/debian_converter/convert_debian.py
@@ -128,15 +128,17 @@ class AdvisoryInfo:
   details: str
   published: str
   modified: str
-  affected: [AffectedInfo]
-  aliases: [str]
-  references: [Reference]
+  affected: list[AffectedInfo]
+  aliases: list[str]
+  related: list[str]
+  references: list[Reference]
 
   def __init__(self, adv_id: str, summary: str, published: str):
     self.id = adv_id
     self.summary = summary
     self.affected = []
     self.aliases = []
+    self.related = []
     # Set a placeholder value for published and modified, if there is wml files
     # this will be replaced
     self.published = published
@@ -199,7 +201,7 @@ def parse_security_tracker_file(advisories: Advisories,
         # {CVE-XXXX-XXXX CVE-XXXX-XXXX}
         line = line.lstrip()
         if line.startswith('{'):
-          advisories[current_advisory].aliases = line.strip('{}').split()
+          advisories[current_advisory].related = line.strip('{}').split()
           continue
 
         if line.startswith('NOTE:'):


### PR DESCRIPTION
Debian advisories' CVE lines lists multiple CVE's that's fixed by the new version. This is not what aliases field is used for, and is better suited to the related field. 

This will have the consequence of not being able to search by the CVE on the osv.dev website to find the DSAs, since only aliases are currently placed in the search_indices, not related. Created #1380 to track this. 