### PR TITLE
Adjusted link checker to run as cron

### DIFF
--- a/.github/workflows/link-checker-on-push.yml
+++ b/.github/workflows/link-checker-on-push.yml
@@ -1,0 +1,14 @@
+name: Check links on push
+
+on: push
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        use-quiet-mode: "yes"
+        check-modified-files-only: "yes"
+# Documentation available here: https://github.com/marketplace/actions/markdown-link-check

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,12 +1,8 @@
-name: Check Markdown links
+name: Scheduled link check
 
 on: 
   schedule:
     - cron: '30 22 * * *'
-  push:
-    branches-ignore:
-      - 'master'
-
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
@@ -15,4 +11,5 @@ jobs:
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: "yes"
+        
 # Documentation available here: https://github.com/marketplace/actions/markdown-link-check

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -3,6 +3,9 @@ name: Check Markdown links
 on: 
   schedule:
     - cron: '30 22 * * *'
+  push:
+    branches-ignore:
+      - 'master'
 
 jobs:
   markdown-link-check:

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,7 +1,8 @@
 name: Check Markdown links
 
-on: schedule
-- cron: '10, 18, *, *, *'
+on: 
+  schedule:
+    - cron: '30 22 * * *'
 
 jobs:
   markdown-link-check:

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -1,6 +1,7 @@
 name: Check Markdown links
 
-on: push
+on: schedule
+- cron: '10, 18, *, *, *'
 
 jobs:
   markdown-link-check:


### PR DESCRIPTION
I have adjusted this so it runs once daily. 

It also runs on pushes, but only scans any files that have been modified. Failures on push should not prevent merging, but we can remove this in the case it does. 

If the link checker finds something when you push, you can either address it in your pull request, or you can open an issue and I will fix it. 