### PR TITLE
Reflect GCS bucket access logging changes in Terraform

### DIFF
--- a/deployment/terraform/environments/oss-vdb-test/main.tf
+++ b/deployment/terraform/environments/oss-vdb-test/main.tf
@@ -5,6 +5,7 @@ module "osv_test" {
 
   public_import_logs_bucket     = "osv-test-public-import-logs"
   vulnerabilities_export_bucket = "osv-test-vulnerabilities"
+  logs_bucket                   = "osv-test-logs"
   cve_osv_conversion_bucket     = "osv-test-cve-osv-conversion"
   debian_osv_conversion_bucket  = "osv-test-debian-osv"
 

--- a/deployment/terraform/environments/oss-vdb/main.tf
+++ b/deployment/terraform/environments/oss-vdb/main.tf
@@ -7,6 +7,7 @@ module "osv" {
   vulnerabilities_export_bucket = "osv-vulnerabilities"
   cve_osv_conversion_bucket     = "cve-osv-conversion"
   debian_osv_conversion_bucket  = "debian-osv"
+  logs_bucket                   = "osv-logs"
 
   api_url     = "api.osv.dev"
   esp_version = "2.41.0"

--- a/deployment/terraform/modules/osv/main.tf
+++ b/deployment/terraform/modules/osv/main.tf
@@ -96,6 +96,11 @@ resource "google_storage_bucket" "osv_vulnerabilities_export" {
   lifecycle {
     prevent_destroy = true
   }
+
+  logging {
+    log_bucket        = var.logs_bucket
+    log_object_prefix = "osv-vulnerabilities"
+  }
 }
 
 resource "google_storage_bucket" "cve_osv_conversion" {
@@ -112,6 +117,17 @@ resource "google_storage_bucket" "cve_osv_conversion" {
 resource "google_storage_bucket" "debian_osv_conversion_bucket" {
   project                     = var.project_id
   name                        = var.debian_osv_conversion_bucket
+  location                    = "US"
+  uniform_bucket_level_access = true
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_storage_bucket" "logs_bucket" {
+  project                     = var.project_id
+  name                        = var.logs_bucket
   location                    = "US"
   uniform_bucket_level_access = true
 

--- a/deployment/terraform/modules/osv/variables.tf
+++ b/deployment/terraform/modules/osv/variables.tf
@@ -13,6 +13,11 @@ variable "vulnerabilities_export_bucket" {
   description = "Name of bucket to export vulnerabilities to."
 }
 
+variable "logs_bucket" {
+  type        = string
+  description = "Name of bucket to export logs to."
+}
+
 variable "cve_osv_conversion_bucket" {
   type        = string
   description = "Name of bucket to store converted CVEs in."


### PR DESCRIPTION
The other week I enabled GCS bucket access logging directly, without reflecting it in Terraform (I think I even did it incorrectly, the logging bucket specified was in my own project).

Also add the logs bucket itself