### PR TITLE
Add a log message for a task's latency

### DIFF
--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -147,7 +147,8 @@ class Importer:
         source=source_repo.name,
         path=path,
         original_sha256=original_sha256,
-        deleted=str(deleted).lower())
+        deleted=str(deleted).lower(),
+        timestamp=str(int(time.time())))
 
   def _request_internal_analysis(self, bug):
     """Request internal analysis."""
@@ -156,7 +157,8 @@ class Importer:
         data=b'',
         type='impact',
         source_id=bug.source_id,
-        allocated_id=bug.key.id())
+        allocated_id=bug.key.id(),
+        timestamp=str(int(time.time())))
 
   def run(self):
     """Run importer."""

--- a/docker/importer/importer_test.py
+++ b/docker/importer/importer_test.py
@@ -81,7 +81,8 @@ class ImporterTest(unittest.TestCase, tests.ExpectationTest(TEST_DATA_DIR)):
 
   @mock.patch('google.cloud.pubsub_v1.PublisherClient.publish')
   @mock.patch('time.time', return_value=12345.0)
-  def test_basic(self, mock_time: mock.MagicMock, mock_publish: mock.MagicMock):
+  def test_basic(self, unused_mock_time: mock.MagicMock,
+                 mock_publish: mock.MagicMock):
     """Test basic run."""
     osv.Bug(
         db_id='OSV-2017-134',
@@ -248,7 +249,7 @@ class ImporterTest(unittest.TestCase, tests.ExpectationTest(TEST_DATA_DIR)):
 
   @mock.patch('google.cloud.pubsub_v1.PublisherClient.publish')
   @mock.patch('time.time', return_value=12345.0)
-  def test_scheduled_updates(self, mock_time: mock.MagicMock,
+  def test_scheduled_updates(self, unused_mock_time: mock.MagicMock,
                              mock_publish: mock.MagicMock):
     """Test scheduled updates."""
     self.mock_repo.add_file('proj/OSV-2021-1337.yaml', _MIN_VALID_VULNERABILITY)
@@ -425,7 +426,8 @@ class BucketImporterTest(unittest.TestCase):
   @mock.patch('google.cloud.storage.Blob.upload_from_string')
   @mock.patch('google.cloud.pubsub_v1.PublisherClient.publish')
   @mock.patch('time.time', return_value=12345.0)
-  def test_bucket(self, mock_time: mock.MagicMock, mock_publish: mock.MagicMock,
+  def test_bucket(self, unused_mock_time: mock.MagicMock,
+                  mock_publish: mock.MagicMock,
                   upload_from_str: mock.MagicMock):
     """Test bucket updates."""
     imp = importer.Importer('fake_public_key', 'fake_private_key', self.tmp_dir,
@@ -495,7 +497,7 @@ class BucketImporterTest(unittest.TestCase):
   @mock.patch('google.cloud.storage.Blob.upload_from_string')
   @mock.patch('google.cloud.pubsub_v1.PublisherClient.publish')
   @mock.patch('time.time', return_value=12345.0)
-  def test_import_override(self, mock_time: mock.MagicMock,
+  def test_import_override(self, unused_mock_time: mock.MagicMock,
                            mock_publish: mock.MagicMock,
                            upload_from_str: mock.MagicMock):
     """Test bucket updates."""

--- a/docker/importer/importer_test.py
+++ b/docker/importer/importer_test.py
@@ -80,7 +80,8 @@ class ImporterTest(unittest.TestCase, tests.ExpectationTest(TEST_DATA_DIR)):
     shutil.rmtree(self.tmp_dir, ignore_errors=True)
 
   @mock.patch('google.cloud.pubsub_v1.PublisherClient.publish')
-  def test_basic(self, mock_publish):
+  @mock.patch('time.time', return_value=12345.0)
+  def test_basic(self, mock_time: mock.MagicMock, mock_publish: mock.MagicMock):
     """Test basic run."""
     osv.Bug(
         db_id='OSV-2017-134',
@@ -178,7 +179,8 @@ class ImporterTest(unittest.TestCase, tests.ExpectationTest(TEST_DATA_DIR)):
                              '19a3cd03fc15360bf16187f54df92a75'),
             path='2021-111.yaml',
             source='oss-fuzz',
-            type='update')
+            type='update',
+            timestamp='12345')
     ])
     bug = osv.Bug.get_by_id('OSV-2017-134')
     self.assertEqual(osv.SourceOfTruth.SOURCE_REPO, bug.source_of_truth)
@@ -245,7 +247,9 @@ class ImporterTest(unittest.TestCase, tests.ExpectationTest(TEST_DATA_DIR)):
     mock_publish.assert_not_called()
 
   @mock.patch('google.cloud.pubsub_v1.PublisherClient.publish')
-  def test_scheduled_updates(self, mock_publish):
+  @mock.patch('time.time', return_value=12345.0)
+  def test_scheduled_updates(self, mock_time: mock.MagicMock,
+                             mock_publish: mock.MagicMock):
     """Test scheduled updates."""
     self.mock_repo.add_file('proj/OSV-2021-1337.yaml', _MIN_VALID_VULNERABILITY)
     self.mock_repo.add_file('proj/OSV-2021-1339.yaml', _MIN_VALID_VULNERABILITY)
@@ -311,13 +315,15 @@ class ImporterTest(unittest.TestCase, tests.ExpectationTest(TEST_DATA_DIR)):
                              '19a3cd03fc15360bf16187f54df92a75'),
             path='proj/OSV-2021-1337.yaml',
             source='oss-fuzz',
-            type='update'),
+            type='update',
+            timestamp='12345'),
         mock.call(
             self.tasks_topic,
             allocated_id='OSV-2021-1339',
             data=b'',
             source_id='oss-fuzz:124',
-            type='impact'),
+            type='impact',
+            timestamp='12345'),
     ])
 
     source_repo = osv.SourceRepository.get_by_id('oss-fuzz')
@@ -418,7 +424,8 @@ class BucketImporterTest(unittest.TestCase):
 
   @mock.patch('google.cloud.storage.Blob.upload_from_string')
   @mock.patch('google.cloud.pubsub_v1.PublisherClient.publish')
-  def test_bucket(self, mock_publish: mock.MagicMock,
+  @mock.patch('time.time', return_value=12345.0)
+  def test_bucket(self, mock_time: mock.MagicMock, mock_publish: mock.MagicMock,
                   upload_from_str: mock.MagicMock):
     """Test bucket updates."""
     imp = importer.Importer('fake_public_key', 'fake_private_key', self.tmp_dir,
@@ -445,7 +452,8 @@ class BucketImporterTest(unittest.TestCase):
             path='a/b/android-test.json',
             original_sha256=('12453f85cd87bc1d465e0d013db572c0'
                              '1f7fb7de3b3a33de94ebcc7bd0f23a14'),
-            deleted='false'),
+            deleted='false',
+            timestamp='12345'),
         mock.call(
             self.tasks_topic,
             data=b'',
@@ -454,7 +462,8 @@ class BucketImporterTest(unittest.TestCase):
             path='a/b/test.json',
             original_sha256=('62966a80f6f9f54161803211069216177'
                              '37340a47f43356ee4a1cabe8f089869'),
-            deleted='false'),
+            deleted='false',
+            timestamp='12345'),
     ])
 
     # Test this entry is not published
@@ -485,7 +494,9 @@ class BucketImporterTest(unittest.TestCase):
 
   @mock.patch('google.cloud.storage.Blob.upload_from_string')
   @mock.patch('google.cloud.pubsub_v1.PublisherClient.publish')
-  def test_import_override(self, mock_publish: mock.MagicMock,
+  @mock.patch('time.time', return_value=12345.0)
+  def test_import_override(self, mock_time: mock.MagicMock,
+                           mock_publish: mock.MagicMock,
                            upload_from_str: mock.MagicMock):
     """Test bucket updates."""
 
@@ -506,7 +517,8 @@ class BucketImporterTest(unittest.TestCase):
             source='bucket',
             path='a/b/DSA-3029-1.json',
             original_sha256=mock.ANY,
-            deleted='false')
+            deleted='false',
+            timestamp='12345')
     ])
     mock_publish.reset_mock()
 
@@ -530,7 +542,8 @@ class BucketImporterTest(unittest.TestCase):
         source='bucket',
         path='a/b/DSA-3029-1.json',
         original_sha256=mock.ANY,
-        deleted='false')
+        deleted='false',
+        timestamp='12345')
     self.assertNotIn(dsa_call, mock_publish.mock_calls)
     # Check if uploaded log str has the failed to parse vuln
     self.assertTrue(

--- a/docker/worker/worker.py
+++ b/docker/worker/worker.py
@@ -579,7 +579,7 @@ class TaskRunner:
     request_time = message.attributes.get('timestamp')
     if request_time:
       request_time = int(request_time)
-      latency = request_time = int(time.time())
+      latency = int(time.time()) - request_time
       task_type = message.attributes['type']
       source_id = get_source_id(message)
 

--- a/vulnfeeds/git/repository_test.go
+++ b/vulnfeeds/git/repository_test.go
@@ -40,6 +40,7 @@ func TestRepoTags(t *testing.T) {
 				{Tag: "v1.7.0-beta", Commit: "08c5e0ac49c9520585eebfe25be0f51239733891"},
 				{Tag: "v1.7.1-2960", Commit: "44b73602ab5518a213e0128a04f57239988847cf"},
 				{Tag: "v1.7.2-3030", Commit: "302e57b5703d92d2f43bbfe86a8d4080647a4ba9"},
+				{Tag: "v1.7.3-3230", Commit: "96a5fcdc3c958268559ec63c8fbd0a60e3c7e1c8"},
 			},
 			expectedOk: true,
 		},

--- a/vulnfeeds/git/repository_test.go
+++ b/vulnfeeds/git/repository_test.go
@@ -66,6 +66,7 @@ func TestRepoTags(t *testing.T) {
 				{Tag: "v1.7.0-beta", Commit: "08c5e0ac49c9520585eebfe25be0f51239733891"},
 				{Tag: "v1.7.1-2960", Commit: "44b73602ab5518a213e0128a04f57239988847cf"},
 				{Tag: "v1.7.2-3030", Commit: "302e57b5703d92d2f43bbfe86a8d4080647a4ba9"},
+				{Tag: "v1.7.3-3230", Commit: "96a5fcdc3c958268559ec63c8fbd0a60e3c7e1c8"},
 			},
 			expectedOk: true,
 		},


### PR DESCRIPTION
Add a new timestamp attribute to pubsub messages emitted by the importer

Then this attribute is present, have the worker log how much time passed between when the messages were published and when the tasks were completed.

This will allow for a log based metric to measure how long things are taking, notably when it comes to importing, for SLO measurement.