### PR TITLE
Fix broken GitHub page

### DIFF
--- a/docs/_sass/color_schemes/better_contrast.scss
+++ b/docs/_sass/color_schemes/better_contrast.scss
@@ -1,5 +1,3 @@
-$content-width: 900px;
-
 // Code snippet colors
 .highlight .c {
     color: #514E56;


### PR DESCRIPTION
I think there was an update to our jekyll theme and it no longer accepts "px" units in the css. So I removed a line so it can build.