### PR TITLE
Statically link libraries in indexer image

### DIFF
--- a/docker/indexer/Dockerfile
+++ b/docker/indexer/Dockerfile
@@ -22,7 +22,7 @@ RUN go mod download
 
 # Do the build here
 COPY ./ /build
-RUN ./build.sh
+RUN CGO_ENABLED=0 ./build.sh
 
 FROM gcr.io/distroless/base
 COPY --from=GO_BUILD build/indexer /indexer


### PR DESCRIPTION
The last few builds/deployments of the indexer have been spitting out errors:
```
/indexer: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /indexer)
/indexer: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /indexer)
```
Set `CGO_ENABLED=0` in the builder image to stop it dynamically linking these libraries that don't seem to be available in the distroless image.