### PR TITLE
Timestamp error fixes

### DIFF
--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -148,7 +148,7 @@ class Importer:
         path=path,
         original_sha256=original_sha256,
         deleted=str(deleted).lower(),
-        timestamp=str(int(time.time())))
+        req_timestamp=str(int(time.time())))
 
   def _request_internal_analysis(self, bug):
     """Request internal analysis."""
@@ -158,7 +158,7 @@ class Importer:
         type='impact',
         source_id=bug.source_id,
         allocated_id=bug.key.id(),
-        timestamp=str(int(time.time())))
+        req_timestamp=str(int(time.time())))
 
   def run(self):
     """Run importer."""

--- a/docker/importer/importer_test.py
+++ b/docker/importer/importer_test.py
@@ -181,7 +181,7 @@ class ImporterTest(unittest.TestCase, tests.ExpectationTest(TEST_DATA_DIR)):
             path='2021-111.yaml',
             source='oss-fuzz',
             type='update',
-            timestamp='12345')
+            req_timestamp='12345')
     ])
     bug = osv.Bug.get_by_id('OSV-2017-134')
     self.assertEqual(osv.SourceOfTruth.SOURCE_REPO, bug.source_of_truth)
@@ -317,14 +317,14 @@ class ImporterTest(unittest.TestCase, tests.ExpectationTest(TEST_DATA_DIR)):
             path='proj/OSV-2021-1337.yaml',
             source='oss-fuzz',
             type='update',
-            timestamp='12345'),
+            req_timestamp='12345'),
         mock.call(
             self.tasks_topic,
             allocated_id='OSV-2021-1339',
             data=b'',
             source_id='oss-fuzz:124',
             type='impact',
-            timestamp='12345'),
+            req_timestamp='12345'),
     ])
 
     source_repo = osv.SourceRepository.get_by_id('oss-fuzz')
@@ -455,7 +455,7 @@ class BucketImporterTest(unittest.TestCase):
             original_sha256=('12453f85cd87bc1d465e0d013db572c0'
                              '1f7fb7de3b3a33de94ebcc7bd0f23a14'),
             deleted='false',
-            timestamp='12345'),
+            req_timestamp='12345'),
         mock.call(
             self.tasks_topic,
             data=b'',
@@ -465,7 +465,7 @@ class BucketImporterTest(unittest.TestCase):
             original_sha256=('62966a80f6f9f54161803211069216177'
                              '37340a47f43356ee4a1cabe8f089869'),
             deleted='false',
-            timestamp='12345'),
+            req_timestamp='12345'),
     ])
 
     # Test this entry is not published
@@ -520,7 +520,7 @@ class BucketImporterTest(unittest.TestCase):
             path='a/b/DSA-3029-1.json',
             original_sha256=mock.ANY,
             deleted='false',
-            timestamp='12345')
+            req_timestamp='12345')
     ])
     mock_publish.reset_mock()
 
@@ -545,7 +545,7 @@ class BucketImporterTest(unittest.TestCase):
         path='a/b/DSA-3029-1.json',
         original_sha256=mock.ANY,
         deleted='false',
-        timestamp='12345')
+        req_timestamp='12345')
     self.assertNotIn(dsa_call, mock_publish.mock_calls)
     # Check if uploaded log str has the failed to parse vuln
     self.assertTrue(

--- a/docker/worker/worker.py
+++ b/docker/worker/worker.py
@@ -576,7 +576,7 @@ class TaskRunner:
     """Determine how long ago the task was requested.
 
     Log how long it took to be serviced."""
-    request_time = message.attributes.get('timestamp')
+    request_time = message.attributes.get('req_timestamp')
     if request_time:
       request_time = int(request_time)
       latency = int(time.time()) - request_time


### PR DESCRIPTION
Renames `timestamp` attribute in the pub/sub message used for logging to `req_timestamp`.

OSS-Fuzz also uses the timestamp attribute in the Pub/Sub message, with a different format and meaning. This clashes with the timestamp info added to help logging. 