### PR TITLE
Make API backend startupProbe use grpc

### DIFF
--- a/deployment/clouddeploy/osv-api/run.yaml
+++ b/deployment/clouddeploy/osv-api/run.yaml
@@ -10,6 +10,9 @@ spec:
         resources:
           limits:
             memory: 4Gi
+        startupProbe:
+          grpc:
+            service: osv.v1.OSV
         livenessProbe:
           grpc:
             service: osv.v1.OSV


### PR DESCRIPTION
The default setting uses TCP, which could potentially report the instance is available before the grpc server is actually ready.