### PR TITLE
Refactor and update PURL matching in the API

### DIFF
--- a/gcp/api/Pipfile.lock
+++ b/gcp/api/Pipfile.lock
@@ -762,11 +762,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:5df61bf30bb10c6f756eb19e7c9f3b473051f48db77fddbe06ff2ca307df9a6f",
-                "sha256:62642358adc77ffa87233bc4d2354c4b2682d214048f500964dbe760ccedf102"
+                "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f",
+                "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==67.8.0"
+            "version": "==68.0.0"
         }
     }
 }

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -408,7 +408,7 @@ class IntegrationTests(unittest.TestCase):
         }),
         timeout=_TIMEOUT)
 
-    self.assert_results_equal(expected_deb, response.json())
+    self.assert_results_equal({'vulns': expected_deb}, response.json())
 
     # A non arch qualifier should be ignored
     response = requests.post(

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -398,7 +398,7 @@ class IntegrationTests(unittest.TestCase):
 
     self.assert_results_equal({'vulns': expected_deb}, response.json())
 
-    # A non source arch should return nothing, as we don't index them
+    # A non source arch should also return the same item
     response = requests.post(
         _api() + '/v1/query',
         data=json.dumps({
@@ -408,7 +408,7 @@ class IntegrationTests(unittest.TestCase):
         }),
         timeout=_TIMEOUT)
 
-    self.assert_results_equal({}, response.json())
+    self.assert_results_equal(expected_deb, response.json())
 
     # A non arch qualifier should be ignored
     response = requests.post(

--- a/gcp/api/run_tests.sh
+++ b/gcp/api/run_tests.sh
@@ -23,4 +23,5 @@ service docker start
 
 export GOOGLE_CLOUD_PROJECT=oss-vdb
 export GOOGLE_APPLICATION_CREDENTIALS="$1"
+python3 -m pipenv run python server_test.py
 python3 -m pipenv run python integration_tests.py "$1"

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -599,6 +599,9 @@ def _match_purl(purl_query: PackageURL, purl_db: PackageURL) -> bool:
     return PackageURL(qualifiers=new_qualifiers, **values)
 
   purl_query = _clean_purl(purl_query)
+  # Most of the time this will have no effect, since PURLs in the db
+  # are already cleaned
+  purl_db = _clean_purl(purl_db)
   if not purl_query.qualifiers:
     # No qualifiers, and our PURLs never have versions, so just match name
     return purl_query.name == purl_db.name

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -529,16 +529,14 @@ def _clean_purl(purl):
   """
   Clean a purl object.
 
-  Removes version, subpath, and qualifiers with the exception of
-  the 'arch' qualifier
+  Removes version, subpath, and qualifiers
   """
   values = purl.to_dict()
   values.pop('version', None)
   values.pop('subpath', None)
-  qualifiers = values.pop('qualifiers', None)
+  # Remove even the arch qualifier, as we currently only have "source"
+  # architectures, which should apply to all arch queries
   new_qualifiers = {}
-  if qualifiers and 'arch' in qualifiers:  # CPU arch for debian packages
-    new_qualifiers['arch'] = qualifiers['arch']
   return PackageURL(qualifiers=new_qualifiers, **values)
 
 

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -593,9 +593,8 @@ def _match_purl(purl_query: PackageURL, purl_db: PackageURL) -> bool:
 
   if purl_db.qualifiers:
     # A arch of 'source' matches all other architectures
-    if purl_db.qualifiers['arch'] == 'source': 
+    if purl_db.qualifiers['arch'] == 'source':
       purl_db.qualifiers['arch'] = purl_query.qualifiers['arch']
-  
 
   return purl_query == purl_db
 
@@ -663,7 +662,7 @@ def _is_version_affected(affected_packages,
           ecosystems.normalize(
               affected_package.package.ecosystem) != ecosystem):
         continue
-      
+
     if purl and not (affected_package.package.purl and _match_purl(
         purl, PackageURL.from_string(affected_package.package.purl))):
       continue

--- a/gcp/api/server_test.py
+++ b/gcp/api/server_test.py
@@ -1,0 +1,50 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Server unit tests."""
+
+import unittest
+
+from server import _match_purl
+from packageurl import PackageURL
+
+class ServerTest(unittest.TestCase):
+  """Server tests."""
+
+  def test_match_purl(self):
+    """Test PURL generation for PyPI."""
+
+    testCases = [
+      # Version diffs are ignored
+      ('pkg:pypi/django', 'pkg:pypi/django@1.2.3', True),
+      ('pkg:deb/debian/nginx@1.14.2-2+deb10u3', 
+       'pkg:deb/debian/nginx@1.14.2-2+deb10u4', True),
+        # Different packages do not match
+      ('pkg:deb/debian/busybox@1.14.2-2+deb10u3', 
+       'pkg:deb/debian/nginx@1.14.2-2+deb10u3', False),
+      ('pkg:deb/debian/nginx@1.14.2-2+deb10u3?arch=amd64', 
+       'pkg:deb/debian/nginx@1.14.2-2?arch=source', True),
+      ('pkg:deb/debian/nginx@1.14.2-2+deb10u3?distro=debian-10', 
+       'pkg:deb/debian/nginx@1.14.2-2?arch=source', True),
+    ]
+
+    for a, b, expected in testCases:
+      self.assertEqual(expected,
+                     _match_purl(PackageURL.from_string(a), 
+                                 PackageURL.from_string(b)),
+                                 a + ' == ' + b)
+
+    
+
+if __name__ == '__main__':
+  unittest.main()

--- a/gcp/api/server_test.py
+++ b/gcp/api/server_test.py
@@ -18,6 +18,7 @@ import unittest
 from server import _match_purl
 from packageurl import PackageURL
 
+
 class ServerTest(unittest.TestCase):
   """Server tests."""
 
@@ -25,26 +26,25 @@ class ServerTest(unittest.TestCase):
     """Test PURL generation for PyPI."""
 
     testCases = [
-      # Version diffs are ignored
-      ('pkg:pypi/django', 'pkg:pypi/django@1.2.3', True),
-      ('pkg:deb/debian/nginx@1.14.2-2+deb10u3', 
-       'pkg:deb/debian/nginx@1.14.2-2+deb10u4', True),
+        # Version diffs are ignored
+        ('pkg:pypi/django', 'pkg:pypi/django@1.2.3', True),
+        ('pkg:deb/debian/nginx@1.14.2-2+deb10u3',
+         'pkg:deb/debian/nginx@1.14.2-2+deb10u4', True),
         # Different packages do not match
-      ('pkg:deb/debian/busybox@1.14.2-2+deb10u3', 
-       'pkg:deb/debian/nginx@1.14.2-2+deb10u3', False),
-      ('pkg:deb/debian/nginx@1.14.2-2+deb10u3?arch=amd64', 
-       'pkg:deb/debian/nginx@1.14.2-2?arch=source', True),
-      ('pkg:deb/debian/nginx@1.14.2-2+deb10u3?distro=debian-10', 
-       'pkg:deb/debian/nginx@1.14.2-2?arch=source', True),
+        ('pkg:deb/debian/busybox@1.14.2-2+deb10u3',
+         'pkg:deb/debian/nginx@1.14.2-2+deb10u3', False),
+        ('pkg:deb/debian/nginx@1.14.2-2+deb10u3?arch=amd64',
+         'pkg:deb/debian/nginx@1.14.2-2?arch=source', True),
+        ('pkg:deb/debian/nginx@1.14.2-2+deb10u3?distro=debian-10',
+         'pkg:deb/debian/nginx@1.14.2-2?arch=source', True),
     ]
 
     for a, b, expected in testCases:
-      self.assertEqual(expected,
-                     _match_purl(PackageURL.from_string(a), 
-                                 PackageURL.from_string(b)),
-                                 a + ' == ' + b)
+      self.assertEqual(
+          expected,
+          _match_purl(PackageURL.from_string(a), PackageURL.from_string(b)),
+          a + ' == ' + b)
 
-    
 
 if __name__ == '__main__':
   unittest.main()

--- a/gcp/api/server_test.py
+++ b/gcp/api/server_test.py
@@ -25,7 +25,7 @@ class ServerTest(unittest.TestCase):
   def test_match_purl(self):
     """Test PURL generation for PyPI."""
 
-    testCases = [
+    test_cases = [
         # Version diffs are ignored
         ('pkg:pypi/django', 'pkg:pypi/django@1.2.3', True),
         ('pkg:deb/debian/nginx@1.14.2-2+deb10u3',
@@ -39,7 +39,7 @@ class ServerTest(unittest.TestCase):
          'pkg:deb/debian/nginx@1.14.2-2?arch=source', True),
     ]
 
-    for a, b, expected in testCases:
+    for a, b, expected in test_cases:
       self.assertEqual(
           expected,
           _match_purl(PackageURL.from_string(a), PackageURL.from_string(b)),


### PR DESCRIPTION
Main functional change in this PR is making `arch=source` to mean `arch=<anything>`, since a source vulnerability will affect all architectures. 

Fixes a problem discussed here: #1321 

Did a bit of refactoring to do this:

- Moved the PURL matching logic around so that PURLs are not cleaned when passed around, but only cleaned when matching specifically with the datastore. 

- Also added the same additional matching step of `_match_purl` to `query_package` that's being used in `query_version`. 

- Updated `_match_purl` to consider `arch=source` to mean `arch=<anything>`.