### PR TITLE
Adding determineversion info to the API index page

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -22,7 +22,7 @@ There are four different types of requests that can be made of the API.
 1. Query vulnerabilities for a particular project at a given [commit hash or version](post-v1-query.md).
 2. [Batched query vulnerabilities](post-v1-querybatch.md) for given package versions and commit hashes.
 3. Return a `Vulnerability` object for a given [OSV ID](get-v1-vulns.md). 
-4. **Experimental** Return a list of [probable versions](post-v1-determineversion.md) of a specified C/C++ project. 
+4. Return a list of [probable versions](post-v1-determineversion.md) of a specified C/C++ project. (**Experimental**)
 
 ### Is the API rate limited?  
 Currently there are no limits on the API.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -17,11 +17,12 @@ Please see the [quickstart](api-quickstart.md).
 
 ### How does the API work?
 
-There are three different types of requests that can be made of the API.
+There are four different types of requests that can be made of the API.
 
 1. Query vulnerabilities for a particular project at a given [commit hash or version](post-v1-query.md).
 2. [Batched query vulnerabilities](post-v1-querybatch.md) for given package versions and commit hashes.
 3. Return a `Vulnerability` object for a given [OSV ID](get-v1-vulns.md). 
+4. **Experimental** Return a list of [probable versions](post-v1-determineversion.md) of a specified C/C++ project. 
 
 ### Is the API rate limited?  
 Currently there are no limits on the API.


### PR DESCRIPTION
When reviewing the docs for pagination, I realized there was another place where we could add something about the determineversion API. 

[Preview available here](https://hayleycd.github.io/osv.dev/api/)