### PR TITLE
Adding information for versioning multiple libraries.

### DIFF
--- a/docs/api/post-v1-determineversion.md
+++ b/docs/api/post-v1-determineversion.md
@@ -47,7 +47,9 @@ We recommend trying the API endpoint with our [indexer-api-caller](https://githu
 
 1. Have a local copy of this repostiory.
 2. Navigate to `/osv.dev/tools/indexer-api-caller`
-3. Run the tool using `go run . -lib path/to/library`
+3. Run the tool with the following commands:
+  - For a single library: `go run . -lib path/to/library`
+  - For a directory with multiple libraries: `go run . -dir /path/to/libs/dir`
 4. Evaluate the response
 
 

--- a/docs/api/post-v1-determineversion.md
+++ b/docs/api/post-v1-determineversion.md
@@ -49,7 +49,7 @@ We recommend trying the API endpoint with our [indexer-api-caller](https://githu
 2. Navigate to `/osv.dev/tools/indexer-api-caller`
 3. Run the tool with the following commands:
   - For a single library: `go run . -lib path/to/library`
-  - For a directory with multiple libraries: `go run . -dir /path/to/libs/dir`
+  - For a directory with multiple libraries as top level subdirectories: `go run . -dir /path/to/libs/dir`
 4. Evaluate the response
 
 

--- a/tools/indexer-api-caller/README.md
+++ b/tools/indexer-api-caller/README.md
@@ -6,6 +6,10 @@ to attempt to identify the given library and its version.
 
 ## Usage
 
-Run with the following command:
+To scan a single library, run with the following command:
 
 `go run . -lib path/to/library`
+
+If you have multiple libraries that you would like to version within a directory, use the following command:
+
+`go run . -dir /path/to/libs/dir`

--- a/tools/indexer-api-caller/README.md
+++ b/tools/indexer-api-caller/README.md
@@ -10,6 +10,6 @@ To scan a single library, run with the following command:
 
 `go run . -lib path/to/library`
 
-If you have multiple libraries that you would like to version within a directory, use the following command:
+For directories than contain multiple libraries as top level subdirectories:
 
 `go run . -dir /path/to/libs/dir`


### PR DESCRIPTION
Added instructions on how to use the API indexer tool to version multiple libraries at once. 

[Preview available](https://hayleycd.github.io/osv.dev/post-v1-determineversion/#try-the-api-with-our-tool)