### PR TITLE
Bump worker-base to Python 3.11.4

### DIFF
--- a/docker/worker-base/Dockerfile
+++ b/docker/worker-base/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get upgrade -y && \
         libssl-dev \
         software-properties-common
 
-ARG PYTHON_VERSION=3.11.3
+ARG PYTHON_VERSION=3.11.4
 RUN curl -sS https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz | tar -C /tmp -xzv && \
     cd /tmp/Python-${PYTHON_VERSION} && \
     ./configure --enable-optimizations --with-lto --enable-loadable-sqlite-extensions && \


### PR DESCRIPTION
Noticed my Cloud Top is now using Python 3.11.4.

I think there should be a way to get dependabot/rennovate to make these PRs.
Alternatively, we could change the base image so we don't need to build python from source.

note: The ci image that runs our tests needs to be manually deployed but is based on the worker image, so it can only really be rebuilt after this is merged...