### PR TITLE
Add --pull to the new build scripts, and pin pipenv version to 2023.6.12

### DIFF
--- a/docker/ci/build.sh
+++ b/docker/ci/build.sh
@@ -14,6 +14,6 @@
 # limitations under the License.
 
 
-docker build -t gcr.io/oss-vdb/ci:$1 -t gcr.io/oss-vdb/ci:latest . && \
-gcloud docker -- push gcr.io/oss-vdb/ci:$1 && \
-gcloud docker -- push gcr.io/oss-vdb/ci:latest
+docker build -t gcr.io/oss-vdb/ci:$1 -t gcr.io/oss-vdb/ci:latest --pull . && \
+docker -- push gcr.io/oss-vdb/ci:$1 && \
+docker -- push gcr.io/oss-vdb/ci:latest

--- a/docker/deployment/Dockerfile
+++ b/docker/deployment/Dockerfile
@@ -7,5 +7,5 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     apt-get update && apt-get install -y google-cloud-sdk
 
-RUN pip3 install pipenv
+RUN pip3 install pipenv==2023.6.12
 COPY --from=gcr.io/oss-vdb/ci /root/go/bin/hugo /usr/local/bin/hugo

--- a/docker/deployment/build.sh
+++ b/docker/deployment/build.sh
@@ -14,6 +14,6 @@
 # limitations under the License.
 
 
-docker build -t gcr.io/oss-vdb/deployment:$1 -t gcr.io/oss-vdb/deployment:latest . && \
-gcloud docker -- push gcr.io/oss-vdb/deployment:$1 && \
-gcloud docker -- push gcr.io/oss-vdb/deployment:latest
+docker build -t gcr.io/oss-vdb/deployment:$1 -t gcr.io/oss-vdb/deployment:latest --pull . && \
+docker -- push gcr.io/oss-vdb/deployment:$1 && \
+docker -- push gcr.io/oss-vdb/deployment:latest

--- a/gcp/appengine/frontend3/package-lock.json
+++ b/gcp/appengine/frontend3/package-lock.json
@@ -32,7 +32,7 @@
         "sass-loader": "12.6.0",
         "style-loader": "3.3.3",
         "webpack": "5.87.0",
-        "webpack-cli": "^4.10.0",
+        "webpack-cli": "4.10.0",
         "webpack-dev-server": "4.15.1"
       }
     },


### PR DESCRIPTION
Add --pull to the new build scripts, and pin pipenv version to 2023.6.12 for the deployment image.

Also remove ^ from package-lock that  was missed in the previous PR.

> We've pinned pipenv because pipenv requirements was behaving differently on the most recent version, and we were matching on the output to remove the requirement from the App Engine deployment:
> 
> in 2023.6.12 the output for the editable osv package was
> 
> -e ./../..
> in 2023.7.23 it was
> 
> ../../

This does not seem to be an intentional change from pipenv, as it's not logged in the patch notes, but from bugs in their new implementation of the requirements: https://github.com/pypa/pipenv/pull/5757, so this might change back in the future versions. 