### PR TITLE
Enable lockfile maintaince

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "labels": ["dependencies"],
   "postUpdateOptions": ["gomodTidy"],
   "osvVulnerabilityAlerts": true,
+  "lockFileMaintenance": { "enabled": true },
   "packageRules": [
     {
       "matchUpdateTypes": ["major"],


### PR DESCRIPTION
Dependabot often has updates that don't show up in renovate bot. That's because renovatebot doesn't directly update any transient dependencies. 

Enabling this option instructs renovatebot to relock the lockfiles, which will bump all transient dependencies.
See https://docs.renovatebot.com/configuration-options/#lockfilemaintenance and https://github.com/renovatebot/renovate/discussions/15762