### PR TITLE
Deploy App Engine from Docker Image

### DIFF
--- a/deployment/build-and-stage.yaml
+++ b/deployment/build-and-stage.yaml
@@ -197,9 +197,12 @@ steps:
 # Build & push Docker image
 # TODO(michaelkedar): Move with rest of docker image creation when migrating to Cloud Run
 - name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', 'docker pull gcr.io/oss-vdb-test/osv-website:latest || exit 0']
+- name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--build-arg', 'BUILDKIT_INLINE_CACHE=1',
          '-t', 'gcr.io/oss-vdb-test/osv-website:latest', '-t', 'gcr.io/oss-vdb-test/osv-website:$COMMIT_SHA',
-         '-f', 'gcp/appengine/Dockerfile, '--cache-from', 'gcr.io/oss-vdb-test/osv-website:latest', '--pull', '.']
+         '-f', 'gcp/appengine/Dockerfile', '--cache-from', 'gcr.io/oss-vdb-test/osv-website:latest', '--pull', '.']
   env:
   - DOCKER_BUILDKIT=1
   - BUILDKIT_PROGRESS=plain

--- a/deployment/build-and-stage.yaml
+++ b/deployment/build-and-stage.yaml
@@ -194,8 +194,23 @@ steps:
   dir:  deployment/terraform/environments/oss-vdb-test
 
 # Deploy App Engine for staging environment
-- name: 'gcr.io/oss-vdb/deployment'
-  args: ['bash', '-ex', 'gcp/appengine/deploy.sh', 'oss-vdb-test', 'deployment/gae/oss-vdb-test', 'app.yaml']
+# Build & push Docker image
+# TODO(michaelkedar): Move with rest of docker image creation when migrating to Cloud Run
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--build-arg', 'BUILDKIT_INLINE_CACHE=1',
+         '-t', 'gcr.io/oss-vdb-test/osv-website:latest', '-t', 'gcr.io/oss-vdb-test/osv-website:$COMMIT_SHA',
+         '-f', 'gcp/appengine/Dockerfile, '--cache-from', 'gcr.io/oss-vdb-test/osv-website:latest', '--pull', '.']
+  env:
+  - DOCKER_BUILDKIT=1
+  - BUILDKIT_PROGRESS=plain
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['push', '--all-tags', 'gcr.io/oss-vdb-test/osv-website']
+
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: bash
+  args: ['-ex', 'gcp/appengine/deploy.sh', 'oss-vdb-test', '$COMMIT_SHA', 'deployment/gae/oss-vdb-test', 'app.yaml']
+  env:
+  - CLOUDBUILD=1
 
 # Clean up older, non-serving App Engine versions to avoid hitting the ceiling on versions
 - name: 'gcr.io/cloud-builders/gcloud'

--- a/deployment/gae/oss-vdb-test/app.yaml
+++ b/deployment/gae/oss-vdb-test/app.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-service: docker
+service: default
 runtime: custom
 env: flex
 

--- a/deployment/gae/oss-vdb-test/app.yaml
+++ b/deployment/gae/oss-vdb-test/app.yaml
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-service: default
-runtime: python311
+service: docker
+runtime: custom
+env: flex
 
 handlers:
   - url: /static
@@ -39,7 +40,7 @@ inbound_services:
   - warmup
 
 automatic_scaling:
-  min_instances: 1
+  min_num_instances: 1
 
 instance_class: F4
 

--- a/deployment/gae/oss-vdb-test/app.yaml
+++ b/deployment/gae/oss-vdb-test/app.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-service: default
+service: docker
 runtime: custom
 env: flex
 
@@ -42,7 +42,18 @@ inbound_services:
 automatic_scaling:
   min_num_instances: 1
 
-instance_class: F4
+resources:
+  cpu: 4
+  memory_gb: 3.6
+
+liveness_check:
+  path: "/health"
+
+readiness_check:
+  path: "/"
+  # App Engine Flex runs multiple redundant readiness checks
+  # The default value (5) was hitting our rate limiting and failing...
+  check_interval_sec: 15
 
 env_variables:
   REDISHOST: 10.189.34.180

--- a/deployment/gae/oss-vdb/app.yaml
+++ b/deployment/gae/oss-vdb/app.yaml
@@ -42,7 +42,18 @@ inbound_services:
 automatic_scaling:
   min_num_instances: 1
 
-instance_class: F4
+resources:
+  cpu: 4
+  memory_gb: 3.6
+
+liveness_check:
+  path: "/health"
+
+readiness_check:
+  path: "/"
+  # App Engine Flex runs multiple redundant readiness checks
+  # The default value (5) was hitting our rate limiting and failing...
+  check_interval_sec: 15
 
 env_variables:
   REDISHOST: 10.85.52.228

--- a/deployment/gae/oss-vdb/app.yaml
+++ b/deployment/gae/oss-vdb/app.yaml
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 service: default
-runtime: python311
+runtime: custom
+env: flex
 
 handlers:
   - url: /static
@@ -39,7 +40,7 @@ inbound_services:
   - warmup
 
 automatic_scaling:
-  min_instances: 1
+  min_num_instances: 1
 
 instance_class: F4
 

--- a/deployment/staging.yaml
+++ b/deployment/staging.yaml
@@ -30,8 +30,26 @@ steps:
   args: [ '-c', "rm /workspace/service_account.json" ]
 - name: 'gcr.io/cloud-builders/git'
   args: ['clean', '-ffdx']
-- name: 'gcr.io/oss-vdb/deployment'
-  args: ['bash', '-ex', 'gcp/appengine/deploy.sh', 'oss-vdb', 'deployment/gae/oss-vdb', 'app.yaml', '--no-promote']
+# Build & push App engine Docker image
+# TODO(michaelkedar): Move with rest of docker image creation when migrating to Cloud Run
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', 'docker pull gcr.io/oss-vdb/osv-website:latest || exit 0']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--build-arg', 'BUILDKIT_INLINE_CACHE=1',
+         '-t', 'gcr.io/oss-vdb/osv-website:latest', '-t', 'gcr.io/oss-vdb/osv-website:$COMMIT_SHA',
+         '-f', 'gcp/appengine/Dockerfile', '--cache-from', 'gcr.io/oss-vdb/osv-website:latest', '--pull', '.']
+  env:
+  - DOCKER_BUILDKIT=1
+  - BUILDKIT_PROGRESS=plain
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['push', '--all-tags', 'gcr.io/oss-vdb/osv-website']
+
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: bash
+  args: ['-ex', 'gcp/appengine/deploy.sh', 'oss-vdb', '$COMMIT_SHA', 'deployment/gae/oss-vdb', 'app.yaml', '--no-promote']
+  env:
+  - CLOUDBUILD=1
 - name: 'gcr.io/oss-vdb/deployment'
   args: ['bash', '-ex', '../deploy_service_proxy', 'oss-vdb', 'api-staging.osv.dev', 'osv-grpc-v1-staging', '../../../deployment/api/oss-vdb/api_config_staging.yaml']
   dir: gcp/api/v1

--- a/gcp/appengine/Dockerfile
+++ b/gcp/appengine/Dockerfile
@@ -1,0 +1,52 @@
+# Build the Javascript frontend
+FROM node:latest AS FRONTEND3_BUILD
+WORKDIR /build/frontend3
+
+# Install dependencies first for better caching
+COPY gcp/appengine/frontend3/package.json gcp/appengine/frontend3/package-lock.json ./
+RUN npm ci
+
+COPY gcp/appengine/frontend3/webpack.prod.js ./
+COPY gcp/appengine/frontend3/img img
+COPY gcp/appengine/frontend3/src src
+
+RUN npm run build:prod
+
+# Build hugo blogs
+# The ci image is a bit heavy for this, but it keeps the hugo version we use in one place
+FROM gcr.io/oss-vdb/ci:latest AS HUGO_BUILD
+WORKDIR /build/blog
+COPY gcp/appengine/blog ./
+
+RUN hugo -d ../dist/static/blog
+
+# OSV.dev site image
+# Adapted from https://cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-python-service#writing
+FROM python:3.11-slim
+
+# Allow statements and log messages to immediately appear in the logs
+ENV PYTHONUNBUFFERED True
+WORKDIR /osv/gcp/appengine
+
+# Install Python dependencies
+COPY setup.py Pipfile* README.md /osv/
+COPY osv /osv/osv
+COPY gcp/appengine/Pipfile* ./
+RUN pip3 install -U pipenv==2023.6.12 && python3 -m pipenv install --deploy --system
+
+# Website Python code
+COPY gcp/appengine/*.py ./
+
+# JS/hugo builds
+COPY gcp/appengine/dist/public_keys dist/public_keys
+COPY gcp/appengine/docs docs
+COPY --from=FRONTEND3_BUILD /build/dist/ dist
+COPY --from=HUGO_BUILD /build/dist dist
+
+
+# Run the web service on container startup. Here we use the gunicorn
+# webserver, with one worker process and 8 threads.
+# For environments with multiple CPU cores, increase the number of workers
+# to be equal to the cores available.
+# Timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling.
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app

--- a/gcp/appengine/Dockerfile
+++ b/gcp/appengine/Dockerfile
@@ -13,8 +13,7 @@ COPY gcp/appengine/frontend3/src src
 RUN npm run build:prod
 
 # Build hugo blogs
-# The ci image is a bit heavy for this, but it keeps the hugo version we use in one place
-FROM gcr.io/oss-vdb/ci:latest AS HUGO_BUILD
+FROM klakegg/hugo:0.111.3 AS HUGO_BUILD
 WORKDIR /build/blog
 COPY gcp/appengine/blog ./
 

--- a/gcp/appengine/Dockerfile
+++ b/gcp/appengine/Dockerfile
@@ -42,8 +42,8 @@ COPY gcp/appengine/*.py ./
 # JS/hugo builds
 COPY gcp/appengine/dist/public_keys dist/public_keys
 COPY gcp/appengine/docs docs
-COPY --from=FRONTEND3_BUILD --link /build/dist/ dist/
-COPY --from=HUGO_BUILD --link /build/dist dist/
+COPY --from=FRONTEND3_BUILD /build/dist/ dist/
+COPY --from=HUGO_BUILD /build/dist dist/
 
 
 # Run the web service on container startup. Here we use the gunicorn

--- a/gcp/appengine/Dockerfile
+++ b/gcp/appengine/Dockerfile
@@ -42,8 +42,8 @@ COPY gcp/appengine/*.py ./
 # JS/hugo builds
 COPY gcp/appengine/dist/public_keys dist/public_keys
 COPY gcp/appengine/docs docs
-COPY --from=FRONTEND3_BUILD /build/dist/ dist
-COPY --from=HUGO_BUILD /build/dist dist
+COPY --from=FRONTEND3_BUILD --link /build/dist/ dist/
+COPY --from=HUGO_BUILD --link /build/dist dist/
 
 
 # Run the web service on container startup. Here we use the gunicorn

--- a/gcp/appengine/Dockerfile
+++ b/gcp/appengine/Dockerfile
@@ -13,7 +13,10 @@ COPY gcp/appengine/frontend3/src src
 RUN npm run build:prod
 
 # Build hugo blogs
-FROM klakegg/hugo:0.111.3 AS HUGO_BUILD
+FROM golang:1.20 AS HUGO_BUILD
+# Build hugo from source - this should usually be cached.
+RUN go install -tags extended github.com/gohugoio/hugo@v0.111.3
+
 WORKDIR /build/blog
 COPY gcp/appengine/blog ./
 
@@ -44,8 +47,8 @@ COPY --from=HUGO_BUILD /build/dist dist
 
 
 # Run the web service on container startup. Here we use the gunicorn
-# webserver, with one worker process and 8 threads.
+# webserver, with 4 worker processes and 8 threads.
 # For environments with multiple CPU cores, increase the number of workers
 # to be equal to the cores available.
 # Timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling.
-CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app
+CMD exec gunicorn --bind :$PORT --workers 4 --threads 8 --timeout 0 main:app

--- a/gcp/appengine/Pipfile
+++ b/gcp/appengine/Pipfile
@@ -19,6 +19,7 @@ packaging = "==21.3"
 redis = "==4.6.0"
 requests = "==2.31.0"
 grpcio-status = "==1.56.2"
+gunicorn = "==21.2.0"
 
 [dev-packages]
 pipenv = "==2022.12.19"

--- a/gcp/appengine/Pipfile.lock
+++ b/gcp/appengine/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0d8248cd6c3cece66b4030ffa8a82c6042b53ff836e8bbf0b16f41ff8fa96c79"
+            "sha256": "0450d182f841b1e18cb7312b800daa6f6c957785f150d9ab5c60ede295349c00"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -379,6 +379,14 @@
             ],
             "index": "pypi",
             "version": "==1.56.2"
+        },
+        "gunicorn": {
+            "hashes": [
+                "sha256:3213aa5e8c24949e792bcacfc176fef362e7aac80b76c56f6b5122bf350722f0",
+                "sha256:88ec8bff1d634f98e61b9f65bc4bf3cd918a90806c6f5c48bc5603849ec81033"
+            ],
+            "index": "pypi",
+            "version": "==21.2.0"
         },
         "idna": {
             "hashes": [

--- a/gcp/appengine/blog/content/posts/test-blog.md
+++ b/gcp/appengine/blog/content/posts/test-blog.md
@@ -1,7 +1,0 @@
----
-title: "Test Blog!"
-date: 2023-1-1T00:00:00+10:00
-draft: false
-author: Mr Test
----
-Testing docker cache!

--- a/gcp/appengine/blog/content/posts/test-blog.md
+++ b/gcp/appengine/blog/content/posts/test-blog.md
@@ -1,0 +1,7 @@
+---
+title: "Test Blog!"
+date: 2023-1-1T00:00:00+10:00
+draft: false
+author: Mr Test
+---
+Testing docker cache!

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -57,7 +57,8 @@ if utils.is_prod():
 
   @blueprint.before_request
   def check_rate_limit():
-    ip_addr = request.headers.get('X-Appengine-User-Ip', 'unknown')
+    # TODO(michaelkedar): Verify this will also work for Cloud Run
+    ip_addr = request.headers.get('X-Forwarded-For', 'unknown').split(',')[0]
     if not limiter.check_request(ip_addr):
       abort(429)
 

--- a/gcp/appengine/handlers.py
+++ b/gcp/appengine/handlers.py
@@ -182,7 +182,7 @@ def backup():
   return 'done'
 
 
-@blueprint.route('/_ah/warmup')
-def warmup():
-  """Warmup handler."""
+@blueprint.route('/health')
+def health():
+  """Health check handler for liveness probes."""
   return 'OK'

--- a/gcp/appengine/utils.py
+++ b/gcp/appengine/utils.py
@@ -17,4 +17,5 @@ import os
 
 
 def is_prod():
-  return os.getenv('GAE_ENV', '').startswith('standard')
+  # TODO(michaelkedar): Need a check that works for Cloud Run
+  return os.getenv('GAE_SERVICE') is not None


### PR DESCRIPTION
First step on our App Engine to Cloud Run migration #973 

- Made a Docker image for our App Engine website, and moved to App Engine flex to start using it in deployment.
- Experimenting with using [BuildKit](https://docs.docker.com/build/buildkit/) for faster Docker builds.
- I've kept the App Engine deployment workflow the same for now, just added the image building steps.
  - To preserve the current behaviour, images end up duplicated on both `gcr.io/oss-vdb` and `gcr.io/oss-vdb-test`
- I also haven't changed how we run the App Engine locally.


Unfortunately, the App Engine flex/custom deployment (without the docker builds) seems to take a few minutes longer than current, which will make our deployments take a bit longer.

The website performance doesn't seem to be changed: [current](https://oss-vdb-test.wl.r.appspot.com/) vs [docker](https://docker-dot-oss-vdb-test.wl.r.appspot.com/)

There are still some things using App Engine that I haven't looked into for Cloud Run migration:
- The `cron-service` (which doesn't actually get automatically deployed?)
- The static files in the `app.yaml`