### PR TITLE
Convert combine-to-osv to use VersionInfo

### DIFF
--- a/vulnfeeds/cmd/alpine/main.go
+++ b/vulnfeeds/cmd/alpine/main.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/google/osv/vulnfeeds/cves"
 	"github.com/google/osv/vulnfeeds/utility"
 	"github.com/google/osv/vulnfeeds/vulns"
 )
@@ -115,10 +116,12 @@ func generateAlpineOSV(allAlpineSecDb map[string][]VersionAndPkg, alpineOutputPa
 
 		for _, verPkg := range verPkgs {
 			pkgInfo := vulns.PackageInfo{
-				PkgName:      verPkg.Pkg,
-				FixedVersion: verPkg.Ver,
-				Ecosystem:    "Alpine:" + verPkg.AlpineVer,
-				PURL:         "pkg:apk/alpine/" + verPkg.Pkg + "?arch=source",
+				PkgName: verPkg.Pkg,
+				VersionInfo: cves.VersionInfo{
+					AffectedVersions: []cves.AffectedVersion{{Fixed: verPkg.Ver}},
+				},
+				Ecosystem: "Alpine:" + verPkg.AlpineVer,
+				PURL:      "pkg:apk/alpine/" + verPkg.Pkg + "?arch=source",
 			}
 			pkgInfos = append(pkgInfos, pkgInfo)
 		}

--- a/vulnfeeds/test_data/parts/alpine/CVE-2015-9251.alpine.json
+++ b/vulnfeeds/test_data/parts/alpine/CVE-2015-9251.alpine.json
@@ -2,9 +2,19 @@
   {
     "pkg_name": "ruby",
     "ecosystem": "Alpine:v3.10",
-    "purl": "pkg:alpine/ruby",
-    "fixed_version": "2.5.6-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/ruby?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "2.5.6-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   }
 ]

--- a/vulnfeeds/test_data/parts/alpine/CVE-2016-2176.alpine.json
+++ b/vulnfeeds/test_data/parts/alpine/CVE-2016-2176.alpine.json
@@ -2,57 +2,127 @@
   {
     "pkg_name": "openssl",
     "ecosystem": "Alpine:v3.2",
-    "purl": "pkg:alpine/openssl",
-    "fixed_version": "1.0.2h-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/openssl?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "1.0.2h-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "openssl",
     "ecosystem": "Alpine:v3.3",
-    "purl": "pkg:alpine/openssl",
-    "fixed_version": "1.0.2h-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/openssl?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "1.0.2h-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "openssl",
     "ecosystem": "Alpine:v3.4",
-    "purl": "pkg:alpine/openssl",
-    "fixed_version": "1.0.2h-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/openssl?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "1.0.2h-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "openssl",
     "ecosystem": "Alpine:v3.5",
-    "purl": "pkg:alpine/openssl",
-    "fixed_version": "1.0.2h-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/openssl?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "1.0.2h-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "openssl",
     "ecosystem": "Alpine:v3.6",
-    "purl": "pkg:alpine/openssl",
-    "fixed_version": "1.0.2h-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/openssl?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "1.0.2h-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "openssl",
     "ecosystem": "Alpine:v3.7",
-    "purl": "pkg:alpine/openssl",
-    "fixed_version": "1.0.2h-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/openssl?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "1.0.2h-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "openssl",
     "ecosystem": "Alpine:v3.8",
-    "purl": "pkg:alpine/openssl",
-    "fixed_version": "1.0.2h-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/openssl?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "1.0.2h-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   }
 ]

--- a/vulnfeeds/test_data/parts/alpine/CVE-2016-8568.alpine.json
+++ b/vulnfeeds/test_data/parts/alpine/CVE-2016-8568.alpine.json
@@ -2,57 +2,127 @@
   {
     "pkg_name": "libgit2",
     "ecosystem": "Alpine:v3.10",
-    "purl": "pkg:alpine/libgit2",
-    "fixed_version": "0.24.3-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/libgit2?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "0.24.3-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "libgit2",
     "ecosystem": "Alpine:v3.11",
-    "purl": "pkg:alpine/libgit2",
-    "fixed_version": "0.24.3-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/libgit2?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "0.24.3-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "libgit2",
     "ecosystem": "Alpine:v3.5",
-    "purl": "pkg:alpine/libgit2",
-    "fixed_version": "0.24.3-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/libgit2?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "0.24.3-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "libgit2",
     "ecosystem": "Alpine:v3.6",
-    "purl": "pkg:alpine/libgit2",
-    "fixed_version": "0.24.3-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/libgit2?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "0.24.3-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "libgit2",
     "ecosystem": "Alpine:v3.7",
-    "purl": "pkg:alpine/libgit2",
-    "fixed_version": "0.24.3-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/libgit2?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "0.24.3-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "libgit2",
     "ecosystem": "Alpine:v3.8",
-    "purl": "pkg:alpine/libgit2",
-    "fixed_version": "0.24.3-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/libgit2?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "0.24.3-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "libgit2",
     "ecosystem": "Alpine:v3.9",
-    "purl": "pkg:alpine/libgit2",
-    "fixed_version": "0.24.3-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/libgit2?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "0.24.3-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   }
 ]

--- a/vulnfeeds/test_data/parts/alpine/CVE-2017-13723.alpine.json
+++ b/vulnfeeds/test_data/parts/alpine/CVE-2017-13723.alpine.json
@@ -2,57 +2,127 @@
   {
     "pkg_name": "xorg-server",
     "ecosystem": "Alpine:v3.10",
-    "purl": "pkg:alpine/xorg-server",
-    "fixed_version": "1.19.5-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/xorg-server?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "1.19.5-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "xorg-server",
     "ecosystem": "Alpine:v3.11",
-    "purl": "pkg:alpine/xorg-server",
-    "fixed_version": "1.19.5-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/xorg-server?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "1.19.5-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "xorg-server",
     "ecosystem": "Alpine:v3.12",
-    "purl": "pkg:alpine/xorg-server",
-    "fixed_version": "1.19.5-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/xorg-server?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "1.19.5-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "xorg-server",
     "ecosystem": "Alpine:v3.6",
-    "purl": "pkg:alpine/xorg-server",
-    "fixed_version": "1.19.5-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/xorg-server?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "1.19.5-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "xorg-server",
     "ecosystem": "Alpine:v3.7",
-    "purl": "pkg:alpine/xorg-server",
-    "fixed_version": "1.19.5-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/xorg-server?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "1.19.5-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "xorg-server",
     "ecosystem": "Alpine:v3.8",
-    "purl": "pkg:alpine/xorg-server",
-    "fixed_version": "1.19.5-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/xorg-server?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "1.19.5-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "xorg-server",
     "ecosystem": "Alpine:v3.9",
-    "purl": "pkg:alpine/xorg-server",
-    "fixed_version": "1.19.5-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/xorg-server?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "1.19.5-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   }
 ]

--- a/vulnfeeds/test_data/parts/alpine/CVE-2017-14448.alpine.json
+++ b/vulnfeeds/test_data/parts/alpine/CVE-2017-14448.alpine.json
@@ -2,57 +2,127 @@
   {
     "pkg_name": "sdl2_image",
     "ecosystem": "Alpine:v3.10",
-    "purl": "pkg:alpine/sdl2_image",
-    "fixed_version": "2.0.3-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/sdl2_image?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "2.0.3-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "sdl2_image",
     "ecosystem": "Alpine:v3.11",
-    "purl": "pkg:alpine/sdl2_image",
-    "fixed_version": "2.0.3-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/sdl2_image?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "2.0.3-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "sdl2_image",
     "ecosystem": "Alpine:v3.5",
-    "purl": "pkg:alpine/sdl2_image",
-    "fixed_version": "2.0.1-r2",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/sdl2_image?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "2.0.1-r2",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "sdl2_image",
     "ecosystem": "Alpine:v3.6",
-    "purl": "pkg:alpine/sdl2_image",
-    "fixed_version": "2.0.1-r2",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/sdl2_image?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "2.0.1-r2",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "sdl2_image",
     "ecosystem": "Alpine:v3.7",
-    "purl": "pkg:alpine/sdl2_image",
-    "fixed_version": "2.0.2-r1",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/sdl2_image?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "2.0.2-r1",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "sdl2_image",
     "ecosystem": "Alpine:v3.8",
-    "purl": "pkg:alpine/sdl2_image",
-    "fixed_version": "2.0.3-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/sdl2_image?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "2.0.3-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "sdl2_image",
     "ecosystem": "Alpine:v3.9",
-    "purl": "pkg:alpine/sdl2_image",
-    "fixed_version": "2.0.3-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/sdl2_image?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "2.0.3-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   }
 ]

--- a/vulnfeeds/test_data/parts/alpine/CVE-2017-9352.alpine.json
+++ b/vulnfeeds/test_data/parts/alpine/CVE-2017-9352.alpine.json
@@ -2,9 +2,19 @@
   {
     "pkg_name": "wireshark",
     "ecosystem": "Alpine:v3.5",
-    "purl": "pkg:alpine/wireshark",
-    "fixed_version": "2.2.7-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/wireshark?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "2.2.7-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   }
 ]

--- a/vulnfeeds/test_data/parts/alpine/CVE-2017-9993.alpine.json
+++ b/vulnfeeds/test_data/parts/alpine/CVE-2017-9993.alpine.json
@@ -2,25 +2,55 @@
   {
     "pkg_name": "ffmpeg",
     "ecosystem": "Alpine:v3.4",
-    "purl": "pkg:alpine/ffmpeg",
-    "fixed_version": "3.1.9-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/ffmpeg?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "3.1.9-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "ffmpeg",
     "ecosystem": "Alpine:v3.5",
-    "purl": "pkg:alpine/ffmpeg",
-    "fixed_version": "3.1.9-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/ffmpeg?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "3.1.9-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "ffmpeg",
     "ecosystem": "Alpine:v3.6",
-    "purl": "pkg:alpine/ffmpeg",
-    "fixed_version": "3.2.6-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/ffmpeg?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "3.2.6-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   }
 ]

--- a/vulnfeeds/test_data/parts/alpine/CVE-2019-14811.alpine.json
+++ b/vulnfeeds/test_data/parts/alpine/CVE-2019-14811.alpine.json
@@ -2,81 +2,217 @@
   {
     "pkg_name": "ghostscript",
     "ecosystem": "Alpine:v3.10",
-    "purl": "pkg:alpine/ghostscript",
-    "fixed_version": "9.27-r3",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/ghostscript?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "9.27-r3",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "ghostscript",
     "ecosystem": "Alpine:v3.11",
-    "purl": "pkg:alpine/ghostscript",
-    "fixed_version": "9.27-r3",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/ghostscript?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "9.27-r3",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "ghostscript",
     "ecosystem": "Alpine:v3.12",
-    "purl": "pkg:alpine/ghostscript",
-    "fixed_version": "9.27-r3",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/ghostscript?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "9.27-r3",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "ghostscript",
     "ecosystem": "Alpine:v3.13",
-    "purl": "pkg:alpine/ghostscript",
-    "fixed_version": "9.27-r3",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/ghostscript?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "9.27-r3",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "ghostscript",
     "ecosystem": "Alpine:v3.14",
-    "purl": "pkg:alpine/ghostscript",
-    "fixed_version": "9.27-r3",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/ghostscript?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "9.27-r3",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "ghostscript",
     "ecosystem": "Alpine:v3.15",
-    "purl": "pkg:alpine/ghostscript",
-    "fixed_version": "9.27-r3",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/ghostscript?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "9.27-r3",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "ghostscript",
     "ecosystem": "Alpine:v3.16",
-    "purl": "pkg:alpine/ghostscript",
-    "fixed_version": "9.27-r3",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/ghostscript?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "9.27-r3",
+          "LastAffected": ""
+        }
+      ]
+    }
+  },
+  {
+    "pkg_name": "ghostscript",
+    "ecosystem": "Alpine:v3.17",
+    "purl": "pkg:apk/alpine/ghostscript?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "9.27-r3",
+          "LastAffected": ""
+        }
+      ]
+    }
+  },
+  {
+    "pkg_name": "ghostscript",
+    "ecosystem": "Alpine:v3.18",
+    "purl": "pkg:apk/alpine/ghostscript?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "9.27-r3",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "ghostscript",
     "ecosystem": "Alpine:v3.7",
-    "purl": "pkg:alpine/ghostscript",
-    "fixed_version": "9.26-r4",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/ghostscript?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "9.26-r4",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "ghostscript",
     "ecosystem": "Alpine:v3.8",
-    "purl": "pkg:alpine/ghostscript",
-    "fixed_version": "9.26-r4",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/ghostscript?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "9.26-r4",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "ghostscript",
     "ecosystem": "Alpine:v3.9",
-    "purl": "pkg:alpine/ghostscript",
-    "fixed_version": "9.26-r4",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/ghostscript?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "9.26-r4",
+          "LastAffected": ""
+        }
+      ]
+    }
   }
 ]

--- a/vulnfeeds/test_data/parts/alpine/CVE-2021-3770.alpine.json
+++ b/vulnfeeds/test_data/parts/alpine/CVE-2021-3770.alpine.json
@@ -2,49 +2,145 @@
   {
     "pkg_name": "vim",
     "ecosystem": "Alpine:v3.11",
-    "purl": "pkg:alpine/vim",
-    "fixed_version": "8.2.3437-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/vim?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "8.2.3437-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "vim",
     "ecosystem": "Alpine:v3.12",
-    "purl": "pkg:alpine/vim",
-    "fixed_version": "8.2.3437-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/vim?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "8.2.3437-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "vim",
     "ecosystem": "Alpine:v3.13",
-    "purl": "pkg:alpine/vim",
-    "fixed_version": "8.2.3437-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/vim?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "8.2.3437-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "vim",
     "ecosystem": "Alpine:v3.14",
-    "purl": "pkg:alpine/vim",
-    "fixed_version": "8.2.3437-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/vim?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "8.2.3437-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "vim",
     "ecosystem": "Alpine:v3.15",
-    "purl": "pkg:alpine/vim",
-    "fixed_version": "8.2.3437-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/vim?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "8.2.3437-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "vim",
     "ecosystem": "Alpine:v3.16",
-    "purl": "pkg:alpine/vim",
-    "fixed_version": "8.2.3437-r0",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/vim?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "8.2.3437-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
+  },
+  {
+    "pkg_name": "vim",
+    "ecosystem": "Alpine:v3.17",
+    "purl": "pkg:apk/alpine/vim?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "8.2.3437-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
+  },
+  {
+    "pkg_name": "vim",
+    "ecosystem": "Alpine:v3.18",
+    "purl": "pkg:apk/alpine/vim?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "8.2.3437-r0",
+          "LastAffected": ""
+        }
+      ]
+    }
   }
 ]

--- a/vulnfeeds/test_data/parts/alpine/CVE-2022-33745.alpine.json
+++ b/vulnfeeds/test_data/parts/alpine/CVE-2022-33745.alpine.json
@@ -2,25 +2,91 @@
   {
     "pkg_name": "xen",
     "ecosystem": "Alpine:v3.13",
-    "purl": "pkg:alpine/xen",
-    "fixed_version": "4.14.5-r5",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/xen?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "4.14.5-r5",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "xen",
     "ecosystem": "Alpine:v3.14",
-    "purl": "pkg:alpine/xen",
-    "fixed_version": "4.15.3-r2",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/xen?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "4.15.3-r2",
+          "LastAffected": ""
+        }
+      ]
+    }
   },
   {
     "pkg_name": "xen",
     "ecosystem": "Alpine:v3.15",
-    "purl": "pkg:alpine/xen",
-    "fixed_version": "4.15.3-r2",
-    "fixed_commit": "",
-    "repo": ""
+    "purl": "pkg:apk/alpine/xen?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "4.15.3-r2",
+          "LastAffected": ""
+        }
+      ]
+    }
+  },
+  {
+    "pkg_name": "xen",
+    "ecosystem": "Alpine:v3.17",
+    "purl": "pkg:apk/alpine/xen?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "4.16.1-r6",
+          "LastAffected": ""
+        }
+      ]
+    }
+  },
+  {
+    "pkg_name": "xen",
+    "ecosystem": "Alpine:v3.18",
+    "purl": "pkg:apk/alpine/xen?arch=source",
+    "fixed_version": {
+      "IntroducedCommits": null,
+      "FixCommits": null,
+      "LimitCommits": null,
+      "LastAffectedCommits": null,
+      "AffectedVersions": [
+        {
+          "Introduced": "",
+          "Fixed": "4.16.1-r6",
+          "LastAffected": ""
+        }
+      ]
+    }
   }
 ]

--- a/vulnfeeds/vulns/vulns_test.go
+++ b/vulnfeeds/vulns/vulns_test.go
@@ -122,17 +122,35 @@ func TestAddPkgInfo(t *testing.T) {
 		ID: cveItem.CVE.CVEDataMeta.ID,
 	}
 	testPkgInfoNameEco := PackageInfo{
-		PkgName:      "TestName",
-		Ecosystem:    "TestEco",
-		FixedVersion: "1.2.3-4",
+		PkgName:   "TestName",
+		Ecosystem: "TestEco",
+		VersionInfo: cves.VersionInfo{
+			AffectedVersions: []cves.AffectedVersion{
+				{
+					Fixed: "1.2.3-4",
+				},
+			},
+		},
 	}
 	testPkgInfoPURL := PackageInfo{
-		PURL:         "pkg:deb/debian/nginx@1.1.2-1",
-		FixedVersion: "1.2.3-4",
+		PURL: "pkg:deb/debian/nginx@1.1.2-1",
+		VersionInfo: cves.VersionInfo{
+			AffectedVersions: []cves.AffectedVersion{
+				{
+					Fixed: "1.2.3-4",
+				},
+			},
+		},
 	}
 	testPkgInfoCommits := PackageInfo{
-		Repo:        "github.com/foo/bar",
-		FixedCommit: "dsafwefwfe370a9e65d68d62ef37345597e4100b0e87021dfb",
+		VersionInfo: cves.VersionInfo{
+			FixCommits: []cves.GitCommit{
+				{
+					Commit: "dsafwefwfe370a9e65d68d62ef37345597e4100b0e87021dfb",
+					Repo:   "github.com/foo/bar",
+				},
+			},
+		},
 	}
 	vuln.AddPkgInfo(testPkgInfoNameEco)
 	vuln.AddPkgInfo(testPkgInfoPURL)
@@ -151,7 +169,7 @@ func TestAddPkgInfo(t *testing.T) {
 		t.Errorf("AddPkgInfo has not corrected added ranges type.")
 	}
 
-	if vuln.Affected[0].Ranges[0].Events[1].Fixed != testPkgInfoNameEco.FixedVersion {
+	if vuln.Affected[0].Ranges[0].Events[1].Fixed != testPkgInfoNameEco.VersionInfo.AffectedVersions[0].Fixed {
 		t.Errorf("AddPkgInfo has not corrected added ranges fixed.")
 	}
 	// testPkgInfoNameEco ^^^^^^^^^^^^^^^
@@ -163,7 +181,7 @@ func TestAddPkgInfo(t *testing.T) {
 	if vuln.Affected[1].Ranges[0].Type != "ECOSYSTEM" {
 		t.Errorf("AddPkgInfo has not corrected added ranges type.")
 	}
-	if vuln.Affected[1].Ranges[0].Events[1].Fixed != testPkgInfoPURL.FixedVersion {
+	if vuln.Affected[1].Ranges[0].Events[1].Fixed != testPkgInfoPURL.VersionInfo.AffectedVersions[0].Fixed {
 		t.Errorf("AddPkgInfo has not corrected added ranges fixed.")
 	}
 	// testPkgInfoPURL ^^^^^^^^^^^^^^^
@@ -174,7 +192,7 @@ func TestAddPkgInfo(t *testing.T) {
 	if vuln.Affected[2].Ranges[0].Type != "GIT" {
 		t.Errorf("AddPkgInfo has not corrected added ranges type.")
 	}
-	if vuln.Affected[2].Ranges[0].Events[1].Fixed != testPkgInfoCommits.FixedCommit {
+	if vuln.Affected[2].Ranges[0].Events[1].Fixed != testPkgInfoCommits.VersionInfo.FixCommits[0].Commit {
 		t.Errorf("AddPkgInfo has not corrected added ranges fixed.")
 	}
 	// testPkgInfoCommits ^^^^^^^^^^^^^^^


### PR DESCRIPTION
Convert combine-to-osv to use VersionInfo to better integrate with cve/cpp conversion code.