### PR TITLE
Reintroduce vulnerability source summary to vulnerability page

### DIFF
--- a/gcp/appengine/frontend3/src/templates/list.html
+++ b/gcp/appengine/frontend3/src/templates/list.html
@@ -2,51 +2,48 @@
 {% set active_section = 'vulnerabilities' %}
 
 {% macro table_header_cell(column_id, column_name, is_sortable, is_sorted, is_descending, hide_on_mobile) %}
-<span
-class="vuln-table-cell mdc-data-table__header-cell vuln-table-header
+<span class="vuln-table-cell mdc-data-table__header-cell vuln-table-header
     {% if is_sortable %}mdc-data-table__header-cell--with-sort__DISABLED{% endif %}
     {% if is_sorted %}mdc-data-table__header-cell--sorted{% endif %}
     {% if is_descending %}mdc-data-table__header-cell--sorted-descending{% endif %}
-    {% if hide_on_mobile%}hide-on-mobile{% endif %}"
-role="columnheader"
-scope="col"
-aria-sort="{% if is_sorted %}{% if is_descending %}descending{% else %}ascending{% endif %}{% else %}none{% endif %}"
-data-column-id="{{ column_id }}"
->
-<div class="mdc-data-table__header-cell-wrapper">
-  <div class="mdc-data-table__header-cell-label">
-    {{ column_name }}
+    {% if hide_on_mobile%}hide-on-mobile{% endif %}" role="columnheader" scope="col"
+  aria-sort="{% if is_sorted %}{% if is_descending %}descending{% else %}ascending{% endif %}{% else %}none{% endif %}"
+  data-column-id="{{ column_id }}">
+  <div class="mdc-data-table__header-cell-wrapper">
+    <div class="mdc-data-table__header-cell-label">
+      {{ column_name }}
+    </div>
+    {% if is_sortable %}
+    <mwc-icon-button class="mdc-data-table__sort-icon-button" icon="arrow_upward" disabled
+      aria-label="Sort by {{ column_name }}" aria-describedby="{{ column_id }}-status-label"></mwc-icon-button>
+    <div class="mdc-data-table__sort-status-label" aria-hidden="true" id="{{ column_id }}-status-label">
+    </div>
+    {% endif %}
   </div>
-  {% if is_sortable %}
-  <mwc-icon-button class="mdc-data-table__sort-icon-button" icon="arrow_upward" disabled
-  aria-label="Sort by {{ column_name }}" aria-describedby="{{ column_id }}-status-label"></mwc-icon-button>
-  <div class="mdc-data-table__sort-status-label" aria-hidden="true" id="{{ column_id }}-status-label">
-  </div>
-  {% endif %}
-</div>
 </span>
 {% endmacro %}
 
 {% block content %}
 <div class="list-page">
-<div class="mdc-layout-grid">
-  <div class="mdc-layout-grid__inner">
-    <div class="mdc-layout-grid__cell--span-12">
-      <h1 class="title">Vulnerability Library</h1>
-      <div class="search">
-        <form action="{{ url_for('frontend_handlers.list_vulnerabilities') }}" data-turbo-frame="vulnerability-table">
-          <div class="mdc-layout-grid__inner">
-            <div class="query-container mdc-layout-grid__cell--span-8">
-              <mwc-icon class="search-icon">search</mwc-icon>
-              <mwc-textfield-with-enter label="Package or ID search" icon="a" class="query-field" name="q" value="{{ query }}"></mwc-textfield-with-enter>
+  <div class="mdc-layout-grid">
+    <div class="mdc-layout-grid__inner">
+      <div class="mdc-layout-grid__cell--span-12">
+        <h1 class="title">Vulnerability Library</h1>
+        <div class="search">
+          <form action="{{ url_for('frontend_handlers.list_vulnerabilities') }}" data-turbo-frame="vulnerability-table">
+            <div class="mdc-layout-grid__inner">
+              <div class="query-container mdc-layout-grid__cell--span-8">
+                <mwc-icon class="search-icon">search</mwc-icon>
+                <mwc-textfield-with-enter label="Package or ID search" icon="a" class="query-field" name="q"
+                  value="{{ query }}"></mwc-textfield-with-enter>
+              </div>
             </div>
-          </div>
-          <submit-radios>
-            {% if ecosystem_counts %}
+            <submit-radios>
+              {% if ecosystem_counts %}
               <spicy-sections class="ecosystem-buttons">
                 <spicy-h>
-                  <input type="radio" name="ecosystem" id="ecosystem-radio-all"
-                      value=""{% if not selected_ecosystem %} checked{% endif %}>
+                  <input type="radio" name="ecosystem" id="ecosystem-radio-all" value="" {% if not selected_ecosystem %}
+                    checked{% endif %}>
                   <label class="ecosystem-label ecosystem-label-all" for="ecosystem-radio-all">
                     <span class="ecosystem-name">All ecosystems</span>
                     <span class="ecosystem-count">{{ ecosystem_counts.values() | sum }}</span>
@@ -55,128 +52,133 @@ data-column-id="{{ column_id }}"
                 <div class="spicy-content">
                   <span class="ecosystems-divider"></span>
                   {% for ecosystem in ecosystem_counts %}
-                    <input type="radio" name="ecosystem" id="ecosystem-radio-{{ loop.index }}"
-                        value="{{ ecosystem }}"{% if selected_ecosystem == ecosystem %} checked{% endif %}>
-                    <label class="ecosystem-label" for="ecosystem-radio-{{ loop.index }}">
-                      <span class="ecosystem-name">{{ ecosystem }}</span>
-                      <span class="ecosystem-count">{{ ecosystem_counts[ecosystem] }}</span>
-                    </label>
+                  <input type="radio" name="ecosystem" id="ecosystem-radio-{{ loop.index }}" value="{{ ecosystem }}" {%
+                    if selected_ecosystem==ecosystem %} checked{% endif %}>
+                  <label class="ecosystem-label" for="ecosystem-radio-{{ loop.index }}">
+                    <span class="ecosystem-name">{{ ecosystem }}</span>
+                    <span class="ecosystem-count">{{ ecosystem_counts[ecosystem] }}</span>
+                  </label>
                   {% endfor %}
                 </div>
               </spicy-sections>
-            {% endif %}
-          </submit-radios>
-          <input type="submit">
-        </form>
+              {% endif %}
+            </submit-radios>
+            <input type="submit">
+          </form>
+        </div>
       </div>
     </div>
   </div>
-</div>
-<turbo-frame class="vuln-table-container mdc-data-table" id="vulnerability-table" data-turbo-action="advance">
-  <div role="table" class="vuln-table mdc-data-table__table" aria-label="Vulnerability table">
-    <div role="rowgroup" class="vuln-table-header">
-      <div role="row" class="vuln-table-row mdc-data-table__header-row">
-        {{ table_header_cell('id', 'ID', is_sortable=False, is_sorted=False, is_descending=False, hide_on_mobile=False) }}
-        {{ table_header_cell('package', 'Packages', is_sortable=False, is_sorted=False, is_descending=False, hide_on_mobile=False) }}
-        {{ table_header_cell('summary', 'Summary', is_sortable=False, is_sorted=False, is_descending=False, hide_on_mobile=True) }}
-        {{ table_header_cell('affected-versions', 'Affected versions', is_sortable=False, is_sorted=False, is_descending=False, hide_on_mobile=True) }}
-        {{ table_header_cell('last-modified', 'Last modified', is_sortable=True, is_sorted=True, is_descending=True, hide_on_mobile=True) }}
-        {{ table_header_cell('fixed', 'Fix', is_sortable=False, is_sorted=False, is_descending=False, hide_on_mobile=True) }}
-      </div>
-    </div>
-    <div role="rowgroup" class="vuln-table-rows mdc-data-table__content">
-      <turbo-frame id="vulnerability-table-page{{ page }}" data-turbo-action="advance" target="_top">
-        {% for vulnerability in vulnerabilities %}
-        <div role="row" class="vuln-table-row mdc-data-table__row">
-          <span role="cell" class="vuln-table-cell mdc-data-table__cell">
-            <a href="{{ url_for('frontend_handlers.vulnerability', vuln_id=vulnerability.id) }}">{{ vulnerability.id }}</a>
-          </span>
-          <span role="cell" class="vuln-table-cell vuln-packages mdc-data-table__cell">
-            <ul class="packages">
-            {%- if vulnerability.affected | map(attribute='package', default=[]) | list == [{}] -%}
-              {%- for repo in vulnerability.affected | git_repo | map('strip_scheme') -%}
-                {%- if loop.index < 8 -%}
-                  <li>{{ repo }}</li>
-                {%- elif loop.index == 8 -%}
-                  <li>...</li>
-                {%- endif -%}
-              {%- else -%}
-                <li>See details.</li>
-              {%- endfor -%}
-            {%- else -%}
-            {%- for affected in vulnerability.affected -%}
-              <li>{{ affected.package.ecosystem }}/{{ affected.package.name }}</li>
-            {%- endfor -%}
-            {%- endif -%}
-            </ul>
-          </span>
-          <span role="cell" class="vuln-table-cell vuln-summary mdc-data-table__cell hide-on-mobile">
-            {{ vulnerability.summary or "Not available, see record for full details" }}
-          </span>
-          <span role="cell" class="vuln-table-cell vuln-versions mdc-data-table__cell hide-on-mobile">
-            <ul class="versions">
-            {#- https://stackoverflow.com/questions/31876069/is-it-possible-to-flatten-a-lists-of-lists-with-ansible-jinja2 -#}
-            {%- for version in vulnerability.affected | map(attribute='versions', default=[]) | sum(start=[]) -%}
-              {% if loop.index < 8 %}
-              <li class="version">{{ version }}</li>
-              {%- elif loop.index == 8 -%}
-              <li class="version">...</li>
-              {%- endif -%}
-            {%- else -%}
-              <li class="version">See details.</li>
-            {%- endfor -%}
-          </ul>
-          </span>
-          <span role="cell" class="vuln-table-cell mdc-data-table__cell hide-on-mobile">
-            <relative-time datetime="{{ vulnerability.modified }}">
-              {{ vulnerability.modified }}
-            </relative-time>
-          </span>
-          <span role="cell" class="vuln-table-cell vuln-fix-status mdc-data-table__cell hide-on-mobile">
-            {%- if vulnerability.isFixed -%}
-            <span class="tag fix-available">Fix available</span>
-            {%- else -%}
-            <span class="tag fix-unavailable">No fix available</span>
-            {%- endif -%}
-          </span>
+  <turbo-frame class="vuln-table-container mdc-data-table" id="vulnerability-table" data-turbo-action="advance">
+    <div role="table" class="vuln-table mdc-data-table__table" aria-label="Vulnerability table">
+      <div role="rowgroup" class="vuln-table-header">
+        <div role="row" class="vuln-table-row mdc-data-table__header-row">
+          {{ table_header_cell('id', 'ID', is_sortable=False, is_sorted=False, is_descending=False,
+          hide_on_mobile=False) }}
+          {{ table_header_cell('package', 'Packages', is_sortable=False, is_sorted=False, is_descending=False,
+          hide_on_mobile=False) }}
+          {{ table_header_cell('summary', 'Summary', is_sortable=False, is_sorted=False, is_descending=False,
+          hide_on_mobile=True) }}
+          {{ table_header_cell('affected-versions', 'Affected versions', is_sortable=False, is_sorted=False,
+          is_descending=False, hide_on_mobile=True) }}
+          {{ table_header_cell('last-modified', 'Last modified', is_sortable=True, is_sorted=True, is_descending=True,
+          hide_on_mobile=True) }}
+          {{ table_header_cell('fixed', 'Fix', is_sortable=False, is_sorted=False, is_descending=False,
+          hide_on_mobile=True) }}
         </div>
-        {%- endfor -%}
-        {%- if vulnerabilities | length == 0 -%}
+      </div>
+      <div role="rowgroup" class="vuln-table-rows mdc-data-table__content">
+        <turbo-frame id="vulnerability-table-page{{ page }}" data-turbo-action="advance" target="_top">
+          {% for vulnerability in vulnerabilities %}
+          <div role="row" class="vuln-table-row mdc-data-table__row">
+            <span role="cell" class="vuln-table-cell mdc-data-table__cell">
+              <a href="{{ url_for('frontend_handlers.vulnerability', vuln_id=vulnerability.id) }}">{{ vulnerability.id
+                }}</a>
+            </span>
+            <span role="cell" class="vuln-table-cell vuln-packages mdc-data-table__cell">
+              <ul class="packages">
+                {%- if vulnerability.affected | map(attribute='package', default=[]) | list == [{}] -%}
+                {%- for repo in vulnerability.affected | git_repo | map('strip_scheme') -%}
+                {%- if loop.index < 8 -%} <li>{{ repo }}</li>
+                  {%- elif loop.index == 8 -%}
+                  <li>...</li>
+                  {%- endif -%}
+                  {%- else -%}
+                  <li>See details.</li>
+                  {%- endfor -%}
+                  {%- else -%}
+                  {%- for affected in vulnerability.affected -%}
+                  <li>{{ affected.package.ecosystem }}/{{ affected.package.name }}</li>
+                  {%- endfor -%}
+                  {%- endif -%}
+              </ul>
+            </span>
+            <span role="cell" class="vuln-table-cell vuln-summary mdc-data-table__cell hide-on-mobile">
+              {{ vulnerability.summary or "See record for full details" }}
+            </span>
+            <span role="cell" class="vuln-table-cell vuln-versions mdc-data-table__cell hide-on-mobile">
+              <ul class="versions">
+                {#-
+                https://stackoverflow.com/questions/31876069/is-it-possible-to-flatten-a-lists-of-lists-with-ansible-jinja2
+                -#}
+                {%- for version in vulnerability.affected | map(attribute='versions', default=[]) | sum(start=[]) -%}
+                {% if loop.index < 8 %} <li class="version">{{ version }}</li>
+                  {%- elif loop.index == 8 -%}
+                  <li class="version">...</li>
+                  {%- endif -%}
+                  {%- else -%}
+                  <li class="version">See details.</li>
+                  {%- endfor -%}
+              </ul>
+            </span>
+            <span role="cell" class="vuln-table-cell mdc-data-table__cell hide-on-mobile">
+              <relative-time datetime="{{ vulnerability.modified }}">
+                {{ vulnerability.modified }}
+              </relative-time>
+            </span>
+            <span role="cell" class="vuln-table-cell vuln-fix-status mdc-data-table__cell hide-on-mobile">
+              {%- if vulnerability.isFixed -%}
+              <span class="tag fix-available">Fix available</span>
+              {%- else -%}
+              <span class="tag fix-unavailable">No fix available</span>
+              {%- endif -%}
+            </span>
+          </div>
+          {%- endfor -%}
+          {%- if vulnerabilities | length == 0 -%}
           <span class="no-results">No results</span>
-        {%- endif -%}
-        {%- if page < total_pages -%}
-          <turbo-frame id="vulnerability-table-page{{ page + 1 }}" data-turbo-action="advance" target="_top"
-                       class="next-page-frame">
-          <div class="next-page-container">
-          <a class="next-page-button link-button" data-turbo-frame="_self"
-             href="{{ url_for(request.endpoint) }}?page={{ page + 1 }}
+          {%- endif -%}
+          {%- if page < total_pages -%} <turbo-frame id="vulnerability-table-page{{ page + 1 }}"
+            data-turbo-action="advance" target="_top" class="next-page-frame">
+            <div class="next-page-container">
+              <a class="next-page-button link-button" data-turbo-frame="_self" href="{{ url_for(request.endpoint) }}?page={{ page + 1 }}
                   {%- if query %}&q={{ query }}{% endif %}
                   {%- if selected_ecosystem %}&ecosystem={{ selected_ecosystem }}{% endif %}">
-            <span>Load more...</span>
-            {%- if total_pages - page <= 3 -%}
-              <span style="margin-left: 5px">({{ total_pages - page }} page{% if total_pages - page > 1 %}s{% endif %} left)</span>
-            {%- endif -%}
-          </a>
-          <mwc-circular-progress class="next-page-indicator" indeterminate density="-4"></mwc-circular-progress>
-          </div>
-          </turbo-frame>
+                <span>Load more...</span>
+                {%- if total_pages - page <= 3 -%} <span style="margin-left: 5px">({{ total_pages - page }} page{% if
+                  total_pages - page > 1 %}s{% endif %} left)</span>
+                  {%- endif -%}
+              </a>
+              <mwc-circular-progress class="next-page-indicator" indeterminate density="-4"></mwc-circular-progress>
+            </div>
+        </turbo-frame>
         {%- endif -%}
-      </turbo-frame>
-    </div>
-  </div>
-  <turbo-stream action="update" target="title">
-    <template>
-      {% if selected_ecosystem %}
-        {{ selected_ecosystem }} - OSV
-      {% else %}
-        Vulnerability Database - OSV
-      {% endif %}
-    </template>
-  </turbo-stream>
+  </turbo-frame>
+</div>
+</div>
+<turbo-stream action="update" target="title">
+  <template>
+    {% if selected_ecosystem %}
+    {{ selected_ecosystem }} - OSV
+    {% else %}
+    Vulnerability Database - OSV
+    {% endif %}
+  </template>
+</turbo-stream>
 </turbo-frame>
 </div>
 <script>
-import {MDCDataTable} from '@material/data-table';
-const dataTable = new MDCDataTable(document.querySelector('.mdc-data-table'));
+  import { MDCDataTable } from '@material/data-table';
+  const dataTable = new MDCDataTable(document.querySelector('.mdc-data-table'));
 </script>
 {% endblock %}

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -70,6 +70,26 @@
       <div class="mdc-layout-grid">
         <div class="vulnerability-package-subsection mdc-layout-grid__inner">
           <h3 class="mdc-layout-grid__cell--span-3">
+            Source Details
+          </h3>
+          <div class="mdc-layout-grid__cell--span-9">
+            <dl>
+              {%- if affected['package']['name'] -%}
+              <dt>Package Name</dt>
+              {# TODO(andrewpollock): link out to the package in the ecosystem -#}
+              <dd>{{ affected['package']['name'] }}</dd>
+              {%- endif -%}
+              {%- if vulnerability.repo -%}
+              <dt>Repository</dt>
+              {# TODO(andrewpollock): it's permissible to have more than one repo, so handle this -#}
+              <dd><a href="{{ vulnerability.repo }}" target="_blank" rel="noopener noreferrer">{{ vulnerability.repo
+                  }}</a></dd>
+              {%- endif -%}
+            </dl>
+          </div>
+        </div>
+        <div class="vulnerability-package-subsection mdc-layout-grid__inner">
+          <h3 class="mdc-layout-grid__cell--span-3">
             Affected ranges
             <a href="https://ossf.github.io/osv-schema/#examples" target="_blank" rel="noopener noreferrer"></a>
           </h3>


### PR DESCRIPTION
Addresses outstanding feedback from #1483, and makes the information presented less consistent, focusing on only displaying what's available and applicable.

Also softened the wording for vulnerabilities without a summary on the listing page to deemphasize the information deficit.