### PR TITLE
Dogfood our OSV-Scanner action!

### DIFF
--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -1,0 +1,29 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: osv-scanner
+
+on:
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
+  merge_group:
+    branches: [ main ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  scan-pr-attempt:
+    uses: "google/osv-scanner/.github/workflows/osv-scanner-reusable-pr.yml@main"

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -1,0 +1,30 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: osv-scanner
+
+on:
+  schedule:
+    - cron: '12 12 * * 1'
+  push:
+    branches: [ "main" ]
+
+# Declare default permissions as read only.
+permissions: 
+  security-events: write
+  contents: read
+
+jobs:
+  scan-pr-attempt:
+    uses: "google/osv-scanner/.github/workflows/osv-scanner-reusable-scheduled.yml@main"


### PR DESCRIPTION
Adds two OSV-Scanner github actions

- `osv-scanner-pr.yml` blocks PRs that introduce new vulnerabilities, and annotates the vulnerable changed file.
- `osv-scanner-scheduled.yml` runs OSV-Scanner periodically and writes new vulnerabilities into the security code scanning tab. No notification system set up, so you have to manually look in code scanning tab for now. 