### PR TITLE
Try using `autoscaling/v2` for pubsub autoscaler

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/scaler.yaml
+++ b/deployment/clouddeploy/gke-workers/base/scaler.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: pubsub

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/scaler.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/scaler.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: pubsub


### PR DESCRIPTION
We're getting an error in Cloud Deploy:
```
error: resource mapping not found for name: "pubsub" namespace: "" from "/workspace/stable/manifest.yaml": no matches for kind "HorizontalPodAutoscaler" in version "autoscaling/v2beta2"
ensure CRDs are installed first
```
Let's see if this fixes it