### PR TITLE
Change Cloud Build to use E2 machines

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -40,4 +40,4 @@ steps:
   args: [ '-c', "rm /workspace/service_account.json" ]
 timeout: 7200s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8

--- a/deployment/build-and-stage.yaml
+++ b/deployment/build-and-stage.yaml
@@ -240,7 +240,7 @@ timeout: 7200s
 serviceAccount: 'projects/oss-vdb/serviceAccounts/deployment@oss-vdb.iam.gserviceaccount.com'
 logsBucket: gs://oss-vdb-tf/apply-logs
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8
 
 tags: ['build-and-stage']
 

--- a/deployment/staging.yaml
+++ b/deployment/staging.yaml
@@ -46,5 +46,5 @@ steps:
   - CLOUDBUILD=1
 timeout: 7200s
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8
   logging: CLOUD_LOGGING_ONLY

--- a/vulnfeeds/git/repository_test.go
+++ b/vulnfeeds/git/repository_test.go
@@ -117,6 +117,7 @@ func TestRepoTags(t *testing.T) {
 				{Tag: "v0.18.3", Commit: "1cf7764293aebb473baee3ff82298d83593943e8"},
 				{Tag: "v0.18.4", Commit: "c03255688a13cf7089eeb7a292c1de2abf1d3a9d"},
 				{Tag: "v0.18.5", Commit: "a164c35a217579b1eec3b548f9421cd030160c5b"},
+				{Tag: "v0.18.6", Commit: "82fd64038788942aef8a394d6d4b802cb529f71b"},
 			},
 			expectedOk: true,
 		},


### PR DESCRIPTION
Moving Cloud Build triggers to 2nd Gen repositories mean that they have to be regional and cannot use N1 machines.