### PR TITLE
Mark disputed CVEs as withdrawn

### DIFF
--- a/docker/ci/install_go.sh
+++ b/docker/ci/install_go.sh
@@ -15,14 +15,10 @@
 #
 ################################################################################
 
-# Install go on x86_64, don't do anything on ARM.
 set -eux
 
-# Download and install the latest stable Go.
+# Download and install Go
 wget https://storage.googleapis.com/golang/getgo/installer_linux -O $1/installer_linux
 chmod +x $1/installer_linux
-SHELL="bash" $1/installer_linux -version 1.18
+SHELL="bash" $1/installer_linux -version 1.20
 rm $1/installer_linux
-# # Set up Golang coverage modules.
-# printf $(find . -name gocoverage)
-# cd $GOPATH/gocoverage && go install ./...

--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -111,6 +111,8 @@ func combineIntoOSV(loadedCves map[string]cves.CVEItem, allParts map[string][]vu
 			continue
 		}
 		convertedCve, _ := vulns.FromCVE(cveId, cve)
+		// Best-effort attempt to mark a disputed CVE as withdrawn.
+		_ = convertedCve.MarkDisputedCVEWithdrawn()
 		for _, pkgInfo := range allParts[cveId] {
 			convertedCve.AddPkgInfo(pkgInfo)
 		}

--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -112,7 +112,13 @@ func combineIntoOSV(loadedCves map[string]cves.CVEItem, allParts map[string][]vu
 		}
 		convertedCve, _ := vulns.FromCVE(cveId, cve)
 		// Best-effort attempt to mark a disputed CVE as withdrawn.
-		_ = convertedCve.MarkDisputedCVEWithdrawn()
+		modified, err := vulns.CVEIsDisputed(convertedCve)
+		if err != nil {
+			Logger.Warnf("Unable to determine CVE dispute status of %s: %v", convertedCve.ID, err)
+		}
+		if err == nil && modified != "" {
+			convertedCve.Withdrawn = modified
+		}
 		for _, pkgInfo := range allParts[cveId] {
 			convertedCve.AddPkgInfo(pkgInfo)
 		}

--- a/vulnfeeds/cves/cve.go
+++ b/vulnfeeds/cves/cve.go
@@ -21,7 +21,8 @@ import (
 )
 
 const (
-	CVETimeFormat = "2006-01-02T15:04Z07:00"
+	CVETimeFormat  = "2006-01-02T15:04Z07:00"
+	CVE5TimeFormat = "2006-01-02T00:00:00"
 )
 
 type CVE struct {
@@ -36,6 +37,7 @@ type CVE struct {
 		} `json:"description_data"`
 	} `json:"description"`
 }
+
 type CVEReferenceData struct {
 	URL       string   `json:"url"`
 	Name      string   `json:"name"`
@@ -96,6 +98,52 @@ func (n *NVDCVE2) ToJSON(w io.Writer) error {
 	return encoder.Encode(n)
 }
 
+type CVE5 struct {
+	DataType    string `json:"dataType"`
+	DataVersion string `json:"dataVersion"`
+	Metadata    struct {
+		State             string `json:"state"`
+		ID                string `json:"cveId"`
+		AssignerOrgId     string `json:"assignerOrgId"`
+		AssignerShortName string `json:"assignerShortName"`
+		DateUpdated       string `json:"dateUpdated"`
+		DateReserved      string `json:"dateReserved"`
+		DatePublished     string `json:"datePublished"`
+	}
+	Containers struct {
+		CNA struct {
+			ProviderMetadata struct {
+				OrgID       string `json:"orgId"`
+				ShortName   string `json:"shortName"`
+				DateUpdated string `json:"dateUpdated"`
+			}
+			Descriptions []struct {
+				Lang  string `json:"lang"`
+				Value string `json:"value"`
+			}
+			Tags     []string `json:"tags"`
+			Affected []struct {
+				Vendor   string `json:"vendor"`
+				Product  string `json:"product"`
+				Versions []struct {
+					Version string `json:"version"`
+					Status  string `json:"status"`
+				}
+			}
+			References []struct {
+				URL string `json:"url"`
+			}
+			ProblemTypes []struct {
+				Descriptions []struct {
+					Type        string `json:"type"`
+					Lang        string `json:"lang"`
+					Description string `json:"description"`
+				}
+			}
+		}
+	}
+}
+
 func EnglishDescription(cve CVE) string {
 	for _, desc := range cve.Description.DescriptionData {
 		if desc.Lang == "en" {
@@ -107,4 +155,8 @@ func EnglishDescription(cve CVE) string {
 
 func ParseTimestamp(timestamp string) (time.Time, error) {
 	return time.Parse(CVETimeFormat, timestamp)
+}
+
+func ParseCVE5Timestamp(timestamp string) (time.Time, error) {
+	return time.Parse(CVE5TimeFormat, timestamp)
 }

--- a/vulnfeeds/vulns/vulns_test.go
+++ b/vulnfeeds/vulns/vulns_test.go
@@ -232,11 +232,10 @@ func TestAddSeverity(t *testing.T) {
 	}
 }
 
-func TestMarkDisputedCVEWithdrawn(t *testing.T) {
+func TestCVEIsDisputed(t *testing.T) {
 	tests := []struct {
 		description       string
 		inputVulnId       string
-		expectedResult    *Vulnerability
 		expectedWithdrawn bool
 		expectedError     error
 	}{
@@ -261,12 +260,11 @@ func TestMarkDisputedCVEWithdrawn(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		inputVuln := &Vulnerability{}
-		inputVuln = &Vulnerability{
+		inputVuln := &Vulnerability{
 			ID: tc.inputVulnId,
 		}
 
-		err := inputVuln.MarkDisputedCVEWithdrawn()
+		modified, err := CVEIsDisputed(inputVuln)
 
 		if err != nil && err != tc.expectedError {
 			var verr *VulnsCVEListError
@@ -281,8 +279,8 @@ func TestMarkDisputedCVEWithdrawn(t *testing.T) {
 			t.Errorf("test %q: did not error as expected, wanted: %#v", tc.description, tc.expectedError)
 		}
 
-		if inputVuln.Withdrawn == "" && tc.expectedWithdrawn {
-			t.Errorf("test: %q: withdrawn (%s) not set as expected", tc.description, inputVuln.Withdrawn)
-		} 
+		if modified == "" && tc.expectedWithdrawn {
+			t.Errorf("test: %q: withdrawn (%s) not set as expected", tc.description, modified)
+		}
 	}
 }


### PR DESCRIPTION
This consults the CVE 5.0 record in the CVE List, because the 4.0 schema in the NVD doesn't have a machine-readable way to determine dispute status.