### PR TITLE
Make the CVE consolidation hermetic to staging

### DIFF
--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/combine-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/combine-to-osv.yaml
@@ -12,5 +12,7 @@ spec:
             env:
             - name: GOOGLE_CLOUD_PROJECT
               value: oss-vdb-test
+            - name: INPUT_GCS_BUCKET
+              value: osv-test-cve-osv-conversion
             - name: OUTPUT_GCS_BUCKET
               value: osv-test-cve-osv-conversion

--- a/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
+++ b/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
@@ -6,7 +6,7 @@
 ## This script is intended to be the entrypoint of the docker image.
 ## with the working directory being the root of the repository
 
-set -e
+set -eu
 
 INPUT_BUCKET="${INPUT_GCS_BUCKET:=cve-osv-conversion}"
 OUTPUT_BUCKET="${OUTPUT_GCS_BUCKET:=cve-osv-conversion}"
@@ -19,7 +19,7 @@ rm -rf $OSV_PARTS_ROOT && mkdir -p $OSV_PARTS_ROOT
 rm -rf $OSV_OUTPUT && mkdir -p $OSV_OUTPUT
 rm -rf $CVE_OUTPUT && mkdir -p $CVE_OUTPUT
 
-echo "Begin syncing from parts in GCS bucket ${BUCKET}"
+echo "Begin syncing from parts in GCS bucket ${INPUT_BUCKET}"
 gsutil -q -m rsync -r "gs://${INPUT_BUCKET}/parts/" $OSV_PARTS_ROOT
 echo "Successfully synced from GCS bucket"
 
@@ -29,6 +29,6 @@ echo "Run download-cves"
 echo "Run combine-to-osv"
 ./combine-to-osv -cvePath $CVE_OUTPUT -partsPath $OSV_PARTS_ROOT -osvOutputPath $OSV_OUTPUT
 
-echo "Begin syncing output to GCS bucket ${BUCKET}"
+echo "Begin syncing output to GCS bucket ${OUTPUT_BUCKET}"
 gsutil -q -m rsync -c -d $OSV_OUTPUT "gs://${OUTPUT_BUCKET}/osv-output/"
 echo "Successfully synced to GCS bucket"


### PR DESCRIPTION
After much poking around, I realised that while combine-to-osv was writing to the staging GCS bucket, it was *reading* from the production one. This was made harder to track down by an incorrect variable being used in the logged output. Also use `set -u` to make incorrect variable usage more self-evident.