### PR TITLE
Fix: Remove --privileged flag and run ESP as root in local dev

### DIFF
--- a/gcp/api/Dockerfile.esp
+++ b/gcp/api/Dockerfile.esp
@@ -14,4 +14,6 @@
 
 FROM gcr.io/endpoints-release/endpoints-runtime:2
 
+# Required to run ESP and map files without encountering permissions
+# issues on glinux. Intended for local development only.
 USER root

--- a/gcp/api/Dockerfile.esp
+++ b/gcp/api/Dockerfile.esp
@@ -15,10 +15,3 @@
 FROM gcr.io/endpoints-release/endpoints-runtime:2
 
 USER root
-
-# Context: https://github.com/mhart/alpine-node/issues/48#issuecomment-370171836
-# The UID needs to be set to 1000 in order to map files without permission issues.
-RUN addgroup -g 1000 -S osv && \
-    adduser --no-create-home -u 1000 -S osv -G osv
-
-USER osv

--- a/gcp/api/test_server.py
+++ b/gcp/api/test_server.py
@@ -103,7 +103,6 @@ def start_esp(port, backend_port, service_account_path, log_path):
   esp_proc = subprocess.Popen([
       'docker',
       'run',
-      '--privileged',
       '--name',
       'osv-esp',
       network,


### PR DESCRIPTION
This allows us to run `make run-api-server` on glinux without file permission issues when mapping in ADC or other credentials.