### PR TITLE
Make lint_and_format.sh more user friendly for first time contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,8 @@ You must install:
 
 1.  Git
 1.  Python 3.11
+1.  [Pylint](https://pypi.org/project/pylint)
+1.  [Yapf](https://github.com/google/yapf)
 1.  [Make](https://www.gnu.org/software/make/)
 1.  [Pipenv](https://pipenv.pypa.io/en/latest/)
 1.  [Google Cloud SDK](https://cloud.google.com/sdk)

--- a/tools/lint_and_format.sh
+++ b/tools/lint_and_format.sh
@@ -27,6 +27,19 @@ IN_SCOPE_GO_MODULES="$(git ls-files | fgrep go.mod | fgrep -v docs | xargs dirna
 
 IN_SCOPE_TERRAFORM_FILES="$script_dir/../deployment/terraform/"
 
+check_prerequisites() {
+  readonly PREREQUISITES="pylint yapf go terraform"
+  for preqrequisite in $PREREQUISITES
+  do
+    if ! which $preqrequisite >/dev/null 2>&1; then
+      echo "Prerequisite tool "${preqrequisite}" not found, please review https://github.com/google/osv.dev/blob/master/CONTRIBUTING.md#contributing-code"
+      return 1
+    fi
+  done
+}
+
+check_prerequisites || exit 1
+
 python_lint_findings=""
 if ! echo "$IN_SCOPE_PYTHON_FILES" | xargs pylint --rcfile="$script_dir/../.pylintrc"; then
   python_lint_findings="python_lint_findings"


### PR DESCRIPTION
Based on observations from #1455, provide a better lit path for new contributors to ensure they have the appropriate prerequisites installed for local validation of proposed changes. 