### PR TITLE
Increase deadline for combine-to-osv

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
@@ -7,7 +7,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
-      activeDeadlineSeconds: 3600
+      activeDeadlineSeconds: 7200
       template:
         spec:
           containers:


### PR DESCRIPTION
Including the NVD input seems to causing the job to run into the current 1h deadline and get terminated, double the deadline to get a sense of how long it is taking to complete and what optimisations might be necessary.

Annoyingly this wasn't being very well surfaced in the logs, and additionally the concurrency policy seemed to be dueling with the deadline, causing further confusing log entries.