### PR TITLE
Use `gcloud storage` to accelerate GCS transfers and use more CPUs

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
@@ -18,10 +18,10 @@ spec:
               privileged: true
             resources:
               requests:
-                cpu: 1
+                cpu: 2
                 memory: "1G"
               limits:
-                cpu: 1
+                cpu: 2
                 memory: "2G"
           restartPolicy: OnFailure
           volumes:

--- a/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
+++ b/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
@@ -20,7 +20,7 @@ rm -rf $OSV_OUTPUT && mkdir -p $OSV_OUTPUT
 rm -rf $CVE_OUTPUT && mkdir -p $CVE_OUTPUT
 
 echo "Begin syncing from parts in GCS bucket ${INPUT_BUCKET}"
-gsutil -q -m rsync -r "gs://${INPUT_BUCKET}/parts/" $OSV_PARTS_ROOT
+gcloud storage -q rsync "gs://${INPUT_BUCKET}/parts/" "$OSV_PARTS_ROOT" -r
 echo "Successfully synced from GCS bucket"
 
 echo "Run download-cves"
@@ -30,5 +30,5 @@ echo "Run combine-to-osv"
 ./combine-to-osv -cvePath $CVE_OUTPUT -partsPath $OSV_PARTS_ROOT -osvOutputPath $OSV_OUTPUT
 
 echo "Begin syncing output to GCS bucket ${OUTPUT_BUCKET}"
-gsutil -q -m rsync -c -d $OSV_OUTPUT "gs://${OUTPUT_BUCKET}/osv-output/"
+gcloud storage -q rsync "$OSV_OUTPUT" "gs://${OUTPUT_BUCKET}/osv-output/" -c --delete-unmatched-destination-objects
 echo "Successfully synced to GCS bucket"

--- a/vulnfeeds/cpp/run_cve_to_osv_generation
+++ b/vulnfeeds/cpp/run_cve_to_osv_generation
@@ -28,7 +28,7 @@ mkdir -p "${WORK_DIR}/nvd"
 
 # Download latest CPE repo map.
 echo "Downloading latest CPE Git repository map"
-gsutil -q cp "${CPEREPO_GCS_PATH}" "${WORK_DIR}"
+gcloud storage -q cp "${CPEREPO_GCS_PATH}" "${WORK_DIR}"
 
 # Dirty hack to get around https://stackoverflow.com/questions/68528541/env-variable-array
 # https://stackoverflow.com/questions/9293887/reading-a-space-delimited-string-into-an-array-in-bash/9294015
@@ -44,11 +44,11 @@ for YEAR in "${IN_SCOPE_YEARS[@]}"; do
 
   # Copy results to GCS bucket.
   echo "Copying NVD CVE records from ${YEAR} successfully converted to OSV to GCS"
-  find "${WORK_DIR}/nvd2osv/${YEAR}" -type f -name \*.json | gsutil -q -m cp -I "${OSV_OUTPUT_GCS_PATH}"
+  find "${WORK_DIR}/nvd2osv/${YEAR}" -type f -name \*.json | gcloud storage -q cp -I "${OSV_OUTPUT_GCS_PATH}"
 
   # Copy conversion summary to GCS bucket.
   DURABLE_OUTCOMES_CSV="${OSV_OUTPUT_GCS_PATH}/nvd-conversion-outcomes-${YEAR}-$(date -Iminutes).csv"
-  gsutil -q cp "${WORK_DIR}/nvd2osv/${YEAR}/outcomes.csv" "$DURABLE_OUTCOMES_CSV"
+  gcloud storage -q cp "${WORK_DIR}/nvd2osv/${YEAR}/outcomes.csv" "$DURABLE_OUTCOMES_CSV"
 
   echo "Results summary available at $DURABLE_OUTCOMES_CSV"
 done


### PR DESCRIPTION
I discovered
https://cloud.google.com/blog/products/storage-data-transfer/new-gcloud-storage-enables-super-fast-data-transfers while I was looking for speed optimisations

Increase CPUs for this job

This job is GCS transfer intensive, and will benefit from the parallelisation available with more than one CPU