### PR TITLE
Improve CVE configuration parsing for CPEs

### DIFF
--- a/vulnfeeds/cves/cve.go
+++ b/vulnfeeds/cves/cve.go
@@ -59,23 +59,30 @@ type CVEImpact struct {
 }
 
 type CVEItem struct {
-	CVE            CVE `json:"cve"`
-	Configurations struct {
-		Nodes []struct {
-			Operator string `json:"operator"`
-			CPEMatch []struct {
-				Vulnerable            bool   `json:"vulnerable"`
-				CPE23URI              string `json:"cpe23Uri"`
-				VersionStartExcluding string `json:"versionStartExcluding"`
-				VersionStartIncluding string `json:"versionStartIncluding"`
-				VersionEndExcluding   string `json:"versionEndExcluding"`
-				VersionEndIncluding   string `json:"versionEndIncluding"`
-			} `json:"cpe_match"`
-		} `json:"nodes"`
-	} `json:"configurations"`
-	Impact           CVEImpact `json:"impact"`
-	PublishedDate    string    `json:"publishedDate"`
-	LastModifiedDate string    `json:"lastModifiedDate"`
+	CVE              CVE           `json:"cve"`
+	Configurations   Configuration `json:"configurations"`
+	Impact           CVEImpact     `json:"impact"`
+	PublishedDate    string        `json:"publishedDate"`
+	LastModifiedDate string        `json:"lastModifiedDate"`
+}
+
+type Configuration struct {
+	Nodes []Node `json:"nodes"`
+}
+
+type Node struct {
+	Operator string     `json:"operator"`
+	Children []Node     `json:"children"`
+	CPEMatch []CPEMatch `json:"cpe_match"`
+}
+
+type CPEMatch struct {
+	Vulnerable            bool   `json:"vulnerable"`
+	CPE23URI              string `json:"cpe23Uri"`
+	VersionStartExcluding string `json:"versionStartExcluding"`
+	VersionStartIncluding string `json:"versionStartIncluding"`
+	VersionEndExcluding   string `json:"versionEndExcluding"`
+	VersionEndIncluding   string `json:"versionEndIncluding"`
 }
 
 type NVDCVE struct {

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -699,7 +699,7 @@ func extractGitCommit(link string, commitType CommitType) (ac AffectedCommit, er
 }
 
 func hasVersion(validVersions []string, version string) bool {
-	if validVersions == nil || len(validVersions) == 0 {
+	if len(validVersions) == 0 {
 		return true
 	}
 	return versionIndex(validVersions, version) != -1
@@ -717,12 +717,12 @@ func versionIndex(validVersions []string, version string) int {
 func nextVersion(validVersions []string, version string) (string, error) {
 	idx := versionIndex(validVersions, version)
 	if idx == -1 {
-		return "", fmt.Errorf("Warning: %s is not a valid version", version)
+		return "", fmt.Errorf("warning: %s is not a valid version", version)
 	}
 
 	idx += 1
 	if idx >= len(validVersions) {
-		return "", fmt.Errorf("Warning: %s does not have a version that comes after.", version)
+		return "", fmt.Errorf("warning: %s does not have a version that comes after", version)
 	}
 
 	return validVersions[idx], nil
@@ -907,6 +907,11 @@ func CPEs(cve CVEItem) []string {
 	for _, node := range cve.Configurations.Nodes {
 		for _, match := range node.CPEMatch {
 			cpes = append(cpes, match.CPE23URI)
+		}
+		for _, child := range node.Children {
+			for _, match := range child.CPEMatch {
+				cpes = append(cpes, match.CPE23URI)
+			}
 		}
 	}
 

--- a/vulnfeeds/cves/versions_test.go
+++ b/vulnfeeds/cves/versions_test.go
@@ -702,3 +702,29 @@ func TestExtractVersionInfo(t *testing.T) {
 		}
 	}
 }
+
+func TestCPEs(t *testing.T) {
+	tests := []struct {
+		description  string
+		inputCVEItem CVEItem
+		expectedCPEs []string
+	}{
+		{
+			description:  "A CVE with child CPEs",
+			inputCVEItem: loadTestData("CVE-2023-24256"),
+			expectedCPEs: []string{"cpe:2.3:o:nio:aspen:*:*:*:*:*:*:*:*", "cpe:2.3:h:nio:ec6:-:*:*:*:*:*:*:*"},
+		},
+		{
+			description:  "A CVE without child CPEs",
+			inputCVEItem: loadTestData("CVE-2022-33745"),
+			expectedCPEs: []string{"cpe:2.3:o:xen:xen:*:*:*:*:*:*:x86:*", "cpe:2.3:o:fedoraproject:fedora:36:*:*:*:*:*:*:*"},
+		},
+	}
+
+	for _, tc := range tests {
+		gotCPEs := CPEs(tc.inputCVEItem)
+		if diff := cmp.Diff(gotCPEs, tc.expectedCPEs); diff != "" {
+			t.Errorf("test %q: CPEs for %#v were incorrect: %s", tc.description, tc.inputCVEItem.Configurations, diff)
+		}
+	}
+}

--- a/vulnfeeds/test_data/nvdcve-1.1-test-data.json
+++ b/vulnfeeds/test_data/nvdcve-1.1-test-data.json
@@ -41508,5 +41508,105 @@
     },
     "publishedDate": "2022-03-29T18:15Z",
     "lastModifiedDate": "2023-02-12T22:15Z"
+  },
+  {
+    "cve": {
+      "data_type": "CVE",
+      "data_format": "MITRE",
+      "data_version": "4.0",
+      "CVE_data_meta": {
+	"ID": "CVE-2023-24256",
+	"ASSIGNER": "cve@mitre.org"
+      },
+      "problemtype": {
+	"problemtype_data": [
+	  {
+	    "description": [
+	      {
+		"lang": "en",
+		"value": "CWE-22"
+	      }
+	    ]
+	  }
+	]
+      },
+      "references": {
+	"reference_data": [
+	  {
+	    "url": "https://github.com/hhj4ck/JailBreakEC6/blob/main/BugReport.md",
+	    "name": "https://github.com/hhj4ck/JailBreakEC6/blob/main/BugReport.md",
+	    "refsource": "MISC",
+	    "tags": [
+	      "Exploit",
+	      "Third Party Advisory"
+	    ]
+	  }
+	]
+      },
+      "description": {
+	"description_data": [
+	  {
+	    "lang": "en",
+	    "value": "An issue in the com.nextev.datastatistic component of NIO EC6 Aspen before v3.3.0 allows attackers to escalate privileges via path traversal."
+	  }
+	]
+      }
+    },
+    "configurations": {
+      "CVE_data_version": "4.0",
+      "nodes": [
+	{
+	  "operator": "AND",
+	  "children": [
+	    {
+	      "operator": "OR",
+	      "children": [],
+	      "cpe_match": [
+		{
+		  "vulnerable": true,
+		  "cpe23Uri": "cpe:2.3:o:nio:aspen:*:*:*:*:*:*:*:*",
+		  "versionEndExcluding": "3.3.0",
+		  "cpe_name": []
+		}
+	      ]
+	    },
+	    {
+	      "operator": "OR",
+	      "children": [],
+	      "cpe_match": [
+		{
+		  "vulnerable": false,
+		  "cpe23Uri": "cpe:2.3:h:nio:ec6:-:*:*:*:*:*:*:*",
+		  "cpe_name": []
+		}
+	      ]
+	    }
+	  ],
+	  "cpe_match": []
+	}
+      ]
+    },
+    "impact": {
+      "baseMetricV3": {
+	"cvssV3": {
+	  "version": "3.1",
+	  "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+	  "attackVector": "LOCAL",
+	  "attackComplexity": "LOW",
+	  "privilegesRequired": "LOW",
+	  "userInteraction": "NONE",
+	  "scope": "UNCHANGED",
+	  "confidentialityImpact": "HIGH",
+	  "integrityImpact": "HIGH",
+	  "availabilityImpact": "HIGH",
+	  "baseScore": 7.8,
+	  "baseSeverity": "HIGH"
+	},
+	"exploitabilityScore": 1.8,
+	"impactScore": 5.9
+      }
+    },
+    "publishedDate": "2023-07-06T02:15Z",
+    "lastModifiedDate": "2023-07-12T13:52Z"
   } ]
 }


### PR DESCRIPTION
The configurations object of an NVD CVE is particularly gnarly and can essentially be recursive. Rework the struct to reflect this, and adjust the parsing to account for it. Add test coverage