### PR TITLE
Cargo cult what the importer is doing (with a tweak)  to get more computing power

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
@@ -10,6 +10,10 @@ spec:
       activeDeadlineSeconds: 7200
       template:
         spec:
+          tolerations:
+          - key: workloadType
+            operator: Equal
+            value: importer-pool
           containers:
           - name: combine-to-osv
             image: combine-to-osv
@@ -23,6 +27,8 @@ spec:
               limits:
                 cpu: 2
                 memory: "2G"
+          nodeSelector:
+            cloud.google.com/gke-nodepool: importer-pool
           restartPolicy: OnFailure
           volumes:
             - name: "ssd"

--- a/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
@@ -13,7 +13,7 @@ spec:
           tolerations:
           - key: workloadType
             operator: Equal
-            value: importer-pool
+            value: highend
           containers:
           - name: combine-to-osv
             image: combine-to-osv
@@ -28,7 +28,7 @@ spec:
                 cpu: 2
                 memory: "2G"
           nodeSelector:
-            cloud.google.com/gke-nodepool: importer-pool
+            cloud.google.com/gke-nodepool: highend
           restartPolicy: OnFailure
           volumes:
             - name: "ssd"


### PR DESCRIPTION
This is intended to increase the concurrency of the GCS file transfers to speed up the entire thing.