### PR TITLE
Fix reference time for CVE 5 timestamps

### DIFF
--- a/vulnfeeds/cves/cve.go
+++ b/vulnfeeds/cves/cve.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	CVETimeFormat  = "2006-01-02T15:04Z07:00"
-	CVE5TimeFormat = "2006-01-02T00:00:00"
+	CVE5TimeFormat = "2006-01-02T15:04:05"
 )
 
 type CVE struct {

--- a/vulnfeeds/vulns/vulns_test.go
+++ b/vulnfeeds/vulns/vulns_test.go
@@ -252,6 +252,12 @@ func TestCVEIsDisputed(t *testing.T) {
 			expectedError:     nil,
 		},
 		{
+			description:       "A disputed CVE vulnerability",
+			inputVulnId:       "CVE-2021-26917",
+			expectedWithdrawn: true,
+			expectedError:     nil,
+		},
+		{
 			description:       "An undisputed CVE vulnerability",
 			inputVulnId:       "CVE-2023-38408",
 			expectedWithdrawn: false,
@@ -269,7 +275,7 @@ func TestCVEIsDisputed(t *testing.T) {
 		if err != nil && err != tc.expectedError {
 			var verr *VulnsCVEListError
 			if errors.As(err, &verr) {
-				t.Errorf("test %q: unexpected errored: %#v", tc.description, verr.Err)
+				t.Errorf("test %q: unexpectedly errored: %#v", tc.description, verr.Err)
 			} else {
 				t.Errorf("test %q: unexpectedly errored: %#v", tc.description, err)
 			}


### PR DESCRIPTION
I don't understand how this was working at all before...