### PR TITLE
Avoid an empty package field in the resulting OSV record

### DIFF
--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -205,10 +205,13 @@ type Vulnerability struct {
 // AddPkgInfo converts a PackageInfo struct to the corresponding AffectedRanges and adds them to the OSV vulnerability object.
 func (v *Vulnerability) AddPkgInfo(pkgInfo PackageInfo) {
 	affected := Affected{}
-	affected.Package = &AffectedPackage{
-		Name:      pkgInfo.PkgName,
-		Ecosystem: pkgInfo.Ecosystem,
-		Purl:      pkgInfo.PURL,
+
+	if pkgInfo.PkgName != "" && pkgInfo.Ecosystem != "" {
+		affected.Package = &AffectedPackage{
+			Name:      pkgInfo.PkgName,
+			Ecosystem: pkgInfo.Ecosystem,
+			Purl:      pkgInfo.PURL,
+		}
 	}
 
 	if len(pkgInfo.VersionInfo.AffectedCommits) > 0 {

--- a/vulnfeeds/vulns/vulns_test.go
+++ b/vulnfeeds/vulns/vulns_test.go
@@ -134,7 +134,9 @@ func TestAddPkgInfo(t *testing.T) {
 		},
 	}
 	testPkgInfoPURL := PackageInfo{
-		PURL: "pkg:deb/debian/nginx@1.1.2-1",
+		PkgName:   "nginx",
+		Ecosystem: "Debian",
+		PURL:      "pkg:deb/debian/nginx@1.1.2-1",
 		VersionInfo: cves.VersionInfo{
 			AffectedVersions: []cves.AffectedVersion{
 				{
@@ -188,13 +190,18 @@ func TestAddPkgInfo(t *testing.T) {
 	// testPkgInfoPURL ^^^^^^^^^^^^^^^
 
 	// testPkgInfoCommits vvvvvvvvvvvvvv
-	// TODO: Where is the Repo field suppose to go?
+	if vuln.Affected[2].Ranges[0].Repo != "github.com/foo/bar" {
+		t.Errorf("AddPkgInfo has not corrected add ranges repo. %#v", vuln.Affected[2])
+	}
 
 	if vuln.Affected[2].Ranges[0].Type != "GIT" {
 		t.Errorf("AddPkgInfo has not correctly added ranges type.")
 	}
 	if vuln.Affected[2].Ranges[0].Events[1].Fixed != testPkgInfoCommits.VersionInfo.AffectedCommits[0].Fixed {
 		t.Errorf("AddPkgInfo has not correctly added ranges fixed.")
+	}
+	if vuln.Affected[2].Package != nil {
+		t.Errorf("AddPkgInfo has not correctly avoided setting a package field for an ecosystem-less vulnerability.")
 	}
 	// testPkgInfoCommits ^^^^^^^^^^^^^^^
 }


### PR DESCRIPTION
Despite the

```
Package  *AffectedPackage `json:"package,omitempty"`
```

I think that because it's a pointer to a struct with default values, it's not being considered "empty" so it doesn't get omitted, and the record winds up with an unsightly looking

```
package: {}
```

which seems to be further angering the importing of it.

Improve the existing tests for this, including the PURL one, which was not testing correct behaviour.