### PR TITLE
Throw even more CPU at the problem

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
@@ -23,7 +23,7 @@ spec:
             resources:
               requests:
                 cpu: 30
-                memory: "1G"
+                memory: "4G"
               limits:
                 cpu: 30
                 memory: "8G"

--- a/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
@@ -22,10 +22,10 @@ spec:
               privileged: true
             resources:
               requests:
-                cpu: 2
+                cpu: 30
                 memory: "1G"
               limits:
-                cpu: 2
+                cpu: 30
                 memory: "2G"
           nodeSelector:
             cloud.google.com/gke-nodepool: highend

--- a/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
@@ -26,7 +26,7 @@ spec:
                 memory: "1G"
               limits:
                 cpu: 30
-                memory: "2G"
+                memory: "8G"
           nodeSelector:
             cloud.google.com/gke-nodepool: highend
           restartPolicy: OnFailure


### PR DESCRIPTION
Now that I (slightly) better understand Kubernetes, throw even more CPU at the problem.

(The GCS file transfer is no longer exceptionally slow, so I'm not sure how much this will help, but hey, let's find out)