### PR TITLE
Don't set (and export) an empty packages field

### DIFF
--- a/osv/models.py
+++ b/osv/models.py
@@ -573,6 +573,11 @@ class Bug(ndb.Model):
             ranges=ranges,
             versions=affected_package.versions)
 
+        # Converted CVE records have no package defined.
+        # Avoid exporting an empty package field.
+        if not current.package.ListFields():
+          current.ClearField("package")
+
         if affected_package.database_specific:
           current.database_specific.update(affected_package.database_specific)
 

--- a/osv/vulnerability.proto
+++ b/osv/vulnerability.proto
@@ -96,7 +96,7 @@ message Range {
 
 // Affected versions and commits.
 message Affected {
-  // Required. Package information.
+  // Optional. Package information.
   Package package = 1;
   // Required. Range information.
   repeated Range ranges = 2;


### PR DESCRIPTION
OSV records converted from CVE records do not have a package specified and the exporter is currently exporting with an empty packages field.