### PR TITLE
Reduce initial workers replicas to 1

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/workers.yaml
+++ b/deployment/clouddeploy/gke-workers/base/workers.yaml
@@ -17,7 +17,7 @@ kind: Deployment
 metadata:
   name: workers
 spec:
-  replicas: 30
+  replicas: 1
   selector:
     matchLabels:
       name: worker-private


### PR DESCRIPTION
Every time we've been deploying, 30 worker nodes were created, then immediately scaled back to 1 (or more depending on pending tasks).
Instead, just start with 1 replica and let the scaler make more if needed.