### PR TITLE
Fix logic error with preferencing predetermined fix commits

### DIFF
--- a/vulnfeeds/cpp/main.go
+++ b/vulnfeeds/cpp/main.go
@@ -144,6 +144,8 @@ func GitVersionsToCommits(CVE string, versions cves.VersionInfo, repos []string,
 			// cves.ExtractVersionInfo() opportunistically returns
 			// AffectedCommits (with Fixed commits) when the CVE has appropriate references.
 			if v.HasFixedCommits(repo) && av.Fixed != "" {
+				Logger.Infof("[%s]: Using preassumed fixed commits %+v instead of deriving from fixed version %q", CVE, v.FixedCommits(repo), av.Fixed)
+			} else if av.Fixed != "" {
 				ac, err := git.VersionToCommit(av.Fixed, repo, cves.Fixed, normalizedTags)
 				if err != nil {
 					Logger.Warnf("[%s]: Failed to get a Git commit for fixed version %q from %q: %v", CVE, av.Fixed, repo, err)

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -92,6 +92,15 @@ func (vi *VersionInfo) HasFixedCommits(repo string) bool {
 	return false
 }
 
+func (vi *VersionInfo) FixedCommits(repo string) (FixedCommits []string) {
+	for _, av := range vi.AffectedCommits {
+		if av.Repo == repo && av.Fixed != "" {
+			FixedCommits = append(FixedCommits, av.Fixed)
+		}
+	}
+	return FixedCommits
+}
+
 // Synthetic enum of supported commit types.
 type CommitType int
 


### PR DESCRIPTION
The refactoring from #1510 introduced an incorrect logic inversion, and records were failing to be converted successfully due to no commits being found. They also weren't being added to what was returned, when they should have been.

Output additional logging to assist with following the flow for troubleshooting purposes.