### PR TITLE
Tolerate bugs with mixed range types

### DIFF
--- a/gcp/appengine/frontend3/src/templates/list.html
+++ b/gcp/appengine/frontend3/src/templates/list.html
@@ -97,20 +97,15 @@
             </span>
             <span role="cell" class="vuln-table-cell vuln-packages mdc-data-table__cell">
               <ul class="packages">
-                {%- if vulnerability.affected | map(attribute='package', default=[]) | list == [{}] -%}
-                {%- for repo in vulnerability.affected | git_repo | map('strip_scheme') -%}
-                {%- if loop.index < 8 -%} <li>{{ repo }}</li>
-                  {%- elif loop.index == 8 -%}
-                  <li>...</li>
-                  {%- endif -%}
-                  {%- else -%}
-                  <li>See details.</li>
-                  {%- endfor -%}
-                  {%- else -%}
-                  {%- for affected in vulnerability.affected -%}
-                  <li>{{ affected.package.ecosystem }}/{{ affected.package.name }}</li>
-                  {%- endfor -%}
-                  {%- endif -%}
+                {% for affected in vulnerability.affected %}
+                {%- for range in affected.ranges -%}
+                {%- if range.type in ('ECOSYSTEM', 'SEMVER') -%}
+                <li>{{ affected.package.ecosystem }}/{{ affected.package.name }}</li>
+                {%- elif range.type == 'GIT' -%}
+                <li>{{ range.repo | strip_scheme }}</li>
+                {%- endif -%}
+                {%- endfor -%}
+                {% endfor %}
               </ul>
             </span>
             <span role="cell" class="vuln-table-cell vuln-summary mdc-data-table__cell hide-on-mobile">

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -47,7 +47,7 @@
           <dd>
             <ul class="links">
               {% for reference in vulnerability.references -%}
-              <li><a href="{{ reference['url'] }}">{{ reference['url'] }}</a></li>
+              <li><a href="{{ reference.url }}">{{ reference.url }}</a></li>
               {% endfor -%}
             </ul>
           </dd>
@@ -60,12 +60,18 @@
     <spicy-sections
       class="vulnerability-packages{% if vulnerability.affected|should_collapse %} force-collapse{% endif %}">
       {% for affected in vulnerability.affected -%}
+      {% if 'package' in affected %}
+      {% set ecosystem = affected.package.ecosystem %}
+      {% set package = affected.package.name %}
+      {% else %}
+      {% set ecosystem = 'Git' %}
+      {% set package = vulnerability.repo | strip_scheme %}
+      {% endif %}
       <h2 class="package-header">
-        <span class="vuln-ecosystem spicy-sections-workaround">{{ affected['package']['ecosystem'] or 'Git' }}</span>
+        <span class="vuln-ecosystem spicy-sections-workaround">{{ ecosystem }}</span>
         <span class="vuln-title-divider spicy-sections-workaround">/</span>
         {# TODO(andrewpollock): it's permissible to have more than one repo, so handle this -#}
-        <span class="vuln-name spicy-sections-workaround">{{ affected['package']['name'] or vulnerability.repo |
-          strip_scheme }}</span>
+        <span class="vuln-name spicy-sections-workaround">{{ package }}</span>
       </h2>
       <div class="mdc-layout-grid">
         <div class="vulnerability-package-subsection mdc-layout-grid__inner">
@@ -74,10 +80,14 @@
           </h3>
           <div class="mdc-layout-grid__cell--span-9">
             <dl>
-              {%- if affected['package']['name'] -%}
+              {%- if 'package' in affected -%}
               <dt>Package Name</dt>
-              {# TODO(andrewpollock): link out to the package in the ecosystem -#}
-              <dd>{{ affected['package']['name'] }}</dd>
+              {%- if affected.package | package_in_ecosystem -%}
+              <dd><a href="{{ affected.package | package_in_ecosystem }}" target="_blank" rel="noopener noreferrer">{{
+                  affected.package.name }}</a></dd>
+              {%- else -%}
+              <dd>{{ affected.package.name }}</dd>
+              {%- endif -%}
               {%- endif -%}
               {%- if vulnerability.repo -%}
               <dt>Repository</dt>
@@ -94,14 +104,14 @@
             <a href="https://ossf.github.io/osv-schema/#examples" target="_blank" rel="noopener noreferrer"></a>
           </h3>
           <div class="mdc-layout-grid__cell--span-9">
-            {% for range in affected['ranges'] -%}
+            {% for range in affected.ranges -%}
             <dl>
               <dt>Type</dt>
-              <dd>{{ range['type'] -}}</dd>
+              <dd>{{ range.type -}}</dd>
               <dt>Events</dt>
               <dd>
                 <div class="mdc-layout-grid__inner events">
-                  {% for event in range['events'] -%}
+                  {% for event in range.events -%}
                   <div class="mdc-layout-grid__cell--span-3">
                     {{ event | event_type -}}
                   </div>
@@ -129,7 +139,7 @@
           {% endfor -%}
         </div>
       </div>
-      {% if affected['versions'] -%}
+      {% if affected.versions -%}
       <div class="vulnerability-package-subsection mdc-layout-grid__inner">
         <h3 class="mdc-layout-grid__cell--span-3">
           Affected versions
@@ -137,7 +147,7 @@
             rel="noopener noreferrer"></a>
         </h3>
         <div class="mdc-layout-grid__cell--span-9 version-value">
-          {% for group, versions in (affected['versions']|group_versions).items() -%}
+          {% for group, versions in (affected.versions|group_versions).items() -%}
           <spicy-sections class="versions-section">
             <h2 class="version-header">{{ group }}</h2>
             <div class="versions {% if not loop.last %}versions-separator{% endif %}">
@@ -150,7 +160,7 @@
         </div>
       </div>
       {% endif -%}
-      {% if affected['ecosystem_specific'] -%}
+      {% if affected.ecosystem_specific -%}
       <div class="vulnerability-package-subsection mdc-layout-grid__inner">
         <h3 class="mdc-layout-grid__cell--span-3">
           Ecosystem specific
@@ -158,11 +168,11 @@
             rel="noopener noreferrer"></a>
         </h3>
         <div class="mdc-layout-grid__cell--span-9">
-          <pre class="specific">{{ affected['ecosystem_specific'] | display_json }}</pre>
+          <pre class="specific">{{ affected.ecosystem_specific | display_json }}</pre>
         </div>
       </div>
       {% endif -%}
-      {% if affected['database_specific'] -%}
+      {% if affected.database_specific -%}
       <div class="vulnerability-package-subsection mdc-layout-grid__inner">
         <h3 class="mdc-layout-grid__cell--span-3">
           Database specific
@@ -170,7 +180,7 @@
             rel="noopener noreferrer"></a>
         </h3>
         <div class="mdc-layout-grid__cell--span-9">
-          <pre class="specific">{{ affected['database_specific'] | display_json }}</pre>
+          <pre class="specific">{{ affected.database_specific | display_json }}</pre>
         </div>
       </div>
       {% endif -%}

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -556,3 +556,11 @@ def git_repo(affected):
         if r.get('type', '') == 'GIT'
     ])
   return git_repos
+
+
+@blueprint.app_template_filter('package_in_ecosystem')
+def package_in_ecosystem(package):
+  ecosystem = osv.ecosystems.normalize(package['ecosystem'])
+  if ecosystem in osv.ecosystems.package_urls:
+    return osv.ecosystems.package_urls[ecosystem] + package['name']
+  return ''

--- a/osv/ecosystems/_ecosystems.py
+++ b/osv/ecosystems/_ecosystems.py
@@ -66,6 +66,24 @@ SEMVER_ECOSYSTEMS = {
     'npm',
 }
 
+package_urls = {
+    'Android': 'https://android.googlesource.com/',
+    'CRAN': 'https://cran.r-project.org/web/packages/',
+    'crates.io': 'https://crates.io/crates/',
+    'Debian': 'https://packages.debian.org/src:',
+    'GitHub Actions': 'https://github.com/marketplace/actions/',
+    'Go': 'https://',
+    'Hackage': 'https://hackage.haskell.org/package/',
+    'Hex': 'https://hex.pm/packages/',
+    'npm': 'https://www.npmjs.com/package/',
+    'NuGet': 'https://www.nuget.org/packages/',
+    'Packagist': 'https://packagist.org/packages/',
+    'Pub': 'https://pub-web.flutter-io.cn/packages/',
+    'PyPI': 'https://pypi.org/project/',
+    'Rocky Linux': 'https://pkgs.org/download/',
+    'RubyGems': 'https://rubygems.org/gems/',
+}
+
 
 def get(name: str) -> Ecosystem:
   """Get ecosystem helpers for a given ecosystem."""


### PR DESCRIPTION
Converted CVE records (without packages) are merged in with records that do have package fields, so the package field is not reliably existent for all items in a given record's `affected` array.

Also add support to outlink to a package in its ecosystem.