### PR TITLE
Fix: Give cloud build service account access so we can remove esp-test

### DIFF
--- a/deployment/terraform/modules/osv/gcp_apis.tf
+++ b/deployment/terraform/modules/osv/gcp_apis.tf
@@ -91,3 +91,9 @@ resource "google_project_service" "resource_manager" {
   service            = "cloudresourcemanager.googleapis.com"
   disable_on_destroy = false
 }
+
+resource "google_project_service" "cloud_build" {
+  project            = var.project_id
+  service            = "cloudbuild.googleapis.com"
+  disable_on_destroy = false
+}

--- a/deployment/terraform/modules/osv/project_iam.tf
+++ b/deployment/terraform/modules/osv/project_iam.tf
@@ -1,0 +1,12 @@
+# Used to dynamically retrieve the project number.
+data "google_project" "vdb" {
+  project_id = var.project_id
+}
+
+# Give the cloud build in-built service account access to retrieve cloud endpoints config.
+resource "google_project_iam_member" "project" {
+  project    = var.project_id
+  role       = "roles/servicemanagement.serviceController"
+  member     = "user:${data.google_project.vdb.number}@cloudbuild.gserviceaccount.com"
+  depends_on = [google_project_service.cloud_build] // If the API is not enabled the default service account above does not exist yet.
+}


### PR DESCRIPTION
Give cloud build default service account access so we can remove esp-test.