### PR TITLE
Remove service account download from cloudbuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ vulnfeed-tests:
 	cd vulnfeeds && ./run_tests.sh
 
 api-server-tests:
-	test $(HOME)/.config/gcloud/application_default_credentials.json || (echo "GCP Application Default Credentials not set."; exit 1)
+	test $(HOME)/.config/gcloud/application_default_credentials.json || (echo "GCP Application Default Credentials not set, try 'gcloud auth login --update-adc'"; exit 1)
 	cd gcp/api && ./run_tests.sh $(HOME)/.config/gcloud/application_default_credentials.json
 
 lint:

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ appengine-tests:
 vulnfeed-tests:
 	cd vulnfeeds && ./run_tests.sh
 
+api-server-tests:
+	test $(HOME)/.config/gcloud/application_default_credentials.json || (echo "GCP Application Default Credentials not set."; exit 1)
+	cd gcp/api && ./run_tests.sh $(HOME)/.config/gcloud/application_default_credentials.json
+
 lint:
 	tools/lint_and_format.sh
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ vulnfeed-tests:
 	cd vulnfeeds && ./run_tests.sh
 
 api-server-tests:
-	test $(HOME)/.config/gcloud/application_default_credentials.json || (echo "GCP Application Default Credentials not set, try 'gcloud auth login --update-adc'"; exit 1)
+	test -f $(HOME)/.config/gcloud/application_default_credentials.json || (echo "GCP Application Default Credentials not set, try 'gcloud auth login --update-adc'"; exit 1)
 	cd gcp/api && ./run_tests.sh $(HOME)/.config/gcloud/application_default_credentials.json
 
 lint:
@@ -45,7 +45,7 @@ run-appengine-staging:
 	cd gcp/appengine && pipenv sync && GOOGLE_CLOUD_PROJECT=oss-vdb-test pipenv run python main.py
 
 run-api-server:
-	test $(HOME)/.config/gcloud/application_default_credentials.json || (echo "GCP Application Default Credentials not set."; exit 1)
+	test -f $(HOME)/.config/gcloud/application_default_credentials.json || (echo "GCP Application Default Credentials not set, try 'gcloud auth login --update-adc'"; exit 1)
 	cd gcp/api && docker build -f Dockerfile.esp -t osv/esp:latest .
 	cd gcp/api && pipenv sync && GOOGLE_CLOUD_PROJECT=oss-vdb pipenv run python test_server.py $(HOME)/.config/gcloud/application_default_credentials.json
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -27,17 +27,12 @@ steps:
 - name: 'gcr.io/oss-vdb/ci'
   dir: vulnfeeds
   args: ['bash', '-ex', 'run_tests.sh']
-- name: 'gcr.io/cloud-builders/gcloud'
-  entrypoint: 'bash'
-  args: [ '-c', "gcloud secrets versions access latest --secret=integration-test-account --format='get(payload.data)' | tr '_-' '/+' | base64 -d > /workspace/service_account.json" ]
 - name: 'gcr.io/oss-vdb/ci'
   dir: gcp/api
-  args: ['bash', '-ex', 'run_tests.sh', '/workspace/service_account.json']
+  #TODO: Update test scripts to support not supplying a credential.
+  args: ['bash', '-ex', 'run_tests.sh', '/workspace/dummy.json']
   env:
     - CLOUDBUILD=1
-- name: 'gcr.io/cloud-builders/gcloud'
-  entrypoint: 'bash'
-  args: [ '-c', "rm /workspace/service_account.json" ]
 timeout: 7200s
 options:
   machineType: E2_HIGHCPU_8

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -595,15 +595,15 @@ def print_logs(filename):
 
 if __name__ == '__main__':
   if len(sys.argv) < 2:
-    print(f'Usage: {sys.argv[0]} path/to/service_account.json')
+    print(f'Usage: {sys.argv[0]} path/to/credential.json')
     sys.exit(1)
 
   subprocess.run(
       ['docker', 'pull', 'gcr.io/endpoints-release/endpoints-runtime:2'],
       check=True)
 
-  service_account_path = sys.argv.pop()
-  server = test_server.start(service_account_path, port=_PORT)
+  credential_path = sys.argv.pop()
+  server = test_server.start(credential_path, port=_PORT)
   time.sleep(30)
 
   try:

--- a/gcp/api/run_tests.sh
+++ b/gcp/api/run_tests.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 if [ $# -lt 1 ]; then
-  echo "Usage: $0 /path/to/service_account.json"
+  echo "Usage: $0 /path/to/credential.json"
   exit 1
 fi
 

--- a/gcp/api/run_tests.sh
+++ b/gcp/api/run_tests.sh
@@ -22,6 +22,5 @@ python3 -m pipenv sync
 service docker start
 
 export GOOGLE_CLOUD_PROJECT=oss-vdb
-export GOOGLE_APPLICATION_CREDENTIALS="$1"
 python3 -m pipenv run python server_test.py
 python3 -m pipenv run python integration_tests.py "$1"

--- a/gcp/api/test_server.py
+++ b/gcp/api/test_server.py
@@ -83,11 +83,9 @@ def get_ip():
   return ip
 
 
-def start_esp(port, backend_port, service_account_path, log_path):
+def start_esp(port, backend_port, credential_path, log_path):
   """Start ESPv2 frontend."""
   log_handle = open(log_path, 'w')
-  service_account_dir = os.path.dirname(os.path.abspath(service_account_path))
-  service_account_name = os.path.basename(service_account_path)
 
   if os.getenv('CLOUDBUILD'):
     network = '--network=cloudbuild'
@@ -114,11 +112,13 @@ def start_esp(port, backend_port, service_account_path, log_path):
         '--envoy_connection_buffer_limit_bytes=10485760',
     ]
   else:
+    # Use custom container and local ADC credential by mapping files
+    # into container.
+    credential_dir = os.path.dirname(os.path.abspath(credential_path))
+    credential_name = os.path.basename(credential_path)
     network = '--network=host'
     host = 'localhost'
     docker_image = 'osv/esp:latest'
-    # Use custom container and local ADC credential by mapping files
-    # into container.
     docker_cmd = [
         'docker',
         'run',
@@ -127,7 +127,7 @@ def start_esp(port, backend_port, service_account_path, log_path):
         network,
         '--rm',
         '-v',
-        f'{service_account_dir}:/esp:ro',
+        f'{credential_dir}:/esp:ro',
         f'--publish={port}',
         f'{docker_image}',
         '--disable_tracing',
@@ -135,7 +135,7 @@ def start_esp(port, backend_port, service_account_path, log_path):
         '--rollout_strategy=managed',
         f'--listener_port={port}',
         f'--backend=grpc://{host}:{backend_port}',
-        f'--service_account_key=/esp/{service_account_name}',
+        f'--service_account_key=/esp/{credential_name}',
         '--non_gcp',
         '--enable_debug',
         '--transcoding_preserve_proto_field_names',
@@ -149,13 +149,13 @@ def start_esp(port, backend_port, service_account_path, log_path):
   return esp_proc
 
 
-def start(service_account_path, port=_ESP_PORT, backend_port=_BACKEND_PORT):
+def start(credential_path, port=_ESP_PORT, backend_port=_BACKEND_PORT):
   """Start the test server."""
   backend = None
   esp = None
   try:
     backend = start_backend(_BACKEND_PORT, 'backend.log')
-    esp = start_esp(port, backend_port, service_account_path, 'esp.log')
+    esp = start_esp(port, backend_port, credential_path, 'esp.log')
   except Exception:
     if esp:
       esp.kill()
@@ -170,7 +170,7 @@ def start(service_account_path, port=_ESP_PORT, backend_port=_BACKEND_PORT):
 
 if __name__ == '__main__':
   if len(sys.argv) < 2:
-    print(f'Usage: {sys.argv[0]} path/to/service_account.json')
+    print(f'Usage: {sys.argv[0]} path/to/credential.json')
     sys.exit(1)
 
   server = start(sys.argv[1])


### PR DESCRIPTION
Once we have done this, we should be able to throw the service account onto the bonfire.