### PR TITLE
Specify short deploy length

### DIFF
--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -29,7 +29,7 @@ git fetch "$UPSTREAM_REMOTE_NAME" --quiet
 
 tag_name="$1"
 commit_sha="$(git rev-parse --verify $tag_name)"
-short_sha="$(git rev-parse --short $tag_name)"
+short_sha="$(git rev-parse --short=7 $tag_name)"
 
 git remote remove "$UPSTREAM_REMOTE_NAME"
 

--- a/deployment/terraform/environments/oss-vdb/.terraform.lock.hcl
+++ b/deployment/terraform/environments/oss-vdb/.terraform.lock.hcl
@@ -15,6 +15,18 @@ provider "registry.terraform.io/hashicorp/external" {
     "h1:gznGscVJ0USxy4CdihpjRKPsKvyGr/zqPvBoFLJTQDc=",
     "h1:p1kxPeKu8Ya8Xj3SUE+PspX6kdqQYUibZzIZPJSAHV0=",
     "h1:uf2KGH9D2vAdfnj8ZAqEwVIpxI82WHsanraXn3dOHzA=",
+    "zh:001e2886dc81fc98cf17cf34c0d53cb2dae1e869464792576e11b0f34ee92f54",
+    "zh:2eeac58dd75b1abdf91945ac4284c9ccb2bfb17fa9bdb5f5d408148ff553b3ee",
+    "zh:2fc39079ba61411a737df2908942e6970cb67ed2f4fb19090cd44ce2082903dd",
+    "zh:472a71c624952cff7aa98a7b967f6c7bb53153dbd2b8f356ceb286e6743bb4e2",
+    "zh:4cff06d31272aac8bc35e9b7faec42cf4554cbcbae1092eaab6ab7f643c215d9",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7ed16ccd2049fa089616b98c0bd57219f407958f318f3c697843e2397ddf70df",
+    "zh:842696362c92bf2645eb85c739410fd51376be6c488733efae44f4ce688da50e",
+    "zh:8985129f2eccfd7f1841ce06f3bf2bbede6352ec9e9f926fbaa6b1a05313b326",
+    "zh:a5f0602d8ec991a5411ef42f872aa90f6347e93886ce67905c53cfea37278e05",
+    "zh:bf4ab82cbe5256dcef16949973bf6aa1a98c2c73a98d6a44ee7bc40809d002b8",
+    "zh:e70770be62aa70198fa899526d671643ff99eecf265bf1a50e798fc3480bd417",
   ]
 }
 
@@ -32,6 +44,18 @@ provider "registry.terraform.io/hashicorp/google" {
     "h1:sBz9KYNhJiyEdOvRrIj+VDNQOmMHLguLmMAQ1Uz4WYo=",
     "h1:sVFLz1ziSEI7TeMCubxwEFkLDLmazYCGI3YctrD3RTg=",
     "h1:wxYr3Z7xTg+rugpIu/DKOW88nJ7V76lYvq50+auW5cc=",
+    "zh:09a09e79ac404ea9ce2030185973130ed5f25e7f2c1d46093ee67fcc8f94e220",
+    "zh:1dd579d1200fd9cb57b84b326f401674cc5c62670c85fff7bb90642fd2379d10",
+    "zh:2d03592a8b370c8409fdffb8b946cc1ce9bca7407b48208743adf0de4a65c20c",
+    "zh:5f29e3155b6d0378d30574ac0f1c21aeedbca851e76c26de69ada81987514345",
+    "zh:75da3bb0ee4d4cf45c578462442e757596c2633e1b12afc0ecaaaed30aed25f5",
+    "zh:78b81c837322d66730c9ca04a06580477bfefb8492277cd653874adf5a8a63dc",
+    "zh:895433b46bd1cb1a599641fc0a619a2b6f59166701e923bf56fa6f46dc6d82ad",
+    "zh:9a734177d6c4223d9d65ca80c12bbb1f594b8e97217df6c4f05aa5250e968654",
+    "zh:cd94c7dd81fa777e0552adbcf043951b44e62bcde6eee391aa4d92c67c371c4a",
+    "zh:ceb97e8d2f7c5687c8591f5f8226b3233cf7b728eebb612b5d916d2af6fbf988",
+    "zh:d8ff449fbf8bf317c57b1c9de4c7d15429d52d9aabc048ea7570c9b3ae9810a2",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
 
@@ -49,6 +73,18 @@ provider "registry.terraform.io/hashicorp/google-beta" {
     "h1:Xmz/PM1Wh+jREUI8fiv2ggb6c61N99eWHMCx5/dO6k8=",
     "h1:gM2TPm8si7S8SNaa/Y5u5b2Xgc1rdzKgU9XseSO6vzI=",
     "h1:xYstmYVMQ5wdTTTOK2WIJ5gHmMMqxHFof76PQo6Qq/k=",
+    "zh:2c5127ffbc2cd8d9fd47a8148ec9ae0e191591630149503ffa7c73d99069969d",
+    "zh:3b00bb6036e30d6bea36ca69e7154853c62c32493c895f5785b17487003733eb",
+    "zh:61355ac08b2105d534c2462a0edea4d4814ee8da58a3140a444576a63ea3503e",
+    "zh:83509a6db2d272e820f802e0ed04f8bc7768618b31462ec77143f9e53fe24160",
+    "zh:a9fe0cf78ba3348af76dbf6f4281fa3c160d8379238be375b34d8207744935db",
+    "zh:c5b556b93c87bbfe118121fd7a9ca0e3951d1544556fe6813f55ce958998b7d8",
+    "zh:d17dbe6437de81f4bb28684e5ee9d0af55cb87f2b52a82a765894e1d140ec833",
+    "zh:d46abd2269704cddbbdf98b79c686adc4d42b9ad0b02de9e6b641e623ead70c2",
+    "zh:dac11e45a083008cd1e56c2816452b28d7f02d31a9ef114b5157a8e6c642877c",
+    "zh:e37bbc72abbd1a51b3d26ab16c7d7f1969facaa6b6a11c98e2108035bc8cbf43",
+    "zh:ec3f17e794d877d03f1a949978cf351bab48efdbab2613cfe7a9858acee77822",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
 


### PR DESCRIPTION
Specify the short sha length to always return 7, which matches the cloud deploy short sha length.

This is needed because sometimes git will return more than 7 characters in the short sha.

https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values#using_default_substitutions
