### PR TITLE
Attempt to fix renovate bot grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,47 +15,47 @@
       "enabled": false
     },
     {
-      "matchPaths": ["gcp/appengine/"],
+      "matchRepositories": ["gcp/appengine/"],
       "matchCategories": ["python"],
       "groupName": "appengine-backend"
     },
     {
-      "matchPaths": ["gcp/appengine/"],
+      "matchRepositories": ["gcp/appengine/"],
       "matchCategories": ["js"],
       "groupName": "appengine-frontend"
     },
     {
-      "matchPaths": ["gcp/api/"],
+      "matchRepositories": ["gcp/api/"],
       "groupName": "api"
     },
     {
-      "matchPaths": ["gcp/functions/"],
+      "matchRepositories": ["gcp/functions/"],
       "groupName": "functions"
     },
     {
-      "matchPaths": ["docker/"],
+      "matchRepositories": ["docker/"],
       "matchCategories": ["python"],
       "groupName": "workers"
     },
     {
-      "matchPaths": ["docker/"],
+      "matchRepositories": ["docker/"],
       "matchCategories": ["golang"],
       "groupName": "indexer"
     },
     {
-      "matchPaths": ["vulnfeeds/"],
+      "matchRepositories": ["vulnfeeds/"],
       "groupName": "vulnfeeds"
     },
     {
-      "matchPaths": ["docs/"],
+      "matchRepositories": ["docs/"],
       "groupName": "docs"
     },
     {
-      "matchPaths": ["tools/"],
+      "matchRepositories": ["tools/"],
       "groupName": "tools"
     },
     {
-      "matchPaths": [".github/"],
+      "matchRepositories": [".github/"],
       "groupName": "workflows"
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -15,51 +15,51 @@
       "enabled": false
     },
     {
-      "matchRepositories": ["gcp/appengine/"],
+      "matchFileNames": ["gcp/appengine/**"],
       "matchCategories": ["python"],
       "groupName": "appengine-backend"
     },
     {
-      "matchRepositories": ["gcp/appengine/"],
+      "matchFileNames": ["gcp/appengine/**"],
       "matchCategories": ["js"],
       "groupName": "appengine-frontend"
     },
     {
-      "matchRepositories": ["gcp/api/"],
+      "matchFileNames": ["gcp/api/**"],
       "groupName": "api"
     },
     {
-      "matchRepositories": ["gcp/functions/"],
+      "matchFileNames": ["gcp/functions/**"],
       "groupName": "functions"
     },
     {
-      "matchRepositories": ["docker/"],
+      "matchFileNames": ["docker/**"],
       "matchCategories": ["python"],
       "groupName": "workers"
     },
     {
-      "matchRepositories": ["docker/"],
+      "matchFileNames": ["docker/**"],
       "matchCategories": ["golang"],
       "groupName": "indexer"
     },
     {
-      "matchRepositories": ["vulnfeeds/"],
+      "matchFileNames": ["vulnfeeds/**"],
       "groupName": "vulnfeeds"
     },
     {
-      "matchRepositories": ["docs/"],
+      "matchFileNames": ["docs/**"],
       "groupName": "docs"
     },
     {
-      "matchRepositories": ["tools/"],
+      "matchFileNames": ["tools/**"],
       "groupName": "tools"
     },
     {
-      "matchRepositories": [".github/"],
+      "matchFileNames": [".github/**"],
       "groupName": "workflows"
     },
     {
-      "matchFiles": ["Pipfile"],
+      "matchFileNames": ["Pipfile"],
       "groupName": "osv-lib"
     }
   ]


### PR DESCRIPTION
Attempt to fix renovate bot grouping, the previous `matchPaths` key has been removed. It's not clear if `matchRepositories` has the same functionality. 