### PR TITLE
Set API containerConcurrency to equal thread pool

### DIFF
--- a/deployment/clouddeploy/osv-api/run.yaml
+++ b/deployment/clouddeploy/osv-api/run.yaml
@@ -17,4 +17,4 @@ spec:
           grpc:
             service: osv.v1.OSV
       timeoutSeconds: 60
-      containerConcurrency: 20
+      containerConcurrency: 10


### PR DESCRIPTION
I had initially set it to 2x the thread pool count in #1291, but it seems we occasionally might run into health check problems because of this.

Curious to see if/how much this increases the number of instances we have.