### PR TITLE
Ease fuzzy tag matching by removing repo name

### DIFF
--- a/vulnfeeds/git/repository.go
+++ b/vulnfeeds/git/repository.go
@@ -17,6 +17,8 @@ package git
 
 import (
 	"context"
+	"net/url"
+	"path"
 	"sort"
 	"strings"
 	"time"
@@ -95,6 +97,17 @@ func RemoteRepoRefsWithRetry(repoURL string, retries uint64) (refs []*plumbing.R
 	return refs, nil
 }
 
+// RepoName returns name of a repo based off the URL for it.
+func RepoName(repoURL string) (name string, e error) {
+	u, err := url.Parse(repoURL)
+	if err != nil {
+		return "", err
+	}
+	assumedReponame := path.Base(u.Path)
+	name = strings.TrimSuffix(assumedReponame, ".git")
+	return name, nil
+}
+
 // RepoTags returns an array of Tag being the (unpeeled, if annotated) tags and associated commits in repoURL.
 // An optional repoTagsCache can be supplied to reduce repeated remote connections to the same repo.
 func RepoTags(repoURL string, repoTagsCache RepoTagsCache) (tags Tags, e error) {
@@ -151,13 +164,21 @@ func NormalizeRepoTags(repoURL string, repoTagsCache RepoTagsCache) (NormalizedT
 		}
 	}
 	// Cache miss.
+	assumedReponame, err := RepoName(repoURL)
+	if err != nil {
+		return nil, err
+	}
 	tags, err := RepoTags(repoURL, repoTagsCache)
 	if err != nil {
 		return nil, err
 	}
 	NormalizedTags = make(map[string]NormalizedTag)
 	for _, t := range tags {
-		normalizedTag, err := cves.NormalizeVersion(t.Tag)
+		// Opportunistically remove parts determined to match the repo name,
+		// to ease particularly difficult to normalize cases like 'openj9-0.38.0'.
+		prenormalizedTag := strings.TrimPrefix(t.Tag, assumedReponame)
+		prenormalizedTag = strings.TrimPrefix(prenormalizedTag, "-")
+		normalizedTag, err := cves.NormalizeVersion(prenormalizedTag)
 		if err != nil {
 			// It's conceivable that not all tags are normalizable or potentially versions.
 			continue

--- a/vulnfeeds/git/versions.go
+++ b/vulnfeeds/git/versions.go
@@ -82,7 +82,7 @@ func VersionToCommit(version string, repo string, commitType cves.CommitType, no
 		// Then try to fuzzy-match.
 		ac, ok = fuzzyVersionToCommit(normalizedVersion, repo, commitType, normalizedTags)
 		if !ok {
-			return ac, fmt.Errorf("Failed to find a commit for version %q normalized as %q", version, normalizedVersion)
+			return ac, fmt.Errorf("failed to find a commit for version %q normalized as %q in %+v", version, normalizedVersion, normalizedTags)
 		}
 		return ac, nil
 	}

--- a/vulnfeeds/git/versions_test.go
+++ b/vulnfeeds/git/versions_test.go
@@ -35,6 +35,14 @@ func TestVersionToCommit(t *testing.T) {
 			expectedOk:     true,
 		},
 		{
+			description:    "A fuzzy version match",
+			inputRepoURL:   "https://github.com/eclipse-openj9/openj9",
+			cache:          cache,
+			inputVersion:   "0.38.0",
+			expectedResult: "d57d05932008a14605bf6cd729bb22dd6f49162c",
+			expectedOk:     true,
+		},
+		{
 			description:    "A failed version match (non-existent version)",
 			inputRepoURL:   "https://github.com/google/go-attestation",
 			cache:          cache,


### PR DESCRIPTION
There's a particularly hairy fuzzy tag matching scenario that doesn't lend itself easily to the regex, where the repo name ends in a digit and the tags have this in their prefix. It leads to incorrect normalization of the tag. So try and identify such cases and preemptively remove the name-based prefix from the tags to be normalized.