### PR TITLE
Avoid adding unnecessary duplicate zero-value introduced fields

### DIFF
--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -217,6 +217,8 @@ func (v *Vulnerability) AddPkgInfo(pkgInfo PackageInfo) {
 	if len(pkgInfo.VersionInfo.AffectedCommits) > 0 {
 		gitVersionRangesByRepo := map[string]AffectedRange{}
 
+		hasAddedZeroIntroduced := false
+
 		for _, ac := range pkgInfo.VersionInfo.AffectedCommits {
 			entry, ok := gitVersionRangesByRepo[ac.Repo]
 			if !ok {
@@ -227,13 +229,14 @@ func (v *Vulnerability) AddPkgInfo(pkgInfo PackageInfo) {
 				}
 			}
 
-			if !pkgInfo.VersionInfo.HasIntroducedCommits(ac.Repo) {
+			if !pkgInfo.VersionInfo.HasIntroducedCommits(ac.Repo) && !hasAddedZeroIntroduced {
 				// There was no explicitly defined introduced commit, so create one at 0
 				entry.Events = append(entry.Events,
 					Event{
 						Introduced: "0",
 					},
 				)
+				hasAddedZeroIntroduced = true
 			}
 
 			entry.Events = append(entry.Events,

--- a/vulnfeeds/vulns/vulns_test.go
+++ b/vulnfeeds/vulns/vulns_test.go
@@ -204,6 +204,20 @@ func TestAddPkgInfo(t *testing.T) {
 		t.Errorf("AddPkgInfo has not correctly avoided setting a package field for an ecosystem-less vulnerability.")
 	}
 	// testPkgInfoCommits ^^^^^^^^^^^^^^^
+
+	zeroIntroducedCommitHashCount := 0
+	for _, a := range vuln.Affected {
+		for _, r := range a.Ranges {
+			for _, e := range r.Events {
+				if r.Type == "GIT" && e.Introduced == "0" {
+					zeroIntroducedCommitHashCount++
+				}
+			}
+		}
+	}
+	if zeroIntroducedCommitHashCount > 1 {
+		t.Errorf("AddPkgInfo has synthesized more than one zero-valued introduced field.")
+	}
 }
 
 func TestAddSeverity(t *testing.T) {


### PR DESCRIPTION
It was discovered during manual validation that for records with multiple ranges and no known introduced commit, redundant zero introduced values are generated