### PR TITLE
frontend: correct handling of GitLab commit and compare URLs

### DIFF
--- a/gcp/appengine/source_mapper.py
+++ b/gcp/appengine/source_mapper.py
@@ -67,9 +67,11 @@ class GitHubVCS(VCSViewer):
   VCS_REVISION_DIFF_SUB = r'\1/compare/{start_revision}...{end_revision}'
 
 
-class GitLabVCS(GitHubVCS):
+class GitLabVCS(VCSViewer):
   VCS_URL_REGEX = re.compile(
       r'(https://gitlab(\.[\w\.\-]+)?\.(com|org)/(.*?))(\.git)?$')
+  VCS_REVISION_SUB = r'\1/-/commit/{revision}'
+  VCS_REVISION_DIFF_SUB = r'\1/-/compare/{start_revision}...{end_revision}'
 
 
 class GoogleSourceVCS(VCSViewer):

--- a/go.work.sum
+++ b/go.work.sum
@@ -196,6 +196,7 @@ golang.org/x/term v0.10.0/go.mod h1:lpqdcUyK/oCiQxvxVrppt5ggO2KCZ5QblwqPnfZ6d5o=
 golang.org/x/term v0.11.0/go.mod h1:zC9APTIj3jG3FdV/Ons+XE1riIZXG4aZ4GTHiPZJPIU=
 golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/vuln v0.2.1-0.20230630202714-a443f34b1a4a/go.mod h1:V0eyhHwaAaHrt42J9bgrN6rd12f6GU4T0Lu0ex2wDg4=
+golang.org/x/vuln v1.0.0/go.mod h1:V0eyhHwaAaHrt42J9bgrN6rd12f6GU4T0Lu0ex2wDg4=
 google.golang.org/api v0.118.0/go.mod h1:76TtD3vkgmZ66zZzp72bUUklpmQmKlhh6sYtIjYK+5E=
 google.golang.org/api v0.122.0/go.mod h1:gcitW0lvnyWjSp9nKxAbdHKIZ6vF4aajGueeslZOyms=
 google.golang.org/api v0.124.0/go.mod h1:xu2HQurE5gi/3t1aFCvhPD781p0a3p11sdunTJ2BlP4=


### PR DESCRIPTION
GitLab is subtly different to GitHub, so subclassing GitHubVCS is not appropriate. Define the necessary regexes for correct operation.