### PR TITLE
Interim overlay support

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
+++ b/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
@@ -29,6 +29,9 @@ echo "Run download-cves"
 echo "Run combine-to-osv"
 ./combine-to-osv -cvePath $CVE_OUTPUT -partsPath $OSV_PARTS_ROOT -osvOutputPath $OSV_OUTPUT
 
+echo "Override"
+gcloud --no-user-output-enabled storage rsync "gs://${INPUT_BUCKET}/osv-output-overrides/" $OSV_OUTPUT
+
 echo "Begin syncing output to GCS bucket ${OUTPUT_BUCKET}"
 gcloud --no-user-output-enabled storage rsync "$OSV_OUTPUT" "gs://${OUTPUT_BUCKET}/osv-output/" -c --delete-unmatched-destination-objects -q
 echo "Successfully synced to GCS bucket"


### PR DESCRIPTION
Allow a hand-curated OSV record to override one that is generated by
`combine-to-osv` in the event that we need/want to manually override
something.

Intended usage:

`gsutil cp gs://${OUTPUT_BUCKET}/osv-output/CVE-YYYY-NNNN.json`
(manually edit the file)
`gsutil cp gs://${INPUT_BUCKET/osv-output-overrides/CVE-YYYY-NNNN.json`
profit
