### PR TITLE
Store an empty ecosystem as a null in Datastore

### DIFF
--- a/osv/models.py
+++ b/osv/models.py
@@ -351,6 +351,12 @@ class Bug(ndb.Model):
     self.ecosystem = list(ecosystems_set)
     self.ecosystem.sort()
 
+    # Store an empty ecosystem list as null in Datastore to allow for searching
+    # by this value. (It is not possible to search Datastore for an empty array
+    # value).
+    if not self.ecosystem:
+      self.ecosystem = None
+
     self.purl = _get_purl_indexes(self.affected_packages)
     self.purl.sort()
 


### PR DESCRIPTION
Datastore does not support searching for an empty array, so for cases where it is empty, set it to None, which will translate to a null.

This will allow for manual searching of the Bug Kind for ecosystem set to null (finding only the converted NVD CVEs being the primary use case).