### PR TITLE
In-progress commit to make consulting the CVE List faster

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/main_test.go
+++ b/vulnfeeds/cmd/combine-to-osv/main_test.go
@@ -83,7 +83,7 @@ func TestCombineIntoOSV(t *testing.T) {
 	}
 	allParts := loadParts("../../test_data/parts")
 
-	combinedOSV := combineIntoOSV(cveStuff, allParts)
+	combinedOSV := combineIntoOSV(cveStuff, allParts, "")
 
 	expectedCombined := 2
 	actualCombined := len(combinedOSV)

--- a/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
+++ b/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
@@ -13,6 +13,8 @@ OUTPUT_BUCKET="${OUTPUT_GCS_BUCKET:=cve-osv-conversion}"
 OSV_PARTS_ROOT="parts/"
 OSV_OUTPUT="osv_output/"
 CVE_OUTPUT="cve_jsons/"
+CVELIST=""
+# CVELIST="cvelistV5/"
 
 echo "Setup initial directories"
 rm -rf $OSV_PARTS_ROOT && mkdir -p $OSV_PARTS_ROOT
@@ -26,8 +28,13 @@ echo "Successfully synced from GCS bucket"
 echo "Run download-cves"
 ./download-cves -cvePath $CVE_OUTPUT
 
+if [[ -n "$CVELIST" ]]; then
+    echo "Clone CVE List"
+    git clone --quiet https://github.com/CVEProject/cvelistV5
+fi
+
 echo "Run combine-to-osv"
-./combine-to-osv -cvePath $CVE_OUTPUT -partsPath $OSV_PARTS_ROOT -osvOutputPath $OSV_OUTPUT
+./combine-to-osv -cvePath "$CVE_OUTPUT" -partsPath "$OSV_PARTS_ROOT" -osvOutputPath "$OSV_OUTPUT" -cveListPath "$CVELIST"
 
 echo "Override"
 gcloud --no-user-output-enabled storage rsync "gs://${INPUT_BUCKET}/osv-output-overrides/" $OSV_OUTPUT

--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -584,7 +584,8 @@ func FromJSON(r io.Reader) (*Vulnerability, error) {
 // CVEIsDisputed will return if the underlying CVE is disputed.
 // It returns the CVE's CNA container's dateUpdated value if it is disputed.
 // This can be used to set the Withdrawn field.
-func CVEIsDisputed(v *Vulnerability) (modified string, e error) {
+// It consults a local clone of https://github.com/CVEProject/cvelistV5 found in the location specified by cveList
+func CVEIsDisputed(v *Vulnerability)  (modified string, e error) {
 	// iff the v.ID starts with a CVE...
 	// 	Try to make an HTTP request for the CVE record in the CVE List
 	// 	iff .containers.cna.tags contains "disputed"


### PR DESCRIPTION
This change makes consulting the CVE List to determine dispute status (for marking converted CVEs as withdrawn) conditional and is the quick interim step to making it consult a local Git clone rather than the CVE List remotely, in an attempt to speed up the run time.

This will temporarily prevent the calls to `vulns.CVEIsDisputed()`, which should speed up run time significantly.

The next PR will refactor `vulns.CVEIsDisputed` to consult a local clone rather than make numerous HTTP requests.