### PR TITLE
Refactor vulns.CVEIsDisputed to use a local clone and speed up execution

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -118,9 +118,7 @@ func combineIntoOSV(loadedCves map[string]cves.CVEItem, allParts map[string][]vu
 		convertedCve, _ := vulns.FromCVE(cveId, cve)
 		if len(cveList) > 0 {
 			// Best-effort attempt to mark a disputed CVE as withdrawn.
-			modified, err := vulns.CVEIsDisputed(convertedCve)
-			// TODO(apollock): This will become:
-			// modified, err := vulns.CVEIsDisputed(convertedCve, cveList)
+			modified, err := vulns.CVEIsDisputed(convertedCve, cveList)
 			if err != nil {
 				Logger.Warnf("Unable to determine CVE dispute status of %s: %v", convertedCve.ID, err)
 			}

--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -16,7 +16,7 @@ const (
 	defaultCvePath        = "cve_jsons"
 	defaultPartsInputPath = "parts"
 	defaultOSVOutputPath  = "osv_output"
-	defaultCVEListPath    = "cvelistV5"
+	defaultCVEListPath    = "."
 )
 
 var Logger utility.LoggerWrapper

--- a/vulnfeeds/cmd/combine-to-osv/main_test.go
+++ b/vulnfeeds/cmd/combine-to-osv/main_test.go
@@ -83,7 +83,7 @@ func TestCombineIntoOSV(t *testing.T) {
 	}
 	allParts := loadParts("../../test_data/parts")
 
-	combinedOSV := combineIntoOSV(cveStuff, allParts)
+	combinedOSV := combineIntoOSV(cveStuff, allParts, "")
 
 	expectedCombined := 2
 	actualCombined := len(combinedOSV)

--- a/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
+++ b/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
@@ -13,7 +13,7 @@ OUTPUT_BUCKET="${OUTPUT_GCS_BUCKET:=cve-osv-conversion}"
 OSV_PARTS_ROOT="parts/"
 OSV_OUTPUT="osv_output/"
 CVE_OUTPUT="cve_jsons/"
-CVELIST="${CVELIST_PATH:=cvelistV5/}"
+CVELIST="${CVELIST_PATH:=./}"
 
 echo "Setup initial directories"
 rm -rf $OSV_PARTS_ROOT && mkdir -p $OSV_PARTS_ROOT

--- a/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
+++ b/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
@@ -13,6 +13,8 @@ OUTPUT_BUCKET="${OUTPUT_GCS_BUCKET:=cve-osv-conversion}"
 OSV_PARTS_ROOT="parts/"
 OSV_OUTPUT="osv_output/"
 CVE_OUTPUT="cve_jsons/"
+CVELIST=""
+# CVELIST="cvelistV5/"
 
 echo "Setup initial directories"
 rm -rf $OSV_PARTS_ROOT && mkdir -p $OSV_PARTS_ROOT
@@ -26,8 +28,13 @@ echo "Successfully synced from GCS bucket"
 echo "Run download-cves"
 ./download-cves -cvePath $CVE_OUTPUT
 
+if [[ -n "$CVELIST" ]]; then
+    echo "Clone CVE List"
+    git clone --quiet https://github.com/CVEProject/cvelistV5
+fi
+
 echo "Run combine-to-osv"
-./combine-to-osv -cvePath $CVE_OUTPUT -partsPath $OSV_PARTS_ROOT -osvOutputPath $OSV_OUTPUT
+./combine-to-osv -cvePath "$CVE_OUTPUT" -partsPath "$OSV_PARTS_ROOT" -osvOutputPath "$OSV_OUTPUT" -cveListPath "$CVELIST"
 
 echo "Override"
 gcloud --no-user-output-enabled storage rsync "gs://${INPUT_BUCKET}/osv-output-overrides/" $OSV_OUTPUT

--- a/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
+++ b/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
@@ -13,8 +13,7 @@ OUTPUT_BUCKET="${OUTPUT_GCS_BUCKET:=cve-osv-conversion}"
 OSV_PARTS_ROOT="parts/"
 OSV_OUTPUT="osv_output/"
 CVE_OUTPUT="cve_jsons/"
-CVELIST=""
-# CVELIST="cvelistV5/"
+CVELIST="${CVELIST_PATH:=cvelistV5/}"
 
 echo "Setup initial directories"
 rm -rf $OSV_PARTS_ROOT && mkdir -p $OSV_PARTS_ROOT

--- a/vulnfeeds/test_data/cvelistV5/cves/2021/26xxx/CVE-2021-26917.json
+++ b/vulnfeeds/test_data/cvelistV5/cves/2021/26xxx/CVE-2021-26917.json
@@ -1,0 +1,157 @@
+{
+    "containers": {
+        "cna": {
+            "affected": [
+                {
+                    "product": "n/a",
+                    "vendor": "n/a",
+                    "versions": [
+                        {
+                            "status": "affected",
+                            "version": "n/a"
+                        }
+                    ]
+                }
+            ],
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "PyBitmessage through 0.6.3.2 allows attackers to write screen captures to Potentially Unwanted Directories via a crafted apinotifypath value. NOTE: the discoverer states \"security mitigation may not be necessary as there is no evidence yet that these screen intercepts are actually transported away from the local host.\" NOTE: it is unclear whether there are any common use cases in which apinotifypath is controlled by an attacker"
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "description": "n/a",
+                            "lang": "en",
+                            "type": "text"
+                        }
+                    ]
+                }
+            ],
+            "providerMetadata": {
+                "dateUpdated": "2021-02-08T22:22:51",
+                "orgId": "8254265b-2729-46b6-b9e3-3dfca2d5bfca",
+                "shortName": "mitre"
+            },
+            "references": [
+                {
+                    "tags": [
+                        "x_refsource_MISC"
+                    ],
+                    "url": "https://poal.co/s/technology/290479"
+                },
+                {
+                    "tags": [
+                        "x_refsource_MISC"
+                    ],
+                    "url": "https://github.com/Bitmessage/PyBitmessage/releases"
+                },
+                {
+                    "tags": [
+                        "x_refsource_MISC"
+                    ],
+                    "url": "https://github.com/Bitmessage/PyBitmessage/blob/f381721bec31641002e2f240309600c4994855a7/src/api.py#L35-L37"
+                },
+                {
+                    "tags": [
+                        "x_refsource_MISC"
+                    ],
+                    "url": "https://attack.mitre.org/techniques/T1113/"
+                }
+            ],
+            "tags": [
+                "disputed"
+            ],
+            "x_legacyV4Record": {
+                "CVE_data_meta": {
+                    "ASSIGNER": "cve@mitre.org",
+                    "ID": "CVE-2021-26917",
+                    "STATE": "PUBLIC"
+                },
+                "affects": {
+                    "vendor": {
+                        "vendor_data": [
+                            {
+                                "product": {
+                                    "product_data": [
+                                        {
+                                            "product_name": "n/a",
+                                            "version": {
+                                                "version_data": [
+                                                    {
+                                                        "version_value": "n/a"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                },
+                                "vendor_name": "n/a"
+                            }
+                        ]
+                    }
+                },
+                "data_format": "MITRE",
+                "data_type": "CVE",
+                "data_version": "4.0",
+                "description": {
+                    "description_data": [
+                        {
+                            "lang": "eng",
+                            "value": "** DISPUTED ** PyBitmessage through 0.6.3.2 allows attackers to write screen captures to Potentially Unwanted Directories via a crafted apinotifypath value. NOTE: the discoverer states \"security mitigation may not be necessary as there is no evidence yet that these screen intercepts are actually transported away from the local host.\" NOTE: it is unclear whether there are any common use cases in which apinotifypath is controlled by an attacker."
+                        }
+                    ]
+                },
+                "problemtype": {
+                    "problemtype_data": [
+                        {
+                            "description": [
+                                {
+                                    "lang": "eng",
+                                    "value": "n/a"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "references": {
+                    "reference_data": [
+                        {
+                            "name": "https://poal.co/s/technology/290479",
+                            "refsource": "MISC",
+                            "url": "https://poal.co/s/technology/290479"
+                        },
+                        {
+                            "name": "https://github.com/Bitmessage/PyBitmessage/releases",
+                            "refsource": "MISC",
+                            "url": "https://github.com/Bitmessage/PyBitmessage/releases"
+                        },
+                        {
+                            "name": "https://github.com/Bitmessage/PyBitmessage/blob/f381721bec31641002e2f240309600c4994855a7/src/api.py#L35-L37",
+                            "refsource": "MISC",
+                            "url": "https://github.com/Bitmessage/PyBitmessage/blob/f381721bec31641002e2f240309600c4994855a7/src/api.py#L35-L37"
+                        },
+                        {
+                            "name": "https://attack.mitre.org/techniques/T1113/",
+                            "refsource": "MISC",
+                            "url": "https://attack.mitre.org/techniques/T1113/"
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    "cveMetadata": {
+        "assignerOrgId": "8254265b-2729-46b6-b9e3-3dfca2d5bfca",
+        "assignerShortName": "mitre",
+        "cveId": "CVE-2021-26917",
+        "datePublished": "2021-02-08T22:22:51",
+        "dateReserved": "2021-02-08T00:00:00",
+        "dateUpdated": "2021-02-08T22:22:51",
+        "state": "PUBLISHED"
+    },
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.0"
+}

--- a/vulnfeeds/test_data/cvelistV5/cves/2023/23xxx/CVE-2023-23127.json
+++ b/vulnfeeds/test_data/cvelistV5/cves/2023/23xxx/CVE-2023-23127.json
@@ -1,0 +1,59 @@
+{
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.0",
+    "cveMetadata": {
+        "state": "PUBLISHED",
+        "cveId": "CVE-2023-23127",
+        "assignerOrgId": "8254265b-2729-46b6-b9e3-3dfca2d5bfca",
+        "assignerShortName": "mitre",
+        "dateUpdated": "2023-02-02T00:00:00",
+        "dateReserved": "2023-01-11T00:00:00",
+        "datePublished": "2023-02-01T00:00:00"
+    },
+    "containers": {
+        "cna": {
+            "providerMetadata": {
+                "orgId": "8254265b-2729-46b6-b9e3-3dfca2d5bfca",
+                "shortName": "mitre",
+                "dateUpdated": "2023-02-02T00:00:00"
+            },
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "In Connectwise Control 22.8.10013.8329, the login page does not implement HSTS headers therefore not enforcing HTTPS. NOTE: the vendor's position is that, by design, this is controlled by a configuration option in which a customer can choose to use HTTP (rather than HTTPS) during troubleshooting."
+                }
+            ],
+            "tags": [
+                "disputed"
+            ],
+            "affected": [
+                {
+                    "vendor": "n/a",
+                    "product": "n/a",
+                    "versions": [
+                        {
+                            "version": "n/a",
+                            "status": "affected"
+                        }
+                    ]
+                }
+            ],
+            "references": [
+                {
+                    "url": "https://github.com/l00neyhacker/CVE-2023-23127"
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "type": "text",
+                            "lang": "en",
+                            "description": "n/a"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/vulnfeeds/test_data/cvelistV5/cves/2023/38xxx/CVE-2023-38408.json
+++ b/vulnfeeds/test_data/cvelistV5/cves/2023/38xxx/CVE-2023-38408.json
@@ -1,0 +1,118 @@
+{
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.0",
+    "cveMetadata": {
+        "state": "PUBLISHED",
+        "cveId": "CVE-2023-38408",
+        "assignerOrgId": "8254265b-2729-46b6-b9e3-3dfca2d5bfca",
+        "assignerShortName": "mitre",
+        "dateUpdated": "2023-08-03T00:00:00",
+        "dateReserved": "2023-07-17T00:00:00",
+        "datePublished": "2023-07-20T00:00:00"
+    },
+    "containers": {
+        "cna": {
+            "providerMetadata": {
+                "orgId": "8254265b-2729-46b6-b9e3-3dfca2d5bfca",
+                "shortName": "mitre",
+                "dateUpdated": "2023-08-03T00:00:00"
+            },
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "The PKCS#11 feature in ssh-agent in OpenSSH before 9.3p2 has an insufficiently trustworthy search path, leading to remote code execution if an agent is forwarded to an attacker-controlled system. (Code in /usr/lib is not necessarily safe for loading into ssh-agent.) NOTE: this issue exists because of an incomplete fix for CVE-2016-10009."
+                }
+            ],
+            "affected": [
+                {
+                    "vendor": "n/a",
+                    "product": "n/a",
+                    "versions": [
+                        {
+                            "version": "n/a",
+                            "status": "affected"
+                        }
+                    ]
+                }
+            ],
+            "references": [
+                {
+                    "url": "https://news.ycombinator.com/item?id=36790196"
+                },
+                {
+                    "url": "https://blog.qualys.com/vulnerabilities-threat-research/2023/07/19/cve-2023-38408-remote-code-execution-in-opensshs-forwarded-ssh-agent"
+                },
+                {
+                    "url": "https://www.qualys.com/2023/07/19/cve-2023-38408/rce-openssh-forwarded-ssh-agent.txt"
+                },
+                {
+                    "url": "https://github.com/openbsd/src/commit/f8f5a6b003981bb824329dc987d101977beda7ca"
+                },
+                {
+                    "url": "https://github.com/openbsd/src/commit/7bc29a9d5cd697290aa056e94ecee6253d3425f8"
+                },
+                {
+                    "url": "https://github.com/openbsd/src/commit/f03a4faa55c4ce0818324701dadbf91988d7351d"
+                },
+                {
+                    "url": "https://www.openssh.com/txt/release-9.3p2"
+                },
+                {
+                    "url": "https://www.openssh.com/security.html"
+                },
+                {
+                    "name": "GLSA-202307-01",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://security.gentoo.org/glsa/202307-01"
+                },
+                {
+                    "name": "[oss-security] 20230719 Re: CVE-2023-38408: Remote Code Execution in OpenSSH's forwarded ssh-agent",
+                    "tags": [
+                        "mailing-list"
+                    ],
+                    "url": "http://www.openwall.com/lists/oss-security/2023/07/20/1"
+                },
+                {
+                    "name": "[oss-security] 20230720 Re: Announce: OpenSSH 9.3p2 released",
+                    "tags": [
+                        "mailing-list"
+                    ],
+                    "url": "http://www.openwall.com/lists/oss-security/2023/07/20/2"
+                },
+                {
+                    "url": "http://packetstormsecurity.com/files/173661/OpenSSH-Forwarded-SSH-Agent-Remote-Code-Execution.html"
+                },
+                {
+                    "name": "FEDORA-2023-878e04f4ae",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/RAXVQS6ZYTULFAK3TEJHRLKZALJS3AOU/"
+                },
+                {
+                    "name": "FEDORA-2023-79a18e1725",
+                    "tags": [
+                        "vendor-advisory"
+                    ],
+                    "url": "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/CEBTJJINE2I3FHAUKKNQWMFGYMLSMWKQ/"
+                },
+                {
+                    "url": "https://security.netapp.com/advisory/ntap-20230803-0010/"
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "type": "text",
+                            "lang": "en",
+                            "description": "n/a"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -584,7 +584,8 @@ func FromJSON(r io.Reader) (*Vulnerability, error) {
 // CVEIsDisputed will return if the underlying CVE is disputed.
 // It returns the CVE's CNA container's dateUpdated value if it is disputed.
 // This can be used to set the Withdrawn field.
-func CVEIsDisputed(v *Vulnerability) (modified string, e error) {
+// It consults a local clone of https://github.com/CVEProject/cvelistV5 found in the location specified by cveList
+func CVEIsDisputed(v *Vulnerability)  (modified string, e error) {
 	// iff the v.ID starts with a CVE...
 	// 	Try to make an HTTP request for the CVE record in the CVE List
 	// 	iff .containers.cna.tags contains "disputed"

--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -15,13 +15,13 @@
 package vulns
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
+	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -29,10 +29,9 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/google/osv/vulnfeeds/cves"
-	"github.com/sethvargo/go-retry"
 )
 
-const CVEListBaseURL = "https://raw.githubusercontent.com/CVEProject/cvelistV5/main/cves"
+const CVEListBasePath = "cvelistV5/cves"
 
 var ErrVulnNotACVE = errors.New("not a CVE")
 
@@ -585,7 +584,7 @@ func FromJSON(r io.Reader) (*Vulnerability, error) {
 // It returns the CVE's CNA container's dateUpdated value if it is disputed.
 // This can be used to set the Withdrawn field.
 // It consults a local clone of https://github.com/CVEProject/cvelistV5 found in the location specified by cveList
-func CVEIsDisputed(v *Vulnerability)  (modified string, e error) {
+func CVEIsDisputed(v *Vulnerability, cveList string) (modified string, e error) {
 	// iff the v.ID starts with a CVE...
 	// 	Try to make an HTTP request for the CVE record in the CVE List
 	// 	iff .containers.cna.tags contains "disputed"
@@ -598,60 +597,23 @@ func CVEIsDisputed(v *Vulnerability)  (modified string, e error) {
 	// Replace the last three digits of the CVE ID with "xxx".
 	CVEYear, CVEIndexShard := CVEParts[0], CVEParts[1][:len(CVEParts[1])-3]+"xxx"
 
-	// https://raw.githubusercontent.com/CVEProject/cvelistV5/main/cves/2023/23xxx/CVE-2023-23127.json
-	CVEListURL, err := url.JoinPath(CVEListBaseURL, CVEYear, CVEIndexShard, v.ID+".json")
+	// cvelistV5/cves/2023/23xxx/CVE-2023-23127.json
+	CVEListFile := path.Join(cveList, CVEListBasePath, CVEYear, CVEIndexShard, v.ID+".json")
+
+	f, err := os.Open(CVEListFile)
 
 	if err != nil {
 		return "", &VulnsCVEListError{"", err}
 	}
 
-	gitHubClient := http.Client{
-		Timeout: 5 * time.Second,
-	}
+	defer f.Close()
 
-	req, err := http.NewRequest(http.MethodGet, CVEListURL, nil)
+	decoder := json.NewDecoder(f)
 
-	if err != nil {
-		return "", &VulnsCVEListError{CVEListURL, err}
-	}
-
-	req.Header.Set("User-Agent", "osv.dev")
-
-	// Retry on timeout or 5xx
-	ctx := context.Background()
-	backoff := retry.NewFibonacci(1 * time.Second)
 	CVE := &cves.CVE5{}
-	if err := retry.Do(ctx, retry.WithMaxRetries(3, backoff), func(ctx context.Context) error {
-		res, err := gitHubClient.Do(req)
-		if err != nil {
-			if err == http.ErrHandlerTimeout {
-				return retry.RetryableError(fmt.Errorf("timeout: %#v", err))
-			}
-			return err
-		}
-		if res.StatusCode/100 == 5 {
-			return retry.RetryableError(fmt.Errorf("bad response: %v", res.StatusCode))
-		}
-		if res.Body != nil {
-			defer res.Body.Close()
-		}
 
-		decoder := json.NewDecoder(res.Body)
-
-		for {
-			if err := decoder.Decode(&CVE); err == io.EOF {
-				break
-			} else if err != nil {
-				return err
-			}
-		}
-		return nil
-	}); err != nil {
-		return "", &VulnsCVEListError{CVEListURL, err}
-	}
-
-	if err != nil {
-		return "", &VulnsCVEListError{CVEListURL, err}
+	if err := decoder.Decode(&CVE); err != nil {
+		return "", &VulnsCVEListError{"", err}
 	}
 
 	if slices.Contains(CVE.Containers.CNA.Tags, "disputed") {

--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -31,7 +31,7 @@ import (
 	"github.com/google/osv/vulnfeeds/cves"
 )
 
-const CVEListBasePath = "cvelistV5/cves"
+const CVEListBasePath = "cves"
 
 var ErrVulnNotACVE = errors.New("not a CVE")
 

--- a/vulnfeeds/vulns/vulns_test.go
+++ b/vulnfeeds/vulns/vulns_test.go
@@ -291,7 +291,7 @@ func TestCVEIsDisputed(t *testing.T) {
 			ID: tc.inputVulnId,
 		}
 
-		modified, err := CVEIsDisputed(inputVuln)
+		modified, err := CVEIsDisputed(inputVuln, "../test_data/")
 
 		if err != nil && err != tc.expectedError {
 			var verr *VulnsCVEListError

--- a/vulnfeeds/vulns/vulns_test.go
+++ b/vulnfeeds/vulns/vulns_test.go
@@ -291,7 +291,7 @@ func TestCVEIsDisputed(t *testing.T) {
 			ID: tc.inputVulnId,
 		}
 
-		modified, err := CVEIsDisputed(inputVuln, "../test_data/")
+		modified, err := CVEIsDisputed(inputVuln, "../test_data/cvelistV5")
 
 		if err != nil && err != tc.expectedError {
 			var verr *VulnsCVEListError


### PR DESCRIPTION
This change makes consulting the CVE List to determine dispute status
(for marking converted CVEs as withdrawn) conditional and consult a local Git clone rather than the CVE
List remotely, in an attempt to speed up the overall run time of `combine-to-osv`.

It refactors `vulns.CVEIsDisputed` to consult a local clone of the CVE List rather than make numerous individual HTTP requests.

This should significantly speed up and improve the reliability of checking CVEs to see if they are disputed.