### PR TITLE
Increase failedJobsHistoryLimit to 3

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   schedule: "30 */1 * * *"
   concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
       activeDeadlineSeconds: 7200


### PR DESCRIPTION
Per
https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#jobs-history-limits this defaults to 1, which makes it difficult to get a sense of how long a failing job has been failing for or to investigate any differences between a job that has started failing and ones that weren't.

I find the defaults to be backwards. Wouldn't you want more failed jobs to be retained than successful? Am I missing something here?