### PR TITLE
Correct path to local CVE list clone

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
+++ b/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
@@ -13,7 +13,7 @@ OUTPUT_BUCKET="${OUTPUT_GCS_BUCKET:=cve-osv-conversion}"
 OSV_PARTS_ROOT="parts/"
 OSV_OUTPUT="osv_output/"
 CVE_OUTPUT="cve_jsons/"
-CVELIST="${CVELIST_PATH:=./}"
+CVELIST="${CVELIST_PATH:=cvelistV5/}"
 
 echo "Setup initial directories"
 rm -rf $OSV_PARTS_ROOT && mkdir -p $OSV_PARTS_ROOT


### PR DESCRIPTION
Looks like I got this wrong, seeing failures in latest run's logs:

```
Unable to determine CVE dispute status of CVE-2017-8832: : open cves/2017/8xxx/CVE-2017-8832.json: no such file or directory
```