### PR TITLE
Change local variable name in ranges method

### DIFF
--- a/osv/impact.py
+++ b/osv/impact.py
@@ -107,13 +107,13 @@ class RangeCollector:
 
   def ranges(self):
     """Return a list representing the collected commit ranges."""
-    ranges = []
+    commit_ranges = []
     for grouped_range in self.grouped_ranges.values():
       for commit_range in grouped_range:
-        if commit_range not in ranges:
-          ranges.append(commit_range)
+        if commit_range not in commit_ranges:
+          commit_ranges.append(commit_range)
 
-    return ranges
+    return commit_ranges
 
 
 class RepoAnalyzer:


### PR DESCRIPTION
### Description

This PR resolves the issue - https://github.com/google/osv.dev/issues/1607

In impact.py, the name "ranges" is used both as a method name and a variable name for a list. The PR changes the variable name to avoid confusion and unexpected behavior.
