### PR TITLE
Add additional missing index

### DIFF
--- a/gcp/appengine/index.yaml
+++ b/gcp/appengine/index.yaml
@@ -124,6 +124,14 @@ indexes:
 
   - kind: Bug
     properties:
+    - name: public
+    - name: status
+    - name: ecosystem
+    - name: timestamp
+      direction: desc
+
+  - kind: Bug
+    properties:
     - name: status
     - name: source
     - name: timestamp


### PR DESCRIPTION
Add in the missing index for ecosystem filtering while sorting by timestamp.