### PR TITLE
Make running the frontend locally more turnkey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,12 @@ lint:
 	tools/lint_and_format.sh
 
 run-appengine:
-	cd gcp/appengine/frontend3 && npm run build
+	cd gcp/appengine/frontend3 && npm install && npm run build
 	cd gcp/appengine/blog && hugo -d ../dist/static/blog
 	cd gcp/appengine && pipenv sync && GOOGLE_CLOUD_PROJECT=oss-vdb pipenv run python main.py
 
 run-appengine-staging:
-	cd gcp/appengine/frontend3 && npm run build
+	cd gcp/appengine/frontend3 && npm install && npm run build
 	cd gcp/appengine/blog && hugo -d ../dist/static/blog
 	cd gcp/appengine && pipenv sync && GOOGLE_CLOUD_PROJECT=oss-vdb-test pipenv run python main.py
 


### PR DESCRIPTION
I encountered some unfamiliar errors trying to run the frontend locally that were resolved by running `npm install`, so run this automatically as part of the relevant Makefile targets to make it easier for people not familiar with NPM to get things done.