### PR TITLE
frontend: render multiple repos correctly

### DIFF
--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -60,17 +60,17 @@
     <spicy-sections
       class="vulnerability-packages{% if vulnerability.affected|should_collapse %} force-collapse{% endif %}">
       {% for affected in vulnerability.affected -%}
+      {% for range in affected.ranges %}
       {% if 'package' in affected %}
       {% set ecosystem = affected.package.ecosystem %}
       {% set package = affected.package.name %}
       {% else %}
       {% set ecosystem = 'Git' %}
-      {% set package = vulnerability.repo | strip_scheme %}
+      {% set package = range.repo | strip_scheme %}
       {% endif %}
       <h2 class="package-header">
         <span class="vuln-ecosystem spicy-sections-workaround">{{ ecosystem }}</span>
         <span class="vuln-title-divider spicy-sections-workaround">/</span>
-        {# TODO(andrewpollock): it's permissible to have more than one repo, so handle this -#}
         <span class="vuln-name spicy-sections-workaround">{{ package }}</span>
       </h2>
       <div class="mdc-layout-grid">
@@ -89,10 +89,9 @@
               <dd>{{ affected.package.name }}</dd>
               {%- endif -%}
               {%- endif -%}
-              {%- if vulnerability.repo -%}
+              {%- if range.repo -%}
               <dt>Repository</dt>
-              {# TODO(andrewpollock): it's permissible to have more than one repo, so handle this -#}
-              <dd><a href="{{ vulnerability.repo }}" target="_blank" rel="noopener noreferrer">{{ vulnerability.repo
+              <dd><a href="{{ range.repo }}" target="_blank" rel="noopener noreferrer">{{ range.repo
                   }}</a></dd>
               {%- endif -%}
             </dl>
@@ -104,7 +103,6 @@
             <a href="https://ossf.github.io/osv-schema/#examples" target="_blank" rel="noopener noreferrer"></a>
           </h3>
           <div class="mdc-layout-grid__cell--span-9">
-            {% for range in affected.ranges -%}
             <dl>
               <dt>Type</dt>
               <dd>{{ range.type -}}</dd>
@@ -132,34 +130,33 @@
                   </div>
                   {% endif -%}
                 </div>
-                {% endfor -%}
           </div>
           </dd>
           </dl>
           {% endfor -%}
         </div>
-      </div>
-      {% if affected.versions -%}
-      <div class="vulnerability-package-subsection mdc-layout-grid__inner">
-        <h3 class="mdc-layout-grid__cell--span-3">
-          Affected versions
-          <a href="https://ossf.github.io/osv-schema/#affectedversions-field" target="_blank"
-            rel="noopener noreferrer"></a>
-        </h3>
-        <div class="mdc-layout-grid__cell--span-9 version-value">
-          {% for group, versions in (affected.versions|group_versions(ecosystem)).items() -%}
-          <spicy-sections class="versions-section">
-            <h2 class="version-header">{{ group }}</h2>
-            <div class="versions {% if not loop.last %}versions-separator{% endif %}">
-              {% for version in versions -%}
-              <div class="version">{{ version }}</div>
-              {% endfor -%}
-            </div>
-          </spicy-sections>
-          {% endfor -%}
+        {% if affected.versions -%}
+        <div class="vulnerability-package-subsection mdc-layout-grid__inner">
+          <h3 class="mdc-layout-grid__cell--span-3">
+            Affected versions
+            <a href="https://ossf.github.io/osv-schema/#affectedversions-field" target="_blank"
+              rel="noopener noreferrer"></a>
+          </h3>
+          <div class="mdc-layout-grid__cell--span-9 version-value">
+            {% for group, versions in (affected.versions|group_versions(ecosystem)).items() -%}
+            <spicy-sections class="versions-section">
+              <h2 class="version-header">{{ group }}</h2>
+              <div class="versions {% if not loop.last %}versions-separator{% endif %}">
+                {% for version in versions -%}
+                <div class="version">{{ version }}</div>
+                {% endfor -%}
+              </div>
+            </spicy-sections>
+            {% endfor -%}
+          </div>
         </div>
+        {% endif -%}
       </div>
-      {% endif -%}
       {% if affected.ecosystem_specific -%}
       <div class="vulnerability-package-subsection mdc-layout-grid__inner">
         <h3 class="mdc-layout-grid__cell--span-3">
@@ -184,8 +181,9 @@
         </div>
       </div>
       {% endif -%}
+      {% endfor -%}
+      {% endfor -%}
   </div>
-  {% endfor -%}
   </spicy-sections>
 </div>
 </div>

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -271,9 +271,6 @@ def add_links(bug):
           event['limit_link'] = _commit_to_link(repo_url, event['limit'])
           continue
 
-  if repo_url:
-    bug['repo'] = repo_url
-
 
 def add_source_info(bug, response):
   """Add source information to `response`."""


### PR DESCRIPTION
Rather than iterate over `affected[].packages`, iterate over each `affected`
element, this way elements with multiple `ranges[]` entries can be
rendered as separate package-like tabs.

This is to predominantly address CVEs that end up with multiple GIT
ranges on them.