### PR TITLE
frontend: surface human-friendly link to record source

### DIFF
--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -12,11 +12,13 @@
         <dl class="vulnerability-details">
           {%- if vulnerability.human_source_link -%}
           <dt>Source</dt>
-          <dd><a href="{{ vulnerability.human_source_link }}" target="_blank">{{ vulnerability.human_source_link }}</a>
+          <dd><a href="{{ vulnerability.human_source_link }}" target="_blank" rel="noopener noreferrer">{{
+              vulnerability.human_source_link }}</a>
           </dd>
           {%- endif -%}
           <dt>Import Source</dt>
-          <dd><a href="{{ vulnerability.source_link }}" target="_blank">{{ vulnerability.source }}</a></dd>
+          <dd><a href="{{ vulnerability.source_link }}" target="_blank" rel="noopener noreferrer">{{
+              vulnerability.source }}</a></dd>
           {% if vulnerability.aliases -%}
           <dt>Aliases</dt>
           <dd>
@@ -52,7 +54,7 @@
           <dd>
             <ul class="links">
               {% for reference in vulnerability.references -%}
-              <li><a href="{{ reference.url }}" target="_blank">{{ reference.url }}</a></li>
+              <li><a href="{{ reference.url }}" target="_blank" rel="noopener noreferrer">{{ reference.url }}</a></li>
               {% endfor -%}
             </ul>
           </dd>

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -10,8 +10,13 @@
       </div>
       <div class="mdc-layout-grid__cell--span-12">
         <dl class="vulnerability-details">
+          {%- if vulnerability.human_source_link -%}
           <dt>Source</dt>
-          <dd><a href="{{ vulnerability.source_link }}">{{ vulnerability.source }}</a></dd>
+          <dd><a href="{{ vulnerability.human_source_link }}" target="_blank">{{ vulnerability.human_source_link }}</a>
+          </dd>
+          {%- endif -%}
+          <dt>Import Source</dt>
+          <dd><a href="{{ vulnerability.source_link }}" target="_blank">{{ vulnerability.source }}</a></dd>
           {% if vulnerability.aliases -%}
           <dt>Aliases</dt>
           <dd>
@@ -47,7 +52,7 @@
           <dd>
             <ul class="links">
               {% for reference in vulnerability.references -%}
-              <li><a href="{{ reference.url }}">{{ reference.url }}</a></li>
+              <li><a href="{{ reference.url }}" target="_blank">{{ reference.url }}</a></li>
               {% endfor -%}
             </ul>
           </dd>

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -288,6 +288,8 @@ def add_source_info(bug, response):
   source_path = osv.source_path(source_repo, bug)
   response['source'] = source_repo.link + source_path
   response['source_link'] = response['source']
+  if source_repo.human_link:
+    response['human_source_link'] = source_repo.human_link + bug.id()
 
 
 def add_related_aliases(bug: osv.Bug, response):


### PR DESCRIPTION
Per "Make the upstream source self-evident to OSV.dev end users" of "MVP for supporting contributed data fixes" ahead of launching NVD CVEs in OSV.

Make more off-site links open in a new tab

This way the originating record is still available to users.

Continuation from #1647 