### PR TITLE
frontend: rework template for correct rendering of range events

### DIFF
--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -105,8 +105,6 @@
           <div class="mdc-layout-grid__cell--span-9">
             <dl>
               <dt>Type</dt>
-              <dd>{{ range.type -}}</dd>
-              <dt>Events</dt>
               <dd>
                 <div class="mdc-layout-grid__inner events">
                   {% for event in range.events -%}
@@ -114,26 +112,27 @@
                     {{ event | event_type -}}
                   </div>
                   <div class="mdc-layout-grid__cell--span-9 version-value">
+                    {% if event | event_type == 'Introduced' and event | event_value == '0'-%}
+                    <div class="tooltip">
+                      {{ event | event_value -}}
+                      <span class="tooltiptext">The exact introduced commit is unknown</span>
+                    </div>
+                    {% else -%}
                     {% set link = event | event_link -%}
                     {% if link -%}
                     <a href="{{ link }}">
-                      {% elif event | event_type == 'Introduced' and event | event_value == '0' -%}
-                      <div class="tooltip">
-                        {% endif -%}
-
-                        {{ event | event_value -}}
-
-                        {% if link -%}
+                      {% endif -%}
+                      {{ event | event_value -}}
+                      {% if link -%}
                     </a>
-                    {% elif event.get('introduced') == '0' -%}
-                    <span class="tooltiptext">The exact introduced commit is unknown</span>
+                    {% endif -%}
+                    {% endif -%}
                   </div>
-                  {% endif -%}
+                  {% endfor -%}
                 </div>
+              </dd>
+            </dl>
           </div>
-          </dd>
-          </dl>
-          {% endfor -%}
         </div>
         {% if affected.versions -%}
         <div class="vulnerability-package-subsection mdc-layout-grid__inner">

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -120,7 +120,7 @@
                     {% else -%}
                     {% set link = event | event_link -%}
                     {% if link -%}
-                    <a href="{{ link }}">
+                    <a href="{{ link }}" target="_blank" rel="noopener noreferrer">
                       {% endif -%}
                       {{ event | event_value -}}
                       {% if link -%}

--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -51,7 +51,7 @@ func main() {
 func loadInnerParts(innerPartInputPath string, output map[string][]vulns.PackageInfo) {
 	dirInner, err := os.ReadDir(innerPartInputPath)
 	if err != nil {
-		Logger.Fatalf("Failed to read dir? %s", err)
+		Logger.Fatalf("Failed to read dir %q: %s", innerPartInputPath, err)
 	}
 	for _, entryInner := range dirInner {
 		if !strings.HasSuffix(entryInner.Name(), ".json") {
@@ -59,7 +59,7 @@ func loadInnerParts(innerPartInputPath string, output map[string][]vulns.Package
 		}
 		file, err := os.Open(path.Join(innerPartInputPath, entryInner.Name()))
 		if err != nil {
-			Logger.Fatalf("Failed to open PackageInfo JSON: %s", err)
+			Logger.Fatalf("Failed to open PackageInfo JSON %q: %s", path.Join(innerPartInputPath, entryInner.Name()), err)
 		}
 		defer file.Close()
 		var pkgInfos []vulns.PackageInfo
@@ -93,12 +93,12 @@ func loadInnerParts(innerPartInputPath string, output map[string][]vulns.Package
 func loadParts(partsInputPath string) map[string][]vulns.PackageInfo {
 	dir, err := os.ReadDir(partsInputPath)
 	if err != nil {
-		Logger.Fatalf("Failed to read dir? %s", err)
+		Logger.Fatalf("Failed to read dir %q: %s", partsInputPath, err)
 	}
 	output := map[string][]vulns.PackageInfo{}
 	for _, entry := range dir {
 		if !entry.IsDir() {
-			Logger.Warnf("Unexpected file entry in " + partsInputPath)
+			Logger.Warnf("Unexpected file entry %q in %s", entry.Name(), partsInputPath)
 			continue
 		}
 		// map is already a reference type, so no need to pass in a pointer
@@ -157,20 +157,23 @@ func writeOSVFile(osvData map[string]*vulns.Vulnerability, osvOutputPath string)
 func loadAllCVEs(cvePath string) map[string]cves.CVEItem {
 	dir, err := os.ReadDir(cvePath)
 	if err != nil {
-		Logger.Fatalf("Failed to read dir? %s", err)
+		Logger.Fatalf("Failed to read dir %s: %s", cvePath, err)
 	}
 
 	result := make(map[string]cves.CVEItem)
 
 	for _, entry := range dir {
+		if !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
 		file, err := os.Open(path.Join(cvePath, entry.Name()))
 		if err != nil {
-			Logger.Fatalf("Failed to open cve json: %s", err)
+			Logger.Fatalf("Failed to open CVE JSON %q: %s", path.Join(cvePath, entry.Name()), err)
 		}
 		var nvdcve cves.NVDCVE
 		err = json.NewDecoder(file).Decode(&nvdcve)
 		if err != nil {
-			Logger.Fatalf("Failed to decode json: %s", err)
+			Logger.Fatalf("Failed to decode JSON in %q: %s", file.Name(), err)
 		}
 
 		for _, item := range nvdcve.CVEItems {


### PR DESCRIPTION
For reasons not entirely clear, the subsequent range elements after the first one were not rendering correctly with the previous approach. This approach, while marginally less DRY does the right thing.

Example with CVE-2021-41272:

Before:

![image](https://github.com/google/osv.dev/assets/6906046/72b139b7-b713-4d11-9027-a5db9ad156d8)

After:

![image](https://github.com/google/osv.dev/assets/6906046/2306b928-ae5f-49ff-8ed8-e48d31e3b0e2)
