### PR TITLE
Remove temporary files when GKE pods start

### DIFF
--- a/docker/exporter/exporter.py
+++ b/docker/exporter/exporter.py
@@ -119,7 +119,7 @@ def main():
   args = parser.parse_args()
 
   tmp_dir = os.path.join(args.work_dir, 'tmp')
-  # Temp files are on the persistent SSD,
+  # Temp files are on the persistent local SSD,
   # and they do not get removed when GKE sends a SIGTERM to stop the pod.
   # Manually clear the tmp_dir folder of any leftover files
   # TODO(michaelkedar): use an ephemeral disk for temp storage.

--- a/docker/exporter/exporter.py
+++ b/docker/exporter/exporter.py
@@ -17,6 +17,7 @@ import argparse
 import concurrent.futures
 import logging
 import os
+import shutil
 import tempfile
 import zipfile
 from typing import List
@@ -123,7 +124,7 @@ def main():
   # Manually clear the tmp_dir folder of any leftover files
   # TODO(michaelkedar): use an ephemeral disk for temp storage.
   if os.path.exists(tmp_dir):
-    os.rmdir(tmp_dir)
+    shutil.rmtree(tmp_dir)
   os.makedirs(tmp_dir, exist_ok=True)
   os.environ['TMPDIR'] = tmp_dir
 

--- a/docker/exporter/exporter.py
+++ b/docker/exporter/exporter.py
@@ -118,6 +118,12 @@ def main():
   args = parser.parse_args()
 
   tmp_dir = os.path.join(args.work_dir, 'tmp')
+  # Temp files are on the persistent SSD,
+  # and they do not get removed when GKE sends a SIGTERM to stop the pod.
+  # Manually clear the tmp_dir folder of any leftover files
+  # TODO(michaelkedar): use an ephemeral disk for temp storage.
+  if os.path.exists(tmp_dir):
+    os.rmdir(tmp_dir)
   os.makedirs(tmp_dir, exist_ok=True)
   os.environ['TMPDIR'] = tmp_dir
 

--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -524,6 +524,12 @@ def main():
   args = parser.parse_args()
 
   tmp_dir = os.path.join(args.work_dir, 'tmp')
+  # Temp files are on the persistent SSD,
+  # and they do not get removed when GKE sends a SIGTERM to stop the pod.
+  # Manually clear the tmp_dir folder of any leftover files
+  # TODO(michaelkedar): use an ephemeral disk for temp storage.
+  if os.path.exists(tmp_dir):
+    os.rmdir(tmp_dir)
   os.makedirs(tmp_dir, exist_ok=True)
   os.environ['TMPDIR'] = tmp_dir
 

--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -525,7 +525,7 @@ def main():
   args = parser.parse_args()
 
   tmp_dir = os.path.join(args.work_dir, 'tmp')
-  # Temp files are on the persistent SSD,
+  # Temp files are on the persistent local SSD,
   # and they do not get removed when GKE sends a SIGTERM to stop the pod.
   # Manually clear the tmp_dir folder of any leftover files
   # TODO(michaelkedar): use an ephemeral disk for temp storage.

--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -19,6 +19,7 @@ import datetime
 import json
 import logging
 import os
+import shutil
 import threading
 import time
 import atexit
@@ -529,7 +530,7 @@ def main():
   # Manually clear the tmp_dir folder of any leftover files
   # TODO(michaelkedar): use an ephemeral disk for temp storage.
   if os.path.exists(tmp_dir):
-    os.rmdir(tmp_dir)
+    shutil.rmtree(tmp_dir)
   os.makedirs(tmp_dir, exist_ok=True)
   os.environ['TMPDIR'] = tmp_dir
 

--- a/docker/worker/worker.py
+++ b/docker/worker/worker.py
@@ -672,7 +672,7 @@ def main():
   oss_fuzz_dir = os.path.join(args.work_dir, 'oss-fuzz')
 
   tmp_dir = os.path.join(args.work_dir, 'tmp')
-  # Temp files are on the persistent SSD,
+  # Temp files are on the persistent local SSD,
   # and they do not get removed when GKE sends a SIGTERM to stop the pod.
   # Manually clear the tmp_dir folder of any leftover files
   # TODO(michaelkedar): use an ephemeral disk for temp storage.

--- a/docker/worker/worker.py
+++ b/docker/worker/worker.py
@@ -677,7 +677,7 @@ def main():
   # Manually clear the tmp_dir folder of any leftover files
   # TODO(michaelkedar): use an ephemeral disk for temp storage.
   if os.path.exists(tmp_dir):
-    os.rmdir(tmp_dir)
+    shutil.rmtree(tmp_dir)
   os.makedirs(tmp_dir, exist_ok=True)
   os.environ['TMPDIR'] = tmp_dir
 

--- a/docker/worker/worker.py
+++ b/docker/worker/worker.py
@@ -672,6 +672,12 @@ def main():
   oss_fuzz_dir = os.path.join(args.work_dir, 'oss-fuzz')
 
   tmp_dir = os.path.join(args.work_dir, 'tmp')
+  # Temp files are on the persistent SSD,
+  # and they do not get removed when GKE sends a SIGTERM to stop the pod.
+  # Manually clear the tmp_dir folder of any leftover files
+  # TODO(michaelkedar): use an ephemeral disk for temp storage.
+  if os.path.exists(tmp_dir):
+    os.rmdir(tmp_dir)
   os.makedirs(tmp_dir, exist_ok=True)
   os.environ['TMPDIR'] = tmp_dir
 


### PR DESCRIPTION
GKE sends SIGTERM signals to pods when it needs to terminate them, and `tempfile.TemporaryDirectory()` does not clean up its files on the persistent SSD when that happens in its scope.
Manually clear the files when starting the pods.