### PR TITLE
Fix vulnerability details page

### DIFF
--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -67,17 +67,17 @@
     <spicy-sections
       class="vulnerability-packages{% if vulnerability.affected|should_collapse %} force-collapse{% endif %}">
       {% for affected in vulnerability.affected -%}
-      {% for range in affected.ranges %}
       {% if 'package' in affected %}
       {% set ecosystem = affected.package.ecosystem %}
       {% set package = affected.package.name %}
       {% else %}
       {% set ecosystem = 'Git' %}
-      {% set package = range.repo | strip_scheme %}
+      {% set package = vulnerability.repo | strip_scheme %}
       {% endif %}
       <h2 class="package-header">
         <span class="vuln-ecosystem spicy-sections-workaround">{{ ecosystem }}</span>
         <span class="vuln-title-divider spicy-sections-workaround">/</span>
+        {# TODO(andrewpollock): it's permissible to have more than one repo, so handle this -#}
         <span class="vuln-name spicy-sections-workaround">{{ package }}</span>
       </h2>
       <div class="mdc-layout-grid">
@@ -96,9 +96,10 @@
               <dd>{{ affected.package.name }}</dd>
               {%- endif -%}
               {%- endif -%}
-              {%- if range.repo -%}
+              {%- if vulnerability.repo -%}
               <dt>Repository</dt>
-              <dd><a href="{{ range.repo }}" target="_blank" rel="noopener noreferrer">{{ range.repo
+              {# TODO(andrewpollock): it's permissible to have more than one repo, so handle this -#}
+              <dd><a href="{{ vulnerability.repo }}" target="_blank" rel="noopener noreferrer">{{ vulnerability.repo
                   }}</a></dd>
               {%- endif -%}
             </dl>
@@ -110,6 +111,7 @@
             <a href="https://ossf.github.io/osv-schema/#examples" target="_blank" rel="noopener noreferrer"></a>
           </h3>
           <div class="mdc-layout-grid__cell--span-9">
+            {% for range in affected.ranges -%}
             <dl>
               <dt>Type</dt>
               <dd>{{ range.type -}}</dd>
@@ -137,33 +139,34 @@
                   </div>
                   {% endif -%}
                 </div>
+                {% endfor -%}
           </div>
           </dd>
           </dl>
           {% endfor -%}
         </div>
-        {% if affected.versions -%}
-        <div class="vulnerability-package-subsection mdc-layout-grid__inner">
-          <h3 class="mdc-layout-grid__cell--span-3">
-            Affected versions
-            <a href="https://ossf.github.io/osv-schema/#affectedversions-field" target="_blank"
-              rel="noopener noreferrer"></a>
-          </h3>
-          <div class="mdc-layout-grid__cell--span-9 version-value">
-            {% for group, versions in (affected.versions|group_versions(ecosystem)).items() -%}
-            <spicy-sections class="versions-section">
-              <h2 class="version-header">{{ group }}</h2>
-              <div class="versions {% if not loop.last %}versions-separator{% endif %}">
-                {% for version in versions -%}
-                <div class="version">{{ version }}</div>
-                {% endfor -%}
-              </div>
-            </spicy-sections>
-            {% endfor -%}
-          </div>
-        </div>
-        {% endif -%}
       </div>
+      {% if affected.versions -%}
+      <div class="vulnerability-package-subsection mdc-layout-grid__inner">
+        <h3 class="mdc-layout-grid__cell--span-3">
+          Affected versions
+          <a href="https://ossf.github.io/osv-schema/#affectedversions-field" target="_blank"
+            rel="noopener noreferrer"></a>
+        </h3>
+        <div class="mdc-layout-grid__cell--span-9 version-value">
+          {% for group, versions in (affected.versions|group_versions(ecosystem)).items() -%}
+          <spicy-sections class="versions-section">
+            <h2 class="version-header">{{ group }}</h2>
+            <div class="versions {% if not loop.last %}versions-separator{% endif %}">
+              {% for version in versions -%}
+              <div class="version">{{ version }}</div>
+              {% endfor -%}
+            </div>
+          </spicy-sections>
+          {% endfor -%}
+        </div>
+      </div>
+      {% endif -%}
       {% if affected.ecosystem_specific -%}
       <div class="vulnerability-package-subsection mdc-layout-grid__inner">
         <h3 class="mdc-layout-grid__cell--span-3">
@@ -188,9 +191,8 @@
         </div>
       </div>
       {% endif -%}
-      {% endfor -%}
-      {% endfor -%}
   </div>
+  {% endfor -%}
   </spicy-sections>
 </div>
 </div>

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -77,13 +77,13 @@
       <h2 class="package-header">
         <span class="vuln-ecosystem spicy-sections-workaround">{{ ecosystem }}</span>
         <span class="vuln-title-divider spicy-sections-workaround">/</span>
-        {# TODO(andrewpollock): it's permissible to have more than one repo, so handle this -#}
         <span class="vuln-name spicy-sections-workaround">{{ package }}</span>
       </h2>
       <div class="mdc-layout-grid">
+        {%- if 'package' in affected -%}
         <div class="vulnerability-package-subsection mdc-layout-grid__inner">
           <h3 class="mdc-layout-grid__cell--span-3">
-            Source Details
+            Package Details
           </h3>
           <div class="mdc-layout-grid__cell--span-9">
             <dl>
@@ -96,53 +96,54 @@
               <dd>{{ affected.package.name }}</dd>
               {%- endif -%}
               {%- endif -%}
-              {%- if vulnerability.repo -%}
-              <dt>Repository</dt>
-              {# TODO(andrewpollock): it's permissible to have more than one repo, so handle this -#}
-              <dd><a href="{{ vulnerability.repo }}" target="_blank" rel="noopener noreferrer">{{ vulnerability.repo
-                  }}</a></dd>
-              {%- endif -%}
             </dl>
           </div>
         </div>
+        {%- endif -%}
         <div class="vulnerability-package-subsection mdc-layout-grid__inner">
           <h3 class="mdc-layout-grid__cell--span-3">
             Affected ranges
             <a href="https://ossf.github.io/osv-schema/#examples" target="_blank" rel="noopener noreferrer"></a>
           </h3>
           <div class="mdc-layout-grid__cell--span-9">
-            {% for range in affected.ranges -%}
+          {% for range in affected.ranges -%}
             <dl>
               <dt>Type</dt>
               <dd>{{ range.type -}}</dd>
+
+              {%- if range.repo -%}
+              <dt>Repository</dt>
+              <dd>{{ range.repo }}</dd>
+              {%- endif -%}
+
               <dt>Events</dt>
               <dd>
                 <div class="mdc-layout-grid__inner events">
                   {% for event in range.events -%}
-                  <div class="mdc-layout-grid__cell--span-3">
-                    {{ event | event_type -}}
-                  </div>
-                  <div class="mdc-layout-grid__cell--span-9 version-value">
-                    {% set link = event | event_link -%}
-                    {% if link -%}
-                    <a href="{{ link }}">
+                    <div class="mdc-layout-grid__cell--span-3">
+                      {{ event | event_type -}}
+                    </div>
+                    <div class="mdc-layout-grid__cell--span-9 version-value">
+                      {% set link = event | event_link -%}
+                      {% if link -%}
+                        <a href="{{ link }}">
                       {% elif event | event_type == 'Introduced' and event | event_value == '0' -%}
-                      <div class="tooltip">
-                        {% endif -%}
+                        <div class="tooltip">
+                      {% endif -%}
 
-                        {{ event | event_value -}}
+                      {{ event | event_value -}}
 
-                        {% if link -%}
-                    </a>
-                    {% elif event.get('introduced') == '0' -%}
-                    <span class="tooltiptext">The exact introduced commit is unknown</span>
-                  </div>
-                  {% endif -%}
+                      {% if link -%}
+                        </a>
+                      {% elif event.get('introduced') == '0' -%}
+                        <span class="tooltiptext">The exact introduced commit is unknown</span>
+                        </div>
+                      {% endif -%}
+                    </div>
+                  {% endfor -%}
                 </div>
-                {% endfor -%}
-          </div>
-          </dd>
-          </dl>
+              </dd>
+            </dl>
           {% endfor -%}
         </div>
       </div>

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -112,7 +112,7 @@
               <dd>{{ range.type -}}</dd>
 
               {%- if range.repo -%}
-              <dt>Repository</dt>
+              <dt>Repo</dt>
               <dd>{{ range.repo }}</dd>
               {%- endif -%}
 

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -83,12 +83,12 @@
         {%- if 'package' in affected -%}
         <div class="vulnerability-package-subsection mdc-layout-grid__inner">
           <h3 class="mdc-layout-grid__cell--span-3">
-            Package Details
+            Package
           </h3>
           <div class="mdc-layout-grid__cell--span-9">
             <dl>
               {%- if 'package' in affected -%}
-              <dt>Package Name</dt>
+              <dt>Name</dt>
               {%- if affected.package | package_in_ecosystem -%}
               <dd><a href="{{ affected.package | package_in_ecosystem }}" target="_blank" rel="noopener noreferrer">{{
                   affected.package.name }}</a></dd>

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -240,7 +240,7 @@ def bug_to_response(bug, detailed=True):
 def add_links(bug):
   """Add VCS links where possible."""
 
-  repo_url = None
+  first_repo_url = None
 
   for entry in bug.get('affected', []):
     for i, affected_range in enumerate(entry.get('ranges', [])):
@@ -251,6 +251,9 @@ def add_links(bug):
       repo_url = affected_range.get('repo')
       if not repo_url:
         continue
+
+      if not first_repo_url:
+        first_repo_url = repo_url
 
       for event in affected_range.get('events', []):
         if event.get('introduced') and event['introduced'] != '0':
@@ -271,8 +274,8 @@ def add_links(bug):
           event['limit_link'] = _commit_to_link(repo_url, event['limit'])
           continue
 
-  if repo_url:
-    bug['repo'] = repo_url
+  if first_repo_url:
+    bug['repo'] = first_repo_url
 
 
 def add_source_info(bug, response):

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -271,6 +271,9 @@ def add_links(bug):
           event['limit_link'] = _commit_to_link(repo_url, event['limit'])
           continue
 
+  if repo_url:
+    bug['repo'] = repo_url
+
 
 def add_source_info(bug, response):
   """Add source information to `response`."""


### PR DESCRIPTION
- Use alternate approach to rendering multiple repo ranges as proposed
  in https://github.com/google/osv.dev/pull/1656#issuecomment-1734978673.

- Fix various unbalanced tag issues and indent the template a bit better
  to make this more apparent. This seems to be the root cause of
  rendering issues in https://github.com/google/osv.dev/pull/1661.

![image](https://github.com/google/osv.dev/assets/759062/25ed3361-3c50-4442-aa5a-5becec62c5bb)
