### PR TITLE
Handle some edge cases in GitLab URLs

### DIFF
--- a/vulnfeeds/cves/versions_test.go
+++ b/vulnfeeds/cves/versions_test.go
@@ -191,6 +191,12 @@ func TestRepo(t *testing.T) {
 			expectedOk:      true,
 		},
 		{
+			description: "Freedesktop GitLab commit URL observed in CVE-2022-46285",
+			inputLink: "https://gitlab.freedesktop.org/xorg/lib/libxpm/-/commit/a3a7c6dcc3b629d7650148",
+			expectedRepoURL: "https://gitlab.freedesktop.org/xorg/lib/libxpm",
+			expectedOk: true,
+		},
+		{
 			description:     "Freedesktop cGit mirror",
 			inputLink:       "https://cgit.freedesktop.org/xorg/lib/libXRes/commit/?id=c05c6d918b0e2011d4bfa370c321482e34630b17",
 			expectedRepoURL: "https://gitlab.freedesktop.org/xorg/lib/libXRes",
@@ -757,6 +763,16 @@ func TestExtractVersionInfo(t *testing.T) {
 			expectedVersionInfo: VersionInfo{
 				AffectedCommits:  []AffectedCommit(nil),
 				AffectedVersions: []AffectedVersion(nil),
+			},
+			expectedNotes: []string{},
+		},
+		{
+			description:        "A CVE with a weird GitLab reference that breaks version enumeration in the worker",
+			inputCVEItem:       loadTestData("CVE-2022-46285"),
+			inputValidVersions: []string{},
+			expectedVersionInfo: VersionInfo{
+				AffectedCommits:  []AffectedCommit{{Repo: "https://gitlab.freedesktop.org/xorg/lib/libxpm", Fixed: "a3a7c6dcc3b629d7650148"}},
+				AffectedVersions: []AffectedVersion{{Fixed: "3.5.15"}},
 			},
 			expectedNotes: []string{},
 		},

--- a/vulnfeeds/test_data/nvdcve-1.1-test-data.json
+++ b/vulnfeeds/test_data/nvdcve-1.1-test-data.json
@@ -41914,5 +41914,113 @@
     },
     "publishedDate": "2023-07-06T02:15Z",
     "lastModifiedDate": "2023-07-12T13:52Z"
+  },
+  {
+    "cve": {
+      "data_type": "CVE",
+      "data_format": "MITRE",
+      "data_version": "4.0",
+      "CVE_data_meta": {
+        "ID": "CVE-2022-46285",
+        "ASSIGNER": "secalert@redhat.com"
+      },
+      "problemtype": {
+        "problemtype_data": [
+          {
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-835"
+              }
+            ]
+          }
+        ]
+      },
+      "references": {
+        "reference_data": [
+          {
+            "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2160092",
+            "name": "https://bugzilla.redhat.com/show_bug.cgi?id=2160092",
+            "refsource": "MISC",
+            "tags": [
+              "Issue Tracking",
+              "Patch",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://gitlab.freedesktop.org/xorg/lib/libxpm/-/commit/a3a7c6dcc3b629d7650148",
+            "name": "https://gitlab.freedesktop.org/xorg/lib/libxpm/-/commit/a3a7c6dcc3b629d7650148",
+            "refsource": "MISC",
+            "tags": []
+          },
+          {
+            "url": "https://lists.x.org/archives/xorg-announce/2023-January/003312.html",
+            "name": "https://lists.x.org/archives/xorg-announce/2023-January/003312.html",
+            "refsource": "MISC",
+            "tags": []
+          },
+          {
+            "url": "https://gitlab.freedesktop.org/xorg/lib/libxpm/-/merge_requests/9",
+            "name": "https://gitlab.freedesktop.org/xorg/lib/libxpm/-/merge_requests/9",
+            "refsource": "MISC",
+            "tags": []
+          },
+          {
+            "url": "https://lists.debian.org/debian-lts-announce/2023/06/msg00021.html",
+            "name": "[debian-lts-announce] 20230620 [SECURITY] [DLA 3459-1] libxpm security update",
+            "refsource": "MLIST",
+            "tags": []
+          }
+        ]
+      },
+      "description": {
+        "description_data": [
+          {
+            "lang": "en",
+            "value": "A flaw was found in libXpm. This issue occurs when parsing a file with a comment not closed; the end-of-file condition will not be detected, leading to an infinite loop and resulting in a Denial of Service in the application linked to the library."
+          }
+        ]
+      }
+    },
+    "configurations": {
+      "CVE_data_version": "4.0",
+      "nodes": [
+        {
+          "operator": "OR",
+          "children": [],
+          "cpe_match": [
+            {
+              "vulnerable": true,
+              "cpe23Uri": "cpe:2.3:a:libxpm_project:libxpm:*:*:*:*:*:*:*:*",
+              "versionEndExcluding": "3.5.15",
+              "cpe_name": []
+            }
+          ]
+        }
+      ]
+    },
+    "impact": {
+      "baseMetricV3": {
+        "cvssV3": {
+          "version": "3.1",
+          "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "attackVector": "NETWORK",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "NONE",
+          "userInteraction": "NONE",
+          "scope": "UNCHANGED",
+          "confidentialityImpact": "NONE",
+          "integrityImpact": "NONE",
+          "availabilityImpact": "HIGH",
+          "baseScore": 7.5,
+          "baseSeverity": "HIGH"
+        },
+        "exploitabilityScore": 3.9,
+        "impactScore": 3.6
+      }
+    },
+    "publishedDate": "2023-02-07T19:15Z",
+    "lastModifiedDate": "2023-06-20T14:15Z"
   } ]
 }


### PR DESCRIPTION
- Not all GitLab URLs (e.g. gitlab.freedesktop.org) have the repo in the first two parts of the URL path
- Not all GitLab URLs (legacy?) have a hyphen separating the repo from the remainder of the path

This was causing an invalid URL to be extracted from CVE-2022-46285, which went on to cause the worker to fail to successfully enumerate versions.