### PR TITLE
Reinstate gsutil rsync -c behaviour

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
+++ b/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
@@ -39,5 +39,5 @@ echo "Override"
 gcloud --no-user-output-enabled storage rsync "gs://${INPUT_BUCKET}/osv-output-overrides/" $OSV_OUTPUT
 
 echo "Begin syncing output to GCS bucket ${OUTPUT_BUCKET}"
-gcloud --no-user-output-enabled storage rsync "$OSV_OUTPUT" "gs://${OUTPUT_BUCKET}/osv-output/" -c --delete-unmatched-destination-objects -q
+gcloud --no-user-output-enabled storage rsync "$OSV_OUTPUT" "gs://${OUTPUT_BUCKET}/osv-output/" --checksums-only -c --delete-unmatched-destination-objects -q
 echo "Successfully synced to GCS bucket"


### PR DESCRIPTION
It turns out that `-c` with `gcloud storage rsync` is the equivalent of `-C` with `gcloud storage rsync`, so we weren't getting the desired behaviour any more :-(