### PR TITLE
Add an explicit log entry for when a task runner starts

### DIFF
--- a/docker/worker/worker.py
+++ b/docker/worker/worker.py
@@ -326,6 +326,7 @@ class TaskRunner:
     self._ssh_key_public_path = ssh_key_public_path
     self._ssh_key_private_path = ssh_key_private_path
     os.makedirs(self._sources_dir, exist_ok=True)
+    logging.info('Created task runner')
 
   def _git_callbacks(self, source_repo):
     """Get git auth callbacks."""


### PR DESCRIPTION
This will assist with debugging the entire logged session of a worker with the same thread ID (as added by `_setup_logging_extra_info()`)