### PR TITLE
Log the creation of a worker task thread

### DIFF
--- a/docker/worker/worker.py
+++ b/docker/worker/worker.py
@@ -616,6 +616,7 @@ class TaskRunner:
           target=self._do_process_task,
           args=(subscriber, subscription, ack_id, message, done_event),
           daemon=True)
+      logging.info('Creating task thread for %s', message)
       thread.start()
 
       done = done_event.wait(timeout=MAX_LEASE_DURATION)


### PR DESCRIPTION
Right now the completion of a worker task thread is logged, but the commencement of it (with any useful contextual information) is not, which makes it difficult to follow the journey of particular failing record imports.