### PR TITLE
Don't emit last_affected versions when there are fixed versions

### DIFF
--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -930,6 +930,18 @@ func ExtractVersionInfo(cve CVEItem, validVersions []string) (v VersionInfo, not
 			notes = append(notes, "  - "+version)
 		}
 	}
+
+	// Remove any lastaffected versions in favour of fixed versions.
+	if v.HasFixedVersions() {
+		affectedVersionsWithoutLastAffected := []AffectedVersion{}
+		for _, av := range v.AffectedVersions {
+			if av.LastAffected != "" {
+				continue
+			}
+			affectedVersionsWithoutLastAffected = append(affectedVersionsWithoutLastAffected, av)
+		}
+		v.AffectedVersions = affectedVersionsWithoutLastAffected
+	}
 	return v, notes
 }
 

--- a/vulnfeeds/cves/versions_test.go
+++ b/vulnfeeds/cves/versions_test.go
@@ -191,10 +191,10 @@ func TestRepo(t *testing.T) {
 			expectedOk:      true,
 		},
 		{
-			description: "Freedesktop GitLab commit URL observed in CVE-2022-46285",
-			inputLink: "https://gitlab.freedesktop.org/xorg/lib/libxpm/-/commit/a3a7c6dcc3b629d7650148",
+			description:     "Freedesktop GitLab commit URL observed in CVE-2022-46285",
+			inputLink:       "https://gitlab.freedesktop.org/xorg/lib/libxpm/-/commit/a3a7c6dcc3b629d7650148",
 			expectedRepoURL: "https://gitlab.freedesktop.org/xorg/lib/libxpm",
-			expectedOk: true,
+			expectedOk:      true,
 		},
 		{
 			description:     "Freedesktop cGit mirror",
@@ -736,21 +736,6 @@ func TestExtractVersionInfo(t *testing.T) {
 						Introduced:   "2.8.0",
 						Fixed:        "2.8.1",
 						LastAffected: "",
-					},
-					{
-						Introduced:   "",
-						Fixed:        "",
-						LastAffected: "2.9.0-rc1",
-					},
-					{
-						Introduced:   "",
-						Fixed:        "",
-						LastAffected: "2.9.0-rc0",
-					},
-					{
-						Introduced:   "",
-						Fixed:        "",
-						LastAffected: "2.9.0-rc2",
 					},
 				},
 			},


### PR DESCRIPTION
At the end of version extraction, strip out any last_affected versions when there are preferred fixed versions present, to avoid the mix of fixed and last_affected versions ever being converted to commits and potentially winding up in the PackageInfo/VersionInfo input to combine-to-osv.