### PR TITLE
Simplify dockerfile and support python 3.11

### DIFF
--- a/vulnfeeds/tools/debian/Dockerfile
+++ b/vulnfeeds/tools/debian/Dockerfile
@@ -12,26 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:22.04
+FROM google/cloud-sdk:449.0.0-alpine
 
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get upgrade -y && \
-    apt-get install -y \
-    apt-transport-https \
-    ca-certificates \
-    curl \
-    git \
-    gnupg-agent \
-    golang-go \
-    software-properties-common \
-    python3 \
-    python3-pip
-
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
-    apt-get update && apt-get install -y google-cloud-sdk
-
-RUN pip install pipenv==2023.6.12
+RUN apk --no-cache add py3-pip \
+    && pip install pipenv==2023.6.12
 
 RUN mkdir /src
 WORKDIR /src

--- a/vulnfeeds/tools/debian/debian_converter/Pipfile
+++ b/vulnfeeds/tools/debian/debian_converter/Pipfile
@@ -13,5 +13,5 @@ pylint = "*"
 yapf = "*"
 
 [requires]
-# debian_converter uses python3 from ubuntu:22.04, which is 3.10.6
+# debian_converter uses python3 from alpine-3.18, which is 3.11
 python_version = "3.11"


### PR DESCRIPTION
Use the google cloud sdk base docker image since it's the main dependency (that can't be installed via pkg manager). https://hub.docker.com/r/google/cloud-sdk

> google/cloud-sdk:alpine, google/cloud-sdk:VERSION-alpine: (smallest image with no additional components installed, Alpine-based)
