### PR TITLE
Translate cGit and GitWeb URLs to a Repo that is cloneable

### DIFF
--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -729,52 +729,6 @@ func Commit(u string) (string, error) {
 	return "", fmt.Errorf("Commit(): unsupported URL: %s", u)
 }
 
-// Some Git hosting has different human-accessible URLs for Git web interfaces to what is cloneable by Git and requires translation.
-// e.g.
-// the cGit-hosted repo:
-//
-//	https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git [web browseable]
-//	https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git [cloneable]
-//
-// the cGit-hosted repo:
-//
-//	https://git.savannah.gnu.org/cgit/emacs.git [web browseable]
-//	https://git.savannah.gnu.org/git/emacs.git [cloneable]
-//
-// the GitWeb-hosted repo:
-//
-//	https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libksba.git [web browseable]
-//	git://git.gnupg.org/libksba.git [cloneable]
-func maybeRemapRepository(repo string, link string) (remappedRepo string) {
-	remappedRepo = repo
-
-	u, err := url.Parse(link)
-	if err != nil {
-		return repo
-	}
-
-	// cGit.
-	// Maybe use a map (hostname -> remapped path) instead of a switch for this?
-	if strings.HasPrefix(u.Path, "/cgit") {
-		switch u.Hostname() {
-		case "git.kernel.org":
-			u.Path = strings.Replace(u.Path, "/cgit", "/pub/scm", 1)
-
-		case "git.savannah.gnu.org":
-			u.Path = strings.Replace(u.Path, "/cgit", "/git", 1)
-		}
-
-		return u.String()
-	}
-
-	// GitWeb behaviour, TBD
-	// if strings.HasPrefix(u.Path, "/cgi-bin/gitweb.cgi") {
-
-	// }
-
-	return remappedRepo
-}
-
 // For URLs referencing commits in supported Git repository hosts, return a cloneable AffectedCommit.
 func extractGitCommit(link string, commitType CommitType) (ac AffectedCommit, err error) {
 	r, err := Repo(link)

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -498,25 +498,47 @@ func Repo(u string) (string, error) {
 	// cGit URLs are structured another way, e.g.
 	// https://git.dpkg.org/cgit/dpkg/dpkg.git/commit/?id=faa4c92debe45412bfcf8a44f26e827800bb24be
 	// https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=817b8b9c5396d2b2d92311b46719aad5d3339dbe
+	//
+	// They also sometimes have characteristics to map from a web-friendly URL to a clone-friendly repo, on a host-by-host basis.
+	//
+	//	https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git [web browseable]
+	//	https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git [cloneable]
+	//
+	//	https://git.savannah.gnu.org/cgit/emacs.git [web browseable]
+	//	https://git.savannah.gnu.org/git/emacs.git [cloneable]
+	//
 	if strings.HasPrefix(parsedURL.Path, "/cgit") &&
 		strings.HasSuffix(parsedURL.Path, "commit/") &&
 		strings.HasPrefix(parsedURL.RawQuery, "id=") {
 		repo := strings.TrimSuffix(parsedURL.Path, "/commit/")
+
+		switch parsedURL.Hostname() {
+		case "git.kernel.org":
+			repo = strings.Replace(repo, "/cgit", "/pub/scm", 1)
+
+		case "git.savannah.gnu.org":
+			repo = strings.Replace(repo, "/cgit", "/git", 1)
+		}
+
 		return fmt.Sprintf("%s://%s%s", parsedURL.Scheme,
 			parsedURL.Hostname(), repo), nil
 	}
 
-	// GitWeb CGI URLs are structured very differently, e.g.
-	// https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libksba.git;a=commit;h=f61a5ea4e0f6a80fd4b28ef0174bee77793cf070 is another variation seen in the wild
-	if strings.HasPrefix(parsedURL.Path, "/cgi-bin/gitweb.cgi") &&
+	// GitWeb CGI URLs are structured very differently, and require significant translation to get a cloneable URL, e.g.
+	// https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libksba.git;a=commit;h=f61a5ea4e0f6a80fd4b28ef0174bee77793cf070 -> git://git.gnupg.org/libksba.git
+	// https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=11d171f1910b508a81d21faa087ad1af573407d8 -> git://sourceware.org/git/binutils-gdb.git
+	if strings.HasSuffix(parsedURL.Path, "/gitweb.cgi") &&
 		strings.HasPrefix(parsedURL.RawQuery, "p=") {
 		params := strings.Split(parsedURL.RawQuery, ";")
 		for _, param := range params {
 			if !strings.HasPrefix(param, "p=") {
 				continue
 			}
-			repo := strings.Split(param, "=")[1]
-			return fmt.Sprintf("%s://%s/%s", parsedURL.Scheme, parsedURL.Hostname(), repo), nil
+			repo, err := url.JoinPath(strings.TrimSuffix(strings.TrimSuffix(parsedURL.Path, "/gitweb.cgi"), "cgi-bin"), strings.Split(param, "=")[1])
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("git://%s%s", parsedURL.Hostname(), repo), nil
 		}
 	}
 
@@ -707,7 +729,53 @@ func Commit(u string) (string, error) {
 	return "", fmt.Errorf("Commit(): unsupported URL: %s", u)
 }
 
-// For URLs referencing commits in supported Git repository hosts, return an AffectedCommit.
+// Some Git hosting has different human-accessible URLs for Git web interfaces to what is cloneable by Git and requires translation.
+// e.g.
+// the cGit-hosted repo:
+//
+//	https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git [web browseable]
+//	https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git [cloneable]
+//
+// the cGit-hosted repo:
+//
+//	https://git.savannah.gnu.org/cgit/emacs.git [web browseable]
+//	https://git.savannah.gnu.org/git/emacs.git [cloneable]
+//
+// the GitWeb-hosted repo:
+//
+//	https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libksba.git [web browseable]
+//	git://git.gnupg.org/libksba.git [cloneable]
+func maybeRemapRepository(repo string, link string) (remappedRepo string) {
+	remappedRepo = repo
+
+	u, err := url.Parse(link)
+	if err != nil {
+		return repo
+	}
+
+	// cGit.
+	// Maybe use a map (hostname -> remapped path) instead of a switch for this?
+	if strings.HasPrefix(u.Path, "/cgit") {
+		switch u.Hostname() {
+		case "git.kernel.org":
+			u.Path = strings.Replace(u.Path, "/cgit", "/pub/scm", 1)
+
+		case "git.savannah.gnu.org":
+			u.Path = strings.Replace(u.Path, "/cgit", "/git", 1)
+		}
+
+		return u.String()
+	}
+
+	// GitWeb behaviour, TBD
+	// if strings.HasPrefix(u.Path, "/cgi-bin/gitweb.cgi") {
+
+	// }
+
+	return remappedRepo
+}
+
+// For URLs referencing commits in supported Git repository hosts, return a cloneable AffectedCommit.
 func extractGitCommit(link string, commitType CommitType) (ac AffectedCommit, err error) {
 	r, err := Repo(link)
 	if err != nil {

--- a/vulnfeeds/cves/versions_test.go
+++ b/vulnfeeds/cves/versions_test.go
@@ -215,13 +215,15 @@ func TestRepo(t *testing.T) {
 			expectedOk:      true,
 		},
 		{
-			description: "cGit cgi-bin URL",
-			inputLink:   "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libksba.git;a=commit;h=f61a5ea4e0f6a80fd4b28ef0174bee77793cf070",
-			// Note to future selves: this isn't valid for this
-			// host, but we have no way of knowing this via purely
-			// URL mangling, so are probably going to need a
-			// mapping table for known odd cases
-			expectedRepoURL: "https://git.gnupg.org/libksba.git",
+			description:     "GitWeb URL, remapped to something cloneable (CVE-2022-47629)",
+			inputLink:       "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libksba.git;a=commit;h=f61a5ea4e0f6a80fd4b28ef0174bee77793cf070",
+			expectedRepoURL: "git://git.gnupg.org/libksba.git",
+			expectedOk:      true,
+		},
+		{
+			description:     "GitWeb URL, remapped to something cloneable (CVE-2023-1579)",
+			inputLink:       "https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=11d171f1910b508a81d21faa087ad1af573407d8",
+			expectedRepoURL: "git://sourceware.org/git/binutils-gdb.git",
 			expectedOk:      true,
 		},
 		{
@@ -386,6 +388,12 @@ func TestRepo(t *testing.T) {
 			expectedRepoURL: "https://gitlab.com/ubports/development/core/click",
 			expectedOk:      true,
 		},
+		{
+			description:     "cGit URL on git.kernel.org remapped to be cloneable",
+			inputLink:       "https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=ee1fee900537b5d9560e9f937402de5ddc8412f3",
+			expectedRepoURL: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
+			expectedOk:      true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -432,10 +440,10 @@ func TestExtractGitCommit(t *testing.T) {
 			},
 		},
 		{
-			description: "Undesired GitHub PR commit URL",
-			inputLink: "https://github.com/OpenZeppelin/cairo-contracts/pull/542/commits/6d4cb750478fca2fd916f73297632f899aca9299",
+			description:     "Undesired GitHub PR commit URL",
+			inputLink:       "https://github.com/OpenZeppelin/cairo-contracts/pull/542/commits/6d4cb750478fca2fd916f73297632f899aca9299",
 			inputCommitType: Fixed,
-			expectFailure: true,
+			expectFailure:   true,
 		},
 		{
 			description:     "Valid GitLab commit URL",
@@ -496,7 +504,7 @@ func TestExtractGitCommit(t *testing.T) {
 			inputLink:       "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libksba.git;a=commit;h=f61a5ea4e0f6a80fd4b28ef0174bee77793cf070",
 			inputCommitType: Fixed,
 			expectedAffectedCommit: AffectedCommit{
-				Repo:  "https://git.gnupg.org/libksba.git",
+				Repo:  "git://git.gnupg.org/libksba.git",
 				Fixed: "f61a5ea4e0f6a80fd4b28ef0174bee77793cf070",
 			},
 		},
@@ -520,6 +528,16 @@ func TestExtractGitCommit(t *testing.T) {
 			inputCommitType:        Fixed,
 			expectedAffectedCommit: AffectedCommit{},
 			expectFailure:          true,
+		},
+		{
+			description:     "cGit reference from CVE-2022-30594, remapped to be cloneable",
+			inputLink:       "https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=ee1fee900537b5d9560e9f937402de5ddc8412f3",
+			inputCommitType: Fixed,
+			expectedAffectedCommit: AffectedCommit{
+				Repo:  "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
+				Fixed: "ee1fee900537b5d9560e9f937402de5ddc8412f3",
+			},
+			expectFailure: true,
 		},
 	}
 


### PR DESCRIPTION
I had previously not considered the import process and the need for the `repo` in the generated records to be cloneable, and was focusing on human-usable repo URLs, which crashes analysis.