### PR TITLE
Add a URL rewriter for Savannah repo URLs

### DIFF
--- a/gcp/appengine/source_mapper.py
+++ b/gcp/appengine/source_mapper.py
@@ -90,10 +90,9 @@ class MercurialVCS(VCSViewer):
 
 
 class SavannahVCS(VCSViewer):
-  VCS_URL_REGEX = re.compile(r'https?://git\.savannah\.gnu\.org/git/(.*\.git)$')
-  VCS_REVISION_SUB = (r'https://git.savannah.gnu.org/cgit/'
-                      r'\1/commit?id={revision}')
-  VCS_REVISION_DIFF_SUB = (r'https://git.savannah.gnu.org/cgit/\1/diff/'
+  VCS_URL_REGEX = re.compile(r'(https?://git\.savannah\.(?:non)?gnu\.org)/git/(.*\.git)$')
+  VCS_REVISION_SUB = (r'\1/cgit/\2/commit?id={revision}')
+  VCS_REVISION_DIFF_SUB = (r'\1/cgit/\2/diff/'
                            r'?id={end_revision}&id2={start_revision}')
 
 

--- a/gcp/appengine/source_mapper.py
+++ b/gcp/appengine/source_mapper.py
@@ -90,8 +90,9 @@ class MercurialVCS(VCSViewer):
 
 
 class SavannahVCS(VCSViewer):
-  VCS_URL_REGEX = re.compile(r'(https?://git\.savannah\.(?:non)?gnu\.org)/git/(.*\.git)$')
-  VCS_REVISION_SUB = (r'\1/cgit/\2/commit?id={revision}')
+  VCS_URL_REGEX = re.compile(
+      r'(https?://git\.savannah\.(?:non)?gnu\.org)/git/(.*\.git)$')
+  VCS_REVISION_SUB = r'\1/cgit/\2/commit?id={revision}'
   VCS_REVISION_DIFF_SUB = (r'\1/cgit/\2/diff/'
                            r'?id={end_revision}&id2={start_revision}')
 

--- a/gcp/appengine/source_mapper.py
+++ b/gcp/appengine/source_mapper.py
@@ -89,12 +89,21 @@ class MercurialVCS(VCSViewer):
                            r'&revcount={range_limit}')
 
 
+class SavannahVCS(VCSViewer):
+  VCS_URL_REGEX = re.compile(r'https?://git\.savannah\.gnu\.org/git/(.*\.git)$')
+  VCS_REVISION_SUB = (r'https://git.savannah.gnu.org/cgit/'
+                      r'\1/commit?id={revision}')
+  VCS_REVISION_DIFF_SUB = (r'https://git.savannah.gnu.org/cgit/\1/diff/'
+                           r'?id={end_revision}&id2={start_revision}')
+
+
 VCS_LIST = [
     FreeDesktopVCS,
     GitHubVCS,
     GitLabVCS,
     GoogleSourceVCS,
     MercurialVCS,
+    SavannahVCS,
 ]
 
 


### PR DESCRIPTION
Manually tested with data from [CVE-2023-40303](https://oss-vdb-test.wl.r.appspot.com/vulnerability/CVE-2023-40303)

```
In [1]: import osv

In [2]: import source_mapper

In [3]: vcs = source_mapper.get_vcs_viewer_for_url("https://git.savannah.gnu.org/git/inetutils.git")

In [4]: vcs.get_source_url_for_revision("e4e65c03f4c11292a3e40ef72ca3f194c8bffdd6")
Out[4]: 'https://git.savannah.gnu.org/cgit/inetutils.git/commit?id=e4e65c03f4c11292a3e40ef72ca3f194c8bffdd6'
```