### PR TITLE
The commit hash used for querying by commit now returns 28 vulns

### DIFF
--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -47,48 +47,54 @@ class IntegrationTests(unittest.TestCase,
                        tests.ExpectationTest(_TEST_DATA_DIR)):
   """Server integration tests."""
 
-  _VULN_744 = {
-      'published': '2020-07-04T00:00:01.948828Z',
+  _VULN_970 = {
+      'published': '2023-10-06T13:02:56.047818Z',
       'schema_version': '1.6.0',
       'affected': [{
           'database_specific': {
               'source': 'https://github.com/google/oss-fuzz-vulns/'
-                        'blob/main/vulns/mruby/OSV-2020-744.yaml'
+                        'blob/main/vulns/ghostscript/OSV-2023-970.yaml'
           },
           'ecosystem_specific': {
               'severity': 'HIGH'
           },
           'package': {
               'ecosystem': 'OSS-Fuzz',
-              'name': 'mruby',
-              'purl': 'pkg:generic/mruby'
+              'name': 'ghostscript',
+              'purl': 'pkg:generic/ghostscript'
           },
           'ranges': [{
               'events': [{
-                  'introduced': '9cdf439db52b66447b4e37c61179d54fad6c8f33'
+                  'introduced': '205d4f51cba82bc7cfa6a64b3d82b77baebf91b4'
               }, {
-                  'fixed': '97319697c8f9f6ff27b32589947e1918e3015503'
+                  'fixed': '6a3097e2262b61a953651b6280247705945f4c82'
               }],
-              'repo': 'https://github.com/mruby/mruby',
+              'repo': 'git://git.ghostscript.com/ghostpdl.git',
               'type': 'GIT'
           }],
-          'versions': ['2.1.2', '2.1.2-rc', '2.1.2-rc2']
+          'versions': [
+              'ghostpdl-10.01.0', 'ghostpdl-10.01.0rc1', 'ghostpdl-10.01.0rc2',
+              'ghostpdl-10.01.1', 'ghostpdl-10.01.1-gse-10174',
+              'ghostpdl-10.01.2', 'ghostpdl-10.02.0',
+              'ghostpdl-10.02.0-test-base-001', 'ghostpdl-10.02.0rc1',
+              'ghostpdl-10.02.0rc2'
+          ]
       }],
       'details': 'OSS-Fuzz report: '
-                 'https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=23801\n'
+                 'https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63013\n'
                  '\n'
                  '```\n'
-                 'Crash type: Heap-double-free\n'
+                 'Crash type: Heap-use-after-free READ 8\n'
                  'Crash state:\n'
-                 'mrb_default_allocf\n'
-                 'mrb_free\n'
-                 'obj_free\n```\n',
-      'id': 'OSV-2020-744',
+                 'gx_device_forward_finalize\n'
+                 'gx_device_finalize\n'
+                 'alloc_restore_step_in\n```\n',
+      'id': 'OSV-2023-970',
       'references': [{
           'type': 'REPORT',
-          'url': 'https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=23801',
+          'url': 'https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63013',
       }],
-      'summary': 'Heap-double-free in mrb_default_allocf',
+      'summary': 'Heap-use-after-free in gx_device_forward_finalize',
   }
 
   def _get(self, vuln_id):
@@ -136,8 +142,8 @@ class IntegrationTests(unittest.TestCase,
 
   def test_get(self):
     """Test getting a vulnerability."""
-    response = requests.get(_api() + '/v1/vulns/OSV-2020-744', timeout=_TIMEOUT)
-    self.assert_vuln_equal(self._VULN_744, response.json())
+    response = requests.get(_api() + '/v1/vulns/OSV-2023-970', timeout=_TIMEOUT)
+    self.assert_vuln_equal(self._VULN_970, response.json())
 
   def test_get_with_multiple(self):
     """Test getting a vulnerability with multiple packages."""
@@ -150,7 +156,7 @@ class IntegrationTests(unittest.TestCase,
     response = requests.post(
         _api() + '/v1/query',
         data=json.dumps({
-            'commit': '233cb49903fa17637bd51f4a16b4ca61e0750f24',
+            'commit': '8add3bf87045b3f83130160462dd8e8299f3a81d',
         }),
         timeout=_TIMEOUT)
     self.assert_results_equal({'vulns': [self._VULN_744]}, response.json())
@@ -571,6 +577,60 @@ class IntegrationTests(unittest.TestCase,
                 {},
                 {
                     'vulns': [{
+                        'id': 'CVE-2020-15866',
+                    }, {
+                        'id': 'CVE-2020-36401',
+                    }, {
+                        'id': 'CVE-2021-4110',
+                    }, {
+                        'id': 'CVE-2021-4188',
+                    }, {
+                        'id': 'CVE-2021-46020',
+                    }, {
+                        'id': 'CVE-2021-46023',
+                    }, {
+                        'id': 'CVE-2022-0080',
+                    }, {
+                        'id': 'CVE-2022-0240',
+                    }, {
+                        'id': 'CVE-2022-0326',
+                    }, {
+                        'id': 'CVE-2022-0481',
+                    }, {
+                        'id': 'CVE-2022-0525',
+                    }, {
+                        'id': 'CVE-2022-0570',
+                    }, {
+                        'id': 'CVE-2022-0614',
+                    }, {
+                        'id': 'CVE-2022-0623',
+                    }, {
+                        'id': 'CVE-2022-0630',
+                    }, {
+                        'id': 'CVE-2022-0631',
+                    }, {
+                        'id': 'CVE-2022-0632',
+                    }, {
+                        'id': 'CVE-2022-0717',
+                    }, {
+                        'id': 'CVE-2022-0890',
+                    }, {
+                        'id': 'CVE-2022-1071',
+                    }, {
+                        'id': 'CVE-2022-1106',
+                    }, {
+                        'id': 'CVE-2022-1201',
+                    }, {
+                        'id': 'CVE-2022-1212',
+                    }, {
+                        'id': 'CVE-2022-1276',
+                    }, {
+                        'id': 'CVE-2022-1286',
+                    }, {
+                        'id': 'CVE-2022-1427',
+                    }, {
+                        'id': 'CVE-2022-1934',
+                    }, {
                         'id': 'OSV-2020-744',
                     }]
                 },

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -183,7 +183,7 @@ class IntegrationTests(unittest.TestCase,
 
   def test_get(self):
     """Test getting a vulnerability."""
-    response = requests.get(_api() + '/v1/vulns/OSV-2023-744', timeout=_TIMEOUT)
+    response = requests.get(_api() + '/v1/vulns/OSV-2020-744', timeout=_TIMEOUT)
     self.assert_vuln_equal(self._VULN_744, response.json())
 
   def test_get_with_multiple(self):

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -97,6 +97,50 @@ class IntegrationTests(unittest.TestCase,
       'summary': 'Heap-use-after-free in gx_device_forward_finalize',
   }
 
+  _VULN_744 = {
+      'published': '2020-07-04T00:00:01.948828Z',
+      'schema_version': '1.6.0',
+      'affected': [{
+          'database_specific': {
+              'source': 'https://github.com/google/oss-fuzz-vulns/'
+                        'blob/main/vulns/mruby/OSV-2020-744.yaml'
+          },
+          'ecosystem_specific': {
+              'severity': 'HIGH'
+          },
+          'package': {
+              'ecosystem': 'OSS-Fuzz',
+              'name': 'mruby',
+              'purl': 'pkg:generic/mruby'
+          },
+          'ranges': [{
+              'events': [{
+                  'introduced': '9cdf439db52b66447b4e37c61179d54fad6c8f33'
+              }, {
+                  'fixed': '97319697c8f9f6ff27b32589947e1918e3015503'
+              }],
+              'repo': 'https://github.com/mruby/mruby',
+              'type': 'GIT'
+          }],
+          'versions': ['2.1.2', '2.1.2-rc', '2.1.2-rc2']
+      }],
+      'details': 'OSS-Fuzz report: '
+                 'https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=23801\n'
+                 '\n'
+                 '```\n'
+                 'Crash type: Heap-double-free\n'
+                 'Crash state:\n'
+                 'mrb_default_allocf\n'
+                 'mrb_free\n'
+                 'obj_free\n```\n',
+      'id': 'OSV-2020-744',
+      'references': [{
+          'type': 'REPORT',
+          'url': 'https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=23801',
+      }],
+      'summary': 'Heap-double-free in mrb_default_allocf',
+  }
+
   def _get(self, vuln_id):
     """Get a vulnerability."""
     response = requests.get(_api() + '/v1/vulns/' + vuln_id, timeout=_TIMEOUT)
@@ -166,26 +210,26 @@ class IntegrationTests(unittest.TestCase,
     response = requests.post(
         _api() + '/v1/query',
         data=json.dumps({
-            'version': '10.02.0',
+            'version': '2.1.2-rc',
             'package': {
-                'name': 'ghostscript',
+                'name': 'mruby',
                 'ecosystem': 'OSS-Fuzz',
             }
         }),
         timeout=_TIMEOUT)
-    self.assert_results_equal({'vulns': [self._VULN_970]}, response.json())
+    self.assert_results_equal({'vulns': [self._VULN_744]}, response.json())
 
     response = requests.post(
         _api() + '/v1/query',
         data=json.dumps({
-            'version': '10.02.0',
+            'version': '2.1.2-rc',
             'package': {
-                'name': 'ghostscript',
+                'name': 'mruby',
             }
         }),
         timeout=_TIMEOUT)
 
-    self.assert_results_equal({'vulns': [self._VULN_970]}, response.json())
+    self.assert_results_equal({'vulns': [self._VULN_744]}, response.json())
     # self.assertEqual(
     #   response.text,
     #   '{"code":3,"message":"Ecosystem not specified"}')

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -47,54 +47,51 @@ class IntegrationTests(unittest.TestCase,
                        tests.ExpectationTest(_TEST_DATA_DIR)):
   """Server integration tests."""
 
-  _VULN_970 = {
-      'published': '2023-10-06T13:02:56.047818Z',
+  _VULN_890 = {
+      'published': '2023-09-21T14:01:03.576514Z',
       'schema_version': '1.6.0',
       'affected': [{
           'database_specific': {
               'source': 'https://github.com/google/oss-fuzz-vulns/'
-                        'blob/main/vulns/ghostscript/OSV-2023-970.yaml'
+                        'blob/main/vulns/libdwarf/OSV-2023-890.yaml'
           },
           'ecosystem_specific': {
               'severity': 'HIGH'
           },
           'package': {
               'ecosystem': 'OSS-Fuzz',
-              'name': 'ghostscript',
-              'purl': 'pkg:generic/ghostscript'
+              'name': 'libdwarf',
+              'purl': 'pkg:generic/libdwarf'
           },
           'ranges': [{
               'events': [{
-                  'introduced': '205d4f51cba82bc7cfa6a64b3d82b77baebf91b4'
+                  'introduced': 'b55ce0185528bf0a99e375cf8f3c84b76b6881a3'
               }, {
-                  'fixed': '6a3097e2262b61a953651b6280247705945f4c82'
+                  'fixed': 'cd741379bd0203a0875b413542d5f982606ae637'
               }],
-              'repo': 'git://git.ghostscript.com/ghostpdl.git',
+              'repo': 'https://github.com/davea42/libdwarf-code',
               'type': 'GIT'
           }],
           'versions': [
-              'ghostpdl-10.01.0', 'ghostpdl-10.01.0rc1', 'ghostpdl-10.01.0rc2',
-              'ghostpdl-10.01.1', 'ghostpdl-10.01.1-gse-10174',
-              'ghostpdl-10.01.2', 'ghostpdl-10.02.0',
-              'ghostpdl-10.02.0-test-base-001', 'ghostpdl-10.02.0rc1',
-              'ghostpdl-10.02.0rc2'
+              'libdwarf-0.7.0', 'libdwarf-0.8.0-fixedtag', 'v0.7.0',
+              'v0.8.0-fixedtag'
           ]
       }],
       'details': 'OSS-Fuzz report: '
-                 'https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63013\n'
+                 'https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62547\n'
                  '\n'
                  '```\n'
-                 'Crash type: Heap-use-after-free READ 8\n'
+                 'Crash type: Heap-use-after-free READ 2\n'
                  'Crash state:\n'
-                 'gx_device_forward_finalize\n'
-                 'gx_device_finalize\n'
-                 'alloc_restore_step_in\n```\n',
-      'id': 'OSV-2023-970',
+                 'dwarf_dealloc\n'
+                 '_dwarf_fde_destructor\n'
+                 'tdestroy_free_node\n```\n',
+      'id': 'OSV-2023-890',
       'references': [{
           'type': 'REPORT',
-          'url': 'https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=63013',
+          'url': 'https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62547',
       }],
-      'summary': 'Heap-use-after-free in gx_device_forward_finalize',
+      'summary': 'Heap-use-after-free in dwarf_dealloc',
   }
 
   _VULN_744 = {
@@ -186,8 +183,8 @@ class IntegrationTests(unittest.TestCase,
 
   def test_get(self):
     """Test getting a vulnerability."""
-    response = requests.get(_api() + '/v1/vulns/OSV-2023-970', timeout=_TIMEOUT)
-    self.assert_vuln_equal(self._VULN_970, response.json())
+    response = requests.get(_api() + '/v1/vulns/OSV-2023-744', timeout=_TIMEOUT)
+    self.assert_vuln_equal(self._VULN_744, response.json())
 
   def test_get_with_multiple(self):
     """Test getting a vulnerability with multiple packages."""
@@ -200,10 +197,10 @@ class IntegrationTests(unittest.TestCase,
     response = requests.post(
         _api() + '/v1/query',
         data=json.dumps({
-            'commit': '8add3bf87045b3f83130160462dd8e8299f3a81d',
+            'commit': '60e572dbf7b4ded66b488f54773f66aaf6184321',
         }),
         timeout=_TIMEOUT)
-    self.assert_results_equal({'vulns': [self._VULN_970]}, response.json())
+    self.assert_results_equal({'vulns': [self._VULN_890]}, response.json())
 
   def test_query_version(self):
     """Test querying by version."""

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -159,33 +159,33 @@ class IntegrationTests(unittest.TestCase,
             'commit': '8add3bf87045b3f83130160462dd8e8299f3a81d',
         }),
         timeout=_TIMEOUT)
-    self.assert_results_equal({'vulns': [self._VULN_744]}, response.json())
+    self.assert_results_equal({'vulns': [self._VULN_970]}, response.json())
 
   def test_query_version(self):
     """Test querying by version."""
     response = requests.post(
         _api() + '/v1/query',
         data=json.dumps({
-            'version': '2.1.2rc',
+            'version': '10.02.0',
             'package': {
-                'name': 'mruby',
+                'name': 'ghostscript',
                 'ecosystem': 'OSS-Fuzz',
             }
         }),
         timeout=_TIMEOUT)
-    self.assert_results_equal({'vulns': [self._VULN_744]}, response.json())
+    self.assert_results_equal({'vulns': [self._VULN_970]}, response.json())
 
     response = requests.post(
         _api() + '/v1/query',
         data=json.dumps({
-            'version': '2.1.2-rc',
+            'version': '10.02.0',
             'package': {
-                'name': 'mruby',
+                'name': 'ghostscript',
             }
         }),
         timeout=_TIMEOUT)
 
-    self.assert_results_equal({'vulns': [self._VULN_744]}, response.json())
+    self.assert_results_equal({'vulns': [self._VULN_970]}, response.json())
     # self.assertEqual(
     #   response.text,
     #   '{"code":3,"message":"Ecosystem not specified"}')


### PR DESCRIPTION
Fix the integration tests by using a different commit hash and reference vulnerability.