### PR TITLE
Specify node:20.9 in website docker image

### DIFF
--- a/gcp/appengine/Dockerfile
+++ b/gcp/appengine/Dockerfile
@@ -1,5 +1,5 @@
 # Build the Javascript frontend
-FROM node:latest AS FRONTEND3_BUILD
+FROM node:20.9 AS FRONTEND3_BUILD
 WORKDIR /build/frontend3
 
 # Install dependencies first for better caching


### PR DESCRIPTION
There's some weirdness going on with docker builds failing. This might help?

We should be using a particular node version in here anyway.