### PR TITLE
Add support for another variation of GitWeb URLs

### DIFF
--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -705,8 +705,8 @@ func Commit(u string) (string, error) {
 
 	// FFMpeg's GitWeb seems to be it's own unique snowflake, e.g.
 	// https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/c94875471e3ba3dc396c6919ff3ec9b14539cd71
-	if strings.HasPrefix(parsedURL.Path, "/gitweb/") && len(strings.Split(parsedURL.Path, "/")) == 4 {
-		return strings.Split(parsedURL.Path, "/")[3], nil
+	if strings.HasPrefix(parsedURL.Path, "/gitweb/") && len(strings.Split(parsedURL.Path, "/")) == 5 {
+		return strings.Split(parsedURL.Path, "/")[4], nil
 	}
 
 	// GitHub and GitLab commit URLs are structured one way, e.g.

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -487,6 +487,9 @@ func Repo(u string) (string, error) {
 					strings.TrimSuffix(parsedURL.Path, "/")),
 				nil
 		}
+		if len(pathParts) >= 2 && parsedURL.Hostname() == "git.ffmpeg.org" {
+			return fmt.Sprintf("%s://%s/%s", parsedURL.Scheme, parsedURL.Hostname(), pathParts[2]), nil
+		}
 		if strings.HasSuffix(parsedURL.Path, ".git") {
 			return fmt.Sprintf("%s://%s%s", parsedURL.Scheme,
 					parsedURL.Hostname(),
@@ -698,6 +701,12 @@ func Commit(u string) (string, error) {
 			}
 			return strings.Split(param, "=")[1], nil
 		}
+	}
+
+	// FFMpeg's GitWeb seems to be it's own unique snowflake, e.g.
+	// https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/c94875471e3ba3dc396c6919ff3ec9b14539cd71
+	if strings.HasPrefix(parsedURL.Path, "/gitweb/") && len(strings.Split(parsedURL.Path, "/")) == 4 {
+		return strings.Split(parsedURL.Path, "/")[3], nil
 	}
 
 	// GitHub and GitLab commit URLs are structured one way, e.g.

--- a/vulnfeeds/cves/versions_test.go
+++ b/vulnfeeds/cves/versions_test.go
@@ -394,6 +394,12 @@ func TestRepo(t *testing.T) {
 			expectedRepoURL: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git",
 			expectedOk:      true,
 		},
+		{
+			description:     "Valid Gitweb repo",
+			inputLink:       "https://git.ffmpeg.org/gitweb/ffmpeg.git/commitdiff/c94875471e3ba3dc396c6919ff3ec9b14539cd71",
+			expectedRepoURL: "https://git.ffmpeg.org/ffmpeg.git",
+			expectedOk:      true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -538,6 +544,15 @@ func TestExtractGitCommit(t *testing.T) {
 				Fixed: "ee1fee900537b5d9560e9f937402de5ddc8412f3",
 			},
 			expectFailure: true,
+		},
+		{
+			description:     "Valid GitWeb commit URL",
+			inputLink:       "https://git.ffmpeg.org/gitweb/ffmpeg.git/commitdiff/c94875471e3ba3dc396c6919ff3ec9b14539cd71",
+			inputCommitType: Fixed,
+			expectedAffectedCommit: AffectedCommit{
+				Repo:  "https://git.ffmpeg.org/ffmpeg.git",
+				Fixed: "c94875471e3ba3dc396c6919ff3ec9b14539cd71",
+			},
 		},
 	}
 


### PR DESCRIPTION
As seen as a reference on [CVE-2021-28429](https://osv.dev/CVE-2021-28429)