### PR TITLE
Build on #1761 to add support for another variation of GitWeb URLs

### DIFF
--- a/gcp/appengine/source_mapper.py
+++ b/gcp/appengine/source_mapper.py
@@ -97,6 +97,13 @@ class SavannahVCS(VCSViewer):
                            r'?id={end_revision}&id2={start_revision}')
 
 
+class FFMpegVCS(VCSViewer):
+  VCS_URL_REGEX = re.compile(r'(https?://git\.ffmpeg\.org)/(.*\.git$')
+  VCS_REVISION_SUB = r'\1/gitweb/\2/commit/{revision}'
+  VCS_REVISION_DIFF_SUB = (r'\1/gitweb/\2/commitdiff/'
+                           r'{start_revision}..{end_version}')
+
+
 VCS_LIST = [
     FreeDesktopVCS,
     GitHubVCS,
@@ -104,6 +111,7 @@ VCS_LIST = [
     GoogleSourceVCS,
     MercurialVCS,
     SavannahVCS,
+    FFMpegVCS,
 ]
 
 

--- a/vulnfeeds/cves/versions_test.go
+++ b/vulnfeeds/cves/versions_test.go
@@ -824,6 +824,14 @@ func TestExtractVersionInfo(t *testing.T) {
 			},
 			expectedNotes: []string{},
 		},
+		{
+			description:  "A CVE with a different GitWeb reference URL that was not previously being extracted successfully",
+			inputCVEItem: loadTestData("CVE-2021-28429"),
+			expectedVersionInfo: VersionInfo{
+				AffectedCommits:  []AffectedCommit{{Repo: "https://git.ffmpeg.org/ffmpeg.git", Fixed: "c94875471e3ba3dc396c6919ff3ec9b14539cd71"}},
+				AffectedVersions: []AffectedVersion{{LastAffected: "4.3.2"}},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/vulnfeeds/test_data/nvdcve-1.1-test-data.json
+++ b/vulnfeeds/test_data/nvdcve-1.1-test-data.json
@@ -42022,5 +42022,86 @@
     },
     "publishedDate": "2023-02-07T19:15Z",
     "lastModifiedDate": "2023-06-20T14:15Z"
+  },
+  {
+    "cve": {
+      "data_type": "CVE",
+      "data_format": "MITRE",
+      "data_version": "4.0",
+      "CVE_data_meta": {
+        "ID": "CVE-2021-28429",
+        "ASSIGNER": "cve@mitre.org"
+      },
+      "problemtype": {
+        "problemtype_data": [
+          {
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-190"
+              }
+            ]
+          }
+        ]
+      },
+      "references": {
+        "reference_data": [
+          {
+            "url": "https://git.ffmpeg.org/gitweb/ffmpeg.git/commitdiff/c94875471e3ba3dc396c6919ff3ec9b14539cd71",
+            "name": "https://git.ffmpeg.org/gitweb/ffmpeg.git/commitdiff/c94875471e3ba3dc396c6919ff3ec9b14539cd71",
+            "refsource": "MISC",
+            "tags": [
+              "Patch"
+            ]
+          }
+        ]
+      },
+      "description": {
+        "description_data": [
+          {
+            "lang": "en",
+            "value": "Integer overflow vulnerability in av_timecode_make_string in libavutil/timecode.c in FFmpeg version 4.3.2, allows local attackers to cause a denial of service (DoS) via crafted .mov file."
+          }
+        ]
+      }
+    },
+    "configurations": {
+      "CVE_data_version": "4.0",
+      "nodes": [
+        {
+          "operator": "OR",
+          "children": [],
+          "cpe_match": [
+            {
+              "vulnerable": true,
+              "cpe23Uri": "cpe:2.3:a:ffmpeg:ffmpeg:4.3.2:*:*:*:*:*:*:*",
+              "cpe_name": []
+            }
+          ]
+        }
+      ]
+    },
+    "impact": {
+      "baseMetricV3": {
+        "cvssV3": {
+          "version": "3.1",
+          "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+          "attackVector": "LOCAL",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "LOW",
+          "userInteraction": "NONE",
+          "scope": "UNCHANGED",
+          "confidentialityImpact": "NONE",
+          "integrityImpact": "NONE",
+          "availabilityImpact": "HIGH",
+          "baseScore": 5.5,
+          "baseSeverity": "MEDIUM"
+        },
+        "exploitabilityScore": 1.8,
+        "impactScore": 3.6
+      }
+    },
+    "publishedDate": "2023-08-11T14:15Z",
+    "lastModifiedDate": "2023-08-18T14:55Z"
   } ]
 }


### PR DESCRIPTION
Add an end-to-end test case to validate [CVE-2021-28429](https://osv.dev/CVE-2021-28429)
Add support to the frontend for linking to commits in the FFmpeg repo.

I haven't been able to test this locally because I'm having problems running the frontend locally.