### PR TITLE
Add permission to read contents

### DIFF
--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -27,5 +27,6 @@ permissions: read-all
 jobs:
   scan-pr:
     permissions:
+      contents: read
       security-events: write
     uses: "google/osv-scanner/.github/workflows/osv-scanner-reusable-pr.yml@main"


### PR DESCRIPTION
It looks like nothing gets inherited from the defaults when you start overriding at the job level.