### PR TITLE
bugfix: use all available repos, not the last one

### DIFF
--- a/vulnfeeds/cpp/main.go
+++ b/vulnfeeds/cpp/main.go
@@ -537,7 +537,16 @@ func main() {
 			}
 			if _, ok := VPRepoCache[VendorProduct{CPE.Vendor, CPE.Product}]; ok {
 				Logger.Infof("[%s]: Pre-references, derived %q for %q %q using cache", CVEID, VPRepoCache[VendorProduct{CPE.Vendor, CPE.Product}], CPE.Vendor, CPE.Product)
-				ReposForCVE[CVEID] = VPRepoCache[VendorProduct{CPE.Vendor, CPE.Product}]
+				if _, ok := ReposForCVE[CVEID]; !ok {
+					ReposForCVE[CVEID] = VPRepoCache[VendorProduct{CPE.Vendor, CPE.Product}]
+					continue
+				}
+				// Don't append duplicates.
+				for _, repo := range VPRepoCache[VendorProduct{CPE.Vendor, CPE.Product}] {
+					if !slices.Contains(ReposForCVE[CVEID], repo) {
+						ReposForCVE[CVEID] = append(ReposForCVE[CVEID], repo)
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
Correct a bug where the last detected repo (for CVEs with multiple CPEs) is the one used by ensuring all repos for all the CPEs on a CVE are included in the per-CVE repo list.