### PR TITLE
Make the individual year's metrics easier to discover

### DIFF
--- a/vulnfeeds/cpp/main.go
+++ b/vulnfeeds/cpp/main.go
@@ -650,5 +650,5 @@ func main() {
 	}
 	// Outcomes is too big to log, so zero it out.
 	Metrics.Outcomes = nil
-	Logger.Infof("Metrics: %+v", Metrics)
+	Logger.Infof("%s Metrics: %+v", filepath.Base(*jsonPath), Metrics)
 }


### PR DESCRIPTION
Because we repeatedly run over year in-scope year's JSON file, searching the logs for the metrics makes it hard to figure out which log entry relates to the run for which year.