### PR TITLE
Avoid datastore comparison bug

### DIFF
--- a/docker/alias/alias_computation.py
+++ b/docker/alias/alias_computation.py
@@ -87,7 +87,7 @@ def main():
   AliasGroups and creating new AliasGroups for un-computed bugs."""
 
   # Query for all bugs that have aliases.
-  bugs = osv.Bug.query(osv.Bug.aliases > '')
+  bugs = osv.Bug.query(osv.Bug.aliases != '')
   all_alias_group = osv.AliasGroup.query()
   allow_list = {
       allow_entry.bug_id for allow_entry in osv.AliasAllowListEntry.query()


### PR DESCRIPTION
For some reason, querying for `> ''` on the repeated property causes some of the same bugs to appear multiple times in the query. It doesn't seem to happen with `!=`