### PR TITLE
Indexer: don't index vendored libraries.

### DIFF
--- a/docker/indexer/shared/shared.go
+++ b/docker/indexer/shared/shared.go
@@ -30,6 +30,8 @@ const (
 	TarExt = ".tar"
 	Git    = "GIT"
 	MD5    = "MD5"
+	// Update this to force reindexing and updating of all entries with lesser version number
+	LatestDocumentVersion = 2
 )
 
 // CopyFromBucket copies a directory from a bucket to a temporary location.


### PR DESCRIPTION
This can cause bad matches against libraries that depend on the correct library we're trying to identify (#1766).