### PR TITLE
Add datastore label to bucket node entry

### DIFF
--- a/docker/indexer/stages/processing/processing.go
+++ b/docker/indexer/stages/processing/processing.go
@@ -57,7 +57,7 @@ type FileResult struct {
 type BucketNode struct {
 	NodeHash        Hash `datastore:"node_hash"`
 	FilesContained  int  `datastore:"files_contained,noindex"`
-	DocumentVersion int
+	DocumentVersion int  `datastore:"document_version,noindex"`
 }
 
 // Stage holds the data structures necessary to perform the processing.


### PR DESCRIPTION
Followup to #1780 , Fixes #1766 .

Just after I merged in the previous PR I realized I missed DocumentVersion datastore name.