### PR TITLE
Skip cleaning older versions for now 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/lib
 .vscode
 *.tfstate*
 .history/*
+**/.history/*

--- a/docker/indexer/stages/processing/processing.go
+++ b/docker/indexer/stages/processing/processing.go
@@ -181,8 +181,10 @@ func (s *Stage) processGit(ctx context.Context, repoInfo *preparation.Result) er
 		return err
 	}
 
-	log.Info("begin cleaning old versions")
-	return s.Storer.Clean(ctx, repoInfo, shared.MD5)
+	// Skip cleaning section
+	return nil
+	// log.Info("begin cleaning old versions")
+	// return s.Storer.Clean(ctx, repoInfo, shared.MD5)
 }
 
 func createFilledBucketBitmap(nodes []*BucketNode) []byte {


### PR DESCRIPTION
Skip cleaning older versions for now, until we update osv-scanner and indexer scanning tools to also ignore vendor folders.