### PR TITLE
Add last_affected support to extractVersionsFromDescription

### DIFF
--- a/vulnfeeds/cves/versions_test.go
+++ b/vulnfeeds/cves/versions_test.go
@@ -859,6 +859,13 @@ func TestExtractVersionInfo(t *testing.T) {
 				AffectedVersions: []AffectedVersion{{LastAffected: "4.3.2"}},
 			},
 		},
+		{
+			description:  "A CVE with a configuration unsupported by ExtractVersionInfo and a limit version in the description",
+			inputCVEItem: loadTestData("CVE-2020-13595"),
+			expectedVersionInfo: VersionInfo{
+				AffectedVersions: []AffectedVersion{{Introduced: "4.0", LastAffected: "4.2"}},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/vulnfeeds/test_data/nvdcve-1.1-test-data.json
+++ b/vulnfeeds/test_data/nvdcve-1.1-test-data.json
@@ -42103,5 +42103,142 @@
     },
     "publishedDate": "2023-08-11T14:15Z",
     "lastModifiedDate": "2023-08-18T14:55Z"
+  },
+  {
+    "cve": {
+      "data_type": "CVE",
+      "data_format": "MITRE",
+      "data_version": "4.0",
+      "CVE_data_meta": {
+        "ID": "CVE-2020-13595",
+        "ASSIGNER": "cve@mitre.org"
+      },
+      "problemtype": {
+        "problemtype_data": [
+          {
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-617"
+              }
+            ]
+          }
+        ]
+      },
+      "references": {
+        "reference_data": [
+          {
+            "url": "https://github.com/espressif/esp32-bt-lib",
+            "name": "https://github.com/espressif/esp32-bt-lib",
+            "refsource": "MISC",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://asset-group.github.io/disclosures/sweyntooth/",
+            "name": "https://asset-group.github.io/disclosures/sweyntooth/",
+            "refsource": "MISC",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://asset-group.github.io/cves.html",
+            "name": "https://asset-group.github.io/cves.html",
+            "refsource": "MISC",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      },
+      "description": {
+        "description_data": [
+          {
+            "lang": "en",
+            "value": "The Bluetooth Low Energy (BLE) controller implementation in Espressif ESP-IDF 4.0 through 4.2 (for ESP32 devices) returns the wrong number of completed BLE packets and triggers a reachable assertion on the host stack when receiving a packet with an MIC failure. An attacker within radio range can silently trigger the assertion (which disables the target's BLE stack) by sending a crafted sequence of BLE packets."
+          }
+        ]
+      }
+    },
+    "configurations": {
+      "CVE_data_version": "4.0",
+      "nodes": [
+        {
+          "operator": "AND",
+          "children": [
+            {
+              "operator": "OR",
+              "children": [],
+              "cpe_match": [
+                {
+                  "vulnerable": true,
+                  "cpe23Uri": "cpe:2.3:a:espressif:esp-idf:*:*:*:*:*:*:*:*",
+                  "versionStartIncluding": "4.0.0",
+                  "versionEndIncluding": "4.2",
+                  "cpe_name": []
+                }
+              ]
+            },
+            {
+              "operator": "OR",
+              "children": [],
+              "cpe_match": [
+                {
+                  "vulnerable": false,
+                  "cpe23Uri": "cpe:2.3:h:espressif:esp32:-:*:*:*:*:*:*:*",
+                  "cpe_name": []
+                }
+              ]
+            }
+          ],
+          "cpe_match": []
+        }
+      ]
+    },
+    "impact": {
+      "baseMetricV3": {
+        "cvssV3": {
+          "version": "3.1",
+          "vectorString": "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "attackVector": "ADJACENT_NETWORK",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "NONE",
+          "userInteraction": "NONE",
+          "scope": "UNCHANGED",
+          "confidentialityImpact": "NONE",
+          "integrityImpact": "NONE",
+          "availabilityImpact": "HIGH",
+          "baseScore": 6.5,
+          "baseSeverity": "MEDIUM"
+        },
+        "exploitabilityScore": 2.8,
+        "impactScore": 3.6
+      },
+      "baseMetricV2": {
+        "cvssV2": {
+          "version": "2.0",
+          "vectorString": "AV:A/AC:L/Au:N/C:N/I:N/A:P",
+          "accessVector": "ADJACENT_NETWORK",
+          "accessComplexity": "LOW",
+          "authentication": "NONE",
+          "confidentialityImpact": "NONE",
+          "integrityImpact": "NONE",
+          "availabilityImpact": "PARTIAL",
+          "baseScore": 3.3
+        },
+        "severity": "LOW",
+        "exploitabilityScore": 6.5,
+        "impactScore": 2.9,
+        "acInsufInfo": false,
+        "obtainAllPrivilege": false,
+        "obtainUserPrivilege": false,
+        "obtainOtherPrivilege": false,
+        "userInteractionRequired": false
+      }
+    },
+    "publishedDate": "2020-08-31T15:15Z",
+    "lastModifiedDate": "2020-09-08T21:09Z"
   } ]
 }


### PR DESCRIPTION
extractVersionsFromDescription wasn't doing the same pragmatic fallback to last_affected for unvalidatable versions that was previously added to ExtractVersionInfo.