### PR TITLE
Improve fuzzy version matching

### DIFF
--- a/vulnfeeds/git/versions.go
+++ b/vulnfeeds/git/versions.go
@@ -16,6 +16,7 @@ package git
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"golang.org/x/exp/maps"
@@ -23,18 +24,28 @@ import (
 	"github.com/google/osv/vulnfeeds/cves"
 )
 
-// Take an already normalized version, repo and the pre-normalized mapping of tags to commits and do fuzzy matching on the version, returning a GitCommit and a bool if successful.
+// Take an already normalized version, repo and the mapping of repo tags
+// normalized tags and commits and do fuzzy matching version, returning a
+// GitCommit and a bool if successful.
 func fuzzyVersionToCommit(normalizedVersion string, repo string, commitType cves.CommitType, normalizedTags map[string]NormalizedTag) (ac cves.AffectedCommit, b bool) {
-	candidateTags := []string{}
+	candidateTags := []string{} // the subset of normalizedTags tags that might be appropriate to use as a fuzzy match for normalizedVersion.
+	// Keep in sync with the regex in cves.NormalizeVersion()
+	var validVersionText = regexp.MustCompile(`(?i)(?:rc|alpha|beta|preview)\d*`)
+
 	for _, k := range maps.Keys(normalizedTags) {
-		if strings.HasPrefix(k, normalizedVersion) {
+		// "1.8.0-RC0" shouldn't be considered a fuzzy match for "1.8.0"
+		if strings.HasPrefix(k, normalizedVersion) && !validVersionText.MatchString(k) {
 			candidateTags = append(candidateTags, k)
 		}
 	}
-	// We may now have one or more tags to further examine for a best choice.
+
+	// There are zero, one or more tags to further examine for a best choice.
+
+	// Nothing even looked like it started with normalizedVersion, fail.
 	if len(candidateTags) == 0 {
 		return ac, false
 	}
+
 	if len(candidateTags) == 1 {
 		ac.SetRepo(repo)
 		switch commitType {
@@ -51,7 +62,9 @@ func fuzzyVersionToCommit(normalizedVersion string, repo string, commitType cves
 	}
 
 	for i, t := range candidateTags {
-		// Handle the case where we were given say "12.0", but what we have is "12.0.0"
+		// Handle the case where where the
+		// normalizedVersion is "12-0" (i.e. was "12.0") but the normalizedTags
+		// has "12-0-0" (i.e. the repo had "12.0.0")
 		if strings.TrimPrefix(t, normalizedVersion) == "-0" {
 			ac.SetRepo(repo)
 			switch commitType {
@@ -67,6 +80,8 @@ func fuzzyVersionToCommit(normalizedVersion string, repo string, commitType cves
 			return ac, true
 		}
 	}
+
+	// All fuzzy matching attempts have failed.
 	return ac, false
 }
 

--- a/vulnfeeds/git/versions_test.go
+++ b/vulnfeeds/git/versions_test.go
@@ -17,8 +17,7 @@ func TestVersionToCommit(t *testing.T) {
 		expectedResult string
 		expectedOk     bool
 	}{
-		{
-			description:    "An exact match",
+		{   description:    "An exact match",
 			inputRepoURL:   "https://github.com/ARMmbed/mbedtls",
 			cache:          cache,
 			inputVersion:   "3.0.0",
@@ -58,11 +57,19 @@ func TestVersionToCommit(t *testing.T) {
 			expectedOk:     false,
 		},
 		{
-			description:    "A version that should not fuzzy match to a release candidate",
+			description:    "An RC version that should match to a (single) release candidate",
 			inputRepoURL:   "https://github.com/apache/inlong",
 			cache:          cache,
-			inputVersion:   "1.8.0",
-			expectedResult: "",
+			inputVersion:   "1.4.0-RC0",
+			expectedResult: "8c8145974548568a68bb81720cabdafbefe545be",
+			expectedOk:     false,
+		},
+		{
+			description:    "An RC version that should match to one of many prefixed release candidates",
+			inputRepoURL:   "https://github.com/apache/inlong",
+			cache:          cache,
+			inputVersion:   "1.8.0-RC0",
+			expectedResult: "15d9fd922ef314977c7ce47c1fdf5e1655efd945",
 			expectedOk:     false,
 		},
 	}

--- a/vulnfeeds/git/versions_test.go
+++ b/vulnfeeds/git/versions_test.go
@@ -7,8 +7,7 @@ import (
 )
 
 func TestVersionToCommit(t *testing.T) {
-	var cache RepoTagsCache
-	cache = make(RepoTagsCache)
+	cache := make(RepoTagsCache)
 
 	tests := []struct {
 		description    string
@@ -47,6 +46,22 @@ func TestVersionToCommit(t *testing.T) {
 			inputRepoURL:   "https://github.com/google/go-attestation",
 			cache:          cache,
 			inputVersion:   "0.3.3", // referred to in CVE-2022-0317
+			expectedResult: "",
+			expectedOk:     false,
+		},
+		{
+			description:    "A version that should not fuzzy match to a release candidate",
+			inputRepoURL:   "https://github.com/apache/inlong",
+			cache:          cache,
+			inputVersion:   "1.4.0",
+			expectedResult: "",
+			expectedOk:     false,
+		},
+		{
+			description:    "A version that should not fuzzy match to a release candidate",
+			inputRepoURL:   "https://github.com/apache/inlong",
+			cache:          cache,
+			inputVersion:   "1.8.0",
 			expectedResult: "",
 			expectedOk:     false,
 		},


### PR DESCRIPTION
When doing prefix matching, do not do it versions with a "pre-release" textual suffix, to avoid undesired matches.

Addresses multiple converted CVEs in Apache InLong that were showing as unfixed (their repo has some strange release tagging practices).