### PR TITLE
Add support for normalizing some more obscure tags

### DIFF
--- a/vulnfeeds/git/repository_test.go
+++ b/vulnfeeds/git/repository_test.go
@@ -181,6 +181,62 @@ func TestRepoTags(t *testing.T) {
 	}
 }
 
+func TestNormalizeRepoTag(t *testing.T) {
+	tests := []struct {
+		description    string
+		inputTag       string
+		repoName       string
+		expectedResult string
+		expectedOk     bool
+	}{
+		{
+			description:    "A tag that is perfectly fine just the way it is",
+			inputTag:       "1.2.3",
+			repoName:       "acme",
+			expectedResult: "1-2-3",
+			expectedOk:     true,
+		},
+		{
+			description:    "A tag with a reponame prepended",
+			inputTag:       "acme-2000",
+			repoName:       "acme",
+			expectedResult: "2000",
+			expectedOk:     true,
+		},
+		{
+			description:    "A tag with a reponame containing a number prepended",
+			inputTag:       "yui2-2000",
+			repoName:       "yui2",
+			expectedResult: "2000",
+			expectedOk:     true,
+		},
+		{
+			description:    "A tag with a reponame containing a number in the middle",
+			inputTag:       "hudson-yui2-2800",
+			repoName:       "yui2",
+			expectedResult: "2800",
+			expectedOk:     true,
+		},
+		{
+			description:    "A tag with a Java package name prefix",
+			inputTag:       "org.apache.sling.i18n-2.0.2",
+			repoName:       "sling-org-apache-sling-i18n",
+			expectedResult: "2-0-2",
+			expectedOk:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		got, err := normalizeRepoTag(tc.inputTag, tc.repoName)
+		if err != nil && tc.expectedOk {
+			t.Errorf("test %q: normalizeRepoTag(%q, %q): %q unexpectedly failed: %+v", tc.description, tc.inputTag, tc.repoName, got, err)
+		}
+		if diff := cmp.Diff(got, tc.expectedResult); diff != "" {
+			t.Errorf("test %q: normalizeRepoTag(%q, %q) incorrect result: %s", tc.description, tc.inputTag, tc.repoName, diff)
+		}
+	}
+}
+
 func TestNormalizeRepoTags(t *testing.T) {
 	tests := []struct {
 		description  string

--- a/vulnfeeds/git/versions.go
+++ b/vulnfeeds/git/versions.go
@@ -64,6 +64,7 @@ func fuzzyVersionToCommit(normalizedVersion string, repo string, commitType cves
 		return ac, true
 	}
 
+	// Find the most suitable tag from multiple.
 	for i, t := range candidateTags {
 		// Handle the case where where the
 		// normalizedVersion is "12-0" (i.e. was "12.0") but the normalizedTags

--- a/vulnfeeds/git/versions_test.go
+++ b/vulnfeeds/git/versions_test.go
@@ -17,7 +17,8 @@ func TestVersionToCommit(t *testing.T) {
 		expectedResult string
 		expectedOk     bool
 	}{
-		{   description:    "An exact match",
+		{
+			description:    "An exact match",
 			inputRepoURL:   "https://github.com/ARMmbed/mbedtls",
 			cache:          cache,
 			inputVersion:   "3.0.0",
@@ -49,10 +50,26 @@ func TestVersionToCommit(t *testing.T) {
 			expectedOk:     false,
 		},
 		{
+			description:    "A fuzzy version match for a tag with a different format to the others in the repo",
+			inputRepoURL:   "https://github.com/yui/yui2",
+			cache:          cache,
+			inputVersion:   "2800",
+			expectedResult: "159208465da41a4796716d8a5bf833c6778b3f61",
+			expectedOk:     true,
+		},
+		{
 			description:    "A version that should not fuzzy match to a release candidate",
 			inputRepoURL:   "https://github.com/apache/inlong",
 			cache:          cache,
 			inputVersion:   "1.4.0",
+			expectedResult: "",
+			expectedOk:     false,
+		},
+		{
+			description:    "An RC version that should match to one of many prefixed release candidates",
+			inputRepoURL:   "https://github.com/apache/inlong",
+			cache:          cache,
+			inputVersion:   "1.8.0",
 			expectedResult: "",
 			expectedOk:     false,
 		},


### PR DESCRIPTION
These have been observed to be involved with CVE conversions that are falsely reporting as unfixed or failing to convert entirely

Support tags that have the repo name in the middle (as seen causing CVE-2023-4366{6,7,8})
Support tags that have the Java package name in them (fixes: #1776)