### PR TITLE
Add lifecycle and import osv-backup into terraform

### DIFF
--- a/deployment/terraform/environments/oss-vdb-test/main.tf
+++ b/deployment/terraform/environments/oss-vdb-test/main.tf
@@ -8,6 +8,8 @@ module "osv_test" {
   logs_bucket                   = "osv-test-logs"
   cve_osv_conversion_bucket     = "osv-test-cve-osv-conversion"
   debian_osv_conversion_bucket  = "osv-test-debian-osv"
+  backups_bucket                = "osv-test-backup"
+  backups_bucket_retention_days = 5
 
   api_url     = "api.test.osv.dev"
   esp_version = "2.41.0"

--- a/deployment/terraform/environments/oss-vdb/main.tf
+++ b/deployment/terraform/environments/oss-vdb/main.tf
@@ -8,6 +8,8 @@ module "osv" {
   cve_osv_conversion_bucket     = "cve-osv-conversion"
   debian_osv_conversion_bucket  = "debian-osv"
   logs_bucket                   = "osv-logs"
+  backups_bucket                = "osv-backup"
+  backups_bucket_retention_days = 60
 
   api_url     = "api.osv.dev"
   esp_version = "2.41.0"

--- a/deployment/terraform/environments/oss-vdb/unmanaged.md
+++ b/deployment/terraform/environments/oss-vdb/unmanaged.md
@@ -30,7 +30,6 @@ Not everything here needs to be managed by Terraform, this is just for reference
   - `oss-fuzz-osv-mappings`
   - `oss-fuzz-osv-vulns`
   - `oss-vdb-tf` (which is where the terraform state is stored)
-  - `osv-backup`
   - `test-python-vulns`
   - `test-bucket-osv`
   - `test-osv-source-bucket`

--- a/deployment/terraform/modules/osv/main.tf
+++ b/deployment/terraform/modules/osv/main.tf
@@ -136,6 +136,24 @@ resource "google_storage_bucket" "logs_bucket" {
   }
 }
 
+resource "google_storage_bucket" "backups_bucket" {
+  project                     = var.project_id
+  name                        = var.backups_bucket
+  location                    = "US"
+  uniform_bucket_level_access = true
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      age = var.backups_bucket_retention_days
+    }
+  }
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 # Service account permissions
 resource "google_service_account" "deployment_service" {
   project      = var.project_id

--- a/deployment/terraform/modules/osv/variables.tf
+++ b/deployment/terraform/modules/osv/variables.tf
@@ -18,6 +18,16 @@ variable "logs_bucket" {
   description = "Name of bucket to export logs to."
 }
 
+variable "backups_bucket" {
+  type        = string
+  description = "Name of bucket to backup osv entries to."
+}
+
+variable "backups_bucket_retention_days" {
+  type        = number
+  description = "Number of days to retain osv backups"
+}
+
 variable "cve_osv_conversion_bucket" {
   type        = string
   description = "Name of bucket to store converted CVEs in."


### PR DESCRIPTION
Import osv-backup into terraform

Add lifecycle policies to avoid keeping really old backups. Currently set to 60 days.