### PR TITLE
Increase RAM for both jobs utilising NVD data

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
@@ -23,11 +23,11 @@ spec:
               privileged: true
             resources:
               requests:
-                cpu: 30
-                memory: "4G"
-              limits:
-                cpu: 30
+                cpu: "30"
                 memory: "8G"
+              limits:
+                cpu: "30"
+                memory: "16G"
           nodeSelector:
             cloud.google.com/gke-nodepool: highend
           restartPolicy: OnFailure

--- a/deployment/clouddeploy/gke-workers/base/nvd-cve-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/nvd-cve-osv.yaml
@@ -11,6 +11,10 @@ spec:
       activeDeadlineSeconds: 86400
       template:
         spec:
+          tolerations:
+          - key: workloadType
+            operator: Equal
+            value: highend
           containers:
           - name: nvd-cve-osv
             image: nvd-cve-osv
@@ -19,11 +23,11 @@ spec:
               privileged: true
             resources:
               requests:
-                cpu: 1
-                memory: "2G"
+                cpu: "30"
+                memory: "8G"
               limits:
-                cpu: 1
-                memory: "4G"
+                cpu: "30"
+                memory: "16G"
             env:
               - name: WORK_DIR
                 value: /tmp


### PR DESCRIPTION
The new API-based approach + splitting by year seems to be OOMing. Switch the NVD conversion job over to the highend cluster as well.