### PR TITLE
Decouple the direct aquisition of the NVD data

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
@@ -23,11 +23,11 @@ spec:
               privileged: true
             resources:
               requests:
-                cpu: "30"
-                memory: "8G"
+                cpu: 30
+                memory: "4G"
               limits:
-                cpu: "30"
-                memory: "16G"
+                cpu: 30
+                memory: "8G"
           nodeSelector:
             cloud.google.com/gke-nodepool: highend
           restartPolicy: OnFailure

--- a/deployment/clouddeploy/gke-workers/base/nvd-cve-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/nvd-cve-osv.yaml
@@ -11,10 +11,6 @@ spec:
       activeDeadlineSeconds: 86400
       template:
         spec:
-          tolerations:
-          - key: workloadType
-            operator: Equal
-            value: highend
           containers:
           - name: nvd-cve-osv
             image: nvd-cve-osv
@@ -23,11 +19,11 @@ spec:
               privileged: true
             resources:
               requests:
-                cpu: "30"
-                memory: "8G"
+                cpu: 1
+                memory: "2G"
               limits:
-                cpu: "30"
-                memory: "16G"
+                cpu: 1
+                memory: "4G"
             env:
               - name: WORK_DIR
                 value: /tmp

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/nvd-cve-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/nvd-cve-osv.yaml
@@ -12,6 +12,8 @@ spec:
             env:
             - name: GOOGLE_CLOUD_PROJECT
               value: oss-vdb-test
+            - name: NVD_GCS_PATH
+              value: gs://osv-test-cve-osv-conversion/nvd
             - name: CPEREPO_GCS_PATH
               value: gs://osv-test-cve-osv-conversion/cpe_repos/cpe_product_to_repo.json
             - name: OSV_OUTPUT_GCS_PATH

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/nvd-cve-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/nvd-cve-osv.yaml
@@ -12,6 +12,8 @@ spec:
             env:
             - name: GOOGLE_CLOUD_PROJECT
               value: oss-vdb
+            - name: NVD_GCS_PATH
+              value: gs://cve-osv-conversion/nvd
             - name: CPEREPO_GCS_PATH
               value: gs://cve-osv-conversion/cpe_repos/cpe_product_to_repo.json
             - name: OSV_OUTPUT_GCS_PATH

--- a/vulnfeeds/cpp/run_cve_to_osv_generation
+++ b/vulnfeeds/cpp/run_cve_to_osv_generation
@@ -24,23 +24,11 @@ echo "Commencing conversion run"
 # Download NVD CVE dumps.
 echo "Downloading NVD CVE dumps"
 mkdir -p "${WORK_DIR}/nvd"
-APIKEY="$(gcloud --project "$GOOGLE_CLOUD_PROJECT" secrets versions access latest --secret=nvd-api --format='get(payload.data)' | base64 -d)"
-/usr/local/bin/download-cves --api_key "$APIKEY" --cvePath "${WORK_DIR}/nvd"
-
-echo "Splitting monolithic file into years"
-for (( YEAR = 2002 ; YEAR <= $(date +%Y) ; YEAR++ ))
-do
-  cat "${WORK_DIR}/nvd/nvdcve-2.0.json" \
-    | jq \
-      --arg year $YEAR \
-      '{ "resultsPerPage": .vulnerabilities | map(select(.cve?.id? | startswith("CVE-" + $year + "-"))) | length, "startIndex": 0, "totalResults": .vulnerabilities | map(select(.cve?.id? | startswith("CVE-" + $year + "-"))) | length, "format": .format, "version": .version, "timestamp": .timestamp, "vulnerabilities": .vulnerabilities | map(select(.cve?.id? | startswith("CVE-" + $year + "-"))) }' > "${WORK_DIR}/nvd/nvdcve-2.0-${YEAR}.json" &
-done
+gcloud --no-user-output-enabled storage -q cp "${NVD_GCS_PATH}/*-????.json" "${WORK_DIR}/nvd"
 
 # Download latest CPE repo map.
 echo "Downloading latest CPE Git repository map"
 gcloud --no-user-output-enabled storage -q cp "${CPEREPO_GCS_PATH}" "${WORK_DIR}"
-
-wait # for year-splitting to complete
 
 # Dirty hack to get around https://stackoverflow.com/questions/68528541/env-variable-array
 # https://stackoverflow.com/questions/9293887/reading-a-space-delimited-string-into-an-array-in-bash/9294015


### PR DESCRIPTION
a) it's slow
b) it's RAM intensive to split into years
c) the acquisition is duplicated

Revert "Increase RAM for both jobs utilising NVD data (#1837)"

This reverts commit 6ee42da2edd8a019e94ef4285cf02c09bd647e43.

Once #1839 lands (I've made a one-time manual copy of the data in the interim so this isn't dependent on it) the source data will be routinely populated.