### PR TITLE
Update golang buildchain Docker image

### DIFF
--- a/vulnfeeds/cmd/alpine/Dockerfile
+++ b/vulnfeeds/cmd/alpine/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21-alpine@sha256:445f34008a77b0b98bf1821bf7ef5e37bb63cc42d22ee7c21cc17041070d134f AS GO_BUILD
+FROM golang:1.21-alpine@sha256:f475434ea2047a83e9ba02a1da8efc250fa6b2ed0e9e8e4eb8c5322ea6997795 AS GO_BUILD
 
 RUN mkdir /src
 WORKDIR /src

--- a/vulnfeeds/cmd/combine-to-osv/Dockerfile
+++ b/vulnfeeds/cmd/combine-to-osv/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21-alpine@sha256:445f34008a77b0b98bf1821bf7ef5e37bb63cc42d22ee7c21cc17041070d134f AS GO_BUILD
+FROM golang:1.21-alpine@sha256:f475434ea2047a83e9ba02a1da8efc250fa6b2ed0e9e8e4eb8c5322ea6997795 AS GO_BUILD
 
 RUN mkdir /src
 WORKDIR /src

--- a/vulnfeeds/cmd/cperepos/Dockerfile
+++ b/vulnfeeds/cmd/cperepos/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21-alpine@sha256:445f34008a77b0b98bf1821bf7ef5e37bb63cc42d22ee7c21cc17041070d134f AS GO_BUILD
+FROM golang:1.21-alpine@sha256:f475434ea2047a83e9ba02a1da8efc250fa6b2ed0e9e8e4eb8c5322ea6997795 AS GO_BUILD
 
 RUN mkdir /src
 WORKDIR /src

--- a/vulnfeeds/cmd/download-cves/Dockerfile
+++ b/vulnfeeds/cmd/download-cves/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21-alpine@sha256:445f34008a77b0b98bf1821bf7ef5e37bb63cc42d22ee7c21cc17041070d134f AS GO_BUILD
+FROM golang:1.21-alpine@sha256:f475434ea2047a83e9ba02a1da8efc250fa6b2ed0e9e8e4eb8c5322ea6997795 AS GO_BUILD
 
 RUN mkdir /src
 WORKDIR /src

--- a/vulnfeeds/cpp/Dockerfile
+++ b/vulnfeeds/cpp/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.21-alpine@sha256:445f34008a77b0b98bf1821bf7ef5e37bb63cc42d22ee7c21cc17041070d134f AS GO_BUILD
+FROM golang:1.21-alpine@sha256:f475434ea2047a83e9ba02a1da8efc250fa6b2ed0e9e8e4eb8c5322ea6997795 AS GO_BUILD
 
 WORKDIR /go/src
 


### PR DESCRIPTION
https://hub.docker.com/layers/library/golang/1.21-alpine/images/sha256-f475434ea2047a83e9ba02a1da8efc250fa6b2ed0e9e8e4eb8c5322ea6997795?context=explore has less vulnerabilities in it

I wonder if we can get Dependabot to do something useful here?