### PR TITLE
Fix shell commands being difficult to copy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,11 +49,11 @@ Then you can set up the development environment by cloning the OSV repo and
 installing the Pipfile dependencies.
 
 ```shell
-$ git clone https://github.com/google/osv.dev
-$ cd osv.dev
-$ git submodule update --init --recursive
-$ pipenv sync --dev
-$ pipenv shell
+git clone https://github.com/google/osv.dev
+cd osv.dev
+git submodule update --init --recursive
+pipenv sync --dev
+pipenv shell
 ```
 
 ### Running tests
@@ -62,11 +62,14 @@ Certain tests require you to auth with the Google Cloud SDK and to install the
 Datastore Emulator:
 
 ```shell
-$ gcloud auth login --update-adc
-$ gcloud components install beta cloud-datastore-emulator
+gcloud auth login --update-adc
+gcloud components install beta cloud-datastore-emulator
 ```
 
-To run tests: `shell $ make all-tests`
+To run tests: 
+```shell 
+make all-tests
+```
 
 #### Test result generation
 
@@ -81,7 +84,7 @@ If a change is made that requires these outputs to be regenerated, you can set
 the environment variable `TESTS_GENERATE=1` and run the tests:
 
 ```shell
-$ TESTS_GENERATE=1 make all-tests
+TESTS_GENERATE=1 make all-tests
 ```
 
 ### Linting and formatting
@@ -89,18 +92,21 @@ $ TESTS_GENERATE=1 make all-tests
 To lint your code, run
 
 ```shell
-$ make lint
+make lint
 ```
 
-To format your code, run `shell $ yapf -i <file>.py`
+To format your code, run 
+```shell 
+yapf -i <file>.py
+```
 
 ### Running local UI and API instances (maintainers only)
 
 #### UI
 
 ```shell
-$ gcloud auth login --update-adc
-$ make run-appengine
+gcloud auth login --update-adc
+make run-appengine
 ```
 
 #### API
@@ -110,8 +116,8 @@ default credentials. The is required so that the ESP container has credentials
 to download API configuration.
 
 ```shell
-$ gcloud auth login --update-adc
-$ make run-api-server
+gcloud auth login --update-adc
+make run-api-server
 ```
 
 ## Contributing data


### PR DESCRIPTION
When shell commands are copied from the codeblocks, the leading '$' is copied as well, which is awkward for the setup process. This commit removes the leading '$'s from the code blocks and changes the incline shell code comments to code blocks so they can also be copied a lot easier.