### PR TITLE
Use the fully fledged struct for downloading

### DIFF
--- a/vulnfeeds/cves/cve.go
+++ b/vulnfeeds/cves/cve.go
@@ -15,29 +15,12 @@
 package cves
 
 import (
-	"encoding/json"
-	"io"
 	"time"
 )
 
 const (
 	CVE5TimeFormat = "2006-01-02T15:04:05"
 )
-
-type NVDCVE2 struct {
-	ResultsPerPage  *int              `json:"resultsPerPage"`
-	StartIndex      *int              `json:"startIndex"`
-	TotalResults    *int              `json:"totalResults"`
-	Format          *string           `json:"format"`
-	Version         *string           `json:"version"`
-	Timestamp       *string           `json:"timestamp"`
-	Vulnerabilities []json.RawMessage `json:"vulnerabilities"`
-}
-
-func (n *NVDCVE2) ToJSON(w io.Writer) error {
-	encoder := json.NewEncoder(w)
-	return encoder.Encode(n)
-}
 
 type CVE5 struct {
 	DataType    string `json:"dataType"`

--- a/vulnfeeds/cves/nvd2.go
+++ b/vulnfeeds/cves/nvd2.go
@@ -22,6 +22,7 @@ package cves
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -379,6 +380,11 @@ func (j *CPEMatch) UnmarshalJSON(b []byte) error {
 	}
 	*j = CPEMatch(plain)
 	return nil
+}
+
+func (n *CVEAPIJSON20Schema) ToJSON(w io.Writer) error {
+	encoder := json.NewEncoder(w)
+	return encoder.Encode(n)
 }
 
 // UnmarshalJSON implements json.Unmarshaler.


### PR DESCRIPTION
The hand-constructed NVD API 2.0 struct was naively done and appears to lead to nil pointer panics under certain conditions.