### PR TITLE
Import `osv.logs` in cron

### DIFF
--- a/docker/cron/backup/backup.py
+++ b/docker/cron/backup/backup.py
@@ -20,7 +20,7 @@ from google.cloud import ndb
 from google.cloud.datastore_admin_v1.services.datastore_admin import client \
     as ds_admin
 
-import osv
+import osv.logs
 
 
 def main():

--- a/docker/cron/make_bugs_public/make_bugs_public.py
+++ b/docker/cron/make_bugs_public/make_bugs_public.py
@@ -21,6 +21,7 @@ import requests
 
 import monorail
 import osv
+import osv.logs
 
 _MONORAIL_ACCOUNT = 'service@oss-vdb.iam.gserviceaccount.com'
 

--- a/docker/cron/process_results/process_results.py
+++ b/docker/cron/process_results/process_results.py
@@ -22,6 +22,7 @@ from google.cloud import ndb
 from google.cloud import pubsub_v1
 
 import osv
+import osv.logs
 
 _TASKS_TOPIC = 'projects/{project}/topics/{topic}'.format(
     project=os.environ['GOOGLE_CLOUD_PROJECT'], topic='tasks')


### PR DESCRIPTION
Python doesn't automatically load these submodules (all other `osv.X` seem to work as side effects of other imports)