### PR TITLE
Add dependency-management-data to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ tools and unsupported by the core OSV maintainers.
     IaC)](https://github.com/marcinguy/betterscan-ce)
 -   [bomber](https://github.com/devops-kung-fu/bomber)
 -   [Cortex XSOAR](https://github.com/demisto/content)
+-   [dependency-management-data](https://dmd.tanna.dev)
 -   [Dependency-Track](https://github.com/DependencyTrack/dependency-track)
 -   [dep-scan](https://github.com/AppThreat/dep-scan)
 -   [EZE-CLI: The one stop shop for security testing in modern development](https://github.com/RiverSafeUK/eze-cli)


### PR DESCRIPTION
As I'd not spotted this was different to the third party docs added in
2a4022c818232b32573841a6f506796a25d13120.
