### PR TITLE
Don't crash importer on invalid repo type

### DIFF
--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -462,7 +462,7 @@ class Importer:
       self._process_updates_bucket(source_repo)
       return
 
-    raise RuntimeError('Invalid repo type.')
+    logging.error('Invalid repo type: %s - %d', source_repo.name, source_repo.type)
 
   def process_oss_fuzz(self, oss_fuzz_source):
     """Process OSS-Fuzz source data."""

--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -462,7 +462,8 @@ class Importer:
       self._process_updates_bucket(source_repo)
       return
 
-    logging.error('Invalid repo type: %s - %d', source_repo.name, source_repo.type)
+    logging.error('Invalid repo type: %s - %d', source_repo.name,
+                  source_repo.type)
 
   def process_oss_fuzz(self, oss_fuzz_source):
     """Process OSS-Fuzz source data."""


### PR DESCRIPTION
@jess-lowe had to add a new repo type to the test instance for her work.
The test instance currently doesn't recognize it and crashes when it encounters it. Don't do that.