### PR TITLE
Revert go.mod minor version change

### DIFF
--- a/vulnfeeds/go.mod
+++ b/vulnfeeds/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/osv/vulnfeeds
 
-go 1.21.5
+go 1.21
 
 require (
 	cloud.google.com/go/logging v1.8.1


### PR DESCRIPTION
The go.mod minor version causes issues with older versions of go (1.20 and older).