### PR TITLE
Revert spicy-sections integrity change

### DIFF
--- a/gcp/appengine/frontend3/package-lock.json
+++ b/gcp/appengine/frontend3/package-lock.json
@@ -5003,7 +5003,7 @@
     "node_modules/spicy-sections": {
       "version": "0.9.0",
       "resolved": "git+ssh://git@github.com/tabvengers/spicy-sections.git#c3aae99dbf1e627cdf03a35c913d7f6e970de22b",
-      "integrity": "sha512-YyjgiaF9vhgpUL1NlXXrRljXJLeWs473YxVGoKWI/yAmimdqxFNrZ0eYqLHfsDjK1h0bzuyAVUkQZLuIg0UoUA==",
+      "integrity": "sha512-JazCiIP9ZXxiBmWeECJLShYHSf3kVBe92UTKvSqh5cSN3dgbkBaUm3Hu/NNngt7mSnQ9JCuuAq5F6O1mlWk/Jw==",
       "license": "W3C"
     },
     "node_modules/statuses": {


### PR DESCRIPTION
@renovate-bot  changed this to be invalid in https://github.com/google/osv.dev/pull/1893#discussion_r1446738483
Revert it to what it used to be.

I don't know how that happened