### PR TITLE
Stop Datastore emulator properly

### DIFF
--- a/docker/alias/alias_computation_test.py
+++ b/docker/alias/alias_computation_test.py
@@ -391,4 +391,4 @@ if __name__ == '__main__':
       context.set_cache_policy(False)
       unittest.main()
   finally:
-    ds_emulator.kill()
+    tests.stop_emulator()

--- a/docker/importer/importer_test.py
+++ b/docker/importer/importer_test.py
@@ -562,4 +562,4 @@ if __name__ == '__main__':
       context.set_cache_policy(False)
       unittest.main()
   finally:
-    ds_emulator.kill()
+    tests.stop_emulator()

--- a/docker/worker/worker_test.py
+++ b/docker/worker/worker_test.py
@@ -1425,4 +1425,4 @@ if __name__ == '__main__':
       context.set_cache_policy(False)
       unittest.main()
   finally:
-    ds_emulator.kill()
+    tests.stop_emulator()

--- a/osv/impact_test.py
+++ b/osv/impact_test.py
@@ -41,7 +41,7 @@ class UpdateAffectedCommitsTests(unittest.TestCase):
 
   @classmethod
   def tearDownClass(cls):
-    cls._ds_emulator.kill()
+    tests.stop_emulator()
     cls._ndb_context.__exit__(None, None, None)  # pylint: disable=unnecessary-dunder-call
 
   def test_update_single_page(self):

--- a/osv/tests.py
+++ b/osv/tests.py
@@ -164,6 +164,18 @@ def reset_emulator():
       'http://localhost:{}/reset'.format(port), timeout=_EMULATOR_TIMEOUT)
   resp.raise_for_status()
 
+def stop_emulator():
+  """Stops emulator."""
+  try:
+    port = os.environ.get('DATASTORE_EMULATOR_PORT', _DATASTORE_EMULATOR_PORT)
+    resp = requests.post(
+        'http://localhost:{}/shutdown'.format(port), timeout=_EMULATOR_TIMEOUT)
+    resp.raise_for_status()
+  except Exception as e:
+    # Something went wrong, manually kill all datastore processes instead.
+    os.system('pkill -f datastore')
+    raise e
+
 
 def mock_datetime(test):
   """Mocks datetime."""

--- a/osv/tests.py
+++ b/osv/tests.py
@@ -164,6 +164,7 @@ def reset_emulator():
       'http://localhost:{}/reset'.format(port), timeout=_EMULATOR_TIMEOUT)
   resp.raise_for_status()
 
+
 def stop_emulator():
   """Stops emulator."""
   try:


### PR DESCRIPTION
Killing the main datastore process leave its child processes running and orphaned.
Should've tested this properly before :upside_down_face:

Used the `/shutdown` endpoint that [apparently exists](https://github.com/googleapis/java-datastore/blob/1849e0be44e94fbfa48211484de4af602ca6b614/google-cloud-datastore/src/main/java/com/google/cloud/datastore/testing/LocalDatastoreHelper.java#L323) (and works!).
I have no idea if there's proper documentation for this...