### PR TITLE
Fixed logging all of the successful GET commands during testing.

### DIFF
--- a/docker/mock_test/mock_test_handler.py
+++ b/docker/mock_test/mock_test_handler.py
@@ -53,3 +53,10 @@ class MockDataHandler(http.server.BaseHTTPRequestHandler):
     self.send_header('Content-Type', 'application/json')
     self.send_header('Last-Modified', self.last_modified)
     self.end_headers()
+
+  def log_message(self, format: str, *args) -> None:  # pylint: disable=redefined-builtin
+    # Disable logging messages if the response is 200
+    if args[1] != '200':
+      super().log_message(format, *args)
+    else:
+      pass

--- a/docker/mock_test/mock_test_handler.py
+++ b/docker/mock_test/mock_test_handler.py
@@ -58,5 +58,4 @@ class MockDataHandler(http.server.BaseHTTPRequestHandler):
     # Disable logging messages if the response is 200
     if args[1] != '200':
       super().log_message(format, *args)
-    else:
-      pass
+

--- a/docker/mock_test/mock_test_handler.py
+++ b/docker/mock_test/mock_test_handler.py
@@ -58,4 +58,3 @@ class MockDataHandler(http.server.BaseHTTPRequestHandler):
     # Disable logging messages if the response is 200
     if args[1] != '200':
       super().log_message(format, *args)
-


### PR DESCRIPTION
The constant spam of successful GET requests, while a good indication that the request is successful, is unnecessary. 

Now it will just log nothing if it is a successful (200) error, and do its normal thing when it's unsuccessful.