### PR TITLE
Fixed vulnerability having no repo field causing 500 errors.

### DIFF
--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -88,7 +88,9 @@
       {% set package = affected.package.name %}
       {% else %}
       {% set ecosystem = 'Git' %}
+      {% if vulnerability.repo %}
       {% set package = vulnerability.repo | strip_scheme %}
+      {% endif %}
       {% endif %}
       <h2 class="package-header">
         <span class="vuln-ecosystem spicy-sections-workaround">{{ ecosystem }}</span>


### PR DESCRIPTION
The vulnerabilities missing packages/ecosystems were causing issues in that they also had no repo field, which caused 500 errors on these endpoints. 