### PR TITLE
modify job permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,7 +21,7 @@ on:
     branches: [ master ]
 
 
-permissions: read-all
+permissions: {}
 
 jobs:
   analyze:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,7 +23,8 @@ on:
   merge_group:
     branches: [ master ]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   lint:

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -8,7 +8,7 @@ on:
     branches: [ master ]
 
 # Declare default permissions as read only.
-permissions: read-all
+permissions: {}
 
 jobs:
   analysis:


### PR DESCRIPTION
Some of the jobs has unnecessary `read-all` access, this PR modifies the default access to none and a job can overwrite the permission.