### PR TITLE
Bias future-year-proofing for the most recent year

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/nvd-cve-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/nvd-cve-osv.yaml
@@ -27,8 +27,8 @@ spec:
             env:
               - name: WORK_DIR
                 value: /tmp
-              - name: IN_SCOPE_YEARS
-                value: "2023 2022 2021 2020 2019 2018 2017 2016"
+              - name: FIRST_INSCOPE_YEAR
+                value: "2016"
           restartPolicy: OnFailure
           volumes:
             - name: "ssd"

--- a/vulnfeeds/cmd/nvd-cve-osv/run_cve_to_osv_generation.sh
+++ b/vulnfeeds/cmd/nvd-cve-osv/run_cve_to_osv_generation.sh
@@ -30,10 +30,7 @@ gcloud --no-user-output-enabled storage -q cp "${NVD_GCS_PATH}/*-????.json" "${W
 echo "Downloading latest CPE Git repository map"
 gcloud --no-user-output-enabled storage -q cp "${CPEREPO_GCS_PATH}" "${WORK_DIR}"
 
-# Dirty hack to get around https://stackoverflow.com/questions/68528541/env-variable-array
-# https://stackoverflow.com/questions/9293887/reading-a-space-delimited-string-into-an-array-in-bash/9294015
-IN_SCOPE_YEARS=($IN_SCOPE_YEARS)
-for (( YEAR = 2002 ; YEAR <= $(date +%Y) ; YEAR++ )); do
+for (( YEAR = $(date +%Y) ; YEAR >= ${FIRST_INSCOPE_YEAR} ; YEAR-- )); do
   # Run OSV record generation.
   echo "Converting NVD CVE records from ${YEAR} to OSV"
   /usr/local/bin/nvd-cve-osv \


### PR DESCRIPTION
Improve on the quick fix shoe-horned into PR #1936 by restoring external configurability of the oldest desired year and biasing for the current and more recent years first (because Andrew hates delayed gratification)