### PR TITLE
Ignore reference resolution errors in indexer preparation.

### DIFF
--- a/docker/indexer/stages/preparation/preparation.go
+++ b/docker/indexer/stages/preparation/preparation.go
@@ -151,7 +151,9 @@ func (s *Stage) processGit(ctx context.Context, repoCfg *config.RepoConfig) erro
 		commitHash, err := repo.ResolveRevision(plumbing.Revision(ref.Name().String()))
 
 		if err != nil {
-			return err
+			log.Errorf("Failed to resolve %s: %v", ref.Name().String(), err)
+			// Ignore errors as this will block the iteration otherwise.
+			return nil
 		}
 
 		found, err := s.Checker.Exists(ctx, repoCfg.Address, shared.MD5, ref.Hash())


### PR DESCRIPTION
This is blocking tags in libuv from being processed. With this change, these errors will be logged and ignored so tags later in the iteration are not ignored.

libuv example:
```
E0212 23:28:24.789819   23579 preparation.go:158] Failed to resolve refs/tags/pubkey-bnoordhuis: unsupported object type
E0212 23:28:24.789910   23579 preparation.go:158] Failed to resolve refs/tags/pubkey-cjihrig: unsupported object type
E0212 23:28:24.789991   23579 preparation.go:158] Failed to resolve refs/tags/pubkey-cjihrig-kb: unsupported object typeE0212 23:28:24.789819   23579 preparation.go:158] Failed to resolve refs/tags/pubkey-bnoordhuis: unsupported object type
E0212 23:28:24.789910   23579 preparation.go:158] Failed to resolve refs/tags/pubkey-cjihrig: unsupported object type
E0212 23:28:24.789991   23579 preparation.go:158] Failed to resolve refs/tags/pubkey-cjihrig-kb: unsupported object type
```