### PR TITLE
Revert spicy-sections sha back

### DIFF
--- a/gcp/appengine/frontend3/package-lock.json
+++ b/gcp/appengine/frontend3/package-lock.json
@@ -5049,7 +5049,8 @@
     "node_modules/spicy-sections": {
       "version": "0.9.0",
       "resolved": "git+ssh://git@github.com/tabvengers/spicy-sections.git#c3aae99dbf1e627cdf03a35c913d7f6e970de22b",
-      "integrity": "sha512-YyjgiaF9vhgpUL1NlXXrRljXJLeWs473YxVGoKWI/yAmimdqxFNrZ0eYqLHfsDjK1h0bzuyAVUkQZLuIg0UoUA=="
+      "integrity": "sha512-JazCiIP9ZXxiBmWeECJLShYHSf3kVBe92UTKvSqh5cSN3dgbkBaUm3Hu/NNngt7mSnQ9JCuuAq5F6O1mlWk/Jw==",
+      "license": "W3C"
     },
     "node_modules/statuses": {
       "version": "2.0.1",


### PR DESCRIPTION
Not sure why the package sha is updated while the version remains the same.
PR https://github.com/google/osv.dev/pull/2012/files