### PR TITLE
Backup AffectedCommits in a separate bucket.

### DIFF
--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/backup.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/backup.yaml
@@ -14,3 +14,5 @@ spec:
               value: "oss-vdb-test"
             - name: BACKUP_BUCKET
               value: "osv-test-backup"
+            - name: AFFECTED_COMMITS_BACKUP_BUCKET
+              value: "osv-test-affected-commits"

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/backup.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/backup.yaml
@@ -14,3 +14,5 @@ spec:
               value: "oss-vdb"
             - name: BACKUP_BUCKET
               value: "osv-backup"
+            - name: AFFECTED_COMMITS_BACKUP_BUCKET
+              value: "osv-affected-commits"

--- a/deployment/terraform/environments/oss-vdb-test/main.tf
+++ b/deployment/terraform/environments/oss-vdb-test/main.tf
@@ -3,13 +3,15 @@ module "osv_test" {
 
   project_id = "oss-vdb-test"
 
-  public_import_logs_bucket     = "osv-test-public-import-logs"
-  vulnerabilities_export_bucket = "osv-test-vulnerabilities"
-  logs_bucket                   = "osv-test-logs"
-  cve_osv_conversion_bucket     = "osv-test-cve-osv-conversion"
-  debian_osv_conversion_bucket  = "osv-test-debian-osv"
-  backups_bucket                = "osv-test-backup"
-  backups_bucket_retention_days = 5
+  public_import_logs_bucket                      = "osv-test-public-import-logs"
+  vulnerabilities_export_bucket                  = "osv-test-vulnerabilities"
+  logs_bucket                                    = "osv-test-logs"
+  cve_osv_conversion_bucket                      = "osv-test-cve-osv-conversion"
+  debian_osv_conversion_bucket                   = "osv-test-debian-osv"
+  backups_bucket                                 = "osv-test-backup"
+  backups_bucket_retention_days                  = 5
+  affected_commits_backups_bucket                = "osv-test-affected-commits"
+  affected_commits_backups_bucket_retention_days = 2
 
   api_url     = "api.test.osv.dev"
   esp_version = "2.41.0"

--- a/deployment/terraform/environments/oss-vdb/main.tf
+++ b/deployment/terraform/environments/oss-vdb/main.tf
@@ -3,13 +3,15 @@ module "osv" {
 
   project_id = "oss-vdb"
 
-  public_import_logs_bucket     = "osv-public-import-logs"
-  vulnerabilities_export_bucket = "osv-vulnerabilities"
-  cve_osv_conversion_bucket     = "cve-osv-conversion"
-  debian_osv_conversion_bucket  = "debian-osv"
-  logs_bucket                   = "osv-logs"
-  backups_bucket                = "osv-backup"
-  backups_bucket_retention_days = 60
+  public_import_logs_bucket                      = "osv-public-import-logs"
+  vulnerabilities_export_bucket                  = "osv-vulnerabilities"
+  cve_osv_conversion_bucket                      = "cve-osv-conversion"
+  debian_osv_conversion_bucket                   = "debian-osv"
+  logs_bucket                                    = "osv-logs"
+  backups_bucket                                 = "osv-backup"
+  backups_bucket_retention_days                  = 60
+  affected_commits_backups_bucket                = "osv-affected-commits"
+  affected_commits_backups_bucket_retention_days = 3
 
   api_url     = "api.osv.dev"
   esp_version = "2.41.0"

--- a/deployment/terraform/modules/osv/main.tf
+++ b/deployment/terraform/modules/osv/main.tf
@@ -154,6 +154,24 @@ resource "google_storage_bucket" "backups_bucket" {
   }
 }
 
+resource "google_storage_bucket" "affected_commits_backups_bucket" {
+  project                     = var.project_id
+  name                        = var.affected_commits_backups_bucket
+  location                    = "US"
+  uniform_bucket_level_access = true
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      age = var.affected_commits_backups_bucket_retention_days
+    }
+  }
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 # Service account permissions
 resource "google_service_account" "deployment_service" {
   project      = var.project_id

--- a/deployment/terraform/modules/osv/variables.tf
+++ b/deployment/terraform/modules/osv/variables.tf
@@ -28,6 +28,16 @@ variable "backups_bucket_retention_days" {
   description = "Number of days to retain osv backups"
 }
 
+variable "affected_commits_backups_bucket" {
+  type        = string
+  description = "Name of bucket to backup osv AffectedCommits entries to."
+}
+
+variable "affected_commits_backups_bucket_retention_days" {
+  type        = number
+  description = "Number of days to retain osv AffectedCommits backups"
+}
+
 variable "cve_osv_conversion_bucket" {
   type        = string
   description = "Name of bucket to store converted CVEs in."

--- a/docker/cron/backup/backup.py
+++ b/docker/cron/backup/backup.py
@@ -17,6 +17,7 @@
 import os
 import sys
 from google.cloud import ndb
+from google.cloud import datastore_admin_v1
 from google.cloud.datastore_admin_v1.services.datastore_admin import client \
     as ds_admin
 
@@ -27,9 +28,17 @@ def main():
   """Create a Datastore backup."""
   client = ds_admin.DatastoreAdminClient()
   backup_bucket = os.environ['BACKUP_BUCKET']
+  affected_commits_backup_bucket = os.environ['AFFECTED_COMMITS_BACKUP_BUCKET']
   project_id = os.environ['GOOGLE_CLOUD_PROJECT']
   client.export_entities(
       project_id=project_id, output_url_prefix=f'gs://{backup_bucket}')
+
+  entity_filter = datastore_admin_v1.EntityFilter()
+  entity_filter.kinds = ['AffectedCommits']
+  client.export_entities(
+      project_id=project_id,
+      output_url_prefix=f'gs://{affected_commits_backup_bucket}',
+      entity_filter=entity_filter)
 
   return 0
 


### PR DESCRIPTION
The existing backup doesn't easily distinguish between entity types. This makes it easier for internal consumers to use our AffectedCommits data.

Using a different bucket here so we can set a different lifecycle policy (3 days TTL) than our existing backup bucket (60 days TTL).