### PR TITLE
Fix use of `mktemp` on alpine

### DIFF
--- a/deployment/terraform/modules/osv/scripts/gcloud_build_image
+++ b/deployment/terraform/modules/osv/scripts/gcloud_build_image
@@ -96,7 +96,7 @@ if [ -z "${ESP_FULL_VERSION}" ]; then
 fi
 echo "Building image for ESP version: ${ESP_FULL_VERSION}"
 
-tempdir="$(mktemp -d /tmp/docker.XXXX)"
+tempdir="$(mktemp -d /tmp/docker.XXXXXX)"
 cd "${tempdir}"
 
 # Be careful about exposing the access token.


### PR DESCRIPTION
The `mktemp` command on our alpine terraform image is actually stricter about what it accepts, causing a fail it to fail to apply.
```
/ # mktemp --help
BusyBox v1.36.1 (2023-07-27 17:12:24 UTC) multi-call binary.

Usage: mktemp [-dt] [-p DIR] [TEMPLATE]

Create a temporary file with name based on TEMPLATE and print its name.
TEMPLATE must end with XXXXXX (e.g. [/dir/]nameXXXXXX).
Without TEMPLATE, -t tmp.XXXXXX is assumed.

	-d	Make directory, not file
	-q	Fail silently on errors
	-t	Prepend base directory name to TEMPLATE
	-p DIR	Use DIR as a base directory (implies -t)
	-u	Do not create anything; print a name

Base directory is: -p DIR, else $TMPDIR, else /tmp
```
Namely:
> TEMPLATE must end with XXXXXX

We've just never updated the ESP image since we changed the terraform image to use alpine.

Changed the usage of mktemp to have the required 6 X's