### PR TITLE
Disable Dockerfile Python upgrading

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -61,6 +61,11 @@
     {
       "matchFileNames": ["Pipfile"],
       "groupName": "osv-lib"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["python"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Prevent Renovate from upgrading Python base image in `Dockerfiles`

Add a new `packageRule` to maintain `python:3.11-slim` for stability in docker. Renovate was previously [automatically upgrading](https://github.com/google/osv.dev/pull/2000/files) this image, causing potential compatibility issues.

