### PR TITLE
Make the copying more resilient

### DIFF
--- a/vulnfeeds/cmd/nvd-cve-osv/run_cve_to_osv_generation.sh
+++ b/vulnfeeds/cmd/nvd-cve-osv/run_cve_to_osv_generation.sh
@@ -46,7 +46,7 @@ for (( YEAR = $(date +%Y) ; YEAR >= ${FIRST_INSCOPE_YEAR} ; YEAR-- )); do
   # Copy results to staging area.
   echo "Copying NVD CVE records from ${YEAR} successfully converted to OSV to aggregated staging"
   find "${WORK_DIR}/nvd2osv/${YEAR}" -type f -name \*.json \
-    | xargs cp -t "${WORK_DIR}/nvd2osv/gcs_stage"
+    -exec cp '{}' "${WORK_DIR}/nvd2osv/gcs_stage/" \;
 
   # Copy conversion summary to GCS bucket.
   DURABLE_OUTCOMES_CSV="${OSV_OUTPUT_GCS_PATH}/nvd-conversion-outcomes-${YEAR}-$(date -Iminutes).csv"


### PR DESCRIPTION
Some filenames wind up with an embedded quote character or are very long due to the CPE vendor/product name and this seemed to cause some copy operations to fail.