### PR TITLE
Also stage the CSV conversion summary

### DIFF
--- a/vulnfeeds/cmd/nvd-cve-osv/run_cve_to_osv_generation.sh
+++ b/vulnfeeds/cmd/nvd-cve-osv/run_cve_to_osv_generation.sh
@@ -48,11 +48,11 @@ for (( YEAR = $(date +%Y) ; YEAR >= ${FIRST_INSCOPE_YEAR} ; YEAR-- )); do
   find "${WORK_DIR}/nvd2osv/${YEAR}" -type f -name \*.json \
     -exec cp '{}' "${WORK_DIR}/nvd2osv/gcs_stage/" \;
 
-  # Copy conversion summary to GCS bucket.
-  DURABLE_OUTCOMES_CSV="${OSV_OUTPUT_GCS_PATH}/nvd-conversion-outcomes-${YEAR}-$(date -Iminutes).csv"
-  gcloud --no-user-output-enabled storage -q cp "${WORK_DIR}/nvd2osv/${YEAR}/outcomes.csv" "$DURABLE_OUTCOMES_CSV"
+  # Copy conversion summary staging area.
+  DURABLE_OUTCOMES_CSV="nvd-conversion-outcomes-${YEAR}-$(date -Iminutes).csv"
+  cp "${WORK_DIR}/nvd2osv/${YEAR}/outcomes.csv" "${WORK_DIR}/nvd2osv/gcs_stage/${DURABLE_OUTCOMES_CSV}"
 
-  echo "Results summary available at $DURABLE_OUTCOMES_CSV"
+  echo "Results summary will be available in ${OSV_OUTPUT_GCS_PATH}/${DURABLE_OUTCOMES_CSV}"
 done
 
 # Copy results to GCS bucket.


### PR DESCRIPTION
Pre-copying the CSV summary to GCS before the final rsync with `--delete-unmatched` (as introduced in #2023) just means that they don't survive :-(