### PR TITLE
Lower concurrency to improve performance

### DIFF
--- a/deployment/clouddeploy/osv-api/run.yaml
+++ b/deployment/clouddeploy/osv-api/run.yaml
@@ -20,4 +20,4 @@ spec:
           failureThreshold: 3
           periodSeconds: 10
       timeoutSeconds: 60
-      containerConcurrency: 10
+      containerConcurrency: 5

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -1007,7 +1007,7 @@ def query_by_package(context: QueryContext, package_name: str, ecosystem: str,
 
 def serve(port: int, local: bool):
   """Configures and runs the OSV API server."""
-  server = grpc.server(concurrent.futures.ThreadPoolExecutor(max_workers=10))
+  server = grpc.server(concurrent.futures.ThreadPoolExecutor(max_workers=5))
   servicer = OSVServicer()
   osv_service_v1_pb2_grpc.add_OSVServicer_to_server(servicer, server)
   health_pb2_grpc.add_HealthServicer_to_server(servicer, server)


### PR DESCRIPTION
Reduce concurrency from 10 to 5 to reduce the number of inflight data store queries are being made per instance. This is an attempt at fixing the latency/timeout issues for the batch_query API endpoint.