### PR TITLE
Allow for json fields in python logs

### DIFF
--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -130,16 +130,18 @@ class OSVServicer(osv_service_v1_pb2_grpc.OSVServicer,
     # Log some information about the query with structured logging
     qtype, ecosystem, versioned = query_info(request.query)
     if ecosystem is not None:
-      # TODO(michaelkedar): work out how to combine json_fields with osv/logs.py
-      import json
       logging.info(
-          'QueryAffected for %s "%s"\n%s', qtype, ecosystem,
-          json.dumps({
-              'details': {
-                  'ecosystem': ecosystem,
-                  'versioned': versioned == 'versioned'
+          'QueryAffected for %s "%s"',
+          qtype,
+          ecosystem,
+          extra={
+              'json_fields': {
+                  'details': {
+                      'ecosystem': ecosystem,
+                      'versioned': versioned == 'versioned'
+                  }
               }
-          }))
+          })
     else:
       logging.info('QueryAffected for %s', qtype)
 
@@ -217,11 +219,12 @@ class OSVServicer(osv_service_v1_pb2_grpc.OSVServicer,
     # Filter out empty fields
     query_details = {k: v for k, v in query_details.items() if v}
 
-    # TODO(michaelkedar): work out how to combine json_fields with osv/logs.py
-    import json
-    logging.info('QueryAffectedBatch with %d queries\n%s',
-                 len(request.query.queries),
-                 json.dumps({'details': query_details}))
+    logging.info(
+        'QueryAffectedBatch with %d queries',
+        len(request.query.queries),
+        extra={'json_fields': {
+            'details': query_details
+        }})
 
     if len(request.query.queries) > _MAX_BATCH_QUERY:
       context.abort(grpc.StatusCode.INVALID_ARGUMENT, 'Too many queries.')

--- a/osv/logs.py
+++ b/osv/logs.py
@@ -19,7 +19,7 @@ from google.cloud import logging as google_logging
 
 class _ErrorReportingFilter:
   """
-  A logging filter that adds necessary json fields to error logs so that they
+  A logging filter that adds necessary JSON fields to error logs so that they
   can be picked up by Error Reporting.
   
   https://cloud.google.com/error-reporting/docs/formatting-error-messages#log-text


### PR DESCRIPTION
The way Error Reporting information was being added to logs was preventing us from adding additional `json_fields` to our logs.
Changed from inserting Error Reporting information in a Log Record Factory to a Log Filter.
See: https://docs.python.org/3/howto/logging-cookbook.html#using-filters-to-impart-contextual-information

Also put the API logged fields back into the json data.