### PR TITLE
Add trace to API logs

### DIFF
--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -110,6 +110,7 @@ def trace_log_fields(context: grpc.ServicerContext) -> dict:
   if trace_context is None:
     return fields
 
+# Trace context header example: "X-Cloud-Trace-Context: TRACE_ID/SPAN_ID;o=TRACE_TRUE"
   parts = trace_context.split('/')
   trace_id = parts[0]
   # We don't set the GOOGLE_CLOUD_PROJECT env var explicitly, and I can't find

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -110,7 +110,8 @@ def trace_log_fields(context: grpc.ServicerContext) -> dict:
   if trace_context is None:
     return fields
 
-# Trace context header example: "X-Cloud-Trace-Context: TRACE_ID/SPAN_ID;o=TRACE_TRUE"
+  # Trace context header example:
+  # "X-Cloud-Trace-Context: TRACE_ID/SPAN_ID;o=TRACE_TRUE"
   parts = trace_context.split('/')
   trace_id = parts[0]
   # We don't set the GOOGLE_CLOUD_PROJECT env var explicitly, and I can't find


### PR DESCRIPTION
Adds the trace fields to most of the logs produced by the API, so it's easier correlate the logs to their requests.

Relevant links:
https://cloud.google.com/trace/docs/setup#force-trace
https://cloud.google.com/logging/docs/agent/logging/configuration#special-fields