### PR TITLE
Set up second Cloud Run backend for batch queries (part 1)

### DIFF
--- a/deployment/clouddeploy/osv-api/run-batch.yaml
+++ b/deployment/clouddeploy/osv-api/run-batch.yaml
@@ -1,0 +1,26 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: osv-grpc-backend-batch
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/maxScale: '100'
+    spec:
+      containers:
+      - image: osv-server
+        resources:
+          limits:
+            memory: 4Gi
+        startupProbe:
+          grpc:
+            service: osv.v1.OSV
+        livenessProbe:
+          grpc:
+            service: osv.v1.OSV
+          timeoutSeconds: 5
+          failureThreshold: 3
+          periodSeconds: 10
+      timeoutSeconds: 60
+      containerConcurrency: 1

--- a/deployment/clouddeploy/osv-api/skaffold.yaml
+++ b/deployment/clouddeploy/osv-api/skaffold.yaml
@@ -9,11 +9,13 @@ profiles:
   manifests:
     rawYaml:
     - run.yaml
+    - run-batch.yaml
 
 - name: prod
   manifests:
     rawYaml:
     - run.yaml
+    - run-batch.yaml
 
 deploy:
   cloudrun: {}

--- a/deployment/terraform/modules/osv/osv_api.tf
+++ b/deployment/terraform/modules/osv/osv_api.tf
@@ -29,6 +29,29 @@ resource "google_cloud_run_service" "api_backend" {
   }
 }
 
+resource "google_cloud_run_v2_service" "api_backend_batch" {
+  project  = var.project_id
+  name     = "osv-grpc-backend-batch"
+  location = "us-central1"
+
+  template {
+    containers {
+      image = "us-docker.pkg.dev/cloudrun/container/hello:latest" # Placeholder image.
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # To be managed by Cloud Deploy.
+      template,
+      traffic,
+      labels,
+      client
+    ]
+    prevent_destroy = true
+  }
+}
+
 variable "_api_descriptor_file" {
   # This isn't actually sensitive, but it's outputted as a massive base64 string which really floods the plan output.
   sensitive = true


### PR DESCRIPTION
Make a duplicate Cloud Run API backend with no concurrent requests for processing batch queries.
Don't route traffic to it yet - the traffic routing is controlled by terraform which is run before Cloud Deploy and we don't want it to completely take down our batch queries if something goes wrong.