### PR TITLE
Set up second Cloud Run backend for batch queries (part 2)

### DIFF
--- a/deployment/terraform/environments/oss-vdb-test/api/api_config.tftpl
+++ b/deployment/terraform/environments/oss-vdb-test/api/api_config.tftpl
@@ -31,3 +31,6 @@ backend:
     - selector: "*"
       address: ${backend_url}
       deadline: 60
+    - selector: "osv.v1.OSV.QueryAffectedBatch"
+      address: ${backend_batch_url}
+      deadline: 60

--- a/deployment/terraform/environments/oss-vdb/api/api_config.tftpl
+++ b/deployment/terraform/environments/oss-vdb/api/api_config.tftpl
@@ -31,6 +31,9 @@ backend:
     - selector: "*"
       address: ${backend_url}
       deadline: 60
+    - selector: "osv.v1.OSV.QueryAffectedBatch"
+      address: ${backend_batch_url}
+      deadline: 60
 documentation:
   summary: >
     OSV is a vulnerability database for open source projects. It exposes an API

--- a/deployment/terraform/modules/osv/osv_api.tf
+++ b/deployment/terraform/modules/osv/osv_api.tf
@@ -65,8 +65,9 @@ resource "google_endpoints_service" "grpc_service" {
   grpc_config = templatefile(
     "api/api_config.tftpl",
     {
-      service_name = var.api_url,
-      backend_url  = replace(google_cloud_run_service.api_backend.status[0].url, "https://", "grpcs://")
+      service_name      = var.api_url,
+      backend_url       = replace(google_cloud_run_service.api_backend.status[0].url, "https://", "grpcs://")
+      backend_batch_url = replace(google_cloud_run_v2_service.api_backend_batch.uri, "https://", "grpcs://")
   })
   protoc_output_base64 = filebase64(var._api_descriptor_file)
 }


### PR DESCRIPTION
Merge this after #2057 / #2058 has been released.

Route batch query traffic to the new Cloud Run service.