### PR TITLE
Add the Ubuntu OSV data source to production

### DIFF
--- a/source.yaml
+++ b/source.yaml
@@ -281,6 +281,7 @@
   extension: '.json'
   db_prefix: 'USN-'
   ignore_git: False
+  human_link: 'https://ubuntu.com/security/notices/{{ BUG_ID }}'
   link: 'https://github.com/canonical/ubuntu-security-notices/blob/main/'
   editable: False
 

--- a/source.yaml
+++ b/source.yaml
@@ -271,6 +271,19 @@
   editable: False
   repo_username: git
 
+- name: 'ubuntu'
+  versions_from_repo: False
+  type: 0
+  ignore_patterns: []
+  directory_path: 'osv'
+  repo_url: 'https://github.com/canonical/ubuntu-security-notices.git'
+  detect_cherrypicks: False
+  extension: '.json'
+  db_prefix: 'USN-'
+  ignore_git: False
+  link: 'https://github.com/canonical/ubuntu-security-notices/blob/main/'
+  editable: False
+
 - name: uvi
   versions_from_repo: True
   type: 0

--- a/source_test.yaml
+++ b/source_test.yaml
@@ -268,6 +268,7 @@
   extension: '.json'
   db_prefix: 'USN-'
   ignore_git: False
+  human_link: 'https://ubuntu.com/security/notices/{{ BUG_ID }}'
   link: 'https://github.com/canonical/ubuntu-security-notices/blob/main/'
   editable: False
 


### PR DESCRIPTION
Caveat: The lack of version enumeration greatly reduces the utility of this data.