### PR TITLE
Add Mageia to source_test.yaml (#2089)

### DIFF
--- a/source_test.yaml
+++ b/source_test.yaml
@@ -170,6 +170,19 @@
   editable: False
   repo_username: 'git'
 
+- name: mageia
+  versions_from_repo: False
+  rest_api_url: 'https://advisories.mageia.org/vulns.json'
+  type: 2
+  directory_path: .
+  detect_cherrypicks: False
+  extension: .json
+  db_prefix: MGASA-
+  ignore_git: True
+  human_link: 'https://advisories.mageia.org/{{ BUG_ID }}.html'
+  link: https://advisories.mageia.org/
+  editable: False
+
 - name: 'malicious-packages'
   versions_from_repo: False
   type: 0


### PR DESCRIPTION
No other source seems to use the style of index Mageia has (not even Go,
which is was derived from), so this probably isn't useful as-is without
code changes.