### PR TITLE
Add 404 template

### DIFF
--- a/gcp/appengine/frontend3/src/base.html
+++ b/gcp/appengine/frontend3/src/base.html
@@ -24,6 +24,7 @@
 
 <body>
   <div class="wrapper {{'decorated' if active_section == 'home'}}">
+    {% block top_bar %}
     <header class="top-bar">
       <div class="logo">
         <a href="{{ url_for('frontend_handlers.index') }}" aria-label="Home page">
@@ -63,6 +64,7 @@
         </li>
       </ul>
     </header>
+    {% endblock %}
     {% block content %}{% endblock %}
   </div>
   <link href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" rel="stylesheet">

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -7,6 +7,7 @@ $osv-accent-color-hover: #c5221fb2;
 $osv-red-300: #ec928e;
 $osv-grey-600: #80868b;
 $osv-grey-800: #3C4043;
+$osv-cyan-300: #C9F5F7;
 $osv-body-font-family: string.unquote('Overpass, sans-serif');
 $osv-heading-font-family: string.unquote('"Overpass Mono", monospace');
 $osv-heading-size: 60px;
@@ -1271,7 +1272,7 @@ div.highlight {
   }
 
   a {
-    color: #C9F5F7
+    color: $osv-cyan-300
   }
 
   .author {
@@ -1288,5 +1289,80 @@ div.highlight {
     width: 100%;
     margin: 0 auto;
     font-size: 16px;
+  }
+}
+
+/** 404 page */
+.not-found-page {
+  height: 100%;
+  margin: 0;
+  align-items: center;
+  justify-content: center;
+  font-family: $osv-heading-font-family;
+  color: $osv-text-color;
+  font-size: 15px;
+  max-width: 1200px;
+  margin: 0 auto;
+
+  .mdc-layout-grid__cell--span-12 {
+    margin: 0 24px;
+  }
+
+  .text-info {
+    max-width: 900px;
+    margin: 20px auto 0;
+
+    .heading {
+      font-size: $osv-heading-size;
+      text-align: center;
+      margin-bottom: 32px;
+    }
+
+    @media (max-width: $osv-mobile-breakpoint) {
+      .heading {
+        font-size: $osv-heading-size-mobile;
+      }
+    }
+
+    .description {
+      font-size: 20px;
+      line-height: 26px;
+      margin-bottom: 24px;
+      margin-left: 8px;
+      margin-right: 8px;
+      text-align: center;
+    }
+
+    .cta {
+      margin: 32px 0;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 4px;
+    }
+
+    h2,h3,h4 {
+      line-height: 1.1;
+      font-weight: 300;
+      margin-top: 3rem;
+      margin-bottom: 1.5rem;
+    }
+    
+    p {
+      margin-bottom: 16px;
+      line-height: 1.6;
+    }
+    
+    a {
+      color: $osv-cyan-300;
+    }
+  }
+
+  footer {
+    background: url('/static/img/footer-decoration.png');
+    background-repeat: no-repeat;
+    background-position: center;
+    min-height: 500px;
+    width: 100%;
   }
 }

--- a/gcp/appengine/frontend3/src/templates/404.html
+++ b/gcp/appengine/frontend3/src/templates/404.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+
+{% block top_bar %} {% endblock %}
+
+{% block content %}
+<div class="mdc-layout-grid not-found-page">
+    <div class="mdc-layout-grid__inner">
+        <div class="mdc-layout-grid__cell--span-12 text-info">
+            <h2 class="heading">Oops! Page Not Found!</h2>
+            <p class="description">
+                While you're here, why not check out our
+                <a href="https://google.github.io/osv.dev/">documentation</a> or
+                <a href="https://google.github.io/osv.dev/faq/">FAQ</a>?
+            </p>
+            <div class="cta">
+                <a class="cta-primary link-button" href="{{ url_for('frontend_handlers.index') }}"
+                    aria-label="Get me back Home!">Back to Home</a>
+            </div>
+        </div>
+    </div>
+    <footer></footer>
+</div>
+{% endblock %}

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -38,6 +38,7 @@ import osv
 import rate_limiter
 import source_mapper
 import utils
+from werkzeug import exceptions
 
 blueprint = Blueprint('frontend_handlers', __name__)
 
@@ -590,3 +591,8 @@ def list_packages(vuln_affected: list[dict]):
           packages.append(parsed_scheme)
 
   return packages
+
+
+@blueprint.app_errorhandler(404)
+def not_found_error(error: exceptions.HTTPException):
+  return render_template('404.html'), 404

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -17,6 +17,7 @@ import json
 import os
 import math
 import re
+import logging
 
 from flask import abort
 from flask import current_app
@@ -595,4 +596,5 @@ def list_packages(vuln_affected: list[dict]):
 
 @blueprint.app_errorhandler(404)
 def not_found_error(error: exceptions.HTTPException):
+  logging.info('Handled %s - Path attempted: %s', error, request.path)
   return render_template('404.html'), 404


### PR DESCRIPTION
This change, adds a custom 404 page. The new template extends the existing base template and uses the existing styles.

issue: https://github.com/google/osv.dev/issues/1556

Here is how it looks:
 
**On desktop screen**
<img width="1310" alt="Screenshot 2024-04-17 at 4 30 14 pm" src="https://github.com/google/osv.dev/assets/73332835/753f16b5-e7ec-4a6b-a9e7-f2b5b3234dad">

**On mobile/tablet screen**
<img width="572" alt="Screenshot 2024-04-17 at 4 30 50 pm" src="https://github.com/google/osv.dev/assets/73332835/e1734a9e-9fb5-4363-9ce6-fefc95eb6cb8">

<img width="566" alt="Screenshot 2024-04-17 at 4 31 22 pm" src="https://github.com/google/osv.dev/assets/73332835/6a33452b-fe39-49c4-907b-5909ef013957">

<img width="522" alt="Screenshot 2024-04-17 at 4 31 45 pm" src="https://github.com/google/osv.dev/assets/73332835/71aacb04-3cac-414c-a5eb-5f39b71ec2bf">
