### PR TITLE
Add RSS link to the page

### DIFF
--- a/gcp/appengine/frontend3/img/feed.svg
+++ b/gcp/appengine/frontend3/img/feed.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 2 2"><circle cx=".276" cy="1.725" r=".274" style="fill:#fff"/><path d="M1.327 2H.94A.937.937 0 0 0 0 1.063v-.39A1.326 1.326 0 0 1 1.327 2z" style="fill:#fff"/><path d="M1.601 2A1.6 1.6 0 0 0 .001.4V0a2 2 0 0 1 2 2z" style="fill:#fff"/></svg>

--- a/gcp/appengine/frontend3/src/base.html
+++ b/gcp/appengine/frontend3/src/base.html
@@ -13,6 +13,7 @@
   <link rel="icon" type="image/png" href="/static/img/favicon-16x16.png" sizes="16x16">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="alternate" type="application/rss+xml" title="RSS Feed" href="{{ url_for('frontend_handlers.blog_rss') }}">
   <meta charset="utf-8">
   <title id="title">OSV - Open Source Vulnerabilities</title>
   <!-- Global site tag (gtag.js) - Google Analytics -->
@@ -60,12 +61,22 @@
           <a href="https://google.github.io/osv.dev/">Docs</a>
         </li>
         
-        <li class="push">
-          <a class="logo-img" href="https://github.com/google/osv.dev" target="_blank"
-            aria-label="Go to our github page">
-            <img class="logo-link" src="/static/img/github-mark-white.svg" alt="Github Logo" width="24" height="24">
-          </a>
-        </li>
+        <ul class="push social-icons">
+          {% if active_section == 'blog' %}
+            <li>
+              <a class="logo-img" href="{{ url_for('frontend_handlers.blog_rss') }}" target="_blank"
+                aria-label="RRS Feed">
+                <img class="logo-link" src="/static/img/feed.svg" alt="RSS Feed" width="24" height="24">
+              </a>
+            </li>
+          {% endif %}
+          <li>
+            <a class="logo-img" href="https://github.com/google/osv.dev" target="_blank"
+              aria-label="Go to our github page">
+              <img class="logo-link" src="/static/img/github-mark-white.svg" alt="Github Logo" width="24" height="24">
+            </a>
+          </li>
+        </ul>
       </ul>
     </header>
     {% endblock %}

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -192,6 +192,12 @@ pre {
       background-image: none;
       content: '';
     }
+
+    .social-icons {
+      padding: 0;
+      display: flex;
+      gap: 20px;
+    }
   }
 
   @media (min-width: $osv-mobile-breakpoint+1) {
@@ -202,7 +208,7 @@ pre {
       margin: 0;
       gap: 40px;
       font-size: 16px;
-
+  
       .push {
         margin-left: auto;
       }


### PR DESCRIPTION
This PR introduces a rss link to the site.

Issue: #1048 

i'm not quite sure about if we should just add a link tag or display a RSS icon beside the Github icon at the top right corner:
<img width="75" alt="image" src="https://github.com/google/osv.dev/assets/13760813/a875c91e-b62c-47c0-ae13-61380200fa6f">
or maybe we want both of them? Please let me know your suggestion.
