### PR TITLE
Sort Debian OSV pkgInfos

### DIFF
--- a/vulnfeeds/cmd/debian/main.go
+++ b/vulnfeeds/cmd/debian/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"sort"
 
 	"github.com/google/osv/vulnfeeds/cves"
 	"github.com/google/osv/vulnfeeds/utility"
@@ -97,9 +98,18 @@ func updateOSVPkgInfos(pkgName string, cveId string, releases map[string]Release
 	if value, ok := osvPkgInfos[cveId]; ok {
 		pkgInfos = value
 	}
-	for releaseName, release := range releases {
+
+	// Sorts releases to ensure pkgInfos remain consistent between runs.
+	var keys []string
+	for name := range releases {
+		keys = append(keys, name)
+	}
+	sort.Strings(keys)
+
+	for _, releaseName := range keys {
 		// Skips 'not yet assigned' entries because their status may change in the future.
 		// For reference on urgency levels, see: https://security-team.debian.org/security_tracker.html#severity-levels
+		release := releases[releaseName]
 		if release.Urgency == "not yet assigned" {
 			continue
 		}
@@ -119,7 +129,7 @@ func updateOSVPkgInfos(pkgName string, cveId string, releases map[string]Release
 				continue
 			}
 			pkgInfo.VersionInfo = cves.VersionInfo{
-				AffectedVersions: []cves.AffectedVersion{{Introduced: "0", Fixed: release.FixedVersion}},
+				AffectedVersions: []cves.AffectedVersion{{Introduced: "0"}, {Fixed: release.FixedVersion}},
 			}
 		} else {
 			pkgInfo.VersionInfo = cves.VersionInfo{

--- a/vulnfeeds/cmd/debian/main.go
+++ b/vulnfeeds/cmd/debian/main.go
@@ -85,7 +85,9 @@ func getDebianReleaseMap() (map[string]string, error) {
 		if row[seriesIndex] == "experimental" || row[seriesIndex] == "sid" {
 			continue
 		}
-
+		if row[versionIndex] == "13" || row[versionIndex] == "14" {
+			continue
+		}
 		releaseMap[row[seriesIndex]] = row[versionIndex]
 	}
 

--- a/vulnfeeds/cmd/debian/main_test.go
+++ b/vulnfeeds/cmd/debian/main_test.go
@@ -18,10 +18,12 @@ func Test_generateDebianSecurityTrackerOSV(t *testing.T) {
 	_ = json.NewDecoder(file).Decode(&decodedDebianData)
 
 	debianReleaseMap := make(map[string]string)
+	debianReleaseMap["trixie"] = "13"
 	debianReleaseMap["buster"] = "10"
 	debianReleaseMap["bullseye"] = "11"
 	debianReleaseMap["bookworm"] = "12"
-	debianReleaseMap["trixie"] = "13"
+	debianReleaseMap["sarge"] = "3.1"
+	debianReleaseMap["stretch"] = "9"
 
 	osvPkgInfos := generateDebianSecurityTrackerOSV(decodedDebianData, debianReleaseMap)
 	expectedCount := 2

--- a/vulnfeeds/cmd/debian/main_test.go
+++ b/vulnfeeds/cmd/debian/main_test.go
@@ -22,7 +22,6 @@ func Test_generateDebianSecurityTrackerOSV(t *testing.T) {
 	debianReleaseMap["bullseye"] = "11"
 	debianReleaseMap["bookworm"] = "12"
 	debianReleaseMap["trixie"] = "13"
-	debianReleaseMap["forky"] = "14"
 
 	osvPkgInfos := generateDebianSecurityTrackerOSV(decodedDebianData, debianReleaseMap)
 	expectedCount := 2

--- a/vulnfeeds/test_data/parts/debian/CVE-2016-1585.debian.json
+++ b/vulnfeeds/test_data/parts/debian/CVE-2016-1585.debian.json
@@ -1,33 +1,54 @@
 [
   {
     "pkg_name": "apparmor",
-    "ecosystem": "Debian12",
-    "fixed_version": {},
-    "ecosystem_specific": {
-      "urgency": "unimportant"
-    }
-  },
-  {
-    "pkg_name": "apparmor",
-    "ecosystem": "Debian11",
-    "fixed_version": {},
-    "ecosystem_specific": {
-      "urgency": "unimportant"
-    }
-  },
-  {
-    "pkg_name": "apparmor",
-    "ecosystem": "Debian10",
-    "fixed_version": {},
-    "ecosystem_specific": {
-      "urgency": "unimportant"
-    }
-  },
-  {
-    "pkg_name": "apparmor",
-    "ecosystem": "Debian13",
+    "ecosystem": "Debian:12",
     "fixed_version": {
       "affected_versions": [
+        {
+          "introduced": "0"
+        }
+      ]
+    },
+    "ecosystem_specific": {
+      "urgency": "unimportant"
+    }
+  },
+  {
+    "pkg_name": "apparmor",
+    "ecosystem": "Debian:11",
+    "fixed_version": {
+      "affected_versions": [
+        {
+          "introduced": "0"
+        }
+      ]
+    },
+    "ecosystem_specific": {
+      "urgency": "unimportant"
+    }
+  },
+  {
+    "pkg_name": "apparmor",
+    "ecosystem": "Debian:10",
+    "fixed_version": {
+      "affected_versions": [
+        {
+          "introduced": "0"
+        }
+      ]
+    },
+    "ecosystem_specific": {
+      "urgency": "unimportant"
+    }
+  },
+  {
+    "pkg_name": "apparmor",
+    "ecosystem": "Debian:13",
+    "fixed_version": {
+      "affected_versions": [
+        {
+          "introduced": "0"
+        },
         {
           "fixed": "3.0.12-1"
         }

--- a/vulnfeeds/test_data/parts/debian/CVE-2016-1585.debian.json
+++ b/vulnfeeds/test_data/parts/debian/CVE-2016-1585.debian.json
@@ -1,7 +1,7 @@
 [
   {
     "pkg_name": "apparmor",
-    "ecosystem": "Debian:12",
+    "ecosystem": "Debian:10",
     "fixed_version": {
       "affected_versions": [
         {
@@ -29,7 +29,7 @@
   },
   {
     "pkg_name": "apparmor",
-    "ecosystem": "Debian:10",
+    "ecosystem": "Debian:12",
     "fixed_version": {
       "affected_versions": [
         {

--- a/vulnfeeds/test_data/parts/debian/CVE-2018-1000500.debian.json
+++ b/vulnfeeds/test_data/parts/debian/CVE-2018-1000500.debian.json
@@ -1,7 +1,7 @@
 [
   {
     "pkg_name": "busybox",
-    "ecosystem": "Debian:12",
+    "ecosystem": "Debian:10",
     "fixed_version": {
       "affected_versions": [
         {
@@ -10,7 +10,7 @@
       ]
     },
     "ecosystem_specific": {
-      "urgency": "unimportant"
+      "urgency": "end-of-life"
     }
   },
   {
@@ -29,7 +29,7 @@
   },
   {
     "pkg_name": "busybox",
-    "ecosystem": "Debian:10",
+    "ecosystem": "Debian:12",
     "fixed_version": {
       "affected_versions": [
         {
@@ -38,7 +38,7 @@
       ]
     },
     "ecosystem_specific": {
-      "urgency": "end-of-life"
+      "urgency": "unimportant"
     }
   },
   {

--- a/vulnfeeds/test_data/parts/debian/CVE-2018-1000500.debian.json
+++ b/vulnfeeds/test_data/parts/debian/CVE-2018-1000500.debian.json
@@ -1,32 +1,56 @@
 [
   {
     "pkg_name": "busybox",
-    "ecosystem": "Debian10",
-    "fixed_version": {},
+    "ecosystem": "Debian:12",
+    "fixed_version": {
+      "affected_versions": [
+        {
+          "introduced": "0"
+        }
+      ]
+    },
     "ecosystem_specific": {
       "urgency": "unimportant"
     }
   },
   {
     "pkg_name": "busybox",
-    "ecosystem": "Debian13",
-    "fixed_version": {},
+    "ecosystem": "Debian:11",
+    "fixed_version": {
+      "affected_versions": [
+        {
+          "introduced": "0"
+        }
+      ]
+    },
     "ecosystem_specific": {
       "urgency": "unimportant"
     }
   },
   {
     "pkg_name": "busybox",
-    "ecosystem": "Debian12",
-    "fixed_version": {},
+    "ecosystem": "Debian:10",
+    "fixed_version": {
+      "affected_versions": [
+        {
+          "introduced": "0"
+        }
+      ]
+    },
     "ecosystem_specific": {
-      "urgency": "unimportant"
+      "urgency": "end-of-life"
     }
   },
   {
     "pkg_name": "busybox",
-    "ecosystem": "Debian11",
-    "fixed_version": {},
+    "ecosystem": "Debian:13",
+    "fixed_version": {
+      "affected_versions": [
+        {
+          "introduced": "0"
+        }
+      ]
+    },
     "ecosystem_specific": {
       "urgency": "unimportant"
     }

--- a/vulnfeeds/tools/debian/debian_converter/first_package_finder.py
+++ b/vulnfeeds/tools/debian/debian_converter/first_package_finder.py
@@ -71,7 +71,9 @@ def retrieve_codename_to_version() -> pd.DataFrame:
     df = pd.read_csv(csv, dtype=str)
     # `series` appears to be `codename` but with no caps
     df['sources'] = ''
-    df.dropna(subset=['release'], inplace=True)
+    df.dropna(subset=['version'], inplace=True)
+    # Set `release` to `created` if not yet released
+    df['release'] = df['release'].fillna(df['created'])
     codename_to_version = df.set_index('series')
 
   return codename_to_version


### PR DESCRIPTION
- Sorts the Debian OSV outputs to remain consistent each runs (https://github.com/google/osv.dev/issues/2103)
- Fixes the `AffectedVersions`
- modifies `first_package_finder.py` to support future Debian releases, like Debian 13.