### PR TITLE
Workaround for Bioconductor test breakage

### DIFF
--- a/osv/ecosystems/bioconductor.py
+++ b/osv/ecosystems/bioconductor.py
@@ -59,7 +59,7 @@ class Bioconductor(Ecosystem):
     versions = []
     # Currently breaking on 3.19,
     # see https://github.com/google/osv.dev/pull/1477/files#r1575458933
-    bioc_versions = bioc_versions[1:]
+    bioc_versions = bioc_versions.remove('3.19')
     for version in bioc_versions:
       response = requests.get(
           url.format(package=package, bioc_version=version),

--- a/osv/ecosystems/bioconductor.py
+++ b/osv/ecosystems/bioconductor.py
@@ -59,7 +59,10 @@ class Bioconductor(Ecosystem):
     versions = []
     # Currently breaking on 3.19,
     # see https://github.com/google/osv.dev/pull/1477/files#r1575458933
-    bioc_versions = bioc_versions.remove('3.19')
+    try:
+      bioc_versions = bioc_versions.remove('3.19')
+    except ValueError
+      pass
     for version in bioc_versions:
       response = requests.get(
           url.format(package=package, bioc_version=version),

--- a/osv/ecosystems/bioconductor.py
+++ b/osv/ecosystems/bioconductor.py
@@ -57,6 +57,9 @@ class Bioconductor(Ecosystem):
     """Helper method to enumerate versions from a specific URL."""
 
     versions = []
+    # Currently breaking on 3.19,
+    # see https://github.com/google/osv.dev/pull/1477/files#r1575458933
+    bioc_versions = bioc_versions[1:]
     for version in bioc_versions:
       response = requests.get(
           url.format(package=package, bioc_version=version),

--- a/osv/ecosystems/bioconductor.py
+++ b/osv/ecosystems/bioconductor.py
@@ -61,7 +61,7 @@ class Bioconductor(Ecosystem):
     # see https://github.com/google/osv.dev/pull/1477/files#r1575458933
     try:
       bioc_versions = bioc_versions.remove('3.19')
-    except ValueError
+    except ValueError:
       pass
     for version in bioc_versions:
       response = requests.get(


### PR DESCRIPTION
Enumeration seems to be failing for Bioconductor 3.19:

```
$ GET https://packagemanager.posit.co/__api__/repos/4/packages/a4?bioc_version=3.19
{"code":4,"error":"Package 'a4' not found","payload":null}
```

but works for 3.18 and 3.1 (the bounds of the array returned by `get_bioc_versions()`)

/cc @tylfin for visibility