### PR TITLE
Add missing OSV schema fields to vulnerability page

### DIFF
--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -707,6 +707,11 @@ dl.vulnerability-details,
   .aliases {
     padding: 0;
   }
+
+  .severity {
+    padding: 0;
+    font-family: $osv-heading-font-family;
+  }
 }
 
 .vulnerability-packages-container {

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -687,7 +687,10 @@ dl.vulnerability-details,
     }
   }
 
-
+  .purl{
+    font-family: $osv-heading-font-family;
+  }
+  
   pre {
     white-space: pre-wrap;
     overflow: auto;

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -687,21 +687,39 @@ dl.vulnerability-details,
     }
   }
 
-  .purl{
-    font-family: $osv-heading-font-family;
+  dd.credits {
+    ul {
+      padding: 0;
+    }
+    
+    li.credit {
+      margin: 0 0 10px 0;
+    }
+    
+    .contact li {
+      margin: 5px 40px 10px 0;
+      display: inline-flex;
+      flex-direction: row;
+      overflow-wrap: break-word;
+    }
   }
   
   pre {
     white-space: pre-wrap;
     overflow: auto;
   }
-
+  
+  .purl{
+    font-family: $osv-heading-font-family;
+  }
+  
   .links {
     padding: 0;
     display: flex;
     flex-direction: column;
     gap: 10px;
     overflow-wrap: break-word;
+    margin-bottom: 20px;
   }
 
   .aliases {

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -891,6 +891,11 @@ dl.vulnerability-details,
     padding: 14px 0;
     border-bottom: 1px dashed #fff;
   }
+
+  .severity {
+    padding: 0;
+    font-family: $osv-heading-font-family;
+  }
 }
 
 /** Home page */

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -709,7 +709,7 @@ dl.vulnerability-details,
     overflow: auto;
   }
   
-  .purl{
+  .purl {
     font-family: $osv-heading-font-family;
   }
   

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -167,7 +167,11 @@
             Severity
           </h3>
           <div class="mdc-layout-grid__cell--span-9">
-            <pre class="specific">{{ affected.severity }}</pre>
+            <ul class="severity">
+              {% for item in affected.severity -%}
+              <li>{{ item.type }} - {{ item.score }}</li>
+              {% endfor -%}
+            </ul>
           </div>
         </div>
         {%- endif -%}

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -146,7 +146,6 @@
           </h3>
           <div class="mdc-layout-grid__cell--span-9">
             <dl>
-              {%- if 'package' in affected -%}
               <dt>Name</dt>
               {%- if affected.package | package_in_ecosystem -%}
               <dd><a href="{{ affected.package | package_in_ecosystem }}" target="_blank" rel="noopener noreferrer">{{
@@ -157,7 +156,6 @@
               {%- if 'purl' in affected.package -%}
               <dt>Purl</dt>
               <dd class="purl">{{ affected.package.purl }}</dd>
-              {%- endif -%}
               {%- endif -%}
             </dl>
           </div>

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -92,6 +92,29 @@
               {% endfor -%}
             </ul>
           </dd>
+          {% if vulnerability.credits -%}
+          <dt class="credits">Credits</dt>
+          <dd class="credits">
+            <ul>
+              {% for credit in vulnerability.credits -%}
+              <li class="credit">
+                <ul>
+                  <li>{{ credit.name }}{%- if 'type' in credit -%} - {{ credit.type }}{%- endif -%}</li>
+                  {%- if 'contact' in credit -%}
+                  <li>
+                    <ul class="contact">
+                      {%- for item in credit.contact -%}
+                      <li><a href="{{ item }}" target="_blank" rel="noopener noreferrer">{{ item }}</a></li>
+                      {%- endfor -%}
+                    </ul>
+                  </li>
+                  {%- endif -%}
+                </ul>
+              </li>
+              {% endfor -%}
+            </ul>
+          </dd>
+          {% endif %}
         </dl>
       </div>
     </div>

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -255,7 +255,7 @@
         <div class="vulnerability-package-subsection mdc-layout-grid__inner">
           <h3 class="mdc-layout-grid__cell--span-3">
             Database specific
-            <a href="https://ossf.github.io/osv-schema/#affectedrangesdatabase_specific-field" target="_blank"
+            <a href="https://ossf.github.io/osv-schema/#affecteddatabase_specific-field" target="_blank"
               rel="noopener noreferrer"></a>
           </h3>
           <div class="mdc-layout-grid__cell--span-9">

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -171,57 +171,57 @@
               </dd>
             </dl>
           {% endfor -%}
+          </div>
         </div>
-      </div>
-      {% if affected.versions -%}
-      <div class="vulnerability-package-subsection mdc-layout-grid__inner">
-        <h3 class="mdc-layout-grid__cell--span-3">
-          Affected versions
-          <a href="https://ossf.github.io/osv-schema/#affectedversions-field" target="_blank"
-            rel="noopener noreferrer"></a>
-        </h3>
-        <div class="mdc-layout-grid__cell--span-9 version-value">
-          {% for group, versions in (affected.versions|group_versions(ecosystem)).items() -%}
-          <spicy-sections class="versions-section">
-            <h2 class="version-header">{{ group }}</h2>
-            <div class="versions {% if not loop.last %}versions-separator{% endif %}">
-              {% for version in versions -%}
-              <div class="version">{{ version }}</div>
-              {% endfor -%}
-            </div>
-          </spicy-sections>
-          {% endfor -%}
+        {% if affected.versions -%}
+        <div class="vulnerability-package-subsection mdc-layout-grid__inner">
+          <h3 class="mdc-layout-grid__cell--span-3">
+            Affected versions
+            <a href="https://ossf.github.io/osv-schema/#affectedversions-field" target="_blank"
+              rel="noopener noreferrer"></a>
+          </h3>
+          <div class="mdc-layout-grid__cell--span-9 version-value">
+            {% for group, versions in (affected.versions|group_versions(ecosystem)).items() -%}
+            <spicy-sections class="versions-section">
+              <h2 class="version-header">{{ group }}</h2>
+              <div class="versions {% if not loop.last %}versions-separator{% endif %}">
+                {% for version in versions -%}
+                <div class="version">{{ version }}</div>
+                {% endfor -%}
+              </div>
+            </spicy-sections>
+            {% endfor -%}
+          </div>
         </div>
-      </div>
-      {% endif -%}
-      {% if affected.ecosystem_specific -%}
-      <div class="vulnerability-package-subsection mdc-layout-grid__inner">
-        <h3 class="mdc-layout-grid__cell--span-3">
-          Ecosystem specific
-          <a href="https://ossf.github.io/osv-schema/#affectedecosystem_specific-field" target="_blank"
-            rel="noopener noreferrer"></a>
-        </h3>
-        <div class="mdc-layout-grid__cell--span-9">
-          <pre class="specific">{{ affected.ecosystem_specific | display_json }}</pre>
+        {% endif -%}
+        {% if affected.ecosystem_specific -%}
+        <div class="vulnerability-package-subsection mdc-layout-grid__inner">
+          <h3 class="mdc-layout-grid__cell--span-3">
+            Ecosystem specific
+            <a href="https://ossf.github.io/osv-schema/#affectedecosystem_specific-field" target="_blank"
+              rel="noopener noreferrer"></a>
+          </h3>
+          <div class="mdc-layout-grid__cell--span-9">
+            <pre class="specific">{{ affected.ecosystem_specific | display_json }}</pre>
+          </div>
         </div>
-      </div>
-      {% endif -%}
-      {% if affected.database_specific -%}
-      <div class="vulnerability-package-subsection mdc-layout-grid__inner">
-        <h3 class="mdc-layout-grid__cell--span-3">
-          Database specific
-          <a href="https://ossf.github.io/osv-schema/#affectedrangesdatabase_specific-field" target="_blank"
-            rel="noopener noreferrer"></a>
-        </h3>
-        <div class="mdc-layout-grid__cell--span-9">
-          <pre class="specific">{{ affected.database_specific | display_json }}</pre>
+        {% endif -%}
+        {% if affected.database_specific -%}
+        <div class="vulnerability-package-subsection mdc-layout-grid__inner">
+          <h3 class="mdc-layout-grid__cell--span-3">
+            Database specific
+            <a href="https://ossf.github.io/osv-schema/#affectedrangesdatabase_specific-field" target="_blank"
+              rel="noopener noreferrer"></a>
+          </h3>
+          <div class="mdc-layout-grid__cell--span-9">
+            <pre class="specific">{{ affected.database_specific | display_json }}</pre>
+          </div>
         </div>
+        {% endif -%}
       </div>
-      {% endif -%}
+      {% endfor -%}
+    </spicy-sections>
   </div>
-  {% endfor -%}
-  </spicy-sections>
-</div>
 </div>
 <turbo-stream action="update" target="title">
   <template>

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -214,6 +214,15 @@
                   {% endfor -%}
                 </div>
               </dd>
+
+              {%- if range.database_specific -%}
+              <dt>
+                Database specific
+                <a href="https://ossf.github.io/osv-schema/#affectedrangesdatabase_specific-field" target="_blank"
+                  rel="noopener noreferrer"></a>
+              </dt>
+              <dd><pre class="specific">{{ range.database_specific | display_json }}</pre></dd>
+              {%- endif -%}
             </dl>
           {% endfor -%}
           </div>

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -62,6 +62,16 @@
           <dd>{{ vulnerability.published }}</dd>
           <dt>Modified</dt>
           <dd>{{ vulnerability.modified }}</dd>
+          {%- if vulnerability.severity -%}
+          <dt>Severity</dt>
+          <dd>
+            <ul class="severity">
+              {% for item in vulnerability.severity -%}
+              <li>{{ item.type }} - {{ item.score }}</li>
+              {% endfor -%}
+            </ul>
+          </dd>
+          {%- endif -%}
           <dt class="summary">Summary</dt>
           <dd class="summary {% if not vulnerability.summary %}muted{% endif %}">
             {% if vulnerability.summary %}

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -161,6 +161,16 @@
           </div>
         </div>
         {%- endif -%}
+        {%- if 'severity' in affected -%}
+        <div class="vulnerability-package-subsection mdc-layout-grid__inner">
+          <h3 class="mdc-layout-grid__cell--span-3">
+            Severity
+          </h3>
+          <div class="mdc-layout-grid__cell--span-9">
+            <pre class="specific">{{ affected.severity }}</pre>
+          </div>
+        </div>
+        {%- endif -%}
         <div class="vulnerability-package-subsection mdc-layout-grid__inner">
           <h3 class="mdc-layout-grid__cell--span-3">
             Affected ranges

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -99,7 +99,7 @@
               {% for credit in vulnerability.credits -%}
               <li class="credit">
                 <ul>
-                  <li>{{ credit.name }}{%- if 'type' in credit -%} - {{ credit.type }}{%- endif -%}</li>
+                  <li>{{ credit.name }}{% if 'type' in credit %} - {{ credit.type }}{% endif %}</li>
                   {%- if 'contact' in credit -%}
                   <li>
                     <ul class="contact">

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -121,6 +121,10 @@
               {%- else -%}
               <dd>{{ affected.package.name }}</dd>
               {%- endif -%}
+              {%- if 'purl' in affected.package -%}
+              <dt>Purl</dt>
+              <dd class="purl">{{ affected.package.purl }}</dd>
+              {%- endif -%}
               {%- endif -%}
             </dl>
           </div>


### PR DESCRIPTION
This change adds the following info to the vulnerability page:
- purl: https://ossf.github.io/osv-schema/#affectedpackage-field
- Severity: https://ossf.github.io/osv-schema/#severity-field
- Credits: https://ossf.github.io/osv-schema/#credits-fields

resolves #2081

Regarding the second items on the issue:  per-range ecosystem/database_specific fields I left a [question](https://github.com/google/osv.dev/issues/2081#issuecomment-2071687782) on the issue.