### PR TITLE
V2 UI: Handle overflowing tabs on vulnerability details better

### DIFF
--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -220,4 +220,19 @@
     {{ vulnerability.id }} - OSV
   </template>
 </turbo-stream>
+
+<script>
+  /*
+  We use `spicy-section` to make the packages content collapsible for mobile view,
+  but the issue is it collapse the content by default but we want to expaneded after
+  the page is loaded. So we decide to programmatically click on header of collapsed
+  packages after the page is loaded, and the content will be visible.
+  */
+  window.addEventListener('load', function() {
+    const package_headers = document.querySelectorAll('.package-header[affordance="collapse"]')
+    package_headers.forEach((header) => {
+      header.click()
+    });
+  })
+</script>
 {% endblock -%}


### PR DESCRIPTION
Issue: #381 

Since [spicy-sections](https://github.com/tabvengers/spicy-sections) doesn't have a feature of expanding all collapsed sections by default, I decided to programmatically click on those package headers when the page is loaded. But this method is bit of awkward, so let me know if you have a better idea.

Mobile view:
![mobile-view](https://github.com/google/osv.dev/assets/13760813/1efe57ee-0c29-4f8e-a041-99de7675f6cd)

An alternative way of implementing similar feature is using `exclusive-collapse` mode for `spicy-section`, but in that mode only the first section is expanded by default, and users are only able to expand one section (which is kind of similar with the tab-bar mode). Here is a demo of different modes of Spicy Section, and you just need to click on the "exclusive-collapse" button to check exclusive-collapse mode:
https://spicy-sections.glitch.me/programatic.html