### PR TITLE
Improve browser navigation back for vulnerability list page

### DIFF
--- a/gcp/appengine/frontend3/src/base.html
+++ b/gcp/appengine/frontend3/src/base.html
@@ -5,6 +5,10 @@
   <meta name="description"
     content="Comprehensive vulnerability database for your open source projects and dependencies.">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- Disable this for vulnerability list page as the weird Turbo cache bug happens when click on browser's back button -->
+  {% if disable_turbo_cache %}
+  <meta name="turbo-cache-control" content="no-cache">
+  {% endif %}
   <link rel="icon" type="image/png" href="/static/img/favicon-32x32.png" sizes="32x32">
   <link rel="icon" type="image/png" href="/static/img/favicon-16x16.png" sizes="16x16">
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/gcp/appengine/frontend3/src/templates/list.html
+++ b/gcp/appengine/frontend3/src/templates/list.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% set active_section = 'vulnerabilities' %}
+{% set disable_turbo_cache = 'true' %}
 
 {% macro table_header_cell(column_id, column_name, is_sortable, is_sorted, is_descending, hide_on_mobile) %}
 <span class="vuln-table-cell mdc-data-table__header-cell vuln-table-header


### PR DESCRIPTION
Issue: #1697 

As mentioned in the issue, the vulnerability list page gets stuck after apply filters and click on the browser's back button, I've done some research on this but can't find a nice solution, and I feel this could be a weird bug of Turbo. So I just disabled the Turbo cache behavior for vulnerability list page, and it just reloads the page after click the back button.

Please let me know if you have a better suggestion.