### PR TITLE
Fix the padding of the background image

### DIFF
--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -1364,5 +1364,7 @@ div.highlight {
     background-position: center;
     min-height: 500px;
     width: 100%;
+    position: absolute;
+    left: 0;
   }
 }


### PR DESCRIPTION
Small PR that fixes the padding issue of the background image in 404 page, to address [this](https://github.com/google/osv.dev/pull/2114#issuecomment-2064688650) comment.

issue: https://github.com/google/osv.dev/issues/1556

Before:
<img width="360" alt="Screenshot 2024-05-01 at 4 21 25 PM" src="https://github.com/google/osv.dev/assets/73332835/c3d32a22-44d7-440b-b165-2dbb8b3cf593">


After:
<img width="365" alt="Screenshot 2024-05-01 at 4 26 22 PM" src="https://github.com/google/osv.dev/assets/73332835/0dd10756-9882-4521-86a6-f794d6951c99">
