### PR TITLE
Add Cache-Control to response

### DIFF
--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -99,6 +99,18 @@ def add_cors_headers(response):
   return response
 
 
+@blueprint.after_request
+def add_cache_control_headers(response):
+  """Add Cache-Control headers."""
+  if 'static' in request.path:
+    response.headers['Cache-Control'] = 'public, max-age=604800'  # 1 week
+  elif 'blog' in request.path:
+    response.headers['Cache-Control'] = 'public, max-age=86400'  # 1 day
+  else:
+    response.headers['Cache-Control'] = 'public, max-age=3600'  # 1 hour
+  return response
+
+
 @blueprint.route('/v2/')
 def index_v2():
   return redirect('/')


### PR DESCRIPTION
This change introduces Cache-Control headers to enhance website performance by improving caching efficiency. The addition of these headers aims to reduce unnecessary HTTP requests and ensure that clients can cache content appropriately, thereby improving page load speeds and reducing server load.

Cache-Control headers have been added with dynamic values based on the request path, enabling browser and intermediate caches to store static assets for optimized durations. The durations have been set as follows:

Static content: 1 week
Blog module: 1 day
Other links: 1 hour
I am open to updating these values based on your feedback.

Issue: https://github.com/google/osv.dev/issues/1013

Before:
<img width="497" alt="before" src="https://github.com/google/osv.dev/assets/73332835/4885b812-6bf2-461f-98da-6e2f9cf1572e">

After:
<img width="550" alt="after_blog" src="https://github.com/google/osv.dev/assets/73332835/8e8781b9-c4cb-402c-a534-6c19cacc8cca">
<img width="510" alt="after_list" src="https://github.com/google/osv.dev/assets/73332835/62116f37-87f4-4b3c-af2d-7802e672f580">
