### PR TITLE
Update last modified time of combine-to-osv entries

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -49,6 +49,7 @@ func main() {
 }
 
 // getModifiedTime gets the modification time of a given file
+// This function assumes that the modified time on disk matches with it in GCS
 func getModifiedTime(filePath string) (time.Time, error) {
 	var emptyTime time.Time
 	fileInfo, err := os.Stat(filePath)

--- a/vulnfeeds/cmd/combine-to-osv/main_test.go
+++ b/vulnfeeds/cmd/combine-to-osv/main_test.go
@@ -35,7 +35,7 @@ func loadTestData2(cveName string) cves.Vulnerability {
 }
 
 func TestLoadParts(t *testing.T) {
-	allParts, _ := loadParts("../../test_data/parts", "")
+	allParts, _ := loadParts("../../test_data/parts")
 	expectedPartCount := 14
 	actualPartCount := len(allParts)
 
@@ -88,7 +88,7 @@ func TestCombineIntoOSV(t *testing.T) {
 		"CVE-2022-32746":   loadTestData2("CVE-2022-32746"),
 		"CVE-2018-1000500": loadTestData2("CVE-2018-1000500"),
 	}
-	allParts, cveModifiedTime := loadParts("../../test_data/parts", "")
+	allParts, cveModifiedTime := loadParts("../../test_data/parts")
 
 	combinedOSV := combineIntoOSV(cveStuff, allParts, "", cveModifiedTime)
 
@@ -105,6 +105,14 @@ func TestCombineIntoOSV(t *testing.T) {
 	}
 }
 
+func TestGetModifiedTime(t *testing.T) {
+	_, err := getModifiedTime("../../test_data/parts/debian/CVE-2016-1585.debian.json")
+	if err != nil {
+		t.Errorf("Failed to get modified time.")
+	}
+
+}
+
 func TestUpdateModifiedDate(t *testing.T) {
 	var cveId1, cveId2 cves.CVEID
 	cveId1 = "CVE-2022-33745"
@@ -114,7 +122,7 @@ func TestUpdateModifiedDate(t *testing.T) {
 		cveId1: loadTestData2("CVE-2022-33745"),
 		cveId2: loadTestData2("CVE-2022-32746"),
 	}
-	allParts, _ := loadParts("../../test_data/parts", "")
+	allParts, _ := loadParts("../../test_data/parts")
 
 	cveModifiedTimeMock := make(map[cves.CVEID]time.Time)
 	time1 := "0001-00-00T00:00:00.000Z"

--- a/vulnfeeds/cmd/combine-to-osv/main_test.go
+++ b/vulnfeeds/cmd/combine-to-osv/main_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	"golang.org/x/exp/maps"
 
@@ -34,7 +35,7 @@ func loadTestData2(cveName string) cves.Vulnerability {
 }
 
 func TestLoadParts(t *testing.T) {
-	allParts := loadParts("../../test_data/parts")
+	allParts, _ := loadParts("../../test_data/parts", "")
 	expectedPartCount := 14
 	actualPartCount := len(allParts)
 
@@ -87,9 +88,9 @@ func TestCombineIntoOSV(t *testing.T) {
 		"CVE-2022-32746":   loadTestData2("CVE-2022-32746"),
 		"CVE-2018-1000500": loadTestData2("CVE-2018-1000500"),
 	}
-	allParts := loadParts("../../test_data/parts")
+	allParts, cveModifiedTime := loadParts("../../test_data/parts", "")
 
-	combinedOSV := combineIntoOSV(cveStuff, allParts, "")
+	combinedOSV := combineIntoOSV(cveStuff, allParts, "", cveModifiedTime)
 
 	expectedCombined := 3
 	actualCombined := len(combinedOSV)
@@ -101,5 +102,44 @@ func TestCombineIntoOSV(t *testing.T) {
 		if len(combinedOSV[cve].Affected) != len(allParts[cve]) {
 			t.Errorf("Affected lengths for %s do not match", cve)
 		}
+	}
+}
+
+func TestUpdateModifiedDate(t *testing.T) {
+	var cveId1, cveId2 cves.CVEID
+	cveId1 = "CVE-2022-33745"
+	cveId2 = "CVE-2022-32746"
+
+	cveStuff := map[cves.CVEID]cves.Vulnerability{
+		cveId1: loadTestData2("CVE-2022-33745"),
+		cveId2: loadTestData2("CVE-2022-32746"),
+	}
+	allParts, _ := loadParts("../../test_data/parts", "")
+
+	cveModifiedTimeMock := make(map[cves.CVEID]time.Time)
+	time1 := "0001-00-00T00:00:00.000Z"
+	time2 := "2024-04-30T00:38:53.057Z"
+	modifiedTime1, _ := time.Parse(time.RFC3339, time1)
+	modifiedTime2, _ := time.Parse(time.RFC3339, time2)
+	cveModifiedTimeMock[cveId1] = modifiedTime1
+	cveModifiedTimeMock[cveId2] = modifiedTime2
+
+	combinedOSV := combineIntoOSV(cveStuff, allParts, "", cveModifiedTimeMock)
+
+	expectedCombined := 2
+	actualCombined := len(combinedOSV)
+
+	if actualCombined != expectedCombined {
+		t.Errorf("Expected %d in combination, got %d: %#v", expectedCombined, actualCombined, combinedOSV)
+	}
+
+	// Keeps CVE modified time if none of its parts have a later modification time
+	if combinedOSV[cveId1].Modified == modifiedTime1.String() {
+		t.Errorf("Wrong modified time: %s", combinedOSV["CVE-2022-33745"].Modified)
+	}
+
+	// Updates the CVE's modified time if any of its parts have a later modification time
+	if combinedOSV[cveId2].Modified != modifiedTime2.String() {
+		t.Errorf("Wrong modified time, expected: %s, got: %s", modifiedTime2.String(), combinedOSV["CVE-2022-32746"].Modified)
 	}
 }

--- a/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
+++ b/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
@@ -35,7 +35,7 @@ if [[ -n "$CVELIST" ]]; then
 fi
 
 echo "Run combine-to-osv"
-./combine-to-osv -cvePath "$CVE_OUTPUT" -partsPath "$OSV_PARTS_ROOT" -osvOutputPath "$OSV_OUTPUT" -cveListPath "$CVELIST" -inputBucket "$INPUT_BUCKET"
+./combine-to-osv -cvePath "$CVE_OUTPUT" -partsPath "$OSV_PARTS_ROOT" -osvOutputPath "$OSV_OUTPUT" -cveListPath "$CVELIST"
 
 echo "Override"
 gcloud --no-user-output-enabled storage rsync "gs://${INPUT_BUCKET}/osv-output-overrides/" $OSV_OUTPUT

--- a/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
+++ b/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
@@ -35,7 +35,7 @@ if [[ -n "$CVELIST" ]]; then
 fi
 
 echo "Run combine-to-osv"
-./combine-to-osv -cvePath "$CVE_OUTPUT" -partsPath "$OSV_PARTS_ROOT" -osvOutputPath "$OSV_OUTPUT" -cveListPath "$CVELIST"
+./combine-to-osv -cvePath "$CVE_OUTPUT" -partsPath "$OSV_PARTS_ROOT" -osvOutputPath "$OSV_OUTPUT" -cveListPath "$CVELIST" -inputBucket "$INPUT_BUCKET"
 
 echo "Override"
 gcloud --no-user-output-enabled storage rsync "gs://${INPUT_BUCKET}/osv-output-overrides/" $OSV_OUTPUT

--- a/vulnfeeds/cmd/debian/main.go
+++ b/vulnfeeds/cmd/debian/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/csv"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"path"
@@ -58,6 +59,10 @@ func getDebianReleaseMap() (map[string]string, error) {
 		return releaseMap, err
 	}
 	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return releaseMap, fmt.Errorf("HTTP request failed: %s", res.Status)
+	}
 
 	reader := csv.NewReader(res.Body)
 	reader.FieldsPerRecord = -1
@@ -196,6 +201,12 @@ func downloadDebianSecurityTracker() (DebianSecurityTrackerData, error) {
 	res, err := http.Get(debianSecurityTrackerURL)
 	if err != nil {
 		return nil, err
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP request failed: %s", res.Status)
 	}
 
 	var decodedDebianData DebianSecurityTrackerData

--- a/vulnfeeds/cmd/debian/main_test.go
+++ b/vulnfeeds/cmd/debian/main_test.go
@@ -18,12 +18,12 @@ func Test_generateDebianSecurityTrackerOSV(t *testing.T) {
 	_ = json.NewDecoder(file).Decode(&decodedDebianData)
 
 	debianReleaseMap := make(map[string]string)
-	debianReleaseMap["trixie"] = "13"
+	debianReleaseMap["sarge"] = "3.1"
+	debianReleaseMap["stretch"] = "9"
 	debianReleaseMap["buster"] = "10"
 	debianReleaseMap["bullseye"] = "11"
 	debianReleaseMap["bookworm"] = "12"
-	debianReleaseMap["sarge"] = "3.1"
-	debianReleaseMap["stretch"] = "9"
+	debianReleaseMap["trixie"] = "13"
 
 	osvPkgInfos := generateDebianSecurityTrackerOSV(decodedDebianData, debianReleaseMap)
 	expectedCount := 2


### PR DESCRIPTION
Fixes https://github.com/google/osv.dev/issues/2103

The current `modfied` time of a combine-to-osv entry only reflects the CVE modified time without checking if any `parts` has been changed. Updates code to set the `modified` field to the most recent modification time of parts' components or the original CVE entry.

- Uses `os.Stat(file).ModTime()` to check the last modified time of each part.
- Maintains a map to record the most recent modification of each part file associated with each CVE ID.
- Updates `PackageInfo`'s `modified` field if the part modified time is later than the original CVE's modified time.

It may not be the best implementation, but its failure wouldn't affect the logic of any existing code.