### PR TITLE
Sort the AffectedCommits

### DIFF
--- a/vulnfeeds/cmd/nvd-cve-osv/main.go
+++ b/vulnfeeds/cmd/nvd-cve-osv/main.go
@@ -292,6 +292,8 @@ func CVEToOSV(CVE cves.CVE, repos []string, cache git.RepoTagsCache, directory s
 		}
 	}
 
+	slices.SortStableFunc(versions.AffectedCommits, cves.AffectedCommitCompare)
+
 	affected := vulns.Affected{}
 	affected.AttachExtractedVersionInfo(versions)
 	v.Affected = append(v.Affected, affected)
@@ -388,6 +390,8 @@ func CVEToPackageInfo(CVE cves.CVE, repos []string, cache git.RepoTagsCache, dir
 	}
 
 	versions.AffectedVersions = nil // these have served their purpose and are not required in the resulting output.
+
+	slices.SortStableFunc(versions.AffectedCommits, cves.AffectedCommitCompare)
 
 	var pkgInfos []vulns.PackageInfo
 	pi := vulns.PackageInfo{VersionInfo: versions}

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -15,6 +15,7 @@
 package cves
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"log"
@@ -57,6 +58,21 @@ func (ac *AffectedCommit) SetLimit(commit string) {
 
 func (ac *AffectedCommit) SetLastAffected(commit string) {
 	ac.LastAffected = commit
+}
+
+// Helper function for sorting AffectedCommit for stability.
+// Sorts by Repo, then Fixed, then LastAffected, then Introduced.
+func AffectedCommitCompare(i, j AffectedCommit) int {
+	if n := cmp.Compare(i.Repo, j.Repo); n != 0 {
+		return n
+	}
+	if n := cmp.Compare(i.Fixed, j.Fixed); n != 0 {
+		return n
+	}
+	if n := cmp.Compare(i.LastAffected, j.LastAffected); n != 0 {
+		return n
+	}
+	return cmp.Compare(i.Introduced, j.Introduced)
 }
 
 type AffectedVersion struct {


### PR DESCRIPTION
Instability in this data structure adds unnecessary noise.

There is currently the potential for variability in the output, which is resulting in unnecessary file copying to GCS (because the checksum of the file changes), and we're trying to get the true modification time of a resultant OSV record to reflect that of the newest constituent input part to `combine-to-osv`.

Before (for CVE-2016-0502):

```
[
  {
    "fixed_version": {
      "affect_commits": [
        {
          "repo": "https://github.com/mysql/mysql-server",
          "introduced": "54df0057e18d8c82c23fbd4e0bf5b5dc2e762955"
        },
        {
          "repo": "https://github.com/mysql/mysql-server",
          "fixed": "020dcec4a12e61cf5853623a2cd7b06d6bdb351f"
        },
        {
          "repo": "https://github.com/mariadb/server",
          "introduced": "5bfe1a3917ee1bddc7f2cde0c88961875148873c"
        },
        {
          "repo": "https://github.com/mariadb/server",
          "fixed": "c0c9b92e37d572cc4452970c81199367048ea198"
        },
        {
          "repo": "https://github.com/mariadb/server",
          "introduced": "776555af021e917ce0d6235386b43ae59fdd5161"
        }
      ]
    }
  }
]
```

After (for CVE-2016-0502):

```
[
  {
    "fixed_version": {
      "affect_commits": [
        {
          "repo": "https://github.com/mariadb/server",
          "introduced": "5bfe1a3917ee1bddc7f2cde0c88961875148873c"
        },
        {
          "repo": "https://github.com/mariadb/server",
          "introduced": "776555af021e917ce0d6235386b43ae59fdd5161"
        },
        {
          "repo": "https://github.com/mariadb/server",
          "fixed": "c0c9b92e37d572cc4452970c81199367048ea198"
        },
        {
          "repo": "https://github.com/mysql/mysql-server",
          "introduced": "54df0057e18d8c82c23fbd4e0bf5b5dc2e762955"
        },
        {
          "repo": "https://github.com/mysql/mysql-server",
          "fixed": "020dcec4a12e61cf5853623a2cd7b06d6bdb351f"
        }
      ]
    }
  }
]
```