### PR TITLE
Enable Debian combine-to-osv on prod

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/debian-cve-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/base/debian-cve-convert.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: debian-cve-convert
+spec:
+  schedule: "0 */1 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3600
+      template:
+        spec:
+          containers:
+          - name: debian-cve-convert
+            image: debian-cve-convert
+            imagePullPolicy: Always
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: 1
+                memory: "1G"
+              limits:
+                cpu: 1
+                memory: "2G"
+          restartPolicy: OnFailure
+          volumes:
+            - name: "ssd"
+              hostPath:
+                path: "/mnt/disks/ssd0"

--- a/deployment/clouddeploy/gke-workers/base/kustomization.yaml
+++ b/deployment/clouddeploy/gke-workers/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - importer.yaml
 - exporter.yaml
 - alpine-cve-convert.yaml
+- debian-cve-convert.yaml
 - combine-to-osv.yaml
 - debian-convert.yaml
 - debian-first-version.yaml

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/kustomization.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/kustomization.yaml
@@ -1,12 +1,12 @@
 resources:
 - ../../base
-- debian-cve-convert.yaml
 patches:
 - path: workers.yaml
 - path: scaler.yaml
 - path: importer.yaml
 - path: exporter.yaml
 - path: alpine-cve-convert.yaml
+- path: debian-cve-convert.yaml
 - path: combine-to-osv.yaml
 - path: debian-convert.yaml
 - path: debian-first-version.yaml

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/debian-cve-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/debian-cve-convert.yaml
@@ -11,6 +11,6 @@ spec:
           - name: debian-cve-convert
             env:
             - name: GOOGLE_CLOUD_PROJECT
-              value: oss-vdb-test
+              value: oss-vdb
             - name: OUTPUT_GCS_BUCKET
-              value: osv-test-cve-osv-conversion
+              value: cve-osv-conversion

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/kustomization.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/kustomization.yaml
@@ -7,6 +7,7 @@ patches:
 - path: importer.yaml
 - path: exporter.yaml
 - path: alpine-cve-convert.yaml
+- path: debian-cve-convert.yaml
 - path: combine-to-osv.yaml
 - path: debian-convert.yaml
 - path: debian-first-version.yaml


### PR DESCRIPTION
Deploy `debian-cve-convert` cron job on production.
