### PR TITLE
Update Go version to 1.22.2

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.22.1'
+          go-version: '>=1.22.2'
       - name: Set up terraform
         uses: hashicorp/setup-terraform@v2
       - name: Run pylint and yapf, go vet

--- a/docker/ci/install_go.sh
+++ b/docker/ci/install_go.sh
@@ -19,4 +19,4 @@ set -eux
 
 # Download and install Go
 # https://pkg.go.dev/golang.org/x/tools/cmd/getgo#section-readme
-curl -LO https://get.golang.org/$(uname)/go_installer && chmod +x go_installer && SHELL="bash" ./go_installer -version 1.22.1 && rm go_installer
+curl -LO https://get.golang.org/$(uname)/go_installer && chmod +x go_installer && SHELL="bash" ./go_installer -version 1.22.2 && rm go_installer

--- a/docker/indexer/Dockerfile
+++ b/docker/indexer/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.1-alpine@sha256:5a99b4049412cd34ad6b4e0c9527ae6beb9ae82d787b4bf3f4eff7aa13fc577a AS GO_BUILD
+FROM golang:1.22.2-alpine@sha256:cdc86d9f363e8786845bea2040312b4efa321b828acdeb26f393faa864d887b0 AS GO_BUILD
 WORKDIR /build
 
 # Cache dependencies in these steps

--- a/docker/indexer/go.mod
+++ b/docker/indexer/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/osv.dev/docker/indexer
 
-go 1.22.1
+go 1.22.2
 
 require (
 	cloud.google.com/go/datastore v1.15.0

--- a/docker/terraform/Dockerfile
+++ b/docker/terraform/Dockerfile
@@ -1,6 +1,6 @@
 # Taken and modified from https://github.com/GoogleCloudPlatform/cloud-builders-community/tree/master/terraform
 
-FROM golang:1.22.1-alpine@sha256:5a99b4049412cd34ad6b4e0c9527ae6beb9ae82d787b4bf3f4eff7aa13fc577a AS GO_BUILD
+FROM golang:1.22.2-alpine@sha256:cdc86d9f363e8786845bea2040312b4efa321b828acdeb26f393faa864d887b0 AS GO_BUILD
 
 ARG TERRAFORM_VERSION
 WORKDIR /build/

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,6 +1,6 @@
 module osv.dev/tools
 
-go 1.22.1
+go 1.22.2
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.22.1
+go 1.22.2
 
 use (
 	./docker/indexer

--- a/tools/datastore-remover/go.mod
+++ b/tools/datastore-remover/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/datastore-remover
 
-go 1.22.1
+go 1.22.2
 
 require (
 	cloud.google.com/go/datastore v1.15.0

--- a/tools/indexer-api-caller/go.mod
+++ b/tools/indexer-api-caller/go.mod
@@ -1,3 +1,3 @@
 module github.com/google/indexer-api-caller
 
-go 1.22.1
+go 1.22.2

--- a/vulnfeeds/cmd/alpine/Dockerfile
+++ b/vulnfeeds/cmd/alpine/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.1-alpine@sha256:5a99b4049412cd34ad6b4e0c9527ae6beb9ae82d787b4bf3f4eff7aa13fc577a AS GO_BUILD
+FROM golang:1.22.2-alpine@sha256:cdc86d9f363e8786845bea2040312b4efa321b828acdeb26f393faa864d887b0 AS GO_BUILD
 
 RUN mkdir /src
 WORKDIR /src

--- a/vulnfeeds/cmd/combine-to-osv/Dockerfile
+++ b/vulnfeeds/cmd/combine-to-osv/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.1-alpine@sha256:5a99b4049412cd34ad6b4e0c9527ae6beb9ae82d787b4bf3f4eff7aa13fc577a AS GO_BUILD
+FROM golang:1.22.2-alpine@sha256:cdc86d9f363e8786845bea2040312b4efa321b828acdeb26f393faa864d887b0 AS GO_BUILD
 
 RUN mkdir /src
 WORKDIR /src

--- a/vulnfeeds/cmd/cpe-repo-gen/Dockerfile
+++ b/vulnfeeds/cmd/cpe-repo-gen/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.1-alpine@sha256:5a99b4049412cd34ad6b4e0c9527ae6beb9ae82d787b4bf3f4eff7aa13fc577a AS GO_BUILD
+FROM golang:1.22.2-alpine@sha256:cdc86d9f363e8786845bea2040312b4efa321b828acdeb26f393faa864d887b0 AS GO_BUILD
 
 RUN mkdir /src
 WORKDIR /src

--- a/vulnfeeds/cmd/debian/Dockerfile
+++ b/vulnfeeds/cmd/debian/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.1-alpine@sha256:5a99b4049412cd34ad6b4e0c9527ae6beb9ae82d787b4bf3f4eff7aa13fc577a AS GO_BUILD
+FROM golang:1.22.2-alpine@sha256:cdc86d9f363e8786845bea2040312b4efa321b828acdeb26f393faa864d887b0 AS GO_BUILD
 
 RUN mkdir /src
 WORKDIR /src

--- a/vulnfeeds/cmd/download-cves/Dockerfile
+++ b/vulnfeeds/cmd/download-cves/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.1-alpine@sha256:5a99b4049412cd34ad6b4e0c9527ae6beb9ae82d787b4bf3f4eff7aa13fc577a AS GO_BUILD
+FROM golang:1.22.2-alpine@sha256:cdc86d9f363e8786845bea2040312b4efa321b828acdeb26f393faa864d887b0 AS GO_BUILD
 
 RUN mkdir /src
 WORKDIR /src

--- a/vulnfeeds/go.mod
+++ b/vulnfeeds/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/osv/vulnfeeds
 
-go 1.22.1
+go 1.22.2
 
 require (
 	cloud.google.com/go/logging v1.8.1


### PR DESCRIPTION
This resolves the vulnerabilities reported on Go 1.22.1.