### PR TITLE
Bump npm version to v8.19.4

### DIFF
--- a/docker/deployment/Dockerfile
+++ b/docker/deployment/Dockerfile
@@ -8,4 +8,8 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
     apt-get update && apt-get install -y google-cloud-sdk
 
 RUN pip3 install pipenv==2023.6.12
+# Install the latest npm version 8 release (last release is in Feb 2023)
+# This will take precedence over the system installed version on the PATH
+RUN npm install -g npm@8
+
 COPY --from=gcr.io/oss-vdb/ci /root/go/bin/hugo /usr/local/bin/hugo


### PR DESCRIPTION
Bump up the npm version to v8.19.4 from v8.5.1 . This allows npm to build the frontend correctly, since as of v8.5.2 integrity checks are not performed on git remotes (the hash is not stable between npm versions).