### PR TITLE
Search for existing commits case-insensitively

### DIFF
--- a/vulnfeeds/cmd/nvd-cve-osv/main.go
+++ b/vulnfeeds/cmd/nvd-cve-osv/main.go
@@ -273,6 +273,7 @@ func CVEToOSV(CVE cves.CVE, repos []string, cache git.RepoTagsCache, directory s
 		for _, repo := range repos {
 			if versions.HasFixedCommits(repo) {
 				hasAnyFixedCommits = true
+				break
 			}
 		}
 
@@ -284,6 +285,7 @@ func CVEToOSV(CVE cves.CVE, repos []string, cache git.RepoTagsCache, directory s
 		for _, repo := range repos {
 			if versions.HasLastAffectedCommits(repo) {
 				hasAnyLastAffectedCommits = true
+				break
 			}
 		}
 

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -106,7 +106,7 @@ func (vi *VersionInfo) HasLastAffectedVersions() bool {
 
 func (vi *VersionInfo) HasIntroducedCommits(repo string) bool {
 	for _, ac := range vi.AffectedCommits {
-		if ac.Repo == repo && ac.Introduced != "" {
+		if strings.EqualFold(ac.Repo, repo) && ac.Introduced != "" {
 			return true
 		}
 	}
@@ -115,7 +115,7 @@ func (vi *VersionInfo) HasIntroducedCommits(repo string) bool {
 
 func (vi *VersionInfo) HasFixedCommits(repo string) bool {
 	for _, ac := range vi.AffectedCommits {
-		if ac.Repo == repo && ac.Fixed != "" {
+		if strings.EqualFold(ac.Repo, repo) && ac.Fixed != "" {
 			return true
 		}
 	}
@@ -124,7 +124,7 @@ func (vi *VersionInfo) HasFixedCommits(repo string) bool {
 
 func (vi *VersionInfo) HasLastAffectedCommits(repo string) bool {
 	for _, ac := range vi.AffectedCommits {
-		if ac.Repo == repo && ac.LastAffected != "" {
+		if strings.EqualFold(ac.Repo, repo) && ac.LastAffected != "" {
 			return true
 		}
 	}
@@ -133,7 +133,7 @@ func (vi *VersionInfo) HasLastAffectedCommits(repo string) bool {
 
 func (vi *VersionInfo) FixedCommits(repo string) (FixedCommits []string) {
 	for _, ac := range vi.AffectedCommits {
-		if ac.Repo == repo && ac.Fixed != "" {
+		if strings.EqualFold(ac.Repo, repo) && ac.Fixed != "" {
 			FixedCommits = append(FixedCommits, ac.Fixed)
 		}
 	}
@@ -142,7 +142,7 @@ func (vi *VersionInfo) FixedCommits(repo string) (FixedCommits []string) {
 
 func (vi *VersionInfo) LastAffectedCommits(repo string) (LastAffectedCommits []string) {
 	for _, ac := range vi.AffectedCommits {
-		if ac.Repo == repo && ac.LastAffected != "" {
+		if strings.EqualFold(ac.Repo, repo) && ac.LastAffected != "" {
 			LastAffectedCommits = append(LastAffectedCommits, ac.Fixed)
 		}
 	}


### PR DESCRIPTION
Also stop looking once one's been found.

While eyeballing the cleanup in staging I noticed some records being deleted that were not expected, and it was because they had previous converted when they only had commit references, but then didn't once they had versions and the commit references, due to this case-sensitivity mishandling the situation.