### PR TITLE
Fix modified time of nvd part entries

### DIFF
--- a/vulnfeeds/cmd/nvd-cve-osv/run_cve_to_osv_generation.sh
+++ b/vulnfeeds/cmd/nvd-cve-osv/run_cve_to_osv_generation.sh
@@ -57,6 +57,6 @@ done
 
 # Copy results to GCS bucket.
 echo "Copying NVD CVE records successfully converted to GCS bucket"
-gcloud --no-user-output-enabled storage rsync "${WORK_DIR}/nvd2osv/gcs_stage" "${OSV_OUTPUT_GCS_PATH}" --checksums-only -c --delete-unmatched-destination-objects -q
+gsutil -q -m rsync -c -d "${WORK_DIR}/nvd2osv/gcs_stage" "${OSV_OUTPUT_GCS_PATH}"
 
 echo "Conversion run complete"


### PR DESCRIPTION
The `gcloud storage rsync --checksums-only` command always updates the modified time on GCS objects once a file has been touched, even if the file content remains the same. Updates it to `gsutil rsync` command to keep the original modified time on GCS objects when nothing has been changed.