### PR TITLE
Fix collapsed packages when navigate to vulnerability page

### DIFF
--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -228,8 +228,8 @@
   the page is loaded. So we decide to programmatically click on header of collapsed
   packages after the page is loaded, and the content will be visible.
   */
-  window.addEventListener('load', function() {
-    const package_headers = document.querySelectorAll('.package-header[affordance="collapse"]')
+  document.addEventListener('turbo:load', function() {
+    const package_headers = document.querySelectorAll('.package-header[affordance="collapse"][aria-expanded="false"]')
     package_headers.forEach((header) => {
       header.click()
     });


### PR DESCRIPTION
Issue: https://github.com/google/osv.dev/issues/381

Initially the page listens the window onload event, and programatically clicks on the headers so the sections will be expanded. But since we use Turbo, it will request the new page by using fetch request rather than doing a full reload, so the `load` event won't be triggered.

In this PR we make the script listens `turbo:load` event which always happens when visiting a new page.

Result:
![May-09-2024 16-34-20](https://github.com/google/osv.dev/assets/13760813/2de992f2-9b28-426b-8dda-6885bddc13ef)
