### PR TITLE
Do not process OSS Fuzz in delete-only mode

### DIFF
--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -182,7 +182,7 @@ class Importer:
   def run(self):
     """Run importer."""
     for source_repo in osv.SourceRepository.query():
-      if source_repo.name == 'oss-fuzz':
+      if not self._delete and source_repo.name == 'oss-fuzz':
         self.process_oss_fuzz(source_repo)
 
       self.validate_source_repo(source_repo)


### PR DESCRIPTION
I noticed this was not behaving as intended during manual dry-run testing in Production.