### PR TITLE
Disable boringssl OSS-Fuzz -> OSV import

### DIFF
--- a/docker/worker/oss_fuzz.py
+++ b/docker/worker/oss_fuzz.py
@@ -39,6 +39,7 @@ UNKNOWN_COMMIT = 'unknown'
 # Large projects which take way too long to build.
 # TODO(ochang): Don't hardcode this.
 PROJECT_DENYLIST = {
+    'boringssl',  # https://github.com/google/osv.dev/issues/2178
     'ffmpeg',
     'imagemagick',
     'libreoffice',

--- a/docker/worker/worker.py
+++ b/docker/worker/worker.py
@@ -51,6 +51,7 @@ _TIMEOUT_SECONDS = 60
 # Large projects which take way too long to build.
 # TODO(ochang): Don't hardcode this.
 PROJECT_DENYLIST = {
+    'boringssl',  # https://github.com/google/osv.dev/issues/2178
     'ffmpeg',
     'imagemagick',
     'libreoffice',

--- a/docker/worker/worker.py
+++ b/docker/worker/worker.py
@@ -48,19 +48,6 @@ TASK_SUBSCRIPTION = 'tasks'
 MAX_LEASE_DURATION = 6 * 60 * 60  # 4 hours.
 _TIMEOUT_SECONDS = 60
 
-# Large projects which take way too long to build.
-# TODO(ochang): Don't hardcode this.
-PROJECT_DENYLIST = {
-    'boringssl',  # https://github.com/google/osv.dev/issues/2178
-    'ffmpeg',
-    'imagemagick',
-    'libreoffice',
-}
-
-REPO_DENYLIST = {
-    'https://github.com/google/AFL.git',
-}
-
 _ECOSYSTEM_PUSH_TOPICS = {
     'PyPI': 'pypi-bridge',
 }


### PR DESCRIPTION
Fixes #2178. 

BoringSSL maintainers would like more control / vetting of entries. Disable the import for now until we have a better system in place to enable that.