### PR TITLE
Improve the usability when operating on a larger number of records

### DIFF
--- a/tools/datafix/reimport_gcs_record.py
+++ b/tools/datafix/reimport_gcs_record.py
@@ -24,6 +24,7 @@ import os
 import functools
 
 MAX_BATCH_SIZE = 500
+MAX_QUERY_SIZE = 30
 
 
 class UnexpectedSituation(Exception):
@@ -121,7 +122,10 @@ def main() -> None:
   parser = argparse.ArgumentParser(
       description="Trigger the reimport of individual GCS-sourced records")
   parser.add_argument(
-      "bugs", action="append", nargs="+", help="The bug IDs to operate on")
+      "bugs",
+      action="append",
+      nargs="+",
+      help=f"The bug IDs to operate on ({MAX_QUERY_SIZE} at most)")
   parser.add_argument(
       "--dry-run",
       action=argparse.BooleanOptionalAction,
@@ -147,6 +151,10 @@ def main() -> None:
       default="/tmp",
       help="Local directory to copy to from GCS")
   args = parser.parse_args()
+
+  if len(args.bugs[0]) > MAX_QUERY_SIZE:
+    parser.error(f"Only {MAX_QUERY_SIZE} bugs can be supplied. "
+                 f"Try running with xargs -n {MAX_QUERY_SIZE}")
 
   ds_client = datastore.Client(project=args.project)
   url_base = url_for_project(args.project)


### PR DESCRIPTION
This prevents a messier Datastore API failure (the IN operator only supports up to 30 values) when querying for more than 30 Bugs and signposts a solution.