### PR TITLE
Support a conversion/extraction corner case as usable

### DIFF
--- a/vulnfeeds/cmd/nvd-cve-osv/main.go
+++ b/vulnfeeds/cmd/nvd-cve-osv/main.go
@@ -383,7 +383,7 @@ func CVEToPackageInfo(CVE cves.CVE, repos []string, cache git.RepoTagsCache, dir
 		return fmt.Errorf("[%s]: Failed to convert fixed version tags to commits: %#v %w", CVE.ID, versions, ErrUnresolvedFix)
 	}
 
-	if versions.HasLastAffectedVersions() && !hasAnyLastAffectedCommits {
+	if versions.HasLastAffectedVersions() && !hasAnyLastAffectedCommits && !hasAnyFixedCommits {
 		return fmt.Errorf("[%s]: Failed to convert last_affected version tags to commits: %#v %w", CVE.ID, versions, ErrUnresolvedFix)
 	}
 


### PR DESCRIPTION
There is a corner case where there was an unresolvable `last_affected` version, but a(n assumed) `fixed` commit (extracted from reference URLs most commonly) and so the failure to resolve the `last_affected` shouldn't be treated as unusable data overall for conversion.