### PR TITLE
Fix 404 error when navigating away from blog page

### DIFF
--- a/gcp/appengine/frontend3/src/templates/blog_post.html
+++ b/gcp/appengine/frontend3/src/templates/blog_post.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% set active_section = 'blog' %}
+{% set disable_turbo_cache = 'true' %}
 
 {% block content %}
 <div class="blog-post-page">


### PR DESCRIPTION
Issue: #2184

Turbo always tries to cache the page after a link, but after navigate to a new page, it can't get the images of the blogs cause they use relative path, e.g.
https://github.com/google/osv.dev/blob/2e1117e5c9360f755d46165eaf2f2bf6b576d09f/gcp/appengine/blog/content/posts/announcing-guided-remediation-in-osv-scanner/index.md?plain=1#L36

This PR disables the cache feature of Turbo Drive which is a quick solution, but this will reduce the performance when navigate back to the blog (content won't be stored and it will load a fresh page).

Another solution is improving the images path for each blog, for example use `/static/blog/posts/announcing-guided-remediation-in-osv-scanner/gr_main.png` instead of `gr_main.png`. But by going this way, we need to keep in mind to use absolute path when adding a new blog.

Please let me know your thought, or any other solution.