### PR TITLE
Remove App Engine from deployment process

### DIFF
--- a/deployment/build-and-stage.yaml
+++ b/deployment/build-and-stage.yaml
@@ -254,15 +254,6 @@ steps:
   args: ['apply', '-no-color', '-auto-approve']
   dir:  deployment/terraform/environments/oss-vdb-test
 
-# Deploy App Engine for staging environment
-- name: 'gcr.io/oss-vdb/deployment'
-  args: ['bash', '-ex', 'gcp/appengine/deploy.sh', 'oss-vdb-test', 'deployment/gae/oss-vdb-test', 'app.yaml']
-
-# Clean up older, non-serving App Engine versions to avoid hitting the ceiling on versions
-- name: 'gcr.io/cloud-builders/gcloud'
-  entrypoint: bash
-  args: ['-ex', 'gcp/appengine/cleanup_versions.sh', 'oss-vdb-test']
-
 # Cloud Deploy
 # GKE Workers
 - name: 'gcr.io/cloud-builders/gcloud'

--- a/deployment/deploy-prod.yaml
+++ b/deployment/deploy-prod.yaml
@@ -13,10 +13,6 @@
 # limitations under the License.
 
 steps:
-# Promote App Engine
-- name: gcr.io/cloud-builders/gcloud
-  args: ['app', 'versions', 'migrate', '--quiet', '$COMMIT_SHA', '--service=default']
-
 # Promote Cloud Deploy
 - name: gcr.io/cloud-builders/gcloud
   args: ['deploy', 'releases', 'promote', '--quiet', '--release=osv-$SHORT_SHA', '--region=us-central1', '--delivery-pipeline=gke-workers', '--to-target=production-workers', '--annotations=tag=$TAG_NAME']

--- a/deployment/staging.yaml
+++ b/deployment/staging.yaml
@@ -33,8 +33,6 @@ steps:
 - name: 'gcr.io/cloud-builders/git'
   args: ['clean', '-ffdx']
 - name: 'gcr.io/oss-vdb/deployment'
-  args: ['bash', '-ex', 'gcp/appengine/deploy.sh', 'oss-vdb', 'deployment/gae/oss-vdb', 'app.yaml', '--no-promote']
-- name: 'gcr.io/oss-vdb/deployment'
   args: ['bash', '-ex', '../deploy_service_proxy', 'oss-vdb', 'api-staging.osv.dev', 'osv-grpc-v1-staging', '../../../deployment/api/oss-vdb/api_config_staging.yaml']
   dir: gcp/api/v1
 - name: 'gcr.io/cloud-builders/docker'

--- a/deployment/terraform/modules/osv/main.tf
+++ b/deployment/terraform/modules/osv/main.tf
@@ -6,9 +6,6 @@ resource "google_app_engine_application" "app" {
   location_id   = "us-west2"
   database_type = "CLOUD_DATASTORE_COMPATIBILITY"
 
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 # MemoryStore

--- a/deployment/terraform/modules/osv/website.tf
+++ b/deployment/terraform/modules/osv/website.tf
@@ -94,6 +94,31 @@ module "gclb" {
   url_map        = google_compute_url_map.website.id
 
   backends = {
+    appengine = {
+      groups = [
+        {
+          group = google_compute_region_network_endpoint_group.appengine_neg.id
+        }
+      ]
+      protocol   = "HTTPS"
+      enable_cdn = true
+      cdn_policy = {
+        cache_key_policy = {
+          include_host         = true
+          include_protocol     = true
+          include_query_string = true
+        }
+        signed_url_cache_max_age_sec = 0
+      }
+
+      iap_config = {
+        enable = false
+      }
+      log_config = {
+        enable = false
+      }
+    }
+
     cloudrun = {
       groups = [
         {

--- a/deployment/terraform/modules/osv/website.tf
+++ b/deployment/terraform/modules/osv/website.tf
@@ -94,31 +94,6 @@ module "gclb" {
   url_map        = google_compute_url_map.website.id
 
   backends = {
-    appengine = {
-      groups = [
-        {
-          group = google_compute_region_network_endpoint_group.appengine_neg.id
-        }
-      ]
-      protocol   = "HTTPS"
-      enable_cdn = true
-      cdn_policy = {
-        cache_key_policy = {
-          include_host         = true
-          include_protocol     = true
-          include_query_string = true
-        }
-        signed_url_cache_max_age_sec = 0
-      }
-
-      iap_config = {
-        enable = false
-      }
-      log_config = {
-        enable = false
-      }
-    }
-
     cloudrun = {
       groups = [
         {
@@ -184,11 +159,6 @@ resource "google_compute_url_map" "website" {
         prefix_match = "/"
       }
       route_action {
-        # TODO(michaelkedar): remove appengine
-        weighted_backend_services {
-          backend_service = module.gclb.backend_services.appengine.id
-          weight          = 0
-        }
         weighted_backend_services {
           backend_service = module.gclb.backend_services.cloudrun.id
           weight          = 100


### PR DESCRIPTION
Since the website's happily running on Cloud Run, we can stop deploying it to App Engine.

Deleting App Engine from terraform is going to take a few steps, because terraform isn't smart enough to delete the resources in the required order (it tries to remove some resources before the resources that are using them)