### PR TITLE
Support converting xz CVE-2024-3094

### DIFF
--- a/gcp/appengine/source_mapper.py
+++ b/gcp/appengine/source_mapper.py
@@ -111,6 +111,14 @@ class SourcewareVCS(VCSViewer):
                            r'hp={end_revision}')
 
 
+class GnuPGVCS(VCSViewer):
+  VCS_URL_REGEX = re.compile(r'git(://git\.gnupg\.org)/(.*\.git)$')
+  VCS_REVISION_SUB = r'https\1/cgi-bin/gitweb.cgi?p=\2;a=commit;h={revision}'
+  VCS_REVISION_DIFF_SUB = (
+      r'https\1/cgi-bin/gitweb.cgi?p=\2;a=commitdiff;h={start_revision};'
+      r'hp={end_revision}')
+
+
 VCS_LIST = [
     FreeDesktopVCS,
     GitHubVCS,
@@ -120,6 +128,7 @@ VCS_LIST = [
     SavannahVCS,
     FFMpegVCS,
     SourcewareVCS,
+    GnuPGVCS,
 ]
 
 

--- a/vulnfeeds/cves/versions_test.go
+++ b/vulnfeeds/cves/versions_test.go
@@ -227,7 +227,7 @@ func TestRepo(t *testing.T) {
 		{
 			description:     "GitWeb URL, remapped to something cloneable (CVE-2023-1579)",
 			inputLink:       "https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;h=11d171f1910b508a81d21faa087ad1af573407d8",
-			expectedRepoURL: "git://sourceware.org/git/binutils-gdb.git",
+			expectedRepoURL: "https://sourceware.org/git/binutils-gdb.git",
 			expectedOk:      true,
 		},
 		{
@@ -407,13 +407,25 @@ func TestRepo(t *testing.T) {
 		{
 			description:     "GNU glibc GitWeb repo (with no distinguishing marks)",
 			inputLink:       "https://sourceware.org/git/?p=glibc.git",
-			expectedRepoURL: "git://sourceware.org/git/glibc.git",
+			expectedRepoURL: "https://sourceware.org/git/glibc.git",
 			expectedOk:      true,
 		},
 		{
 			description:     "GNU glibc GitWeb repo (with distinguishing marks)",
 			inputLink:       "https://sourceware.org/git/gitweb.cgi?p=glibc.git",
-			expectedRepoURL: "git://sourceware.org/git/glibc.git",
+			expectedRepoURL: "https://sourceware.org/git/glibc.git",
+			expectedOk:      true,
+		},
+		{
+			description:     "GnuPG GitWeb repo that doesn't talk https",
+			inputLink:       "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=libksba.git;a=commit;h=f61a5ea4e0f6a80fd4b28ef0174bee77793cf070",
+			expectedRepoURL: "git://git.gnupg.org/libksba.git",
+			expectedOk:      true,
+		},
+		{
+			description:     "high profile repo encountered on CVE-2024-3094",
+			inputLink:       "https://git.tukaani.org/?p=xz.git;a=tags",
+			expectedRepoURL: "https://git.tukaani.org/xz.git",
 			expectedOk:      true,
 		},
 	}


### PR DESCRIPTION
GitWeb URLs are very snowflakey. They don't always have the `gitweb.cgi` distinguishing URI, but they do seem to have the `p=\*.git` query string.

Furthermore, they don't always map to a cloneable https:// URL.

This PR handles the small range of GitWeb URLs currently observed in the wild, extending support for the repo that will make CVE-2024-3094 (that xz vulnerability) convertible.

Also teach the frontend how to rewrite GnuPG repos for existing CVEs that are converting.