### PR TITLE
Fix for a small conversion regression

### DIFF
--- a/vulnfeeds/cmd/cpe-repo-gen/main.go
+++ b/vulnfeeds/cmd/cpe-repo-gen/main.go
@@ -378,10 +378,14 @@ func analyzeCPEDictionary(d CPEDict) (ProductToRepo VendorProductToRepoMap, Desc
 			repo := MaybeGetSourceRepoFromDebian(*DebianMetadataPath, vp.Product)
 			if repo != "" {
 				Logger.Infof("Derived repo: %s for %s:%s", repo, vp.Vendor, vp.Product)
-				// Now check that what Debian gave us meets our expectations
+				// Now check that what Debian gave us meets our expectations and is valid.
 				repo, err := cves.Repo(repo)
 				if err != nil {
 					Logger.Infof("Disregarding derived repo %s for %s:%s because %v", repo, vp.Vendor, vp.Product, err)
+					continue
+				}
+				if !git.ValidRepoAndHasUsableRefs(repo) {
+					Logger.Infof("Disregarding derived repo %s for %s:%s because it is unusable for version resolution", repo, vp.Vendor, vp.Product)
 					continue
 				}
 				ProductToRepo[VendorProduct{vp.Vendor, vp.Product}] = append(ProductToRepo[VendorProduct{vp.Vendor, vp.Product}], repo)

--- a/vulnfeeds/cmd/cpe-repo-gen/main.go
+++ b/vulnfeeds/cmd/cpe-repo-gen/main.go
@@ -401,7 +401,7 @@ func validateRepos(prm VendorProductToRepoMap) (validated VendorProductToRepoMap
 		entryCount++
 		// As a side-effect, this also omits any with no repos.
 		for _, r := range prm[vp] {
-			if !git.ValidRepo(r) {
+			if !git.ValidRepoAndHasUsableRefs(r) {
 				Logger.Infof("%d/%d: %q is not a valid repo for %s:%s", entryCount, len(prm), r, vp.Vendor, vp.Product)
 				continue
 			}

--- a/vulnfeeds/cmd/nvd-cve-osv/main.go
+++ b/vulnfeeds/cmd/nvd-cve-osv/main.go
@@ -442,7 +442,10 @@ func maybeUpdateVPRepoCache(cache VendorProductToRepoMap, vp *VendorProduct, rep
 	if slices.Contains(cache[*vp], repo) {
 		return
 	}
-	cache[*vp] = append(cache[*vp], repo)
+	// Avoid poluting the cache with existant-but-useless repos.
+	if git.ValidRepoAndHasUsableRefs(repo) {
+		cache[*vp] = append(cache[*vp], repo)
+	}
 }
 
 // Removes the repo from the cache for the Vendor/Product combination if already present.

--- a/vulnfeeds/cmd/nvd-cve-osv/main.go
+++ b/vulnfeeds/cmd/nvd-cve-osv/main.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -98,34 +97,6 @@ var VendorProductDenyList = []VendorProduct{
 	// [CVE-2021-28957]: Incorrectly associates with github.com/lxml/lxml
 	{"oracle", "zfs_storage_appliance_kit"},
 	{"gradle", "enterprise"}, // The OSS repo gets mis-attributed via CVE-2020-15767
-}
-
-// Looks at what the repo to determine if it contains code using an in-scope language
-func InScopeRepo(repoURL string) bool {
-	parsedURL, err := url.Parse(repoURL)
-	if err != nil {
-		Logger.Infof("Warning: %s failed to parse, skipping", repoURL)
-		return false
-	}
-
-	switch parsedURL.Hostname() {
-	case "github.com":
-		return InScopeGitHubRepo(repoURL)
-	default:
-		return InScopeGitRepo(repoURL)
-	}
-}
-
-// Use the GitHub API to query the repository's language metadata to make the determination.
-func InScopeGitHubRepo(repoURL string) bool {
-	// TODO(apollock): Implement
-	return true
-}
-
-// Clone the repo and look for C/C++ files to make the determination.
-func InScopeGitRepo(repoURL string) bool {
-	// TODO(apollock): Implement
-	return true
 }
 
 // Examines repos and tries to convert versions to commits by treating them as Git tags.
@@ -465,7 +436,7 @@ func loadCPEDictionary(ProductToRepo *VendorProductToRepoMap, f string) error {
 
 // Adds the repo to the cache for the Vendor/Product combination if not already present.
 func maybeUpdateVPRepoCache(cache VendorProductToRepoMap, vp *VendorProduct, repo string) {
-	if vp == nil {
+	if cache == nil {
 		return
 	}
 	if slices.Contains(cache[*vp], repo) {
@@ -476,7 +447,7 @@ func maybeUpdateVPRepoCache(cache VendorProductToRepoMap, vp *VendorProduct, rep
 
 // Removes the repo from the cache for the Vendor/Product combination if already present.
 func maybeRemoveFromVPRepoCache(cache VendorProductToRepoMap, vp *VendorProduct, repo string) {
-	if vp == nil {
+	if cache == nil {
 		return
 	}
 	cacheEntry, ok := cache[*vp]
@@ -668,12 +639,6 @@ func main() {
 		}
 
 		Logger.Infof("[%s]: Repos: %#v", CVEID, ReposForCVE[CVEID])
-
-		for _, repo := range ReposForCVE[CVEID] {
-			if !InScopeRepo(repo) {
-				continue
-			}
-		}
 
 		Metrics.CVEsForKnownRepos++
 

--- a/vulnfeeds/cmd/nvd-cve-osv/main_test.go
+++ b/vulnfeeds/cmd/nvd-cve-osv/main_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/osv/vulnfeeds/cves"
+)
+
+func TestReposFromReferences(t *testing.T) {
+	type args struct {
+		CVE         string
+		cache       VendorProductToRepoMap
+		vp          *VendorProduct
+		refs        []cves.Reference
+		tagDenyList []string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantRepos []string
+	}{
+		{
+			name: "A CVE with a repo not already present in the VendorRepo cache",
+			args: args{
+				CVE:   "CVE-2023-0327",
+				cache: nil,
+				vp:    &VendorProduct{"theradsystem_project", "theradsystem"},
+				refs: []cves.Reference{
+				{
+						Source: "cna@vuldb.com",
+						Tags:   []string{"Patch", "Third Party Advisory"},
+						Url:    "https://github.com/saemorris/TheRadSystem/commit/bfba26bd34af31648a11af35a0bb66f1948752a6"},
+				},
+				tagDenyList: RefTagDenyList,
+			},
+			wantRepos: []string{"https://github.com/saemorris/TheRadSystem"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotRepos := ReposFromReferences(tt.args.CVE, tt.args.cache, tt.args.vp, tt.args.refs, tt.args.tagDenyList); !reflect.DeepEqual(gotRepos, tt.wantRepos) {
+				t.Errorf("ReposFromReferences() = %v, want %v", gotRepos, tt.wantRepos)
+			}
+		})
+	}
+}

--- a/vulnfeeds/git/repository.go
+++ b/vulnfeeds/git/repository.go
@@ -236,8 +236,20 @@ func RefBranches(refs []*plumbing.Reference) (branches []*plumbing.Reference) {
 }
 
 // Validate the repo by attempting to query it's references.
-// Repos that don't have any tags are not valid.
 func ValidRepo(repoURL string) (valid bool) {
+	_, err := RemoteRepoRefsWithRetry(repoURL, 3)
+	if err != nil && err == transport.ErrAuthenticationRequired {
+		// somewhat strangely, we get an authentication prompt via Git on non-existent repos.
+		return false
+	}
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+// Otherwise functional repos that don't have any tags are not valid.
+func ValidRepoAndHasUsableRefs(repoURL string) (valid bool) {
 	refs, err := RemoteRepoRefsWithRetry(repoURL, 3)
 	if err != nil && err == transport.ErrAuthenticationRequired {
 		// somewhat strangely, we get an authentication prompt via Git on non-existent repos.

--- a/vulnfeeds/git/repository_test.go
+++ b/vulnfeeds/git/repository_test.go
@@ -316,7 +316,7 @@ func TestValidRepo(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		got := ValidRepo(tc.repoURL)
+		got := ValidRepoAndHasUsableRefs(tc.repoURL)
 		if diff := cmp.Diff(got, tc.expectedResult); diff != "" {
 			t.Errorf("test %q: ValidRepo(%q) was incorrect: %s", tc.description, tc.repoURL, diff)
 		}
@@ -326,7 +326,7 @@ func TestValidRepo(t *testing.T) {
 func TestInvalidRepos(t *testing.T) {
 	redundantRepos := []string{}
 	for _, repo := range cves.InvalidRepos {
-		if !ValidRepo(repo) {
+		if !ValidRepoAndHasUsableRefs(repo) {
 			redundantRepos = append(redundantRepos, repo)
 		}
 	}


### PR DESCRIPTION
#2233 introduced a small regression, in that repositories for CPEs that have no usable tags are no longer present in the VendorProductToRepoMap (intentionally).

This also means that CVEs for these repos that lack tags but otherwise have a commit hash in the CVE's references now get excluded from consideration from conversion.

CVE-2023-0327 before #2233 had an entry in the VendorProductToRepoMap for `theradsystem_project:theradsystem`,
even though the repo wasn't usable. Afterwards, it does not, resulting in:

```
[CVE-2023-0327]: Failed to derive any repos for "theradsystem_project" "theradsystem"
[CVE-2023-0327]: Summary: [CPEs=1 AppCPEs=1 DerivedRepos=0]
[CVE-2023-0327]: Passing due to lack of viable repository
```

because of the added rigour of `cves.ValidRepo()`

https://github.com/google/osv.dev/blob/7ab7d213d4daba3f0c65954b06c035aad5feb498/vulnfeeds/cmd/nvd-cve-osv/main.go#L248-L250

Add a less rigourous variation of repo validation that merely validates repo _existence_ for this last resort conversion attempt.

Add test coverage for `ReposFromReferences()` and fix a couple of bugs that it flushed out for when there is no VendorProductToRepoMap cache in use.

Remove some unnecessary code stubs that aren't going to get filled out (the approach to determining CVE scope changed to trying them all, regardless of language)