### PR TITLE
Fixed UI Affected Packages Ecosystems label being in uppercase

### DIFF
--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -833,7 +833,6 @@ dl.vulnerability-details,
     .vuln-ecosystem {
       display: inline;
       font-weight: bold;
-      text-transform: uppercase;
     }
 
     .vuln-name {
@@ -869,7 +868,6 @@ dl.vulnerability-details,
     .vuln-ecosystem {
       display: block;
       font-weight: bold;
-      text-transform: uppercase;
     }
 
     .vuln-name {


### PR DESCRIPTION
Removed the text-transform property so affected packages ecosystems should be in normal case:
<img width="518" alt="image" src="https://github.com/google/osv.dev/assets/86962800/d6f0f16b-ef20-478f-88ee-850f575f8a3e">

Closes #2240

P.S Hey again :D

