### PR TITLE
Improve multiline formatting in issue automation

### DIFF
--- a/.github/workflows/issue-signposting.yml
+++ b/.github/workflows/issue-signposting.yml
@@ -16,7 +16,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.issue.number }}
-          BODY: >
+          BODY: |
             :sparkles: Thank you for your interest in OSV.dev's data quality! :sparkles:
+            
             **Please review our [FAQ entry](https://google.github.io/osv.dev/faq/#ive-found-something-wrong-with-the-data) on how to most efficiently have this addressed.**
 


### PR DESCRIPTION
According to https://stackoverflow.com/questions/3790454/how-do-i-break-a-string-in-yaml-over-multiple-lines this ought to do the trick and make the output look a little nicer, based on how it's currently rendering for #2251

YAML sucks.