### PR TITLE
Update to the latest pipenv version to make renovatebot changes valid

### DIFF
--- a/docker/worker-base/Dockerfile
+++ b/docker/worker-base/Dockerfile
@@ -35,7 +35,7 @@ RUN curl -sS https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON
     make -j && \
     make install && \
     rm -rf /tmp/Python-${PYTHON_VERSION}
-RUN pip3 install pipenv==2023.6.12
+RUN pip3 install pipenv==2023.12.1
 
 # Install Docker.
 # Pin the version to an older one due to gVisor incompatibilities.


### PR DESCRIPTION
Renovatebot lockfile maintenance #2245 and #2244 uses the latest Pipenv version, which doesn't seem to be backwards compatible. Specifically, it adds a marker (python >= 3.7) to an editable dependency (./../..) (our osv dependency).

Older versions of Pipenv running `pipenv sync` will fail, so updating the CI image to the latest version of pipenv. If you have manually installed pipenv, you'll also need to update your local dev pipenv after #2245 and #2244 is merged.