### PR TITLE
Update rest of pipenv versions to 2023.12.1

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install pipenv
-        run: pip install pipenv==2023.6.12
+        run: pip install pipenv==2023.12.1
       - name: Set up pipenv
         run: pipenv sync --dev
       - name: Set up Go

--- a/docker/deployment/Dockerfile
+++ b/docker/deployment/Dockerfile
@@ -7,7 +7,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     apt-get update && apt-get install -y google-cloud-sdk
 
-RUN pip3 install pipenv==2023.6.12
+RUN pip3 install pipenv==2023.12.1
 # Install the latest npm version 8 release (last release is in Feb 2023)
 # This will take precedence over the system installed version on the PATH
 RUN npm install -g npm@8

--- a/gcp/appengine/Dockerfile
+++ b/gcp/appengine/Dockerfile
@@ -33,7 +33,7 @@ WORKDIR /osv/gcp/appengine
 COPY setup.py Pipfile* README.md /osv/
 COPY osv /osv/osv
 COPY gcp/appengine/Pipfile* ./
-RUN pip3 install -U pipenv==2023.6.12 && python3 -m pipenv install --deploy --system
+RUN pip3 install -U pipenv==2023.12.1 && python3 -m pipenv install --deploy --system
 
 # Website Python code
 COPY gcp/appengine/*.py ./
@@ -54,4 +54,4 @@ RUN python -m whitenoise.compress dist/static/
 # For environments with multiple CPU cores, increase the number of workers
 # to be equal to the cores available.
 # Timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling.
-CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 --preload main:app

--- a/gcp/appengine/Dockerfile
+++ b/gcp/appengine/Dockerfile
@@ -54,4 +54,4 @@ RUN python -m whitenoise.compress dist/static/
 # For environments with multiple CPU cores, increase the number of workers
 # to be equal to the cores available.
 # Timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling.
-CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 --preload main:app
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app

--- a/vulnfeeds/tools/debian/Dockerfile
+++ b/vulnfeeds/tools/debian/Dockerfile
@@ -15,7 +15,7 @@
 FROM google/cloud-sdk:449.0.0-alpine
 
 RUN apk --no-cache add py3-pip \
-    && pip install pipenv==2023.6.12
+    && pip install pipenv==2023.12.1
 
 RUN mkdir /src
 WORKDIR /src


### PR DESCRIPTION
Turns out we are setting the pipenv version in quite a few places 

Follow up to #2260 