### PR TITLE
Update terraform version

### DIFF
--- a/docker/terraform/README.md
+++ b/docker/terraform/README.md
@@ -18,10 +18,10 @@ steps:
 ```
 
 ## Updating Terraform Version
-`_TERRAFORM_VERSION` is defined in `cloudbuild.yaml`. Currently version 1.3.8
+`_TERRAFORM_VERSION` is defined in `cloudbuild.yaml`. Currently version 1.5.7
 
 This can be modified in place, or set in Cloud Build CLI:
 ```
 gcloud builds submit --project=oss-vdb --config=cloudbuild.yaml \
-  --substitutions=_TERRAFORM_VERSION="1.3.8"
+  --substitutions=_TERRAFORM_VERSION="1.5.7"
 ```

--- a/docker/terraform/cloudbuild.yaml
+++ b/docker/terraform/cloudbuild.yaml
@@ -2,7 +2,7 @@
 # In this directory, run the following command to build this builder.
 # $ gcloud builds submit . --config=cloudbuild.yaml
 substitutions:
-  _TERRAFORM_VERSION: 1.3.8
+  _TERRAFORM_VERSION: 1.5.7
 steps:
 - name: 'gcr.io/cloud-builders/docker'
   env:


### PR DESCRIPTION
I'd like to use an [import block](https://developer.hashicorp.com/terraform/language/v1.5.x/import) to help import the datastore into terraform, which was introduced in v1.5.

Please also update your local terraform versions to at least 1.5.

1.5.7 isn't the latest version of terraform, but version 1.6 is when they changed their license and I don't really understand those ramifications :sweat_smile: 