### PR TITLE
Explicitly manage datastore in terraform

### DIFF
--- a/deployment/terraform/environments/oss-vdb-test/main.tf
+++ b/deployment/terraform/environments/oss-vdb-test/main.tf
@@ -18,6 +18,11 @@ module "osv_test" {
   esp_version    = "2.47.0"
 }
 
+import {
+  to = module.osv_test.google_firestore_database.datastore
+  id = "oss-vdb-test/(default)"
+}
+
 output "website_dns_records" {
   description = "DNS records that need to be created for the osv.dev website"
   value       = module.osv_test.website_dns_records

--- a/deployment/terraform/environments/oss-vdb/main.tf
+++ b/deployment/terraform/environments/oss-vdb/main.tf
@@ -18,6 +18,11 @@ module "osv" {
   esp_version    = "2.47.0"
 }
 
+import {
+  to = module.osv.google_firestore_database.datastore
+  id = "oss-vdb/(default)"
+}
+
 output "website_dns_records" {
   description = "DNS records that need to be created for the osv.dev website"
   value       = module.osv.website_dns_records

--- a/deployment/terraform/modules/osv/main.tf
+++ b/deployment/terraform/modules/osv/main.tf
@@ -8,6 +8,18 @@ resource "google_app_engine_application" "app" {
 
 }
 
+# Datastore
+resource "google_firestore_database" "datastore" {
+  project = var.project_id
+  name = "(default)"
+  location_id = "us-west2"
+  type = "DATASTORE_MODE"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 # MemoryStore
 resource "google_redis_instance" "frontend" {
   project            = var.project_id

--- a/deployment/terraform/modules/osv/main.tf
+++ b/deployment/terraform/modules/osv/main.tf
@@ -10,10 +10,10 @@ resource "google_app_engine_application" "app" {
 
 # Datastore
 resource "google_firestore_database" "datastore" {
-  project = var.project_id
-  name = "(default)"
+  project     = var.project_id
+  name        = "(default)"
   location_id = "us-west2"
-  type = "DATASTORE_MODE"
+  type        = "DATASTORE_MODE"
 
   lifecycle {
     prevent_destroy = true


### PR DESCRIPTION
The App Engine resource automatically created the datastore database. Added & imported the datastore resource explicitly.