### PR TITLE
A smarter osv.dev website caching implementation

### DIFF
--- a/gcp/appengine/cache.py
+++ b/gcp/appengine/cache.py
@@ -80,7 +80,8 @@ def smart_cache(
                                                      _should_refresh_suffix)
       future = _future_map.get(key)
       if should_refresh_cached_value and (future is None or future.done()):
-        # Store the future to make sure it executes. (Dropped futures are not executed)
+        # Store the future to make sure it executes.
+        # (Dropped futures are not executed)
         # Also for reference to prevent queueing up multiple updates
         _future_map[key] = _executor_map[key].submit(update_func)
 

--- a/gcp/appengine/cache.py
+++ b/gcp/appengine/cache.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 """Caching."""
 
+import functools
 import os
+from typing import Callable
+from concurrent.futures import ThreadPoolExecutor, Future
 
 import flask_caching
 
@@ -30,3 +33,59 @@ else:
   instance = flask_caching.Cache(config={
       'CACHE_TYPE': 'SimpleCache',
   })
+
+_should_refresh_suffix = '__refresh_marker'
+_executor_map: dict[str, ThreadPoolExecutor] = {}
+_future_map: dict[str, Future] = {}
+
+
+def smart_cache(
+    key: str,
+    timeout: int,
+) -> Callable:
+  """
+  The decorated function will be cached with the given key. 
+
+  If the decorated function is called any time after half the timeout of the cache,
+  the cached value will still be returned, but the cache will be refreshed in an 
+  asynchronous background thread.
+
+  Currently this decorator does not support differing arguments.
+  """
+  if key in _executor_map:
+    raise Exception('key already exists')
+
+  # Only require one background thread to run per cache key
+  # since we check whether an existing update task is already running
+  # before queuing another update.
+  _executor_map[key] = ThreadPoolExecutor(1)
+
+  def decorator(f):
+
+    @functools.wraps(f)
+    def decorated_function(*args, **kwargs):
+
+      def update_func():
+        result = f(*args, **kwargs)
+        instance.set(key, result, timeout=timeout)
+        instance.set(key + _should_refresh_suffix, True, timeout=timeout / 2)
+        return result
+
+      result = instance.get(key)
+      if result is None:  # If the main cached value expires, refresh normally
+        return update_func()
+
+      # Only refresh the cached value once instance times out
+      should_refresh_cached_value = not instance.has(key +
+                                                     _should_refresh_suffix)
+      future = _future_map.get(key)
+      if should_refresh_cached_value and (future is None or future.done()):
+        # Store the future to make sure it executes. (Dropped futures are not executed)
+        # Also for reference to prevent queueing up multiple updates
+        _future_map[key] = _executor_map[key].submit(update_func)
+
+      return result
+
+    return decorated_function
+
+  return decorator

--- a/gcp/appengine/cache.py
+++ b/gcp/appengine/cache.py
@@ -46,14 +46,14 @@ def smart_cache(
   """
   The decorated function will be cached with the given key. 
 
-  If the decorated function is called any time after half the timeout of the cache,
-  the cached value will still be returned, but the cache will be refreshed in an 
-  asynchronous background thread.
+  If the decorated function is called any time after half the timeout 
+  of the cache, the cached value will still be returned, but the cache 
+  will be refreshed in an asynchronous background thread.
 
   Currently this decorator does not support differing arguments.
   """
   if key in _executor_map:
-    raise Exception('key already exists')
+    raise ValueError('key already exists')
 
   # Only require one background thread to run per cache key
   # since we check whether an existing update task is already running

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -349,7 +349,8 @@ def osv_get_ecosystems():
 def osv_get_ecosystem_counts_cached():
   """Get count of vulnerabilities per ecosystem, cached"""
   # Check if we're already in ndb context, if not, put us in one
-  # We can sometimes not be in ndb context because caching runs in a separate thread
+  # We can sometimes not be in ndb context because caching
+  # runs in a separate thread
   if ndb.get_context(raise_context_error=False) is None:
     # Make sure this ndb.Client is the same as the one defined in main.py
     with ndb.Client().context():

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -352,7 +352,8 @@ def osv_get_ecosystem_counts_cached():
   # We can sometimes not be in ndb context because caching
   # runs in a separate thread
   if ndb.get_context(raise_context_error=False) is None:
-    # IMPORTANT: Ensure this ndb.Client remains consistent with the one defined in main.py
+    # IMPORTANT: Ensure this ndb.Client remains consistent 
+    # with the one defined in main.py
     with ndb.Client().context():
       return osv_get_ecosystem_counts()
 

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -352,7 +352,7 @@ def osv_get_ecosystem_counts_cached():
   # We can sometimes not be in ndb context because caching
   # runs in a separate thread
   if ndb.get_context(raise_context_error=False) is None:
-    # Make sure this ndb.Client is the same as the one defined in main.py
+    # IMPORTANT: Ensure this ndb.Client remains consistent with the one defined in main.py
     with ndb.Client().context():
       return osv_get_ecosystem_counts()
 

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -28,7 +28,8 @@ from flask import render_template, render_template_string
 from flask import request
 from flask import url_for
 from flask import send_from_directory
-from werkzeug.utils import safe_join
+from werkzeug.security import safe_join
+from werkzeug import exceptions
 from google.cloud import ndb
 
 import markdown2
@@ -39,7 +40,6 @@ import osv
 import rate_limiter
 import source_mapper
 import utils
-from werkzeug import exceptions
 
 blueprint = Blueprint('frontend_handlers', __name__)
 
@@ -345,11 +345,16 @@ def osv_get_ecosystems():
                 key=str.lower)
 
 
-# TODO: Figure out how to skip cache when testing
-@cache.instance.cached(
-    timeout=24 * 60 * 60, key_prefix='osv_get_ecosystem_counts')
+@cache.smart_cache("osv_get_ecosystem_counts", timeout=24 * 60 * 60)
 def osv_get_ecosystem_counts_cached():
   """Get count of vulnerabilities per ecosystem, cached"""
+  # Check if we're already in ndb context, if not, put us in one
+  # We can sometimes not be in ndb context because caching runs in a separate thread
+  if ndb.get_context(raise_context_error=False) is None:
+    # Make sure this ndb.Client is the same as the one defined in main.py
+    with ndb.Client().context():
+      return osv_get_ecosystem_counts()
+
   return osv_get_ecosystem_counts()
 
 

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -352,7 +352,7 @@ def osv_get_ecosystem_counts_cached():
   # We can sometimes not be in ndb context because caching
   # runs in a separate thread
   if ndb.get_context(raise_context_error=False) is None:
-    # IMPORTANT: Ensure this ndb.Client remains consistent 
+    # IMPORTANT: Ensure this ndb.Client remains consistent
     # with the one defined in main.py
     with ndb.Client().context():
       return osv_get_ecosystem_counts()

--- a/gcp/appengine/main.py
+++ b/gcp/appengine/main.py
@@ -52,18 +52,22 @@ def create_app():
   flask_app.register_blueprint(handlers.blueprint)
   flask_app.register_blueprint(frontend_handlers.blueprint)
   flask_app.config['TEMPLATES_AUTO_RELOAD'] = True
+  flask_app.config['COMPRESS_MIMETYPES'] = ['text/html']
 
+  flask_app.wsgi_app = ndb_wsgi_middleware(flask_app.wsgi_app)
+  flask_app.wsgi_app = WhiteNoise(
+      flask_app.wsgi_app,
+      root='dist/static/',
+      prefix='static',
+      max_age=60 * 60 * 24)
+
+  cache.instance.init_app(flask_app)
+  compress = Compress()
+  compress.init_app(flask_app)
   return flask_app
 
 
 app = create_app()
-app.wsgi_app = ndb_wsgi_middleware(app.wsgi_app)
-app.wsgi_app = WhiteNoise(
-    app.wsgi_app, root='dist/static/', prefix='static', max_age=60 * 60 * 24)
-cache.instance.init_app(app)
-app.config['COMPRESS_MIMETYPES'] = ['text/html']
-compress = Compress()
-compress.init_app(app)
 
 if __name__ == '__main__':
   app.run(host='127.0.0.1', port=8000, debug=False)


### PR DESCRIPTION
**Problem:**
Every 24 hours, a few unfortunate visitors will have osv.dev take incredibly long to load (over 30 seconds), as the ecosystem counts cache expires, and the website tries to count the number of advisories in each ecosystem.

**Solution:**
This PR adds a smarter refresh logic where at half the cache timeout duration (24 hours / 2 = 12 hours), the next request will update the cache in a background thread, while still returning results instantly from the existing cache. When updated, the old cache value is updated and the cache timeout reset. 

This also keeps track of whether an update is already in progress, and prevents python from spawning multiple threads to update the same thing.

---

Also some minor cleanup of main.py