### PR TITLE
Add a link to dep.dev for the supported ecosystems

### DIFF
--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -173,6 +173,10 @@
               {%- else -%}
               <dd>{{ affected.package.name }}</dd>
               {%- endif -%}
+              {%- if ecosystem | has_link_to_deps_dev -%}
+              <dd><a href="{{ package | link_to_deps_dev(ecosystem) }}" target="_blank" rel="noopener noreferrer">
+                View open source insights on deps.dev</a></dd>
+              {%- endif -%}
               {%- if 'purl' in affected.package -%}
               <dt>Purl</dt>
               <dd class="purl">{{ affected.package.purl }}</dd>

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -50,6 +50,15 @@ _WORD_CHARACTERS_OR_DASH = re.compile(r'^[+\w-]+$')
 _VALID_BLOG_NAME = _WORD_CHARACTERS_OR_DASH
 _VALID_VULN_ID = _WORD_CHARACTERS_OR_DASH
 _BLOG_CONTENTS_DIR = 'blog'
+_DEPS_BASE_URL = 'https://deps.dev'
+_OSV_TO_DEPS_ECOSYSTEMS_MAP = {
+    'npm': 'npm',
+    'Go': 'go',
+    'Maven': 'maven',
+    'PyPI': 'pypi',
+    'NuGet': 'nuget',
+    'crates.io': 'cargo'
+}
 
 if utils.is_prod():
   redis_host = os.environ.get('REDISHOST', 'localhost')
@@ -651,3 +660,34 @@ def list_packages(vuln_affected: list[dict]):
 def not_found_error(error: exceptions.HTTPException):
   logging.info('Handled %s - Path attempted: %s', error, request.path)
   return render_template('404.html'), 404
+
+
+@blueprint.app_template_filter('has_link_to_deps_dev')
+def has_link_to_deps_dev(ecosystem):
+  """
+  Check if a given ecosystem has a corresponding link in deps.dev.
+
+  Returns:
+      bool: True if the ecosystem has a corresponding link in deps.dev,
+            False otherwise.
+  """
+  return ecosystem in _OSV_TO_DEPS_ECOSYSTEMS_MAP
+
+
+@blueprint.app_template_filter('link_to_deps_dev')
+def link_to_deps_dev(package, ecosystem):
+  """
+  Generate a link to the deps.dev page for a given package in the specified
+  ecosystem.
+
+  Args:
+      package (str): The name of the package.
+      ecosystem (str): The ecosystem name.
+  Returns:
+      str or None: The URL to the deps.dev page for the package if the
+      ecosystem is supported, None otherwise.
+  """
+  system = _OSV_TO_DEPS_ECOSYSTEMS_MAP.get(ecosystem)
+  if not system:
+    return None
+  return f"{_DEPS_BASE_URL}/{system}/{package}"

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -51,14 +51,6 @@ _VALID_BLOG_NAME = _WORD_CHARACTERS_OR_DASH
 _VALID_VULN_ID = _WORD_CHARACTERS_OR_DASH
 _BLOG_CONTENTS_DIR = 'blog'
 _DEPS_BASE_URL = 'https://deps.dev'
-_OSV_TO_DEPS_ECOSYSTEMS_MAP = {
-    'npm': 'npm',
-    'Go': 'go',
-    'Maven': 'maven',
-    'PyPI': 'pypi',
-    'NuGet': 'nuget',
-    'crates.io': 'cargo'
-}
 
 if utils.is_prod():
   redis_host = os.environ.get('REDISHOST', 'localhost')
@@ -671,7 +663,7 @@ def has_link_to_deps_dev(ecosystem):
       bool: True if the ecosystem has a corresponding link in deps.dev,
             False otherwise.
   """
-  return ecosystem in _OSV_TO_DEPS_ECOSYSTEMS_MAP
+  return osv.ecosystems.is_supported_in_deps_dev(ecosystem)
 
 
 @blueprint.app_template_filter('link_to_deps_dev')
@@ -687,7 +679,7 @@ def link_to_deps_dev(package, ecosystem):
       str or None: The URL to the deps.dev page for the package if the
       ecosystem is supported, None otherwise.
   """
-  system = _OSV_TO_DEPS_ECOSYSTEMS_MAP.get(ecosystem)
+  system = osv.ecosystems.map_ecosystem_to_deps_dev(ecosystem)
   if not system:
     return None
   return f"{_DEPS_BASE_URL}/{system}/{package}"

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -682,4 +682,9 @@ def link_to_deps_dev(package, ecosystem):
   system = osv.ecosystems.map_ecosystem_to_deps_dev(ecosystem)
   if not system:
     return None
-  return f"{_DEPS_BASE_URL}/{system}/{package}"
+  # This ensures that special characters such as / are properly encoded,
+  # preventing invalid paths and 404 errors.
+  # e.g. for the package name github.com/rancher/wrangler,
+  # return https://deps.dev/go/github.com%2Francher%2Fwrangler
+  encoded_package = parse.quote(package, safe='')
+  return f"{_DEPS_BASE_URL}/{system}/{encoded_package}"

--- a/osv/__init__.py
+++ b/osv/__init__.py
@@ -18,3 +18,4 @@ from .impact import *
 from .repos import *
 from .sources import *
 from .models import *
+from .ecosystems import *

--- a/osv/ecosystems/_ecosystems.py
+++ b/osv/ecosystems/_ecosystems.py
@@ -92,6 +92,15 @@ package_urls = {
     'RubyGems': 'https://rubygems.org/gems/',
 }
 
+_OSV_TO_DEPS_ECOSYSTEMS_MAP = {
+    'npm': 'npm',
+    'Go': 'go',
+    'Maven': 'maven',
+    'PyPI': 'pypi',
+    'NuGet': 'nuget',
+    'crates.io': 'cargo'
+}
+
 
 def get(name: str) -> Ecosystem:
   """Get ecosystem helpers for a given ecosystem."""
@@ -123,3 +132,11 @@ def get(name: str) -> Ecosystem:
 
 def normalize(ecosystem_name: str):
   return ecosystem_name.split(':')[0]
+
+
+def is_supported_in_deps_dev(ecosystem_name: str) -> bool:
+  return ecosystem_name in _OSV_TO_DEPS_ECOSYSTEMS_MAP
+
+
+def map_ecosystem_to_deps_dev(ecosystem_name: str) -> str:
+  return _OSV_TO_DEPS_ECOSYSTEMS_MAP.get(ecosystem_name)


### PR DESCRIPTION
This change adds deps.dev link for supported ecosystems in the vulnerability page.

- Implemented a check against a map of supported ecosystems to ensure compatibility with deps.dev.
- Added functionality to generate a link to deps.dev for packages if they're supported.

resolves https://github.com/google/osv.dev/issues/1551

Sample output:
<img width="716" alt="Screenshot 2024-06-05 at 11 10 38 AM" src="https://github.com/google/osv.dev/assets/73332835/fad76638-3763-4dc0-8d92-48fd071f191f">
