### PR TITLE
Replicate the exception handling fix from #2283

### DIFF
--- a/tools/datafix/delete_bugs_with_source.py
+++ b/tools/datafix/delete_bugs_with_source.py
@@ -72,6 +72,8 @@ def main() -> None:
       # subsequent batches from being attempted.
       if args.dryrun and e.args[0].startswith("Dry run mode"):
         pass
+      else:
+        raise
   if len(result) > 0 and not args.dryrun:
     print("Deleted!")
 

--- a/tools/datafix/delete_invalid.py
+++ b/tools/datafix/delete_invalid.py
@@ -87,6 +87,8 @@ def main() -> None:
       # subsequent batches from being attempted.
       if args.dryrun and e.args[0].startswith("Dry run mode"):
         pass
+      else:
+        raise
   if len(result_to_delete) > 0 and not args.dryrun:
     print("Deleted!")
 

--- a/tools/datafix/withdraw_invalid.py
+++ b/tools/datafix/withdraw_invalid.py
@@ -64,6 +64,8 @@ def main() -> None:
       # subsequent batches from being attempted.
       if args.dryrun and e.args[0].startswith("Dry run mode"):
         pass
+      else:
+        raise
   if len(result_to_fix) > 0 and not args.dryrun:
     print("Fixed!")
 


### PR DESCRIPTION
Avoid any copy pasta fails if someone cribs from one of these for a future script and replicate the exception handling fix from #2283 to all the scripts.