### PR TITLE
Update docs to reflect API case sensitivity and python version

### DIFF
--- a/docs/api/get-v1-vulns.md
+++ b/docs/api/get-v1-vulns.md
@@ -25,6 +25,8 @@ The only parameter you need for this API call is the vulnerability id, in order 
 
 `https://api.osv.dev/v1/vulns/{id}`
 
+Case Sensitivity: API requests are case-sensitive. Please ensure that you use the correct case for parameter names and values. For example, use 'GHSA' instead of 'ghsa'.
+
 ## Request sample
 
 ```bash

--- a/docs/api/post-v1-determineversion.md
+++ b/docs/api/post-v1-determineversion.md
@@ -72,6 +72,7 @@ If you want to use the API manually, or build your own tool to use the endpoint,
 | `file_hashes.hash`      | string | the MD5 hash bytes encoded in base64.                                             |
 | `file_hashes.file_path` | string | the path to the file that's hashed, relative to the root directory of the library |
 
+Case Sensitivity: API requests are case-sensitive. Please ensure that you use the correct case for parameter names and values. For example, use 'stdlib' instead of 'Stdlib'.
 
 ### Manual API calls
 After locating the library directory, walk through the directory, saving the MD5 hash of every file with the following extensions:

--- a/docs/api/post-v1-query.md
+++ b/docs/api/post-v1-query.md
@@ -41,6 +41,8 @@ Package Objects can be described by package name AND ecosystem OR by the package
 | `ecosystem` | string | The ecosystem for this package. For the complete list of valid ecosystem names, see [here](https://ossf.github.io/osv-schema/#affectedpackage-field). Must be included if identifying the package by `name`. If specifying by `name` and `ecosystem`, `purl` should not be set.                 |
 | `purl`      | string | The package URL for this package. If `purl` is used to specify the package, `name` and `ecosystem` should not be set.                                                                                                                                                                           |
 
+Case Sensitivity: API requests are case-sensitive. Please ensure that you use the correct case for parameter names and values. For example, use 'PyPI' instead of 'pypi'.
+
 ## Payload
 ```json
 {

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,6 @@ setuptools.setup(
         # Include any JSON schemas.
         '': ['*.json'],
     },
-    python_requires='>=3.10',
+    python_requires='>=3.11',
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,6 @@ setuptools.setup(
         # Include any JSON schemas.
         '': ['*.json'],
     },
-    python_requires='>=3.7',
+    python_requires='>=3.10',
     zip_safe=False,
 )


### PR DESCRIPTION
https://github.com/google/osv.dev/issues/1637: Add case sensitive requirement to API docs 
https://github.com/google/osv.dev/issues/2281: Update Python required version to 3.11+