### PR TITLE
Fix incorrect formatting in the FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -69,6 +69,7 @@ present (but empty) in the [data exports](#is-the-database-available-to-download
 Records that have the [`withdrawn`](https://ossf.github.io/osv-schema/#withdrawn-field) field set will be excluded from:
 * the responses to POST API queries
 * the main [list page](https://osv.dev/list) and related search results
+
 The entry remains in the database, and:
 * is returned by the `/vulns/<ID>` GET API
 * is visible at `https://osv.dev/vulnerability/<ID>` page (and clearly visibly marked as "withdrawn")

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -70,9 +70,9 @@ Records that have the [`withdrawn`](https://ossf.github.io/osv-schema/#withdrawn
 * the responses to POST API queries
 * the main [list page](https://osv.dev/list) and related search results
 
-The entry remains in the database, and:
-* is returned by the `/vulns/<ID>` GET API
-* is visible at `https://osv.dev/vulnerability/<ID>` page (and clearly visibly marked as "withdrawn")
+The entry remains in the database, and is:
+* returned by the `/vulns/<ID>` GET API
+* visible at `https://osv.dev/vulnerability/<ID>` page (and clearly visibly marked as "withdrawn")
 * still exported in the [GCS exports](#is-the-database-available-to-download) (including the `withdrawn` field)
 
 ## How does OSV.dev handle deleted records?


### PR DESCRIPTION
Add a line break to prevent a section being considered part of the previous one.

Also fix a minor grammatical inconsistency. 