### PR TITLE
Prevent invalid empty Events from being added by AddPkgInfo()

### DIFF
--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -18,7 +18,6 @@ import (
 	"cmp"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/url"
 	"os"
@@ -249,16 +248,16 @@ func (v *Vulnerability) AddPkgInfo(pkgInfo PackageInfo) {
 				hasAddedZeroIntroduced[ac.Repo] = true
 			}
 
-			if pkgInfo.VersionInfo.HasIntroducedCommits(ac.Repo) {
+			if ac.Introduced != "" && pkgInfo.VersionInfo.HasIntroducedCommits(ac.Repo) {
 				entry.Events = append(entry.Events, Event{Introduced: ac.Introduced})
 			}
-			if pkgInfo.VersionInfo.HasFixedCommits(ac.Repo) {
+			if ac.Fixed != "" && pkgInfo.VersionInfo.HasFixedCommits(ac.Repo) {
 				entry.Events = append(entry.Events, Event{Fixed: ac.Fixed})
 			}
-			if pkgInfo.VersionInfo.HasLastAffectedCommits(ac.Repo) {
+			if ac.LastAffected != "" && pkgInfo.VersionInfo.HasLastAffectedCommits(ac.Repo) {
 				entry.Events = append(entry.Events, Event{LastAffected: ac.LastAffected})
 			}
-			if pkgInfo.VersionInfo.HasLimitCommits(ac.Repo) {
+			if ac.Limit != "" && pkgInfo.VersionInfo.HasLimitCommits(ac.Repo) {
 				entry.Events = append(entry.Events, Event{Limit: ac.Limit})
 			}
 			gitCommitRangesByRepo[ac.Repo] = entry
@@ -599,18 +598,9 @@ func FromCVE(id cves.CVEID, cve cves.CVE) (*Vulnerability, []string) {
 		Details: cves.EnglishDescription(cve),
 		Aliases: extractAliases(id, cve),
 	}
-	var err error
 	var notes []string
 	v.Published = cve.Published.Format(time.RFC3339)
-	if err != nil {
-		notes = append(notes, fmt.Sprintf("Failed to parse published date: %v\n", err))
-	}
-
 	v.Modified = cve.LastModified.Format(time.RFC3339)
-	if err != nil {
-		notes = append(notes, fmt.Sprintf("Failed to parse modified date: %v\n", err))
-	}
-
 	v.References = ClassifyReferences(cve.References)
 	v.AddSeverity(cve.Metrics)
 	return &v, notes

--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -250,16 +250,16 @@ func (v *Vulnerability) AddPkgInfo(pkgInfo PackageInfo) {
 				}
 			}
 
-			if ac.Introduced != "" && pkgInfo.VersionInfo.HasIntroducedCommits(ac.Repo) {
+			if ac.Introduced != "" {
 				entry.Events = append(entry.Events, Event{Introduced: ac.Introduced})
 			}
-			if ac.Fixed != "" && pkgInfo.VersionInfo.HasFixedCommits(ac.Repo) {
+			if ac.Fixed != "" {
 				entry.Events = append(entry.Events, Event{Fixed: ac.Fixed})
 			}
-			if ac.LastAffected != "" && pkgInfo.VersionInfo.HasLastAffectedCommits(ac.Repo) {
+			if ac.LastAffected != "" {
 				entry.Events = append(entry.Events, Event{LastAffected: ac.LastAffected})
 			}
-			if ac.Limit != "" && pkgInfo.VersionInfo.HasLimitCommits(ac.Repo) {
+			if ac.Limit != "" {
 				entry.Events = append(entry.Events, Event{Limit: ac.Limit})
 			}
 			gitCommitRangesByRepo[ac.Repo] = entry

--- a/vulnfeeds/vulns/vulns_test.go
+++ b/vulnfeeds/vulns/vulns_test.go
@@ -204,6 +204,10 @@ func TestAddPkgInfo(t *testing.T) {
 					Fixed: "658fe213",
 					Repo:  "github.com/foo/bar",
 				},
+				{
+					LastAffected: "0xdeadf00d",
+					Repo:  "github.com/foo/baz",
+				},
 			},
 		},
 	}

--- a/vulnfeeds/vulns/vulns_test.go
+++ b/vulnfeeds/vulns/vulns_test.go
@@ -200,6 +200,10 @@ func TestAddPkgInfo(t *testing.T) {
 					Fixed:      "dsafwefwfe370a9e65d68d62ef37345597e4100b0e87021dfb",
 					Repo:       "github.com/foo/bar",
 				},
+				{
+					Fixed: "658fe213",
+					Repo:  "github.com/foo/bar",
+				},
 			},
 		},
 	}
@@ -210,7 +214,7 @@ func TestAddPkgInfo(t *testing.T) {
 			AffectedVersions: []cves.AffectedVersion{
 				{
 					Introduced: "1.0.0-1",
-					Fixed: "1.2.3-4",
+					Fixed:      "1.2.3-4",
 				},
 			},
 		},
@@ -220,7 +224,7 @@ func TestAddPkgInfo(t *testing.T) {
 	vuln.AddPkgInfo(testPkgInfoCommits)         // This will end up in vuln.Affected[2]
 	vuln.AddPkgInfo(testPkgInfoHybrid)          // This will end up in vuln.Affected[3]
 	vuln.AddPkgInfo(testPkgInfoCommitsMultiple) // This will end up in vuln.Affected[4]
-	vuln.AddPkgInfo(testPkgInfoEcoMultiple) 	// This will end up in vuln.Affected[5]
+	vuln.AddPkgInfo(testPkgInfoEcoMultiple)     // This will end up in vuln.Affected[5]
 
 	t.Logf("Resulting vuln: %+v", vuln)
 
@@ -283,7 +287,7 @@ func TestAddPkgInfo(t *testing.T) {
 	// testPkgInfoCommits ^^^^^^^^^^^^^^^
 
 	// testPkgInfoCommitsMultiple vvvvvvvvvvvvv
-	if len(vuln.Affected[4].Ranges[0].Events) != 2 {
+	if len(vuln.Affected[4].Ranges[0].Events) != 3 {
 		t.Errorf("AddPkgInfo has not correctly added distinct range events from commits: %+v", vuln.Affected[4].Ranges)
 	}
 	// testPkgInfoCommitsMultiple ^^^^^^^^^^^^^
@@ -293,7 +297,6 @@ func TestAddPkgInfo(t *testing.T) {
 		t.Errorf("AddPkgInfo has not correctly added distinct range events from versions: %+v", vuln.Affected[5].Ranges)
 	}
 	// testPkgInfoEcoMultiple ^^^^^^^^^^^^^
-
 
 	for _, a := range vuln.Affected {
 		perRepoZeroIntroducedCommitHashCount := make(map[string]int)
@@ -306,6 +309,9 @@ func TestAddPkgInfo(t *testing.T) {
 					} else {
 						perRepoZeroIntroducedCommitHashCount[r.Repo]++
 					}
+				}
+				if e == (Event{}) {
+					t.Errorf("Empty event detected for the repo %s", r.Repo)
 				}
 			}
 		}


### PR DESCRIPTION
While investigating some schema violations, I noticed that #2280 was adding empty Event structs when there were multiple non-`introduced` events for a repo.

Clean up some dead code that the static checker was complaining about.