### PR TITLE
Prepare for pygit2 1.15.0

### DIFF
--- a/osv/tests.py
+++ b/osv/tests.py
@@ -58,7 +58,7 @@ def ExpectationTest(test_data_dir):  # pylint: disable=invalid-name
       self.assertDictEqual(self._load_expected(expected_name, actual), actual)
 
     def expect_lines_equal(self, expected_name, actual_lines):
-      """Check if the output lines is equal to the expected value, 
+      """Check if the output lines is equal to the expected value,
       printing a diff when it is different."""
       expected_lines = self._load_expected(expected_name, actual_lines)
       if expected_lines != actual_lines:
@@ -101,7 +101,7 @@ class MockRepo:
     tree = self._repo.index.write_tree()
     author = pygit2.Signature(author_name, author_email)
     self._repo.create_commit('HEAD', author, author, message, tree,
-                             [self._repo.head.peel().oid])
+                             [self._repo.head.peel().id])
 
 
 def start_datastore_emulator():


### PR DESCRIPTION
- Unbreak the tests for https://github.com/google/osv.dev/pull/2244
- https://github.com/libgit2/pygit2/blob/master/CHANGELOG.md#1150-2024-05-18 states that the deprecated `object.oid` has been removed in favour of `object.id` (it would be nice to have a way to surface deprecated but not decommissioned usage so this didn't need to be done so reactively)
- Tidy up some whitespace