### PR TITLE
Display the correct introduced event tooltip

### DIFF
--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -135,6 +135,7 @@ pre {
 .tooltip {
   position: relative;
   display: inline-block;
+  width: 650px;
 }
 
 .tooltip .tooltiptext {
@@ -146,7 +147,7 @@ pre {
   padding: 5px;
   border-radius: $osv-border-radius-small;
 
-  max-width: 250px;
+  max-width: 700px;
   line-height: 16px;
 
   top: -5px;

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -226,17 +226,19 @@
                       {% set link = event | event_link -%}
                       {% if link -%}
                         <a href="{{ link }}">
+                          {{ event | event_value -}}
+                        </a>
                       {% elif event | event_type == 'Introduced' and event | event_value == '0' -%}
                         <div class="tooltip">
-                      {% endif -%}
-
-                      {{ event | event_value -}}
-
-                      {% if link -%}
-                        </a>
-                      {% elif event.get('introduced') == '0' -%}
-                        <span class="tooltiptext">The exact introduced commit is unknown</span>
+                          {{ event | event_value -}}
+                          {% if range.type == 'GIT' %}
+                            <span class="tooltiptext">Unknown commit / All previous commits are affected</span>
+                          {% else -%}
+                            <span class="tooltiptext">Unknown version / All previous versions are affected</span>
+                          {% endif -%}
                         </div>
+                      {% else -%}
+                        {{ event | event_value -}}
                       {% endif -%}
                     </div>
                   {% endfor -%}

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -232,9 +232,9 @@
                         <div class="tooltip">
                           {{ event | event_value -}}
                           {% if range.type == 'GIT' %}
-                            <span class="tooltiptext">Unknown commit / All previous commits are affected</span>
+                            <span class="tooltiptext">Unknown introduced commit / All previous commits are affected</span>
                           {% else -%}
-                            <span class="tooltiptext">Unknown version / All previous versions are affected</span>
+                            <span class="tooltiptext">Unknown introduced version / All previous versions are affected</span>
                           {% endif -%}
                         </div>
                       {% else -%}


### PR DESCRIPTION
Prior to this change, when the introduced version in the affected range was 0, the tooltip displayed: "The exact introduced commit is unknown".

This change, updates the html block to be more readable, and displays a more descriptive tooltip based on the type of the range, indicating if it has versions or commits.

resolves: https://github.com/google/osv.dev/issues/2336

Sample output for GIT range:
<img width="1293" alt="Screenshot 2024-06-25 at 12 31 10 PM" src="https://github.com/google/osv.dev/assets/73332835/f85cf9d6-15ee-4d1c-a788-67421f8791b6">


Sample output for other type of ranges:
<img width="1250" alt="Screenshot 2024-06-25 at 12 30 53 PM" src="https://github.com/google/osv.dev/assets/73332835/806ee0a4-b934-4a5a-a3fa-58f006740115">
