### PR TITLE
Fix layout shift in list page

### DIFF
--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -164,6 +164,7 @@ pre {
   $left-padding: 40px;
   display: flex;
   padding: 34px $left-padding;
+  height: 98px;
 
   .logo {
     $logo-width: 53px;
@@ -316,6 +317,7 @@ pre {
 .list-page {
   .title {
     font-size: 20px;
+    height: 25px;
   }
 
   .ecosystem-buttons {
@@ -370,6 +372,7 @@ pre {
       padding: 10px 20px;
       background: #696969;
       border-radius: 999px;
+      height: 38px;
 
       .ecosystem-count {
         font-weight: bold;

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -410,6 +410,7 @@ pre {
   --md-sys-color-primary: $osv-text-color;
   --md-sys-color-on-surface: $osv-text-color;
   --md-sys-color-on-surface-variant: $osv-text-color;
+  height: 56px;
 
   // Make the inner search field full-width.
   .query-field {

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -438,8 +438,8 @@ pre {
 
 // Hax: Make @material/md-icon-button play well with @material/data-table.
 md-icon-button.mdc-data-table__sort-icon-button {
-  width: auto;
-  height: auto;
+  width: 18px;
+  height: 18px;
   --md-icon-button-icon-size: 18px;
   --md-icon-button-icon-color: $osv-text-color;
   --md-icon-button-disabled-icon-color: $osv-grey-600;


### PR DESCRIPTION
issue: https://github.com/google/osv.dev/issues/1013

This change:
- declares the height of search box to avoid layout shift
- declares the size of published sorted arrow icon
- declares the height of text fields above the turbo frame

Before:
<img width="791" alt="Screenshot 2024-06-26 at 1 23 55 PM" src="https://github.com/google/osv.dev/assets/73332835/46f8fa63-852b-4868-a39e-7ba73e58c6be">

After:
<img width="659" alt="Screenshot 2024-06-26 at 5 15 40 PM" src="https://github.com/google/osv.dev/assets/73332835/fcb7ff1f-937d-4036-9b6c-ad3d471377c3">
