### PR TITLE
Issue 2254/add link to cvss calculator

### DIFF
--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -163,6 +163,40 @@ pre {
   opacity: 1;
 }
 
+.tag {
+  display: inline-block;
+  background: $osv-text-color;
+  color: $osv-background;
+  padding: 0 7px;
+  border-radius: $osv-border-radius-small;
+
+  &.severity-low {
+    background: $osv-green;
+    color: black;
+  }
+
+  &.severity-medium {
+    background: $osv-yellow;
+    color: black;
+  }
+
+  &.severity-high {
+    background: $osv-orange;
+    color: black;
+  }
+
+  &.severity-critical {
+    background: $osv-red-700;
+    color: white;
+  }
+}
+
+.severity-level {
+  @extend .tag;
+  padding: 2px 7px;
+  margin-bottom: 4px;
+}
+
 /** Top bar */
 
 .top-bar {
@@ -545,34 +579,10 @@ md-icon-button.mdc-data-table__sort-icon-button {
     }
   }
   .tag {
-    display: inline-block;
-    background: $osv-text-color;
-    color: $osv-background;
-    padding: 0 7px;
-    border-radius: $osv-border-radius-small;
+    @extend .tag;
 
     &.fix-unavailable {
       background: $osv-red-300;
-    }
-
-    &.severity-low {
-      background: $osv-green;
-      color: black;
-    }
-
-    &.severity-medium {
-      background: $osv-yellow;
-      color: black;
-    }
-
-    &.severity-high {
-      background: $osv-orange;
-      color: black;
-    }
-
-    &.severity-critical {
-      background: $osv-red-700;
-      color: white;
     }
   }
 
@@ -785,33 +795,6 @@ dl.vulnerability-details,
     padding: 0;
     font-family: $osv-heading-font-family;
     font-size: 14px;
-
-    .tag {
-      display: inline-block;
-      padding: 2px 7px;
-      border-radius: $osv-border-radius-small;
-      margin-bottom: 4px;
-
-      &.severity-low {
-        background: $osv-green;
-        color: black;
-      }
-
-      &.severity-medium {
-        background: $osv-yellow;
-        color: black;
-      }
-
-      &.severity-high {
-        background: $osv-orange;
-        color: black;
-      }
-
-      &.severity-critical {
-        background: $osv-red-700;
-        color: white;
-      }
-    }
   }
 }
 
@@ -976,32 +959,6 @@ dl.vulnerability-details,
   .severity {
     padding: 0;
     font-family: $osv-heading-font-family;
-    .tag {
-      display: inline-block;
-      padding: 2px 7px;
-      border-radius: $osv-border-radius-small;
-      margin-bottom: 4px;
-
-      &.severity-low {
-        background: $osv-green;
-        color: black;
-      }
-
-      &.severity-medium {
-        background: $osv-yellow;
-        color: black;
-      }
-
-      &.severity-high {
-        background: $osv-orange;
-        color: black;
-      }
-
-      &.severity-critical {
-        background: $osv-red-700;
-        color: white;
-      }
-    }
   }
 }
 

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -782,6 +782,34 @@ dl.vulnerability-details,
   .severity {
     padding: 0;
     font-family: $osv-heading-font-family;
+    font-size: 14px;
+
+    .tag {
+      display: inline-block;
+      padding: 2px 7px;
+      border-radius: $osv-border-radius-small;
+      margin-bottom: 4px;
+
+      &.severity-low {
+        background: $osv-green;
+        color: black;
+      }
+
+      &.severity-medium {
+        background: $osv-yellow;
+        color: black;
+      }
+
+      &.severity-high {
+        background: $osv-orange;
+        color: black;
+      }
+
+      &.severity-critical {
+        background: $osv-red-700;
+        color: white;
+      }
+    }
   }
 }
 
@@ -946,6 +974,32 @@ dl.vulnerability-details,
   .severity {
     padding: 0;
     font-family: $osv-heading-font-family;
+    .tag {
+      display: inline-block;
+      padding: 2px 7px;
+      border-radius: $osv-border-radius-small;
+      margin-bottom: 4px;
+
+      &.severity-low {
+        background: $osv-green;
+        color: black;
+      }
+
+      &.severity-medium {
+        background: $osv-yellow;
+        color: black;
+      }
+
+      &.severity-high {
+        background: $osv-orange;
+        color: black;
+      }
+
+      &.severity-critical {
+        background: $osv-red-700;
+        color: white;
+      }
+    }
   }
 }
 

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -88,7 +88,8 @@
             <ul class="severity">
               {% for item in vulnerability.severity -%}
               <li>
-                {{ item.type }} - {{ item | display_severity_rating }} - {{ item.score }}
+                <span class="tag severity-{{ item | severity_level }}">{{ item | display_severity_rating }}</span>
+                {{ item.type }} - {{ item.score }}
                 <a href="{{ item | cvss_calculator_url }}" target="_blank" rel="noopener noreferrer">
                   CVSS Calculator</a>
               </li>
@@ -198,7 +199,8 @@
             <ul class="severity">
               {% for item in affected.severity -%}
               <li>
-                {{ item.type }} - {{ item | display_severity_rating }} - {{ item.score }}
+                <span class="tag severity-{{ item | severity_level }}">{{ item | display_severity_rating }}</span>
+                {{ item.type }} - {{ item.score }}
                 <a href="{{ item | cvss_calculator_url }}" target="_blank" rel="noopener noreferrer">
                   CVSS Calculator</a>
               </li>

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -87,7 +87,11 @@
           <dd>
             <ul class="severity">
               {% for item in vulnerability.severity -%}
-              <li>{{ item.type }} - {{ item | display_severity_rating }} - {{ item.score }}</li>
+              <li>
+                {{ item.type }} - {{ item | display_severity_rating }} - {{ item.score }}
+                <a href="{{ item | cvss_calculator_url }}" target="_blank" rel="noopener noreferrer">
+                  CVSS Calculator</a>
+              </li>
               {% endfor -%}
             </ul>
           </dd>
@@ -193,7 +197,11 @@
           <div class="mdc-layout-grid__cell--span-9">
             <ul class="severity">
               {% for item in affected.severity -%}
-              <li>{{ item.type }} - {{ item | display_severity_rating }} - {{ item.score }}</li>
+              <li>
+                {{ item.type }} - {{ item | display_severity_rating }} - {{ item.score }}
+                <a href="{{ item | cvss_calculator_url }}" target="_blank" rel="noopener noreferrer">
+                  CVSS Calculator</a>
+              </li>
               {% endfor -%}
             </ul>
           </div>

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -88,7 +88,7 @@
             <ul class="severity">
               {% for item in vulnerability.severity -%}
               <li>
-                <span class="tag severity-{{ item | severity_level }}">{{ item | display_severity_rating }}</span>
+                <span class="severity-level severity-{{ item | severity_level }}">{{ item | display_severity_rating }}</span>
                 {{ item.type }} - {{ item.score }}
                 <a href="{{ item | cvss_calculator_url }}" target="_blank" rel="noopener noreferrer">
                   CVSS Calculator</a>
@@ -199,7 +199,7 @@
             <ul class="severity">
               {% for item in affected.severity -%}
               <li>
-                <span class="tag severity-{{ item | severity_level }}">{{ item | display_severity_rating }}</span>
+                <span class="severity-level severity-{{ item | severity_level }}">{{ item | display_severity_rating }}</span>
                 {{ item.type }} - {{ item.score }}
                 <a href="{{ item | cvss_calculator_url }}" target="_blank" rel="noopener noreferrer">
                   CVSS Calculator</a>

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -87,7 +87,7 @@
           <dd>
             <ul class="severity">
               {% for item in vulnerability.severity -%}
-              <li>{{ item.type }} - {{ item.score }}</li>
+              <li>{{ item.type }} - {{ item | display_severity_rating }} - {{ item.score }}</li>
               {% endfor -%}
             </ul>
           </dd>
@@ -193,7 +193,7 @@
           <div class="mdc-layout-grid__cell--span-9">
             <ul class="severity">
               {% for item in affected.severity -%}
-              <li>{{ item.type }} - {{ item.score }}</li>
+              <li>{{ item.type }} - {{ item | display_severity_rating }} - {{ item.score }}</li>
               {% endfor -%}
             </ul>
           </div>

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -52,6 +52,7 @@ _VALID_BLOG_NAME = _WORD_CHARACTERS_OR_DASH
 _VALID_VULN_ID = _WORD_CHARACTERS_OR_DASH
 _BLOG_CONTENTS_DIR = 'blog'
 _DEPS_BASE_URL = 'https://deps.dev'
+_FIRST_CVSS_CALCULATOR_BASE_URL = 'https://www.first.org/cvss/calculator'
 
 if utils.is_prod():
   redis_host = os.environ.get('REDISHOST', 'localhost')
@@ -735,3 +736,14 @@ def display_severity_rating(severity: dict) -> str:
   """Return base score and rating of the severity."""
   severity_base_score, severity_rating = calculate_severity_details(severity)
   return f"{severity_base_score} ({severity_rating})"
+
+
+@blueprint.app_template_filter('cvss_calculator_url')
+def cvss_calculator_url(severity):
+  """Generate the FIRST CVSS calculator URL from a CVSS string."""
+  score = severity.get('score')
+
+  # Extract CVSS version from the vector string
+  version = score.split('/')[0].split(':')[1]
+
+  return f"{_FIRST_CVSS_CALCULATOR_BASE_URL}/{version}#{score}"

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -728,3 +728,10 @@ def link_to_deps_dev(package, ecosystem):
   # return https://deps.dev/go/github.com%2Francher%2Fwrangler
   encoded_package = parse.quote(package, safe='')
   return f"{_DEPS_BASE_URL}/{system}/{encoded_package}"
+
+
+@blueprint.app_template_filter('display_severity_rating')
+def display_severity_rating(severity: dict) -> str:
+  """Return base score and rating of the severity."""
+  severity_base_score, severity_rating = calculate_severity_details(severity)
+  return f"{severity_base_score} ({severity_rating})"

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -738,6 +738,13 @@ def display_severity_rating(severity: dict) -> str:
   return f"{severity_base_score} ({severity_rating})"
 
 
+@blueprint.app_template_filter('severity_level')
+def severity_level(severity: dict) -> str:
+  """Return rating of the severity."""
+  _, rating = calculate_severity_details(severity)
+  return rating.lower()
+
+
 @blueprint.app_template_filter('cvss_calculator_url')
 def cvss_calculator_url(severity):
   """Generate the FIRST CVSS calculator URL from a CVSS string."""


### PR DESCRIPTION
resolves https://github.com/google/osv.dev/issues/2254

This change applies the following changes to both severity details in the body as well as affected ranges:
- displays severity base score and rate score in vuln page
- adds link to external cvss calculator (FIRST website)

Before:
<img width="805" alt="Screenshot 2024-06-27 at 10 58 16 AM" src="https://github.com/google/osv.dev/assets/73332835/c8b16ee1-6ea9-46ba-a6b5-64bc9ba68277">

After:
<img width="940" alt="Screenshot 2024-06-27 at 10 57 43 AM" src="https://github.com/google/osv.dev/assets/73332835/428f42ee-d8fc-42fd-bd1e-827bdf219f1a">
