### PR TITLE
Fix integration tests

### DIFF
--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -294,11 +294,14 @@ class IntegrationTests(unittest.TestCase,
     go_2020_0001 = self._get('GO-2020-0001')
     go_2021_0052 = self._get('GO-2021-0052')
     ghsa_6vm3_jj99_7229 = self._get('GHSA-6vm3-jj99-7229')
+    ghsa_869c_j7wc_8jqv = self._get('GHSA-869c-j7wc-8jqv')
     ghsa_h395_qcrw_5vmq = self._get('GHSA-h395-qcrw-5vmq')
     ghsa_3vp4_m3rf_835h = self._get('GHSA-3vp4-m3rf-835h')
 
+
     expected_vulns = [
         ghsa_6vm3_jj99_7229,
+        ghsa_869c_j7wc_8jqv,
         go_2020_0001,
         ghsa_h395_qcrw_5vmq,
         go_2021_0052,
@@ -486,8 +489,6 @@ class IntegrationTests(unittest.TestCase,
     self.assert_results_equal({'vulns': another_expected}, response.json())
 
     expected_deb = [
-        self._get('CVE-2009-4487'),
-        self._get('CVE-2013-0337'),
         self._get('DLA-3203-1'),
         self._get('DSA-4921-1')
     ]

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -298,7 +298,6 @@ class IntegrationTests(unittest.TestCase,
     ghsa_h395_qcrw_5vmq = self._get('GHSA-h395-qcrw-5vmq')
     ghsa_3vp4_m3rf_835h = self._get('GHSA-3vp4-m3rf-835h')
 
-
     expected_vulns = [
         ghsa_6vm3_jj99_7229,
         ghsa_869c_j7wc_8jqv,
@@ -488,10 +487,7 @@ class IntegrationTests(unittest.TestCase,
 
     self.assert_results_equal({'vulns': another_expected}, response.json())
 
-    expected_deb = [
-        self._get('DLA-3203-1'),
-        self._get('DSA-4921-1')
-    ]
+    expected_deb = [self._get('DLA-3203-1'), self._get('DSA-4921-1')]
 
     response = requests.post(
         _api() + _BASE_QUERY,


### PR DESCRIPTION
Update the expected responses in API integration tests:
 - add a new Go vulnerability to test response
 - versions that we test against are no longer affected