### PR TITLE
Handle pagination of GHC enumeration

### DIFF
--- a/osv/ecosystems/haskell.py
+++ b/osv/ecosystems/haskell.py
@@ -68,7 +68,6 @@ class Hackage(Ecosystem):
 class GHC(Ecosystem):
   """Glasgow Haskell Compiler (GHC) ecosystem."""
 
-  # FIXME: https://github.com/google/osv.dev/issues/2367
   _API_PACKAGE_URL = ('https://gitlab.haskell.org'
                       '/api/v4/projects/3561/repository/tags?per_page=100')
   """

--- a/osv/ecosystems/haskell.py
+++ b/osv/ecosystems/haskell.py
@@ -70,7 +70,7 @@ class GHC(Ecosystem):
 
   # FIXME: https://github.com/google/osv.dev/issues/2367
   _API_PACKAGE_URL = ('https://gitlab.haskell.org'
-                      '/api/v4/projects/3561/repository/tags?per_page=-1')
+                      '/api/v4/projects/3561/repository/tags?per_page=100')
   """
   Historical versions do not have tags in the Git repo, so we hardcode the
   list.  See https://github.com/google/osv.dev/pull/1463 for discussion.
@@ -136,18 +136,25 @@ class GHC(Ecosystem):
 
     """
 
-    response = requests.get(self._API_PACKAGE_URL, timeout=config.timeout)
-    if response.status_code == 404:
-      raise EnumerateError('GHC tag list not found')
-    if response.status_code != 200:
-      raise RuntimeError(f'Failed to get GHC versions with: {response.text}')
+    # Versions come from tags from the GitLab API, which are paginated.
+    # https://docs.gitlab.com/ee/api/rest/index.html#pagination-link-header
+    url = self._API_PACKAGE_URL
+    versions = self.HISTORICAL_VERSIONS.copy()
+    while url is not None:
+      response = requests.get(url, timeout=config.timeout)
+      if response.status_code == 404:
+        raise EnumerateError(f'GHC tag list not found at {url}')
+      if response.status_code != 200:
+        raise RuntimeError(
+            f'Failed to get GHC versions from: {url} with: {response.text}')
 
-    response = response.json()
-    versions = self.HISTORICAL_VERSIONS + [
-        self.tag_to_version(x['name'])
-        for x in response
-        if self.tag_to_version(x['name'])
-    ]
+      versions.extend(self.tag_to_version(x['name']) for x in response.json())
+
+      if 'next' not in response.links:
+        break
+      url = response.links['next'].get('url')
+
+    versions = [v for v in versions if v is not None]
 
     self.sort_versions(versions)
     return self._get_affected_versions(versions, introduced, fixed,

--- a/osv/ecosystems/haskell.py
+++ b/osv/ecosystems/haskell.py
@@ -70,6 +70,8 @@ class GHC(Ecosystem):
 
   _API_PACKAGE_URL = ('https://gitlab.haskell.org'
                       '/api/v4/projects/3561/repository/tags?per_page=100')
+  # 100 is the maximum per_page size according to GitLab docs:
+  # https://docs.gitlab.com/ee/api/rest/index.html#offset-based-pagination
   """
   Historical versions do not have tags in the Git repo, so we hardcode the
   list.  See https://github.com/google/osv.dev/pull/1463 for discussion.

--- a/osv/ecosystems/haskell_test.py
+++ b/osv/ecosystems/haskell_test.py
@@ -41,8 +41,7 @@ class GHCEcosystemTest(unittest.TestCase):
     self.assertEqual('0.29', ecosystem.next_version('GHC', '0'))
     self.assertEqual('7.0.4', ecosystem.next_version('GHC', '7.0.4-rc1'))
     # 7.0.4 is the last of the hardcoded versions
-    # Disabled due to https://github.com/google/osv.dev/issues/2367
-    # self.assertEqual('7.2.1', ecosystem.next_version('GHC', '7.0.4'))
+    self.assertEqual('7.2.1', ecosystem.next_version('GHC', '7.0.4'))
 
     # The whole GHC ecosystem is versioned together.  Enumeration ignores
     # package/component name.  Therefore this should NOT raise:


### PR DESCRIPTION
Fixes #2367 
We were using `per_page=-1` on the GitLab tag get request to get every tag for GHC enumeration. That recently stopped returning every tag.

Changed it to query for each page, per  https://docs.gitlab.com/ee/api/rest/index.html#pagination-link-header