### PR TITLE
Temporarily disable GHC test

### DIFF
--- a/osv/ecosystems/haskell.py
+++ b/osv/ecosystems/haskell.py
@@ -68,6 +68,7 @@ class Hackage(Ecosystem):
 class GHC(Ecosystem):
   """Glasgow Haskell Compiler (GHC) ecosystem."""
 
+  # FIXME: https://github.com/google/osv.dev/issues/2367
   _API_PACKAGE_URL = ('https://gitlab.haskell.org'
                       '/api/v4/projects/3561/repository/tags?per_page=-1')
   """

--- a/osv/ecosystems/haskell_test.py
+++ b/osv/ecosystems/haskell_test.py
@@ -41,7 +41,8 @@ class GHCEcosystemTest(unittest.TestCase):
     self.assertEqual('0.29', ecosystem.next_version('GHC', '0'))
     self.assertEqual('7.0.4', ecosystem.next_version('GHC', '7.0.4-rc1'))
     # 7.0.4 is the last of the hardcoded versions
-    self.assertEqual('7.2.1', ecosystem.next_version('GHC', '7.0.4'))
+    # Disabled due to https://github.com/google/osv.dev/issues/2367
+    # self.assertEqual('7.2.1', ecosystem.next_version('GHC', '7.0.4'))
 
     # The whole GHC ecosystem is versioned together.  Enumeration ignores
     # package/component name.  Therefore this should NOT raise:


### PR DESCRIPTION
Test failure due to #2367 is preventing anything getting merged.