### PR TITLE
Assign source aliases if no alias group is defined

### DIFF
--- a/osv/models.py
+++ b/osv/models.py
@@ -688,7 +688,7 @@ class Bug(ndb.Model):
       credits_.append(cr)
 
     related = self.related
-    aliases = []
+    aliases = self.aliases
 
     if include_alias:
       related_bugs = Bug.query(Bug.related == self.db_id).fetch()


### PR DESCRIPTION
Some vulnerabilities may lack listed aliases, even if their source data contains them. This occurs when an `alias_group` exceeds a maximum number of aliases, causing this group to be not added. For example: https://osv.dev/vulnerability/GO-2024-2947 

In such cases, assign the original source aliases to the `aliases` field to match with the source info.

Fixes: #2374