### PR TITLE
chore(gcp/appengine/frontend3): tabs anchor with external icon and target blank

### DIFF
--- a/gcp/appengine/frontend3/src/base.html
+++ b/gcp/appengine/frontend3/src/base.html
@@ -61,11 +61,11 @@
         <li class="{{ 'active' if active_section == 'blog' else '' }} page-link">
           <a href="{{ url_for('frontend_handlers.blog') }}">Blog</a>
         </li>
-        <li class="{{ 'active' if active_section == 'faq' else '' }} page-link">
-          <a href="https://google.github.io/osv.dev/faq/">FAQ</a>
+        <li class="{{ 'active' if active_section == 'faq' else '' }} page-link external-link">
+          <a href="https://google.github.io/osv.dev/faq/" target=”_blank” >FAQ</a>
         </li>
-        <li class="{{ 'active' if active_section == 'docs' else '' }} page-link">
-          <a href="https://google.github.io/osv.dev/">Docs</a>
+        <li class="{{ 'active' if active_section == 'docs' else '' }} page-link external-link">
+          <a href="https://google.github.io/osv.dev/" target=”_blank” >Docs</a>
         </li>
         
         <ul class="push social-icons">

--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -229,6 +229,16 @@ pre {
 
   .tabs {
 
+    li.external-link a::after {
+      display: inline-block;
+      content: ' ';
+      background-image: url('/static/img/external-link.svg');
+      width: 16px;
+      height: 16px;
+      margin-left: 3px;
+      vertical-align: middle;
+    }
+
     // Remove external link indicator.
     a.logo-img::after {
       display: none;
@@ -262,7 +272,7 @@ pre {
         padding: $active-spacing 0;
         border-bottom: 8px solid #fff0;
 
-        a {
+        &:not(.external-link) a {
           text-decoration: none;
         }
 


### PR DESCRIPTION
## Description

@another-rex first contribution here!

We may need to expand on this, but briefly, improving accessibility of the front end. There are more suggestions where this one comes from. Not sure if this document has free access: https://www.notion.so/ackamagroup/OSV-Design-work-May-2024-52c16f640bd640a9a6ad5b6d4bb8721e?pvs=4#40d7a1b9587040019c2c051b025a66dc

Added icon to external links, I'm using the one that is already used on the website, to enhance navigation. This icon would indicate external links within the top main tab.


## Preview changes
<img width="599" alt="Screenshot 2024-07-15 at 4 35 49 PM" src="https://github.com/user-attachments/assets/74841f0e-cd64-41d2-9125-7197e8a31226">
