### PR TITLE
style(gcp/appengine/frontend): changed style of codecard to improve usability

### DIFF
--- a/gcp/appengine/frontend3/src/styles.scss
+++ b/gcp/appengine/frontend3/src/styles.scss
@@ -1286,12 +1286,13 @@ dl.vulnerability-details,
 
   .code-card {
     position: relative;
-    background: #d46d59;
+    background: #202020;
     border-radius: 10px;
     padding: 32px;
     margin-bottom: 32px;
 
     .code-card-title {
+      color: #C5221F;
       font-size: 28px;
     }
 


### PR DESCRIPTION
## Description

Updated code card styles to meet AA colour contrast accessibility standards. This is part of some [recommendations](https://www.notion.so/ackamagroup/OSV-Design-work-May-2024-52c16f640bd640a9a6ad5b6d4bb8721e#40d7a1b9587040019c2c051b025a66dc) discovered through some accessibility analysis.


## Screenshot

![Screenshot 2024-07-17 at 11 58 20 AM](https://github.com/user-attachments/assets/dec79389-8f0e-4031-bfff-5d8063b70351)
