### PR TITLE
Revert "chore(deps): lock file maintenance api"

### DIFF
--- a/gcp/api/Pipfile
+++ b/gcp/api/Pipfile
@@ -6,12 +6,12 @@ name = "pypi"
 [packages]
 google-cloud-ndb = "==2.3.1"
 google-cloud-logging = "==3.10.0"
-packageurl-python = "==0.15.4"
+packageurl-python = "==0.15.1"
 packaging = "==20.9"
 requests = "==2.32.3"
 grpcio = "==1.64.1"
-grpcio-reflection = "==1.64.1"
-grpcio-health-checking = "==1.64.1"
+grpcio-reflection = "==1.62.2"
+grpcio-health-checking = "==1.62.2"
 
 osv = {editable = true, path = "../../"}
 

--- a/gcp/api/pyproject.toml
+++ b/gcp/api/pyproject.toml
@@ -7,12 +7,12 @@ python = "^3.11"
 
 google-cloud-ndb = "==2.3.1"
 google-cloud-logging = "==3.10.0"
-packageurl-python = "==0.15.4"
+packageurl-python = "==0.15.1"
 packaging = "==20.9"
 requests = "==2.32.3"
 grpcio = "==1.64.1"
-grpcio-reflection = "==1.64.1"
-grpcio-health-checking = "==1.64.1"
+grpcio-reflection = "==1.62.2"
+grpcio-health-checking = "==1.62.2"
 
 osv = { path = "../../", develop = true }
 


### PR DESCRIPTION
Reverts google/osv.dev#2379
Our deployments have been failing because this update had conflicting dependencies on protobuf.