### PR TITLE
Exempt backlog label from stale treatment

### DIFF
--- a/.github/workflows/staleness.yml
+++ b/.github/workflows/staleness.yml
@@ -14,7 +14,7 @@ jobs:
           stale-issue-label: stale
           stale-pr-label: stale
           remove-stale-when-updated: true
-          exempt-issue-labels: "good first issue"
+          exempt-issue-labels: "good first issue", "backlog"
           exempt-all-assignees: true
           ignore-updates: false
           stale-issue-message: "This issue has not had any activity for 60 days and will be automatically closed in two weeks"

--- a/.github/workflows/staleness.yml
+++ b/.github/workflows/staleness.yml
@@ -14,7 +14,7 @@ jobs:
           stale-issue-label: stale
           stale-pr-label: stale
           remove-stale-when-updated: true
-          exempt-issue-labels: "good first issue", "backlog"
+          exempt-issue-labels: "good first issue,backlog"
           exempt-all-assignees: true
           ignore-updates: false
           stale-issue-message: "This issue has not had any activity for 60 days and will be automatically closed in two weeks"


### PR DESCRIPTION
https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels#applying-a-label

> Anyone with triage access to a repository can apply and dismiss labels.