### PR TITLE
Run `pipenv verify` before sync

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Install pipenv
         run: pip install pipenv==2023.12.1
       - name: Set up pipenv
-        run: pipenv sync --dev
+        run: pipenv verify && pipenv sync --dev
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ifeq "$(USE_POETRY)" "true"
 	install-cmd := poetry install
 	run-cmd := poetry run
 else
-	install-cmd := pipenv sync
+	install-cmd := pipenv verify && pipenv sync
 	run-cmd := pipenv run
 endif
 

--- a/docker/importer/run_tests.sh
+++ b/docker/importer/run_tests.sh
@@ -23,5 +23,6 @@ then
 fi
 
 export PIPENV_IGNORE_VIRTUALENVS=1
+pipenv verify
 pipenv sync
 pipenv run python ../importer/importer_test.py

--- a/docker/worker/run_tests.sh
+++ b/docker/worker/run_tests.sh
@@ -23,5 +23,6 @@ then
 fi
 
 export PIPENV_IGNORE_VIRTUALENVS=1
+pipenv verify
 pipenv sync
 pipenv run python worker_test.py

--- a/gcp/api/run_tests.sh
+++ b/gcp/api/run_tests.sh
@@ -21,10 +21,11 @@ fi
 export GOOGLE_CLOUD_PROJECT=oss-vdb
 service docker start
 
+# Set -e later as service docker start should be able to successfully fail
+set -e
+
 if [ "$USE_POETRY" == "true" ]
 then
-  # Set -e later as service docker start should be able to successfully fail
-  set -e
   poetry install
   poetry run python server_test.py
   poetry run python integration_tests.py "$1"

--- a/gcp/api/run_tests.sh
+++ b/gcp/api/run_tests.sh
@@ -31,6 +31,7 @@ then
   exit 0
 fi
 
+python3 -m pipenv verify
 python3 -m pipenv sync
 
 export PIPENV_IGNORE_VIRTUALENVS=1

--- a/gcp/appengine/run_tests.sh
+++ b/gcp/appengine/run_tests.sh
@@ -8,5 +8,6 @@ then
 fi
 
 export PIPENV_IGNORE_VIRTUALENVS=1
+python3 -m pipenv verify
 python3 -m pipenv sync
 python3 -m pipenv run python frontend_handlers_test.py

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -15,6 +15,7 @@ then
 fi
 
 export PIPENV_IGNORE_VIRTUALENVS=1
+python3 -m pipenv verify
 python3 -m pipenv sync
 python3 -m pipenv run python -m unittest osv.bug_test
 python3 -m pipenv run python -m unittest osv.purl_helpers_test

--- a/tools/sourcerepo-sync/run_source_update.sh
+++ b/tools/sourcerepo-sync/run_source_update.sh
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 export PIPENV_IGNORE_VIRTUALENVS=1
+pipenv verify
 pipenv sync
 
 pipenv run python source_sync.py --kind SourceRepository --project oss-vdb --file ../../source.yaml --no-dry-run --verbose

--- a/tools/sourcerepo-sync/run_tests.sh
+++ b/tools/sourcerepo-sync/run_tests.sh
@@ -22,6 +22,7 @@ then
 fi
 
 export PIPENV_IGNORE_VIRTUALENVS=1
+pipenv verify
 pipenv sync
 
 pipenv run python source_sync.py --kind SourceRepository --project oss-vdb --file ../../source.yaml --verbose --validate


### PR DESCRIPTION
Pipenv doesn't automatically check if the `Pipfile` matches the `Pipfile.lock` when running `pipenv sync`. Added `pipenv verify` commands in all the places to do the manifest/lockfile verification. This should prevent things like #2379 from passing our tests.

Poetry seems to automatically do this validation when you run `poetry install` (But there is a `poetry check` command as well?)