### PR TITLE
Ignore CVE IDs from Ubuntu

### DIFF
--- a/source.yaml
+++ b/source.yaml
@@ -287,7 +287,7 @@
 - name: 'ubuntu'
   versions_from_repo: False
   type: 0
-  ignore_patterns: []
+  ignore_patterns: ['CVE-.*']
   directory_path: 'osv'
   repo_url: 'https://github.com/canonical/ubuntu-security-notices.git'
   detect_cherrypicks: False

--- a/source_test.yaml
+++ b/source_test.yaml
@@ -261,7 +261,7 @@
 - name: 'ubuntu'
   versions_from_repo: False
   type: 0
-  ignore_patterns: []
+  ignore_patterns: ['CVE-.*']
   directory_path: 'osv'
   repo_url: 'https://github.com/canonical/ubuntu-security-notices.git'
   detect_cherrypicks: False


### PR DESCRIPTION
Ubuntu has recently published a bunch of records with CVE IDs which is causing problems for us.
Explicitly ignore them for now.