### PR TITLE
Label closed stale issues/PRs

### DIFF
--- a/.github/workflows/staleness.yml
+++ b/.github/workflows/staleness.yml
@@ -12,13 +12,21 @@ jobs:
           days-before-stale: 60
           days-before-close: 14
           operations-per-run: 100
-          stale-issue-label: stale
-          stale-pr-label: stale
           remove-stale-when-updated: true
           exempt-issue-labels: "good first issue,backlog"
           exempt-all-assignees: true
           ignore-updates: false
-          stale-issue-message: "This issue has not had any activity for 60 days and will be automatically closed in two weeks"
-          stale-pr-message: "This pull request has not had any activity for 60 days and will be automatically closed in two weeks"
-          close-issue-message: "Automatically closing stale issue"
-          close-pr-message: "Automatically closing stale pull request"
+          stale-issue-label: stale
+          stale-issue-message: |
+            This issue has not had any activity for 60 days and will be automatically closed in two weeks
+
+            See https://github.com/google/osv.dev/blob/master/CONTRIBUTING.md for how to contribute a PR if you're interested in helping out.
+          stale-pr-label: stale
+          stale-pr-message: |
+            This pull request has not had any activity for 60 days and will be automatically closed in two weeks
+          close-issue-label: "autoclosed"
+          close-issue-message: |
+            Automatically closing stale issue
+          close-pr-label: "autoclosed"
+          close-pr-message: |
+            Automatically closing stale pull request


### PR DESCRIPTION
This way they're easily identifiable for later review

Add a nudge to encourage contribution for stale issues.

Convert message text to multiline strings for ease of future maintenance

Aggregate related configuration for ease of comprehension and future maintenance