### PR TITLE
Don't crash on an UnexpectedSituation

### DIFF
--- a/tools/datafix/reimport_gcs_record.py
+++ b/tools/datafix/reimport_gcs_record.py
@@ -171,7 +171,12 @@ def main() -> None:
   try:
     with ds_client.transaction() as xact:
       for bug in result_to_fix:
-        bug_in_gcs = objname_for_bug(ds_client, bug)
+        try:
+          bug_in_gcs = objname_for_bug(ds_client, bug)
+        except UnexpectedSituation as e:
+          if args.verbose:
+            print(f"Skipping {bug}, got {e}\n")
+          continue
         if args.verbose:
           print(f"Resetting creation time for {bug_in_gcs['uri']}")
         if not args.dryrun:

--- a/tools/datafix/reimport_gcs_record.py
+++ b/tools/datafix/reimport_gcs_record.py
@@ -175,7 +175,7 @@ def main() -> None:
           bug_in_gcs = objname_for_bug(ds_client, bug)
         except UnexpectedSituation as e:
           if args.verbose:
-            print(f"Skipping {bug}, got {e}\n")
+            print(f"Skipping {bug['db_id']}, got {e}\n")
           continue
         if args.verbose:
           print(f"Resetting creation time for {bug_in_gcs['uri']}")


### PR DESCRIPTION
Rather than crash and prematurely end an invocation with potentially more bugs left to process, gracefully handle `UnexpectedSituation` exceptions and continue processing the rest of the bugs.

Necessary because there are still some Git-sourced CVEs in Datastore that require reimporting from GCS, and tickle this edge case.