### PR TITLE
fix: datastore emulator startup race condition

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -26,6 +26,9 @@ steps:
   args: ['bash', '-ex', 'run_tests.sh']
   env:
     # Each concurrent test that uses the datastore emulator must have a unique port number
+    # lib-tests is the first test that starts the emulator. The first emulator call creates the
+    # test project config. Every other datastore must wait till this finishes, otherwise
+    # we risk multiple attempts at creating the config directory, causing failure.
     - DATASTORE_EMULATOR_PORT=8002
   waitFor: ['init']
 
@@ -42,8 +45,9 @@ steps:
   args: ['bash', '-ex', 'run_tests.sh']
   env:
     # Each concurrent test that uses the datastore emulator must have a unique port number
+    # Wait for lib-tests to make sure the project directory is created
     - DATASTORE_EMULATOR_PORT=8003
-  waitFor: ['init']
+  waitFor: ['init', 'lib-tests']
 
 - name: 'gcr.io/oss-vdb/ci'
   id: 'importer-tests'
@@ -72,8 +76,9 @@ steps:
   args: ['bash', '-ex', 'run_tests.sh']
   env:
     # Each concurrent test that uses the datastore emulator must have a unique port number
+    # Wait for lib-tests to make sure the project directory is created
     - DATASTORE_EMULATOR_PORT=8004
-  waitFor: ['init']
+  waitFor: ['init', 'lib-tests']
 
 - name: 'gcr.io/oss-vdb/ci'
   id: 'vulnfeed-tests'

--- a/osv/tests.py
+++ b/osv/tests.py
@@ -128,19 +128,26 @@ def start_datastore_emulator():
   return proc
 
 
+emulator_stdout_thread_output = ''
+
+
 def _wait_for_emulator_ready(proc,
                              emulator,
                              indicator,
                              timeout=_EMULATOR_TIMEOUT):
   """Waits for emulator to be ready."""
+  global emulator_stdout_thread_output
+  emulator_stdout_thread_output = ''
 
   def _read_thread(proc, ready_event):
     """Thread to continuously read from the process stdout."""
+    global emulator_stdout_thread_output
     ready = False
     while True:
       line = proc.stdout.readline()
       if not line:
         break
+      emulator_stdout_thread_output += str(line) + '\n'
 
       if not ready and indicator in line:
         ready = True
@@ -153,6 +160,7 @@ def _wait_for_emulator_ready(proc,
   thread.start()
 
   if not ready_event.wait(timeout):
+    print(emulator_stdout_thread_output)
     raise RuntimeError(
         '{} emulator did not get ready in time.'.format(emulator))
 


### PR DESCRIPTION
The `start_datastore_emulator()` function that runs the gcloud emulator actually will run two commands.

First it will check whether `/builder/home/.config/gcloud/emulators/datastore` exists, if not it will run `cloud_datastore_emulator create` with the test project ID, which makes the directory. Then it will follow up with the actual datastore emulator command.

The problem is with the first command, if multiple datastore emulator tests are ran at the start without `/builder/home/.config/gcloud/emulators/datastore` existing, it will try to run `cloud_datastore_emulator create` multiple times, which will fail, as by the time it's ran, the directory would have started existing.

This fix makes it so one data store emulator is ran by itself at the start (`lib-tests`), before any concurrent tests start. 