### PR TITLE
feat: clarify record type expected for template

### DIFF
--- a/.github/ISSUE_TEMPLATE/converted-nvd-cve-data-quality-report.md
+++ b/.github/ISSUE_TEMPLATE/converted-nvd-cve-data-quality-report.md
@@ -8,7 +8,9 @@ assignees: ''
 ---
 
 **The CVE ID**
-For convenience, link directly to the record in OSV.dev
+For convenience, link directly to the CVE record in OSV.dev.
+Please ensure it is indeed a **CVE** record. We see a lot of reports for GHSA
+records.
 
 **Describe the data quality issue observed**
 A clear and concise description of what the observed issue with the record is.


### PR DESCRIPTION
I've seen many reports using this template that are about GHSA records, not CVE records, so try to reiterate at reporting time what is expected to minimise user confusion and unnecessary work for everyone.