### PR TITLE
docs: update third party tool list

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ to determine suitability for your use. Some popular third party tools are:
 - [Cortex XSOAR](https://github.com/demisto/content)
 - [dep-scan](https://github.com/AppThreat/dep-scan)
 - [Dependency-Track](https://github.com/DependencyTrack/dependency-track)
+- [GUAC](https://github.com/guacsec/guac)
 - [OSS Review Toolkit](https://github.com/oss-review-toolkit/ort)
 - [pip-audit](https://github.com/pypa/pip-audit)
 - [Renovate](https://github.com/renovatebot/renovate)

--- a/README.md
+++ b/README.md
@@ -56,35 +56,12 @@ Do you have a question or a suggestion? Please [open an issue](https://github.co
 There are also community tools that use OSV. Note that these are community built
 tools and as such are not supported or endorsed by the core OSV maintainers. You may wish
 to consult the [OpenSSF's Concise Guide for Evaluating Open Source Software](https://best.openssf.org/Concise-Guide-for-Evaluating-Open-Source-Software)
-to determine suitability for your use.
+to determine suitability for your use. Some popular third party tools are:
 
-- [Betterscan.io: Code Scanning/SAST/Static Analysis/Linting using many
-  tools/Scanners with One Report (Code,
-  IaC)](https://github.com/marcinguy/betterscan-ce)
-- [bomber](https://github.com/devops-kung-fu/bomber)
 - [Cortex XSOAR](https://github.com/demisto/content)
-- [dependency-management-data](https://dmd.tanna.dev)
-- [Dependency-Track](https://github.com/DependencyTrack/dependency-track)
 - [dep-scan](https://github.com/AppThreat/dep-scan)
-- [G-Rath/osv-detector](https://github.com/G-Rath/osv-detector): A scanner
-  that uses the OSV database.
-- [GUAC](https://guac.sh)
-- [it-depends](https://github.com/trailofbits/it-depends)
-- [.NET client library and support for the schema](https://github.com/JamieMagee/osv.net)
+- [Dependency-Track](https://github.com/DependencyTrack/dependency-track)
 - [OSS Review Toolkit](https://github.com/oss-review-toolkit/ort)
-- [OSV4k: a Java/Kotlin MPP library for serialization and deserialization of OSV schema](https://github.com/saveourtool/osv4k)
-- [Packj](https://github.com/ossillate-inc/packj)
-- [pip-audit](https://pypi.org/project/pip-audit/)
+- [pip-audit](https://github.com/pypa/pip-audit)
 - [Renovate](https://github.com/renovatebot/renovate)
-- [rosv: an R package to access the OSV database and help administer Posit Package Manager](https://github.com/al-obrien/rosv)
-- [Rust client library](https://github.com/gcmurphy/osv)
-- [Skjold: Security audit python project dependencies against several security
-  advisory databases](https://github.com/twu/skjold)
 - [Trivy](https://github.com/aquasecurity/trivy)
-- [IronDome: SCA scanner for Ruby applications](https://rubygems.org/gems/iron_dome)
-- [OSV module in x-cmd: A shell CLI for OSV.dev API with osv-scanner integration](https://x-cmd.com/mod/osv)
-
-Feel free to send a PR to add your project here. We ask that you consider
-[adopting](https://scorecard.dev/#run-the-checks) [OpenSSF
-Scorecard](https://scorecard.dev) for your repo to help boost the security
-credibility of the project.

--- a/docs/third-party.md
+++ b/docs/third-party.md
@@ -15,6 +15,7 @@ to determine suitability for your use. Some popular third party tools are:
 - [Cortex XSOAR](https://github.com/demisto/content)
 - [dep-scan](https://github.com/AppThreat/dep-scan)
 - [Dependency-Track](https://github.com/DependencyTrack/dependency-track)
+- [GUAC](https://github.com/guacsec/guac)
 - [OSS Review Toolkit](https://github.com/oss-review-toolkit/ort)
 - [pip-audit](https://github.com/pypa/pip-audit)
 - [Renovate](https://github.com/renovatebot/renovate)

--- a/docs/third-party.md
+++ b/docs/third-party.md
@@ -10,33 +10,12 @@ nav_order: 5
 There are community tools that use OSV. Note that these are community built
 tools as such are not supported or endorsed by the core OSV maintainers. You may wish
 to consult the [OpenSSF's Concise Guide for Evaluating Open Source Software](https://best.openssf.org/Concise-Guide-for-Evaluating-Open-Source-Software)
-to determine suitability for your use.
+to determine suitability for your use. Some popular third party tools are:
 
-- [Betterscan.io: Code Scanning/SAST/Static Analysis/Linting using many
-  tools/Scanners with One Report (Code,
-  IaC)](https://github.com/marcinguy/betterscan-ce)
-- [bomber](https://github.com/devops-kung-fu/bomber)
 - [Cortex XSOAR](https://github.com/demisto/content)
-- [dependency-management-data](https://dmd.tanna.dev)
-- [Dependency-Track](https://github.com/DependencyTrack/dependency-track)
 - [dep-scan](https://github.com/AppThreat/dep-scan)
-- [G-Rath/osv-detector](https://github.com/G-Rath/osv-detector): A scanner
-  that uses the OSV database.
-- [GUAC](https://guac.sh)
-- [it-depends](https://github.com/trailofbits/it-depends)
-- [.NET client library and support for the schema](https://github.com/JamieMagee/osv.net)
+- [Dependency-Track](https://github.com/DependencyTrack/dependency-track)
 - [OSS Review Toolkit](https://github.com/oss-review-toolkit/ort)
-- [Packj](https://github.com/ossillate-inc/packj)
-- [pip-audit](https://pypi.org/project/pip-audit/)
+- [pip-audit](https://github.com/pypa/pip-audit)
 - [Renovate](https://github.com/renovatebot/renovate)
-- [rosv: an R package to access the OSV database and help administer Posit Package Manager](https://github.com/al-obrien/rosv)
-- [Rust client library](https://github.com/gcmurphy/osv)
-- [Skjold: Security audit python project dependencies against several security
-  advisory databases](https://github.com/twu/skjold)
 - [Trivy](https://github.com/aquasecurity/trivy)
-- [IronDome: SCA scanner for Ruby applications](https://rubygems.org/gems/iron_dome)
-- [OSV module in x-cmd: A shell CLI for OSV.dev API with osv-scanner integration](https://x-cmd.com/mod/osv)
-
-Feel free to [send a PR](https://github.com/google/osv.dev/blob/master/docs/third-party.md) to add
-your project here. We ask that you consider [adopting](https://scorecard.dev/#run-the-checks) [OpenSSF
-Scorecard](https://scorecard.dev) for your repo to help boost the security credibility of the project.


### PR DESCRIPTION
More third-party tools are using OSV, making it difficult for us to maintain the OSV third-party tool list. 
- Discontinue maintaining the full list and trim it down to only popular ones (currently those with 900+ stars).
- Update the `pip-audit`/`GUAC` link to its GitHub page to maintain consistency.