### PR TITLE
fix: Fix cloud run images by having poetry install the virtualenv directly into the project directory.

### DIFF
--- a/docker/worker-base/Dockerfile
+++ b/docker/worker-base/Dockerfile
@@ -46,6 +46,10 @@ RUN $POETRY_HOME/bin/pip install poetry==1.8.3
 # Link in PATH to make it possible to directly call poetry
 RUN ln -s $POETRY_HOME/bin/poetry /usr/local/bin/poetry
 
+# Keep the virtualenv directly in the project directory. This isn't strictly neccesary for
+# this image as it runs on kubernetes, but it keeps it consistent with other cloud run images.
+ENV POETRY_VIRTUALENVS_IN_PROJECT=true
+
 # Install Docker.
 # Pin the version to an older one due to gVisor incompatibilities.
 # See https://github.com/google/osv.dev/issues/1019#issuecomment-1427418758

--- a/gcp/api/Dockerfile
+++ b/gcp/api/Dockerfile
@@ -14,6 +14,12 @@
 
 FROM python:3.11-slim
 
+# Generation 1 of cloud run overrides the HOME environment variable, causing
+# poetry to run in the incorrect environment, as it defaults to using $HOME/.cache/virtualenvs/...
+# 
+# This forces it to create the virtualenv in the same directory as the project, avoiding this issue.
+ENV POETRY_VIRTUALENVS_IN_PROJECT=true
+
 # TODO(ochang): Just copy the entire project (needs a clean checkout).
 COPY setup.py pyproject.toml poetry.lock README.md /osv/
 COPY osv /osv/osv

--- a/gcp/appengine/Dockerfile
+++ b/gcp/appengine/Dockerfile
@@ -2,6 +2,12 @@
 FROM node:20.9 AS FRONTEND3_BUILD
 WORKDIR /build/frontend3
 
+# Generation 1 of cloud run overrides the HOME environment variable, causing
+# poetry to run in the incorrect environment, as it defaults to using $HOME/.cache/virtualenvs/...
+# 
+# This forces it to create the virtualenv in the same directory as the project, avoiding this issue.
+ENV POETRY_VIRTUALENVS_IN_PROJECT=true
+
 # Install dependencies first for better caching
 COPY gcp/appengine/frontend3/package.json gcp/appengine/frontend3/package-lock.json ./
 RUN npm ci

--- a/vulnfeeds/tools/debian/Dockerfile
+++ b/vulnfeeds/tools/debian/Dockerfile
@@ -14,6 +14,10 @@
 
 FROM google/cloud-sdk:449.0.0-alpine
 
+# Keep the virtualenv directly in the project directory. This isn't strictly neccesary for
+# this project as it runs on kubernetes, but it keeps it consistent with other cloud run images
+ENV POETRY_VIRTUALENVS_IN_PROJECT=true
+
 RUN apk --no-cache add py3-pip \
     && pip install poetry==1.8.3
 


### PR DESCRIPTION
This should fix the current API and osv-website deployment failure.

> Generation 1 of cloud run overrides the HOME environment variable, causing
> poetry to run in the incorrect environment, as it defaults to using `$HOME/.cache/poetry/virtualenvs/...`
> 
> This forces it to create the virtualenv in the same directory as the project, avoiding this issue.

https://cloud.google.com/run/docs/known-issues#home