### PR TITLE
fix: missing Packages for some malicious packages

### DIFF
--- a/gcp/appengine/frontend3/src/templates/list.html
+++ b/gcp/appengine/frontend3/src/templates/list.html
@@ -94,7 +94,9 @@
             <span role="cell" class="vuln-table-cell vuln-packages mdc-data-table__cell">
               <ul class="packages">
                 {% for package in (vulnerability.affected | list_packages) %}
-                <li>{{ package }}</li>
+                  <li>{{ package }}</li>
+                {% else %}
+                  <li>Not specified</li>
                 {% endfor %}
               </ul>
             </span>


### PR DESCRIPTION
https://github.com/google/osv.dev/issues/2422

Display "Not specified" if packages is missed in the vulnerability details

Before fix:
<img width="2538" alt="image" src="https://github.com/user-attachments/assets/ef33e80c-0afa-48d0-aa35-70abcb501e68">

Result:
<img width="2559" alt="image" src="https://github.com/user-attachments/assets/d5f21160-c40d-42b3-bf95-0f76059211f5">


