### PR TITLE
fix(combine-to-osv): attempt to work around execution latency problems

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
@@ -4,11 +4,11 @@ metadata:
   name: combine-to-osv
 spec:
   schedule: "30 */1 * * *"
-  concurrencyPolicy: Forbid
+  concurrencyPolicy: Allow # on the assumption the dominant part of the runtime is the GCS copy at the end
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
-      activeDeadlineSeconds: 7200
+      activeDeadlineSeconds: 14400
       template:
         spec:
           tolerations:
@@ -30,7 +30,7 @@ spec:
                 memory: "8G"
           nodeSelector:
             cloud.google.com/gke-nodepool: highend
-          restartPolicy: OnFailure
+          restartPolicy: Never # on the assumption that the next scheduled run is soon enough
           volumes:
             - name: "ssd"
               hostPath:

--- a/vulnfeeds/cmd/combine-to-osv/Dockerfile
+++ b/vulnfeeds/cmd/combine-to-osv/Dockerfile
@@ -26,7 +26,7 @@ RUN go build -o combine-to-osv ./cmd/combine-to-osv/
 RUN go build -o download-cves ./cmd/download-cves/
 
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
 RUN apk --no-cache add jq
 
 WORKDIR /root/

--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -148,7 +148,7 @@ func loadParts(partsInputPath string) (map[cves.CVEID][]vulns.PackageInfo, map[c
 
 // combineIntoOSV creates OSV entry by combining loaded CVEs from NVD and PackageInfo information from security advisories.
 func combineIntoOSV(loadedCves map[cves.CVEID]cves.Vulnerability, allParts map[cves.CVEID][]vulns.PackageInfo, cveList string, cvePartsModifiedTime map[cves.CVEID]time.Time) map[cves.CVEID]*vulns.Vulnerability {
-	Logger.Infof("Begin writing OSV files")
+	Logger.Infof("Begin writing OSV files from %d parts", len(allParts))
 	convertedCves := map[cves.CVEID]*vulns.Vulnerability{}
 	for cveId, cve := range loadedCves {
 		if len(allParts[cveId]) == 0 {
@@ -185,6 +185,7 @@ func combineIntoOSV(loadedCves map[cves.CVEID]cves.Vulnerability, allParts map[c
 		}
 		convertedCves[cveId] = convertedCve
 	}
+	Logger.Infof("Ended writing %d OSV files", len(convertedCves))
 	return convertedCves
 }
 
@@ -204,7 +205,7 @@ func writeOSVFile(osvData map[cves.CVEID]*vulns.Vulnerability, osvOutputPath str
 		file.Close()
 	}
 
-	Logger.Infof("Successfully written all OSV files")
+	Logger.Infof("Successfully written %d OSV files", len(osvData))
 }
 
 // loadAllCVEs loads the downloaded CVE's from the NVD database into memory.


### PR DESCRIPTION
Given that we're seeing the GCS copy phase at the end of the execution
of combine-to-osv overrun the current CronJob:
- allow the CronJob to run concurrently, on the assumption that they
  will be operating on different sets of files concurrently, in the
  worst case scenario
- double the maximum runtime to 4h to prevent premature termination
- don't restart on failure, to advoid masking failures and on the
  assumption the next scheduled run will be "soon enough"

Pin Cloud SDK at [485.0.0](https://cloud.google.com/sdk/docs/release-notes#48500_2024-07-23) to test the hypothesis that something was introduced in [486.0.0](https://cloud.google.com/sdk/docs/release-notes#48600_2024-07-30) that caused a latency regression.

Also add some additional instrumentation to what gets logged so we have data on the scale of various operations.