### PR TITLE
fix: remove security tracker URL validation to reduce job runtime

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -252,10 +252,5 @@ func addReference(cveId string, ecosystem string, convertedCve *vulns.Vulnerabil
 		return
 	}
 
-	_, err := cves.ValidateAndCanonicalizeLink(securityReference.URL)
-	if err != nil {
-		Logger.Warnf("Failed to add reference for %s in %s: %v", cveId, ecosystem, err)
-		return
-	}
 	convertedCve.References = append(convertedCve.References, securityReference)
 }


### PR DESCRIPTION
https://github.com/google/osv.dev/pull/2388 significantly increased `combine-to-osv` runtime and caused job failures. Remove the URL validation to reduce time.

Follow up PR: run all HTTP request parallelly. 