### PR TITLE
docs: add Git conventional commit requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,12 @@ gcloud auth login --update-adc
 make run-api-server
 ```
 
+### Making commits
+
+Please follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification for commit messages. This helps us to automate processes like changelog generation and ensures a clear and consistent commit history.
+
+Some types: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, and others.
+
 ## Contributing data
 
 Data contributions are also welcome!


### PR DESCRIPTION
add [Git conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) requirement to keep commit history clean.