### PR TITLE
fix(build): pin all usage of cloud-sdk image

### DIFF
--- a/docker/terraform/Dockerfile
+++ b/docker/terraform/Dockerfile
@@ -6,7 +6,7 @@ ARG TERRAFORM_VERSION
 WORKDIR /build/
 RUN GOBIN=$(pwd) go install github.com/hashicorp/terraform@v${TERRAFORM_VERSION}
 
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
 
 COPY --from=GO_BUILD /build/terraform /usr/bin/terraform
 COPY entrypoint.bash /builder/entrypoint.bash

--- a/vulnfeeds/cmd/alpine/Dockerfile
+++ b/vulnfeeds/cmd/alpine/Dockerfile
@@ -25,7 +25,7 @@ COPY ./ /src/
 RUN go build -o alpine-osv ./cmd/alpine/
 
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
 
 WORKDIR /root/
 COPY --from=GO_BUILD /src/alpine-osv ./

--- a/vulnfeeds/cmd/alpine/Dockerfile
+++ b/vulnfeeds/cmd/alpine/Dockerfile
@@ -25,7 +25,7 @@ COPY ./ /src/
 RUN go build -o alpine-osv ./cmd/alpine/
 
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
 
 WORKDIR /root/
 COPY --from=GO_BUILD /src/alpine-osv ./

--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -253,10 +253,5 @@ func addReference(cveId string, ecosystem string, convertedCve *vulns.Vulnerabil
 		return
 	}
 
-	_, err := cves.ValidateAndCanonicalizeLink(securityReference.URL)
-	if err != nil {
-		Logger.Warnf("Failed to add reference for %s in %s: %v", cveId, ecosystem, err)
-		return
-	}
 	convertedCve.References = append(convertedCve.References, securityReference)
 }

--- a/vulnfeeds/cmd/cpe-repo-gen/Dockerfile
+++ b/vulnfeeds/cmd/cpe-repo-gen/Dockerfile
@@ -24,7 +24,7 @@ RUN go mod download
 COPY ./ /src/
 RUN CGO_ENABLED=0 go build -o cpe-repo-gen ./cmd/cpe-repo-gen
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
 
 COPY --from=GO_BUILD /src/cpe-repo-gen ./
 COPY ./cmd/cpe-repo-gen/cpe-repo-gen_map.sh ./

--- a/vulnfeeds/cmd/cpe-repo-gen/Dockerfile
+++ b/vulnfeeds/cmd/cpe-repo-gen/Dockerfile
@@ -24,7 +24,7 @@ RUN go mod download
 COPY ./ /src/
 RUN CGO_ENABLED=0 go build -o cpe-repo-gen ./cmd/cpe-repo-gen
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
 
 COPY --from=GO_BUILD /src/cpe-repo-gen ./
 COPY ./cmd/cpe-repo-gen/cpe-repo-gen_map.sh ./

--- a/vulnfeeds/cmd/debian-copyright-mirror/Dockerfile
+++ b/vulnfeeds/cmd/debian-copyright-mirror/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
 
 RUN apk add wget
 

--- a/vulnfeeds/cmd/debian-copyright-mirror/Dockerfile
+++ b/vulnfeeds/cmd/debian-copyright-mirror/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
 
 RUN apk add wget
 

--- a/vulnfeeds/cmd/debian/Dockerfile
+++ b/vulnfeeds/cmd/debian/Dockerfile
@@ -25,7 +25,7 @@ COPY ./ /src/
 RUN go build -o debian-osv ./cmd/debian/
 
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
 
 WORKDIR /root/
 COPY --from=GO_BUILD /src/debian-osv ./

--- a/vulnfeeds/cmd/debian/Dockerfile
+++ b/vulnfeeds/cmd/debian/Dockerfile
@@ -25,7 +25,7 @@ COPY ./ /src/
 RUN go build -o debian-osv ./cmd/debian/
 
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
 
 WORKDIR /root/
 COPY --from=GO_BUILD /src/debian-osv ./

--- a/vulnfeeds/cmd/download-cves/Dockerfile
+++ b/vulnfeeds/cmd/download-cves/Dockerfile
@@ -24,7 +24,7 @@ RUN go mod download
 COPY ./ /src/
 RUN go build -o download-cves ./cmd/download-cves/
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
 RUN apk --no-cache add jq
 
 WORKDIR /usr/local/bin

--- a/vulnfeeds/cmd/download-cves/Dockerfile
+++ b/vulnfeeds/cmd/download-cves/Dockerfile
@@ -24,7 +24,7 @@ RUN go mod download
 COPY ./ /src/
 RUN go build -o download-cves ./cmd/download-cves/
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
 RUN apk --no-cache add jq
 
 WORKDIR /usr/local/bin

--- a/vulnfeeds/cmd/nvd-cve-osv/Dockerfile
+++ b/vulnfeeds/cmd/nvd-cve-osv/Dockerfile
@@ -22,7 +22,7 @@ RUN go mod download && go mod verify
 COPY . .
 RUN CGO_ENABLED=0 go build -v -o /usr/local/bin ./cmd/nvd-cve-osv ./cmd/download-cves
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine AS runtime
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4 AS runtime
 RUN apk --no-cache add jq
 
 COPY --from=GO_BUILD /usr/local/bin/ ./usr/local/bin/

--- a/vulnfeeds/cmd/nvd-cve-osv/Dockerfile
+++ b/vulnfeeds/cmd/nvd-cve-osv/Dockerfile
@@ -22,7 +22,7 @@ RUN go mod download && go mod verify
 COPY . .
 RUN CGO_ENABLED=0 go build -v -o /usr/local/bin ./cmd/nvd-cve-osv ./cmd/download-cves
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4 AS runtime
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4 AS runtime
 RUN apk --no-cache add jq
 
 COPY --from=GO_BUILD /usr/local/bin/ ./usr/local/bin/

--- a/vulnfeeds/tools/debian/Dockerfile
+++ b/vulnfeeds/tools/debian/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google/cloud-sdk:449.0.0-alpine
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
 
 # Keep the virtualenv directly in the project directory. This isn't strictly neccesary for
 # this project as it runs on kubernetes, but it keeps it consistent with other cloud run images


### PR DESCRIPTION
A recent apparent GCS performance regression in the Cloud SDK highlighted uncontrolled upgrading of the Cloud SDK Docker image. Pin everything to what #2480 pinned to for stability.