### PR TITLE
fix(api): add CVSS_V4 to API Swagger documentation

### DIFF
--- a/docs/osv_service_v1.swagger.json
+++ b/docs/osv_service_v1.swagger.json
@@ -336,6 +336,7 @@
       "type": "string",
       "enum": [
         "UNSPECIFIED",
+        "CVSS_V4",
         "CVSS_V3",
         "CVSS_V2"
       ],


### PR DESCRIPTION
The addition of `CVSS_V4` in #2312 did not add it to the Swagger documentation.

Open to suggestions on how to guard against such divergence in the future.

Fixes: #2485