### PR TITLE
fix(build): install Poetry via apk instead of pip

### DIFF
--- a/vulnfeeds/tools/debian/Dockerfile
+++ b/vulnfeeds/tools/debian/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
+FROM google/cloud-sdk:449.0.0-alpine
 
 # Keep the virtualenv directly in the project directory. This isn't strictly neccesary for
 # this project as it runs on kubernetes, but it keeps it consistent with other cloud run images

--- a/vulnfeeds/tools/debian/Dockerfile
+++ b/vulnfeeds/tools/debian/Dockerfile
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM google/cloud-sdk:449.0.0-alpine
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
 
 # Keep the virtualenv directly in the project directory. This isn't strictly neccesary for
 # this project as it runs on kubernetes, but it keeps it consistent with other cloud run images
 ENV POETRY_VIRTUALENVS_IN_PROJECT=true
 
-RUN apk --no-cache add py3-pip \
-    && pip install poetry==1.8.3
+RUN apk --no-cache add poetry
 
 RUN mkdir /src
 WORKDIR /src


### PR DESCRIPTION
The switch from `google/cloud-sdk:449.0.0-alpine` to `gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine` was not a drop-in replacement:

This moved from Alpine 3.18.4 to 3.20.2 and 3.20.2 is more intolerant of the `pip install poetry==1.8.3` being performed:

```
error: externally-managed-environment
```

Install Poetry via `apk` instead.