### PR TITLE
fix: bump exporter memory allowances

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/exporter.yaml
+++ b/deployment/clouddeploy/gke-workers/base/exporter.yaml
@@ -28,10 +28,10 @@ spec:
             resources:
               requests:
                 cpu: "6"
-                memory: "8G"
+                memory: "16G"
               limits:
                 cpu: "6"
-                memory: "12G"
+                memory: "32G"
           restartPolicy: OnFailure
           volumes:
             - name: "ssd"


### PR DESCRIPTION
The large number and size of records coming from Ubuntu made our exporter job start exceeding the memory limit.
Throw some more memory at the problem until it goes away.