### PR TITLE
build: pin remaining unpinned third-party Docker images

### DIFF
--- a/docker/deployment/Dockerfile
+++ b/docker/deployment/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:22.04@sha256:fa17826afb526a9fc7250e0fbcbfd18d03fe7a54849472f86879d8bf562c629e
 
 RUN apt-get update && \
     apt-get install -y curl jq

--- a/docker/indexer/Dockerfile
+++ b/docker/indexer/Dockerfile
@@ -24,7 +24,7 @@ RUN go mod download
 COPY ./ /build
 RUN CGO_ENABLED=0 ./build.sh
 
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/base@sha256:237b9021dd6224b2a41bb1bdbea5cd9ea84c758126482e3c6331faaca90c4d29
 COPY --from=GO_BUILD build/indexer /indexer
 ENTRYPOINT ["/indexer"]
 CMD ["--help"]

--- a/docker/worker-base/Dockerfile
+++ b/docker/worker-base/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:20.04
+FROM ubuntu:20.04@sha256:fa17826afb526a9fc7250e0fbcbfd18d03fe7a54849472f86879d8bf562c629e
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get upgrade -y && \

--- a/gcp/api/Dockerfile
+++ b/gcp/api/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.11-slim
+FROM python:3.11-slim@sha256:ad5dadd957a398226996bc4846e522c39f2a77340b531b28aaab85b2d361210b
 
 # Generation 1 of cloud run overrides the HOME environment variable, causing
 # poetry to run in the incorrect environment, as it defaults to using $HOME/.cache/virtualenvs/...

--- a/gcp/appengine/Dockerfile
+++ b/gcp/appengine/Dockerfile
@@ -1,5 +1,5 @@
 # Build the Javascript frontend
-FROM node:20.9 AS FRONTEND3_BUILD
+FROM node:20.9@sha256:146bbe4eaee99ae885be2a0a767f63a4b96032141d70d80e590f10e0d7ebabcb AS FRONTEND3_BUILD
 WORKDIR /build/frontend3
 
 # Install dependencies first for better caching
@@ -23,7 +23,7 @@ RUN hugo -d ../dist/static/blog
 
 # OSV.dev site image
 # Adapted from https://cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-python-service#writing
-FROM python:3.11-slim
+FROM python:3.11-slim@sha256:ad5dadd957a398226996bc4846e522c39f2a77340b531b28aaab85b2d361210b
 
 # Generation 1 of cloud run overrides the HOME environment variable, causing
 # poetry to run in the incorrect environment, as it defaults to using $HOME/.cache/virtualenvs/...


### PR DESCRIPTION
This avoids uncontrolled changes to build dependencies sneaking into our Docker image builds, and is considered best practice.

The Docker Hub expresses both an "index digest" and a "manifest digest". I have used the latter, as this seemed the correct thing to do.