### PR TITLE
fix: add total ordering to Maven version

### DIFF
--- a/osv/ecosystems/maven.py
+++ b/osv/ecosystems/maven.py
@@ -14,6 +14,7 @@
 """Maven ecosystem helper."""
 
 import collections
+import functools
 import re
 
 from .helper_base import DepsDevMixin
@@ -95,6 +96,7 @@ class VersionToken(
     return qualifier_order(self) < qualifier_order(other)
 
 
+@functools.total_ordering
 class Version:
   """Maven version."""
 

--- a/osv/ecosystems/maven_test.py
+++ b/osv/ecosystems/maven_test.py
@@ -43,6 +43,10 @@ class MavenVersionTest(unittest.TestCase):
             parsed_versions[j],
             parsed_versions[i],
             msg=f'Expected {versions[j]} > {versions[i]}')
+        self.assertGreaterEqual(
+            parsed_versions[j],
+            parsed_versions[i],
+            msg=f'Expected {versions[j]} >= {versions[i]}')
 
   def check_versions_equal(self, *versions):
     """Check that the provided versions are equivalent."""


### PR DESCRIPTION
Maven `Version` doesn't support `>=`, causing [version query](https://github.com/google/osv.dev/blob/30d55798022eabb000ecc091f03ec7d5a2002c4a/gcp/api/server.py#L1250) failures. Add the `total_ordering` function to support all kinds of ordering.