### PR TITLE
fix(api): Reduce dynamic paging time to 20 seconds

### DIFF
--- a/deployment/terraform/modules/osv/osv_api.tf
+++ b/deployment/terraform/modules/osv/osv_api.tf
@@ -126,7 +126,7 @@ resource "google_cloud_run_service" "api" {
         image = data.google_container_registry_image.api.image_url
         env {
           name  = "ESPv2_ARGS"
-          value = "^++^--transcoding_preserve_proto_field_names++--envoy_connection_buffer_limit_bytes=10485760"
+          value = "^++^--transcoding_preserve_proto_field_names++--envoy_connection_buffer_limit_bytes=104857600"
         }
       }
     }

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -410,7 +410,8 @@ class QueryContext:
   total_responses: ResponsesCount
 
   def should_break_page(self, response_count: int):
-    return response_count >= self.total_responses.page_limit() or self.request_cutoff_time < datetime.now()
+    return response_count >= self.total_responses.page_limit(
+    ) or self.request_cutoff_time < datetime.now()
 
 
 def should_skip_bucket(path: str) -> bool:

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -50,7 +50,7 @@ import osv_service_v1_pb2_grpc
 
 _SHUTDOWN_GRACE_DURATION = 5
 
-_MAX_QUERY_TIME = timedelta(seconds=30)
+_MAX_QUERY_TIME = timedelta(seconds=20)
 _MAX_BATCH_QUERY = 1000
 # Maximum number of responses to return before applying post exceeded limit
 _MAX_VULN_RESP_THRESH = 3000


### PR DESCRIPTION
- Refactored the code to take in a cutoff time and place all the shared logic in a context method.
- Separate out batch query time limit and normal query time limit, as they have very different behavior. The batch query can and should be longer as it does not return all the details, the `to_response` step after the initial query takes much less time compared to the full response. Batch query also takes longer in general in the querying step compared to normal queries.
- Bump up the envoy_connection_buffer_limit_bytes by 10x. I'm not sure what impact this will have, but currently the responses made by the ubuntu query will exceed the previous limit (10mb to 100mb limit).

At 30 seconds, the current query might timeout on a fresh instance (fresh datastore connection, no JIT optimisations yet...etc.). On a warm instance, it took 51 seconds to return a 35mb json response. 

This reduces it down to 20 seconds to more reliably return. 