### PR TITLE
fix: give way more memory to exporter

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/exporter.yaml
+++ b/deployment/clouddeploy/gke-workers/base/exporter.yaml
@@ -31,7 +31,7 @@ spec:
                 memory: "16G"
               limits:
                 cpu: "6"
-                memory: "32G"
+                memory: "128G"
           restartPolicy: OnFailure
           volumes:
             - name: "ssd"


### PR DESCRIPTION
It's kind of concerning that it's still running out of memory on some Ubuntu exports - we probably should look at *why* it's using so much.
128GB should be way overkill, I just wanted to get a sense of how much it actually uses.