### PR TITLE
build: repin distroless image dependency

### DIFF
--- a/docker/indexer/Dockerfile
+++ b/docker/indexer/Dockerfile
@@ -24,7 +24,7 @@ RUN go mod download
 COPY ./ /build
 RUN CGO_ENABLED=0 ./build.sh
 
-FROM gcr.io/distroless/base@sha256:237b9021dd6224b2a41bb1bdbea5cd9ea84c758126482e3c6331faaca90c4d29
+FROM gcr.io/distroless/base@sha256:5c395fa86ad4eb0613bc9cae7412003f575a25ff9b5cb4845e37e175d2a50bba
 COPY --from=GO_BUILD build/indexer /indexer
 ENTRYPOINT ["/indexer"]
 CMD ["--help"]


### PR DESCRIPTION
The previous hash was resulting in a weird error when pulling the image.

Verified this hash by pulling it locally first.