### PR TITLE
feat: Proper working cursor

### DIFF
--- a/gcp/api/cursor.py
+++ b/gcp/api/cursor.py
@@ -1,0 +1,126 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OSV API server cursor implementation."""
+
+import base64
+from enum import Enum
+from typing import Self
+import typing
+
+from google.cloud import ndb
+import google.cloud.ndb.exceptions as ndb_exceptions
+
+_FIRST_PAGE_TOKEN = base64.urlsafe_b64encode(b'FIRST_PAGE_TOKEN').decode()
+# Use ':' as the separator as it doesn't appear in urlsafe_b64encode
+# (which is what is used for both _FIRST_PAGE_TOKEN, and ndb.Cursor.urlsafe())
+_METADATA_SEPARATOR = ':'
+
+
+class _QueryCursorState(Enum):
+  """
+  Stores the 3 states a query cursor can be in.
+  """
+
+  # The cursor has reached the end, no need to return to the user
+  ENDED = 0
+  # The cursor is at the very start of the query, no cursor needs to be
+  # set when querying ndb
+  STARTED = 1
+  # ndb.Cursor is set and in progress
+  IN_PROGRESS = 2
+
+
+class QueryCursor:
+  """
+  Custom cursor class that wraps the ndb cursor.
+  This cursor should be initialized every time a pageable 
+  query.iter() is called.
+
+  Allows us to represent the "starting" cursor.
+
+  This type could have 3 states encoded in _QueryCursorState.
+  If the current state is IN_PROGRESS, self.cursor will not be None.
+  """
+
+  cursor: ndb.Cursor | None = None
+  cursor_state: _QueryCursorState = _QueryCursorState.ENDED
+  query_number: int = 1
+
+  def __init__(self, query_number: int) -> None:
+    self.query_number = query_number
+    pass
+
+  @classmethod
+  def from_page_token(cls, page_token: str | None) -> Self:
+    """Generate a query cursor from a url safe page token."""
+    qc = cls(0)
+
+    if not page_token:
+      qc.cursor_state = _QueryCursorState.STARTED
+      qc.cursor = None
+      return qc
+
+    split_values = page_token.split(_METADATA_SEPARATOR, 1)
+    if len(split_values) == 2:
+      page_token = split_values[1]
+      try:
+        qc.query_number = int(split_values[0])
+      except ValueError as e:
+        raise ValueError('Invalid page token.') from e
+
+    if not page_token or page_token == _FIRST_PAGE_TOKEN:
+      qc.cursor_state = _QueryCursorState.STARTED
+      qc.cursor = None
+      return qc
+
+    qc.cursor = ndb.Cursor(urlsafe=page_token)
+    qc.cursor_state = _QueryCursorState.IN_PROGRESS
+    return qc
+
+  def update_from_iterator(self, it: ndb.QueryIterator) -> None:
+    try:
+      self.cursor = typing.cast(ndb.Cursor, it.cursor_after())
+      self.cursor_state = _QueryCursorState.IN_PROGRESS
+    except ndb_exceptions.BadArgumentError:
+      self.cursor = None
+      self.cursor_state = _QueryCursorState.STARTED
+
+  def get_cursor(self) -> ndb.Cursor | None:
+    if self.cursor_state == _QueryCursorState.IN_PROGRESS:
+      return self.cursor
+
+    return None
+
+  def ended(self) -> bool:
+    return self.cursor_state == _QueryCursorState.ENDED
+
+  def url_safe_encode(self) -> str | None:
+    """Create a url safe page token to pass back to the API caller"""
+    cursor_part: str = ''
+    match self.cursor_state:
+      case _QueryCursorState.STARTED:
+        cursor_part = _FIRST_PAGE_TOKEN
+      case _QueryCursorState.IN_PROGRESS:
+        # Assume that IN_PROGRESS means self.cursor is always set.
+        # Loudly throw an exception if this is not the case
+        cursor_part = self.cursor.urlsafe().decode()  # type: ignore
+      case _QueryCursorState.ENDED:
+        # If ENDED, we want to return None to not include
+        # a token in the response
+        return None
+
+    if self.query_number == 0:
+      return cursor_part
+
+    return str(self.query_number) + _METADATA_SEPARATOR + cursor_part

--- a/gcp/api/cursor.py
+++ b/gcp/api/cursor.py
@@ -90,6 +90,12 @@ class QueryCursor:
     return qc
 
   def update_from_iterator(self, it: ndb.QueryIterator) -> None:
+    """
+    Update the current cursor from the value of the ndb.iterator passed in.
+
+    Args:
+      it: the iterator to take the cursor position from.
+    """
     try:
       self._ndb_cursor = typing.cast(ndb.Cursor, it.cursor_after())
       self._cursor_state = _QueryCursorState.IN_PROGRESS

--- a/gcp/api/cursor.py
+++ b/gcp/api/cursor.py
@@ -94,7 +94,7 @@ class QueryCursor:
       self._ndb_cursor = typing.cast(ndb.Cursor, it.cursor_after())
       self._cursor_state = _QueryCursorState.IN_PROGRESS
     except ndb_exceptions.BadArgumentError:
-      # This exception can happen when iterator has not begun iterating.
+      # This exception can happen when iterator has not begun iterating
       # and it.next() is the very first element.
       #
       # In those cases, `cursor_after()`` would not be 'after' any element,

--- a/gcp/api/cursor.py
+++ b/gcp/api/cursor.py
@@ -44,10 +44,9 @@ class _QueryCursorState(Enum):
 class QueryCursor:
   """
   Custom cursor class that wraps the ndb cursor.
-  This cursor should be initialized every time a pageable 
-  query.iter() is called.
-
   Allows us to represent the "starting" cursor.
+
+  The default state is ENDED with no ndb.Cursor.
 
   This type could have 3 states encoded in _QueryCursorState.
   If the current state is IN_PROGRESS, self.cursor will not be None.
@@ -57,14 +56,10 @@ class QueryCursor:
   cursor_state: _QueryCursorState = _QueryCursorState.ENDED
   query_number: int = 1
 
-  def __init__(self, query_number: int) -> None:
-    self.query_number = query_number
-    pass
-
   @classmethod
   def from_page_token(cls, page_token: str | None) -> Self:
     """Generate a query cursor from a url safe page token."""
-    qc = cls(0)
+    qc = cls()
 
     if not page_token:
       qc.cursor_state = _QueryCursorState.STARTED

--- a/gcp/api/cursor.py
+++ b/gcp/api/cursor.py
@@ -53,13 +53,15 @@ class QueryCursor:
 
   Attributes:
     query_number: This cursor is specifically for the Nth ndb datastore
-      query in the current query request.
+      query in the current query request. (Starts from 1)
     ndb_cursor: Get the internal ndb_cursor. This could be None.
     ended: Whether this cursor is for a query that has finished returning data.
   """
 
   _ndb_cursor: ndb.Cursor | None = None
   _cursor_state: _QueryCursorState = _QueryCursorState.ENDED
+  # The first query is numbered 1. This is because the query counter is
+  # incremented **before** the query and the query number being used.
   query_number: int = 1
 
   @classmethod
@@ -141,8 +143,5 @@ class QueryCursor:
         # If ENDED, we want to return None to not include
         # a token in the response
         return None
-
-    if self.query_number == 0:
-      return cursor_part
 
     return str(self.query_number) + _METADATA_SEPARATOR + cursor_part

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -730,9 +730,9 @@ class IntegrationTests(unittest.TestCase,
             ]
         }, response.json())
 
-  @unittest.skipIf(os.getenv('LOW_MAX_THRESH', '0') != '1' ,
-                   "Run this test locally with " +
-                   "MAX_VULN_LISTED_PRE_EXCEEDED at a lower value (around 10)")
+  @unittest.skipIf(
+      os.getenv('LOW_MAX_THRESH', '0') != '1', "Run this test locally with " +
+      "MAX_VULN_LISTED_PRE_EXCEEDED at a lower value (around 10)")
   def test_query_pagination(self):
     """Test query by package with pagination."""
     response = requests.post(
@@ -764,10 +764,9 @@ class IntegrationTests(unittest.TestCase,
 
     self.assertEqual(set(), vulns_first.intersection(vulns_second))
 
-
-  @unittest.skipIf(os.getenv('LOW_MAX_THRESH', '0') != '1',
-                   "Run this test locally with " +
-                   "MAX_VULN_LISTED_PRE_EXCEEDED at a lower value (around 10)")
+  @unittest.skipIf(
+      os.getenv('LOW_MAX_THRESH', '0') != '1', "Run this test locally with " +
+      "MAX_VULN_LISTED_PRE_EXCEEDED at a lower value (around 10)")
   def test_query_pagination_no_ecosystem(self):
     """Test query with pagination but no ecosystem."""
     response = requests.post(
@@ -805,9 +804,9 @@ class IntegrationTests(unittest.TestCase,
     # self.assertTrue(str.startswith(result['next_page_token'], '1:'))
     self.assertEqual(set(), vulns_first.intersection(vulns_second))
 
-  @unittest.skipIf(os.getenv('LOW_MAX_THRESH', '0') != '1',
-                   "Run this test locally with " +
-                   "MAX_VULN_LISTED_PRE_EXCEEDED at a lower value (around 10)")
+  @unittest.skipIf(
+      os.getenv('LOW_MAX_THRESH', '0') != '1', "Run this test locally with " +
+      "MAX_VULN_LISTED_PRE_EXCEEDED at a lower value (around 10)")
   def test_query_package_purl_paging(self):
     """Test query by package (purl)."""
     response = requests.post(
@@ -933,7 +932,9 @@ def print_logs(filename):
 
 if __name__ == '__main__':
   if len(sys.argv) < 2:
-    print(f'Usage: {sys.argv[0]} path/to/credential.json [...optional specific tests]')
+    print(
+        f'Usage: {sys.argv[0]} path/to/credential.json [...optional specific tests]'
+    )
     sys.exit(1)
 
   subprocess.run(

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -775,14 +775,14 @@ class IntegrationTests(unittest.TestCase,
             'package': {
                 'name': 'django',
             },
-            'version': '5.0',
+            'version': '5.0.1',
         }),
         timeout=_TIMEOUT)
 
     result = response.json()
     vulns_first = set(v['id'] for v in result['vulns'])
     self.assertIn('next_page_token', result)
-    self.assertTrue(str.startswith(result['next_page_token'], '1:'))
+    self.assertTrue(str.startswith(result['next_page_token'], '2:'))
 
     response = requests.post(
         _api() + _BASE_QUERY,
@@ -790,7 +790,7 @@ class IntegrationTests(unittest.TestCase,
             'package': {
                 'name': 'django',
             },
-            'version': '5.0',
+            'version': '5.0.1',
             'page_token': result['next_page_token'],
         }),
         timeout=_TIMEOUT)

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -775,6 +775,8 @@ class IntegrationTests(unittest.TestCase,
             'package': {
                 'name': 'django',
             },
+            # Test with a version that is ambiguous whether it 
+            # belongs to semver or generic version
             'version': '5.0.1',
         }),
         timeout=_TIMEOUT)

--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -775,7 +775,7 @@ class IntegrationTests(unittest.TestCase,
             'package': {
                 'name': 'django',
             },
-            # Test with a version that is ambiguous whether it 
+            # Test with a version that is ambiguous whether it
             # belongs to semver or generic version
             'version': '5.0.1',
         }),

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -203,7 +203,7 @@ class OSVServicer(osv_service_v1_pb2_grpc.OSVServicer,
         service_context=context,
         request_cutoff_time=datetime.now() + _MAX_SINGLE_QUERY_TIME,
         input_cursor=page_token,
-        output_cursor=QueryCursor(0),
+        output_cursor=QueryCursor(),
         total_responses=ResponsesCount(0))
 
     try:
@@ -295,7 +295,7 @@ class OSVServicer(osv_service_v1_pb2_grpc.OSVServicer,
           service_context=context,
           request_cutoff_time=req_cutoff_time,
           input_cursor=page_token,
-          output_cursor=QueryCursor(0),
+          output_cursor=QueryCursor(),
           total_responses=total_responses)
 
       futures.append(do_query(query, query_context, include_details=False))

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -1113,7 +1113,7 @@ def query_by_version(context: QueryContext,
       bugs = yield _query_by_semver(context, query, package_name, ecosystem,
                                     purl, version)
 
-      # If the previous query has fully finished (or skipped), 
+      # If the previous query has fully finished (or skipped),
       # try generic version
       new_bugs = yield _query_by_generic_version(context, query, package_name,
                                                  ecosystem, purl, version)

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -413,6 +413,17 @@ class QueryContext:
   """
   Information about the query the server is currently
   responding to.
+
+  Attributes:
+    service_context: Context of the underlying grpc call.
+    input_cursor: Cursor from the user API query input.
+    output_cursor: Cursor to potentially return to the user.
+    request_cutoff_time: Time past which all further datastore 
+      queries stop and a page cut is made.
+    total_responses: **Reference** to the total count of responses
+      across all queries in the batch.
+    query_counter: Number of queries which has already been executed
+      (does not count batch queries).
   """
   service_context: grpc.ServicerContext
   input_cursor: QueryCursor
@@ -420,7 +431,6 @@ class QueryContext:
   request_cutoff_time: datetime
   # Use a dataclass to copy by reference
   total_responses: ResponsesCount
-  # Number of queries that has already been executed
   query_counter: int = 0
 
   def should_break_page(self, response_count: int):

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -48,6 +48,8 @@ from osv.logs import setup_gcp_logging
 import osv_service_v1_pb2
 import osv_service_v1_pb2_grpc
 
+from gcp.api.cursor import QueryCursor
+
 _SHUTDOWN_GRACE_DURATION = 5
 
 _MAX_SINGLE_QUERY_TIME = timedelta(seconds=20)
@@ -188,18 +190,20 @@ class OSVServicer(osv_service_v1_pb2_grpc.OSVServicer,
     else:
       logging.info('QueryAffected for %s', qtype)
 
-    page_token = None
-    if request.query.page_token:
-      try:
-        page_token = ndb.Cursor(urlsafe=request.query.page_token)
-      except ValueError as e:
-        logging.warning(e)
-        context.abort(grpc.StatusCode.INVALID_ARGUMENT, 'Invalid page token.')
+    try:
+      page_token = QueryCursor.from_page_token(request.query.page_token)
+    except ValueError as e:
+      logging.warning(e)
+      context.abort(grpc.StatusCode.INVALID_ARGUMENT, 'Invalid page token.')
+      # This is just for the type checker which doesn't know
+      # abort will kill the code flow
+      raise
 
     query_context = QueryContext(
         service_context=context,
         request_cutoff_time=datetime.now() + _MAX_SINGLE_QUERY_TIME,
-        page_token=page_token,
+        input_cursor=page_token,
+        output_cursor=QueryCursor(0),
         total_responses=ResponsesCount(0))
 
     try:
@@ -277,19 +281,21 @@ class OSVServicer(osv_service_v1_pb2_grpc.OSVServicer,
     total_responses = ResponsesCount(0)
     req_cutoff_time = datetime.now() + _MAX_BATCH_QUERY_TIME
     for i, query in enumerate(request.query.queries):
-      page_token = None
-      if query.page_token:
-        try:
-          page_token = ndb.Cursor(urlsafe=query.page_token)
-        except ValueError as e:
-          logging.warning(e)
-          context.abort(grpc.StatusCode.INVALID_ARGUMENT,
-                        f'Invalid page token at index: {i}.')
+      try:
+        page_token = QueryCursor.from_page_token(query.page_token)
+      except ValueError as e:
+        logging.warning(e)
+        context.abort(grpc.StatusCode.INVALID_ARGUMENT,
+                      f'Invalid page token at index: {i}.')
+        # This is just for the type checker which doesn't know
+        # abort will kill the code flow
+        raise
 
       query_context = QueryContext(
           service_context=context,
           request_cutoff_time=req_cutoff_time,
-          page_token=page_token,
+          input_cursor=page_token,
+          output_cursor=QueryCursor(0),
           total_responses=total_responses)
 
       futures.append(do_query(query, query_context, include_details=False))
@@ -409,10 +415,13 @@ class QueryContext:
   responding to.
   """
   service_context: grpc.ServicerContext
-  page_token: ndb.Cursor | None
+  input_cursor: QueryCursor
+  output_cursor: QueryCursor
   request_cutoff_time: datetime
   # Use a dataclass to copy by reference
   total_responses: ResponsesCount
+  # Number of queries that has already been executed
+  query_counter: int = 0
 
   def should_break_page(self, response_count: int):
     """
@@ -425,6 +434,26 @@ class QueryContext:
     """
     return (response_count >= self.total_responses.page_limit() or
             datetime.now() > self.request_cutoff_time)
+  
+  def should_skip_query(self):
+    """
+    Returns whether a query should be executed or skipped depending
+    on the cursor position.
+
+    A query should be skipped when:
+      - Input cursor is for a future query
+      - Output cursor is not ended(), which means we already hit page limit
+        in a previous query.
+    """
+    return (self.query_counter < self.input_cursor.query_number or
+            not self.output_cursor.ended())
+  
+  def save_cursor_at_page_break(self, it: ndb.QueryIterator):
+    """
+    Saves the cursor at the current page break position
+    """
+    self.output_cursor.update_from_iterator(it)
+    self.output_cursor.query_number = self.query_counter
 
 
 def should_skip_bucket(path: str) -> bool:
@@ -629,7 +658,9 @@ def determine_version(version_query: osv_service_v1_pb2.VersionQuery,
 
 
 @ndb.tasklet
-def do_query(query, context: QueryContext, include_details=True):
+def do_query(query,
+             context: QueryContext,
+             include_details=True) -> tuple[list, str | None]:
   """Do a query."""
   if query.HasField('package'):
     package_name = query.package.name
@@ -677,8 +708,6 @@ def do_query(query, context: QueryContext, include_details=True):
     # Retrieve it asynchronously later.
     return bug_to_response(b, include_details)
 
-  next_page_token = None
-
   if query.WhichOneof('param') == 'commit':
     try:
       commit_bytes = codecs.decode(query.commit, 'hex')
@@ -687,10 +716,10 @@ def do_query(query, context: QueryContext, include_details=True):
                                     'Invalid hash.')
       return None
 
-    bugs, next_page_token = yield query_by_commit(
+    bugs = yield query_by_commit(
         context, commit_bytes, to_response=to_response)
   elif purl and purl_version:
-    bugs, next_page_token = yield query_by_version(
+    bugs = yield query_by_version(
         context,
         package_name,
         ecosystem,
@@ -698,7 +727,7 @@ def do_query(query, context: QueryContext, include_details=True):
         purl_version,
         to_response=to_response)
   elif query.WhichOneof('param') == 'version':
-    bugs, next_page_token = yield query_by_version(
+    bugs = yield query_by_version(
         context,
         package_name,
         ecosystem,
@@ -707,7 +736,7 @@ def do_query(query, context: QueryContext, include_details=True):
         to_response=to_response)
   elif (package_name != '' and ecosystem != '') or (purl and not purl_version):
     # Package specified without version.
-    bugs, next_page_token = yield query_by_package(
+    bugs = yield query_by_package(
         context, package_name, ecosystem, purl, to_response=to_response)
   else:
     context.service_context.abort(grpc.StatusCode.INVALID_ARGUMENT,
@@ -739,11 +768,17 @@ def do_query(query, context: QueryContext, include_details=True):
       bugs[i].related[:] = sorted(
           list(set(related_bug_ids + list(bugs[i].related))))
 
-  if next_page_token:
-    next_page_token = next_page_token.urlsafe()
-    logging.warning('Page size limit hit, response size: %s', len(bugs))
+  if context.query_counter < context.input_cursor.query_number:
+    # If the input cursor is for a query number that's greater than
+    # the number of queries performed, the cursor must be invalid
+    # (and there will be no results, as everything is skipped)
+    raise ValueError("Cursor is invalid/does not belong to this query")
 
-  return bugs, next_page_token
+  next_page_token_str = context.output_cursor.url_safe_encode()
+  if next_page_token_str:
+    logging.warning('Page size limit hit, response size: %s', len(bugs))
+  
+  return bugs, next_page_token_str
 
 
 def bug_to_response(bug, include_details=True, include_alias=False):
@@ -784,18 +819,21 @@ def _datastore_normalized_purl(purl: PackageURL):
 def query_by_commit(
     context: QueryContext,
     commit: bytes,
-    to_response: Callable = bug_to_response) -> tuple[list, ndb.Cursor]:
+    to_response: Callable = bug_to_response) -> list:
   """Query by commit."""
   query = osv.AffectedCommits.query(osv.AffectedCommits.commits == commit)
 
+  context.query_counter += 1
+  if context.should_skip_query():
+    return []
+
   bug_ids = []
   it: ndb.QueryIterator = query.iter(
-      keys_only=True, start_cursor=context.page_token)
+      keys_only=True, start_cursor=context.input_cursor.get_cursor())
 
-  cursor = None
   while (yield it.has_next_async()):
     if context.should_break_page(len(bug_ids)):
-      cursor = it.cursor_after()
+      context.save_cursor_at_page_break(it)
       break
 
     # Affect commits key follows this format:
@@ -807,7 +845,7 @@ def query_by_commit(
     context.total_responses.add(1)
 
   bugs = yield _get_bugs(bug_ids, to_response=to_response)
-  return bugs, cursor
+  return bugs
 
 
 def _match_purl(purl_query: PackageURL, purl_db: PackageURL) -> bool:
@@ -935,17 +973,22 @@ def _query_by_semver(context: QueryContext, query: ndb.Query, package_name: str,
                      ecosystem: str, purl: PackageURL | None, version: str):
   """Query by semver."""
   if not semver_index.is_valid(version):
-    return [], None
+    return []
 
   results = []
   query = query.filter(
       osv.Bug.semver_fixed_indexes > semver_index.normalize(version))
-  it: ndb.QueryIterator = query.iter(start_cursor=context.page_token)
-  cursor = None
+  
+  context.query_counter += 1
+  if context.should_skip_query():
+    return []
+
+  it: ndb.QueryIterator = query.iter(
+      start_cursor=context.input_cursor.get_cursor())
 
   while (yield it.has_next_async()):
     if context.should_break_page(len(results)):
-      cursor = it.cursor_after()
+      context.save_cursor_at_page_break(it)
       break
 
     bug: osv.Bug = it.next()  # type: ignore
@@ -954,7 +997,7 @@ def _query_by_semver(context: QueryContext, query: ndb.Query, package_name: str,
       results.append(bug)
       context.total_responses.add(1)
 
-  return results, cursor
+  return results
 
 
 @ndb.tasklet
@@ -967,47 +1010,37 @@ def _query_by_generic_version(
     version: str,
 ):
   """Query by generic version."""
-
-  results = []
-
-  cursor = None
   # Try without normalizing.
-  results, cursor = yield query_by_generic_helper(results, cursor, context,
+  results = yield query_by_generic_helper(context,
                                                   base_query, project,
                                                   ecosystem, purl, version,
                                                   False)
 
-  # If no results is because of a page break, then there is no reason
-  # to pass further down as page break would still be in effect with
-  # the following queries, and would have to immediately return.
-  if results or context.should_break_page(0):
-    return results, cursor
+  # If there is results, then we should return with this query,
+  # as no normalization seem to be the correct format.
+  if results:
+    return results
 
-  # page_token can be the token for this query, or the token for the one
-  # below. If the token is used for the normalized query below, this query
-  # must have returned no results, so will still return no results, fall
-  # through to the query below again.
-  # Try again after normalizing.
-  results, cursor = yield query_by_generic_helper(results, cursor, context,
+  results = yield query_by_generic_helper(context,
                                                   base_query, project,
                                                   ecosystem, purl,
                                                   osv.normalize_tag(version),
                                                   True)
 
-  if results or context.should_break_page(0):
-    return results, cursor
+  if results:
+    return results
 
   # Try again after canonicalizing + normalizing version.
-  results, cursor = yield query_by_generic_helper(results, cursor, context,
-                                                  base_query, project,
-                                                  ecosystem, purl,
+  results = yield query_by_generic_helper(context, base_query,
+                                                  project, ecosystem, purl,
                                                   canonicalize_version(version),
                                                   True)
-  return results, cursor
+
+  return results
 
 
 @ndb.tasklet
-def query_by_generic_helper(results: list, cursor, context: QueryContext,
+def query_by_generic_helper(context: QueryContext,
                             base_query: ndb.Query, project: str, ecosystem: str,
                             purl: PackageURL | None, version: str,
                             is_normalized):
@@ -1016,17 +1049,17 @@ def query_by_generic_helper(results: list, cursor, context: QueryContext,
   This function can be called multiple times.
   """
   query: ndb.Query = base_query.filter(osv.Bug.affected_fuzzy == version)
-  it: ndb.QueryIterator = query.iter(start_cursor=context.page_token)
+  results = []
+  context.query_counter += 1
+  if context.should_skip_query():
+    return []
+
+  it: ndb.QueryIterator = query.iter(
+      start_cursor=context.input_cursor.get_cursor())
+
   while (yield it.has_next_async()):
     if context.should_break_page(len(results)):
-      # Because this helper function might be called multiple times
-      # we might break before the first result is even queried, raising
-      # a BadArgumentError
-      try:
-        cursor = it.cursor_after()
-      except ndb_exceptions.BadArgumentError:
-        # Don't set the cursor in this case and just return existing cursor
-        pass
+      context.save_cursor_at_page_break(it)
       break
     bug = it.next()
     if _is_version_affected(
@@ -1038,7 +1071,7 @@ def query_by_generic_helper(results: list, cursor, context: QueryContext,
         normalize=is_normalized):
       results.append(bug)
       context.total_responses.add(1)
-  return results, cursor
+  return results
 
 
 @ndb.tasklet
@@ -1065,7 +1098,7 @@ def query_by_version(context: QueryContext,
         osv.Bug.public == True,  # noqa: E712
     )
   else:
-    return [], None
+    return []
 
   if ecosystem:
     query = query.filter(osv.Bug.ecosystem == ecosystem)
@@ -1080,72 +1113,75 @@ def query_by_version(context: QueryContext,
   supports_ordering = ecosystem_info and ecosystem_info.supports_ordering
 
   bugs = []
-  next_page_token = None
   project = get_gcp_project()
   if ecosystem:
     if is_semver:
       # Ecosystem supports semver only.
-      bugs, _ = yield _query_by_semver(context, query, package_name, ecosystem,
-                                       purl, version)
+      bugs = yield _query_by_semver(context, query, package_name, ecosystem,
+                                        purl, version)
 
-      new_bugs, _ = yield _query_by_generic_version(context, query,
+
+      # If the previous query has fully finished (or skipped), try generic version
+      new_bugs = yield _query_by_generic_version(context, query,
                                                     package_name, ecosystem,
                                                     purl, version)
       for bug in new_bugs:
         if bug not in bugs:
           bugs.append(bug)
+        
     elif project == 'oss-vdb-test' and supports_ordering:
       # Query for non-enumerated ecosystems.
 
       # Performance testing only
       # TODO(gongh): revert change back after testing.
-      # bugs, next_page_token = yield _query_by_comparing_versions(
+      # bugs = yield _query_by_comparing_versions(
       #     context, query, ecosystem, version)
-      bugs, next_page_token = yield _query_by_generic_version(
+      bugs = yield _query_by_generic_version(
           context, query, package_name, ecosystem, purl, version)
     else:
-      bugs, next_page_token = yield _query_by_generic_version(
+      bugs = yield _query_by_generic_version(
           context, query, package_name, ecosystem, purl, version)
 
   else:
     logging.warning("Package query without ecosystem specified")
     # Unspecified ecosystem. Try semver first.
-
-    # TODO: Remove after testing how many consumers are
-    # querying the API this way.
-    context.page_token = None
-    new_bugs, _ = yield _query_by_semver(context, query, package_name,
-                                         ecosystem, purl, version)
+    new_bugs = yield _query_by_semver(context, query, package_name,
+                                              ecosystem, purl, version)
     bugs.extend(new_bugs)
 
-    new_bugs, _ = yield _query_by_generic_version(context, query, package_name,
-                                                  ecosystem, purl, version)
+    new_bugs = yield _query_by_generic_version(
+        context, query, package_name, ecosystem, purl, version)
     for bug in new_bugs:
       if bug not in bugs:
         bugs.append(bug)
 
-    # Trying both is too difficult/ugly with paging
     # Our documentation states that this is an invalid query
     # context.service_context.abort(grpc.StatusCode.INVALID_ARGUMENT,
     #                               'Ecosystem not specified')
 
-  return [to_response(bug) for bug in bugs], next_page_token
+  return [to_response(bug) for bug in bugs]
 
 
 @ndb.tasklet
 def _query_by_comparing_versions(context: QueryContext, query: ndb.Query,
                                  ecosystem: str,
-                                 version: str) -> tuple[list, ndb.Cursor]:
+                                 version: str) -> list:
   """Query by package."""
   bugs = []
-  it: ndb.QueryIterator = query.iter(start_cursor=context.page_token)
-  cursor = None
+
+  context.query_counter += 1
+  if context.should_skip_query():
+    return []
+
+  it: ndb.QueryIterator = query.iter(
+      start_cursor=context.input_cursor.get_cursor())
+
   # Checks if the query specifies a release (e.g., "Debian:12")
   has_release = ':' in ecosystem
 
   while (yield it.has_next_async()):
     if context.should_break_page(len(bugs)):
-      cursor = it.cursor_after()
+      context.save_cursor_at_page_break(it)
       break
 
     bug: osv.Bug = it.next()
@@ -1173,13 +1209,13 @@ def _query_by_comparing_versions(context: QueryContext, query: ndb.Query,
         context.total_responses.add(1)
         break
 
-  return bugs, cursor
+  return bugs
 
 
 @ndb.tasklet
 def query_by_package(context: QueryContext, package_name: str, ecosystem: str,
                      purl: PackageURL | None,
-                     to_response: Callable) -> tuple[list, ndb.Cursor]:
+                     to_response: Callable) -> list:
   """Query by package."""
   bugs = []
   if package_name and ecosystem:
@@ -1198,13 +1234,18 @@ def query_by_package(context: QueryContext, package_name: str, ecosystem: str,
         osv.Bug.public == True,  # noqa: E712
     )
   else:
-    return [], None
+    return []
 
-  it: ndb.QueryIterator = query.iter(start_cursor=context.page_token)
-  cursor = None
+  context.query_counter += 1
+  if context.should_skip_query():
+    return []
+
+  it: ndb.QueryIterator = query.iter(
+      start_cursor=context.input_cursor.get_cursor())
+
   while (yield it.has_next_async()):
     if context.should_break_page(len(bugs)):
-      cursor = it.cursor_after()
+      context.save_cursor_at_page_break(it)
       break
 
     bug: osv.Bug = it.next()
@@ -1227,7 +1268,7 @@ def query_by_package(context: QueryContext, package_name: str, ecosystem: str,
       bugs.append(bug)
       context.total_responses.add(1)
 
-  return [to_response(bug) for bug in bugs], cursor
+  return [to_response(bug) for bug in bugs]
 
 
 def serve(port: int, local: bool):

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -446,7 +446,7 @@ class QueryContext:
         in a previous query.
     """
     return (self.query_counter < self.input_cursor.query_number or
-            not self.output_cursor.ended())
+            not self.output_cursor.ended)
 
   def save_cursor_at_page_break(self, it: ndb.QueryIterator):
     """
@@ -768,10 +768,13 @@ def do_query(query,
           list(set(related_bug_ids + list(bugs[i].related))))
 
   if context.query_counter < context.input_cursor.query_number:
+    logging.error(
+        'Cursor is invalid - received "%d" while total query count is "%d".',
+        context.input_cursor.query_number, context.query_counter)
     # If the input cursor is for a query number that's greater than
     # the number of queries performed, the cursor must be invalid
     # (and there will be no results, as everything is skipped)
-    raise ValueError("Cursor is invalid/does not belong to this query")
+    raise ValueError('Cursor is invalid/does not belong to this query')
 
   next_page_token_str = context.output_cursor.url_safe_encode()
   if next_page_token_str:
@@ -827,7 +830,7 @@ def query_by_commit(context: QueryContext,
 
   bug_ids = []
   it: ndb.QueryIterator = query.iter(
-      keys_only=True, start_cursor=context.input_cursor.get_cursor())
+      keys_only=True, start_cursor=context.input_cursor.ndb_cursor)
 
   while (yield it.has_next_async()):
     if context.should_break_page(len(bug_ids)):
@@ -982,7 +985,7 @@ def _query_by_semver(context: QueryContext, query: ndb.Query, package_name: str,
     return []
 
   it: ndb.QueryIterator = query.iter(
-      start_cursor=context.input_cursor.get_cursor())
+      start_cursor=context.input_cursor.ndb_cursor)
 
   while (yield it.has_next_async()):
     if context.should_break_page(len(results)):
@@ -1012,7 +1015,7 @@ def _query_by_generic_version(
   results = yield query_by_generic_helper(context, base_query, project,
                                           ecosystem, purl, version, False)
 
-  # If there is results, then we should return with this query,
+  # If there are results, then we should return with this query,
   # as no normalization seem to be the correct format.
   if results:
     return results
@@ -1048,7 +1051,7 @@ def query_by_generic_helper(context: QueryContext, base_query: ndb.Query,
     return []
 
   it: ndb.QueryIterator = query.iter(
-      start_cursor=context.input_cursor.get_cursor())
+      start_cursor=context.input_cursor.ndb_cursor)
 
   while (yield it.has_next_async()):
     if context.should_break_page(len(results)):
@@ -1161,7 +1164,7 @@ def _query_by_comparing_versions(context: QueryContext, query: ndb.Query,
     return []
 
   it: ndb.QueryIterator = query.iter(
-      start_cursor=context.input_cursor.get_cursor())
+      start_cursor=context.input_cursor.ndb_cursor)
 
   # Checks if the query specifies a release (e.g., "Debian:12")
   has_release = ':' in ecosystem
@@ -1227,7 +1230,7 @@ def query_by_package(context: QueryContext, package_name: str, ecosystem: str,
     return []
 
   it: ndb.QueryIterator = query.iter(
-      start_cursor=context.input_cursor.get_cursor())
+      start_cursor=context.input_cursor.ndb_cursor)
 
   while (yield it.has_next_async()):
     if context.should_break_page(len(bugs)):

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -1231,7 +1231,15 @@ def _query_by_comparing_versions(context: QueryContext, query: ndb.Query,
   """
   Query by comparing versions.
 
-  TODO:
+  Args:
+    context: QueryContext for the current query.
+    query: A partially completed ndb.Query object which only needs 
+      version filters to be added before query is performed.
+    ecosystem: Optional ecosystem of the package to query.
+    version: The version str to query by.
+
+  Returns:
+    list of osv.Bugs
   """
   bugs = []
 

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -464,7 +464,7 @@ class QueryContext:
     """
     if self.input_cursor.query_number == self.query_counter:
       return self.input_cursor.ndb_cursor
-    
+
     return None
 
   def save_cursor_at_page_break(self, it: ndb.QueryIterator):

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -464,9 +464,8 @@ class QueryContext:
     """
     if self.input_cursor.query_number == self.query_counter:
       return self.input_cursor.ndb_cursor
-    else:
-      return None
-
+    
+    return None
 
   def save_cursor_at_page_break(self, it: ndb.QueryIterator):
     """
@@ -1034,8 +1033,7 @@ def _query_by_semver(context: QueryContext, query: ndb.Query,
   if context.should_skip_query():
     return []
 
-  it: ndb.QueryIterator = query.iter(
-      start_cursor=context.cursor_at_current())
+  it: ndb.QueryIterator = query.iter(start_cursor=context.cursor_at_current())
 
   while (yield it.has_next_async()):
     if context.should_break_page(len(results)):
@@ -1116,8 +1114,7 @@ def query_by_generic_helper(context: QueryContext, base_query: ndb.Query,
   if context.should_skip_query():
     return []
 
-  it: ndb.QueryIterator = query.iter(
-      start_cursor=context.cursor_at_current())
+  it: ndb.QueryIterator = query.iter(start_cursor=context.cursor_at_current())
 
   while (yield it.has_next_async()):
     if context.should_break_page(len(results)):
@@ -1257,8 +1254,7 @@ def _query_by_comparing_versions(context: QueryContext, query: ndb.Query,
   if context.should_skip_query():
     return []
 
-  it: ndb.QueryIterator = query.iter(
-      start_cursor=context.cursor_at_current())
+  it: ndb.QueryIterator = query.iter(start_cursor=context.cursor_at_current())
 
   # Checks if the query specifies a release (e.g., "Debian:12")
   has_release = ':' in ecosystem
@@ -1340,8 +1336,7 @@ def query_by_package(context: QueryContext, package_name: str | None,
   if context.should_skip_query():
     return []
 
-  it: ndb.QueryIterator = query.iter(
-      start_cursor=context.cursor_at_current())
+  it: ndb.QueryIterator = query.iter(start_cursor=context.cursor_at_current())
 
   while (yield it.has_next_async()):
     if context.should_break_page(len(bugs)):

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -45,8 +45,8 @@ from osv import ecosystems
 from osv import semver_index
 from osv import purl_helpers
 from osv.logs import setup_gcp_logging
-import osv_service_v1_pb2
-import osv_service_v1_pb2_grpc
+from gcp.api import osv_service_v1_pb2
+from gcp.api import osv_service_v1_pb2_grpc
 
 from gcp.api.cursor import QueryCursor
 
@@ -343,7 +343,7 @@ class OSVServicer(osv_service_v1_pb2_grpc.OSVServicer,
     context.abort(grpc.StatusCode.UNIMPLEMENTED, "Unimplemented")
 
 
-def query_info(query) -> tuple[str, str, str]:
+def query_info(query) -> tuple[str, str | None, str | None]:
   """Returns information about a query, for logging purposes.
   First return value is one of 'commit', 'purl', 'ecosystem', 'invalid'.
   If 'ecosystem' or 'purl', second two return values are the ecosystem name,


### PR DESCRIPTION
The current paging/cursor implementation is slightly hacky and fails at various edge cases, and for many query types does not work at all, e.g. (queries without ecosystem, semver queries...). 

When initially implemented, the assumption was almost all API calls resulted in one datastore query. This is no longer the case. 

This refactor/rework adds:
- New cursor type
  -  which can represent 3 states (Start, End, InProgress) in a type safe way (through enums, thanks for the ideas @michaelkedar @DonggeLiu!)
  - Also stores the ndb.Cursor inside
  - Also stores which query number the ndb.Cursor is for when there are multiple queries
  - can serialise to a page token, and deserialise in a backward compatible fashion.
- Reworked logic to centralise cursor handling to make the code more readable and predicable:
  - Cursor state is stored in context, rather than passed through a tuple through return types
  - Query skips are determined next to each `query.iter()` function, where the datastore queries actually happens, rather than in outer functions.
- Context now accounts for the number of datastore queries that has been performed
  - This is used to know which query a cursor belongs to
- Minor refactors to `query_generic_helper()` to remove unnecessary arguments being passed in
- Add a skipIf on env variable to allow actually running the pagination tests locally.
- Modify the tests to run faster (by lowering the sleep duration haha), 
- Modify tests to take in unittest arguments of which tests to run from the second argument onwards (rather than having the gcloud service account always being the last argument)