### PR TITLE
fix(nvd-mirror): use a more efficient technique to split NVD by year

### DIFF
--- a/vulnfeeds/cmd/download-cves/mirror_nvd
+++ b/vulnfeeds/cmd/download-cves/mirror_nvd
@@ -32,7 +32,20 @@ do
   cat "${WORK_DIR}/nvd/nvdcve-2.0.json" \
     | jq \
       --arg year $YEAR \
-      '{ "resultsPerPage": .vulnerabilities | map(select(.cve?.id? | startswith("CVE-" + $year + "-"))) | length, "startIndex": 0, "totalResults": .vulnerabilities | map(select(.cve?.id? | startswith("CVE-" + $year + "-"))) | length, "format": .format, "version": .version, "timestamp": .timestamp, "vulnerabilities": .vulnerabilities | map(select(.cve?.id? | startswith("CVE-" + $year + "-"))) }' > "${WORK_DIR}/nvd/nvdcve-2.0-${YEAR}.json"
+      'def count_matching_cves:
+          reduce .vulnerabilities[] as $v (0;
+          if $v.cve?.id? | startswith("CVE-" + $year + "-") then . + 1 else . end
+        );
+
+        {
+        "resultsPerPage": count_matching_cves,
+        "startIndex": 0,
+        "totalResults": count_matching_cves,
+        "format": .format,
+        "version": .version,
+        "timestamp": .timestamp,
+        "vulnerabilities": .vulnerabilities | map(select(.cve?.id? | startswith("CVE-" + $year + "-")))
+       }' > "${WORK_DIR}/nvd/nvdcve-2.0-${YEAR}.json"
 done
 
 echo "Copying files to GCS bucket"


### PR DESCRIPTION
To address apparent overrun issues (and also hopefully reduce the amount of RAM the job requires) use a more time and memory efficient technique to split the monolithic NVD dump by year.

This avoids creating multiple in-memory arrays of the same data

Refactor invocation for better readability