### PR TITLE
fix(deps): manually update docs Ruby deps

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -25,7 +25,7 @@ platforms :mingw, :x64_mingw, :mswin, :jruby do
 end
 
 # Performance-booster for watching directories on Windows
-gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+gem "wdm", "~> 0.2.0", :platforms => [:mingw, :x64_mingw, :mswin]
 
 # Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
 # do not have a Java counterpart.

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -40,7 +40,7 @@ GEM
       logger
     faraday-net_http (3.1.1)
       net-http
-    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0-x86_64-linux)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
     github-pages (232)
@@ -275,8 +275,8 @@ DEPENDENCIES
   jekyll-feed (~> 0.12)
   tzinfo (>= 1, < 3)
   tzinfo-data
-  wdm (~> 0.1.1)
+  wdm (~> 0.2.0)
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.5.10
+   2.4.20


### PR DESCRIPTION
Manual reproduction of the Ruby dependency update from #2501 that seems to be glitching: https://github.com/google/osv.dev/pull/2501#issuecomment-2298972141