### PR TITLE
fix(nvd-mirror): do not restart on failure

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/nvd-mirror.yaml
+++ b/deployment/clouddeploy/gke-workers/base/nvd-mirror.yaml
@@ -33,7 +33,7 @@ spec:
                 memory: "192G"
           nodeSelector:
             cloud.google.com/gke-nodepool: highend
-          restartPolicy: OnFailure
+          restartPolicy: Never
           volumes:
             - name: "ssd"
               hostPath:


### PR DESCRIPTION
When the NVD API is being flaky, as it often is, and a page of results 503's enough times to cause the whole download to abort, it's highly unlikely that another shot at it from the very beginning is going to complete within the overall deadline, so save the time and network resources for the next regularly scheduled run.

A recent failed run blew up trying to retrieve offset 100,000 of 261,123 total results, and the second attempt ran into its deadline at offset 50,000.