### PR TITLE
feat(nvd-mirror): run the year splitting in parallel

### DIFF
--- a/vulnfeeds/cmd/download-cves/mirror_nvd
+++ b/vulnfeeds/cmd/download-cves/mirror_nvd
@@ -45,8 +45,10 @@ do
         "version": .version,
         "timestamp": .timestamp,
         "vulnerabilities": .vulnerabilities | map(select(.cve?.id? | startswith("CVE-" + $year + "-")))
-       }' > "${WORK_DIR}/nvd/nvdcve-2.0-${YEAR}.json"
+       }' > "${WORK_DIR}/nvd/nvdcve-2.0-${YEAR}.json" &
 done
+
+wait
 
 echo "Copying files to GCS bucket"
 gcloud config set storage/parallel_composite_upload_enabled True


### PR DESCRIPTION
This greatly speeds up the completion of this final stage of the mirroring and based on manual testing in Staging, comfortably fits within the existing RAM allowances for the job.