### PR TITLE
feat(api): support Chainguard and Wolfi version query on test instance

### DIFF
--- a/osv/ecosystems/_ecosystems.py
+++ b/osv/ecosystems/_ecosystems.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Ecosystem helpers."""
 
+from osv.ecosystems.chainguard import Chainguard
+from osv.ecosystems.wolfi import Wolfi
 from .helper_base import Ecosystem, OrderingUnsupportedEcosystem
 from .alma_linux import AlmaLinux
 from .alpine import Alpine
@@ -31,8 +33,17 @@ from .semver_ecosystem_helper import SemverEcosystem
 from .ubuntu import Ubuntu
 
 _ecosystems = {
+    # SemVer-based ecosystems (remember keep synced with SEMVER_ECOSYSTEMS):
+    'Bitnami': SemverEcosystem(),
+    'crates.io': SemverEcosystem(),
+    'Go': SemverEcosystem(),
+    'Hex': SemverEcosystem(),
+    'npm': SemverEcosystem(),
+    'SwiftURL': SemverEcosystem(),
+    # Non SemVer-based ecosystems
     'Bioconductor': Bioconductor(),
     'CRAN': CRAN(),
+    'Chainguard': Chainguard(),
     'GHC': GHC(),
     'Hackage': Hackage(),
     'Maven': Maven(),
@@ -41,22 +52,14 @@ _ecosystems = {
     'Pub': Pub(),
     'PyPI': PyPI(),
     'RubyGems': RubyGems(),
-    # SemVer-based ecosystems (remember keep synced with SEMVER_ECOSYSTEMS):
-    'Bitnami': SemverEcosystem(),
-    'crates.io': SemverEcosystem(),
-    'Go': SemverEcosystem(),
-    'Hex': SemverEcosystem(),
-    'npm': SemverEcosystem(),
-    'SwiftURL': SemverEcosystem(),
+    'Wolfi': Wolfi(),
     # Ecosystems which require a release version for enumeration, which is
     # handled separately in get().
     'AlmaLinux': OrderingUnsupportedEcosystem(),
     'Alpine': OrderingUnsupportedEcosystem(),
-    'Chainguard': OrderingUnsupportedEcosystem(),
     'Debian': OrderingUnsupportedEcosystem(),
     'Rocky Linux': OrderingUnsupportedEcosystem(),
     'Ubuntu': OrderingUnsupportedEcosystem(),
-    'Wolfi': OrderingUnsupportedEcosystem(),
     # Ecosystems missing implementations:
     'Android': OrderingUnsupportedEcosystem(),
     'ConanCenter': OrderingUnsupportedEcosystem(),

--- a/osv/ecosystems/chainguard.py
+++ b/osv/ecosystems/chainguard.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Chainguard ecosystem helper."""
 
-
 from osv.ecosystems.helper_base import Ecosystem
 from ..third_party.univers.alpine import AlpineLinuxVersion
 

--- a/osv/ecosystems/chainguard.py
+++ b/osv/ecosystems/chainguard.py
@@ -1,0 +1,38 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Chainguard ecosystem helper."""
+
+
+from osv.ecosystems.helper_base import Ecosystem
+from ..third_party.univers.alpine import AlpineLinuxVersion
+
+
+class Chainguard(Ecosystem):
+  """Chainguard packages ecosystem"""
+
+  def sort_key(self, version):
+    # Chainguard uses `apk` package format
+    if not AlpineLinuxVersion.is_valid(version):
+      # If version is not valid, it is most likely an invalid input
+      # version then sort it to the last/largest element
+      return AlpineLinuxVersion('999999')
+    return AlpineLinuxVersion(version)
+
+  def enumerate_versions(self,
+                         package,
+                         introduced,
+                         fixed=None,
+                         last_affected=None,
+                         limits=None):
+    raise NotImplementedError('Ecosystem helper does not support enumeration')

--- a/osv/ecosystems/chainguard_test.py
+++ b/osv/ecosystems/chainguard_test.py
@@ -24,11 +24,8 @@ class ChainguardEcosystemTest(unittest.TestCase):
     """Test sort_key"""
     ecosystem = ecosystems.get('Chainguard')
     self.assertGreater(
-        ecosystem.sort_key('38.52.0-r0'),
-        ecosystem.sort_key('37.52.0-r0'))
-    self.assertLess(
-        ecosystem.sort_key('453'),
-        ecosystem.sort_key('453-r1'))
+        ecosystem.sort_key('38.52.0-r0'), ecosystem.sort_key('37.52.0-r0'))
+    self.assertLess(ecosystem.sort_key('453'), ecosystem.sort_key('453-r1'))
     self.assertGreater(ecosystem.sort_key('5.4.13-r1'), ecosystem.sort_key('0'))
     self.assertGreater(
         ecosystem.sort_key('1.4.0-r1'), ecosystem.sort_key('1.4.0-r0'))

--- a/osv/ecosystems/chainguard_test.py
+++ b/osv/ecosystems/chainguard_test.py
@@ -1,0 +1,36 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Chainguard ecosystem helper tests."""
+
+import unittest
+from .. import ecosystems
+
+
+class ChainguardEcosystemTest(unittest.TestCase):
+  """Chainguard ecosystem helper tests."""
+
+  def test_chainguard(self):
+    """Test sort_key"""
+    ecosystem = ecosystems.get('Chainguard')
+    self.assertGreater(
+        ecosystem.sort_key('38.52.0-r0'),
+        ecosystem.sort_key('37.52.0-r0'))
+    self.assertLess(
+        ecosystem.sort_key('453'),
+        ecosystem.sort_key('453-r1'))
+    self.assertGreater(ecosystem.sort_key('5.4.13-r1'), ecosystem.sort_key('0'))
+    self.assertGreater(
+        ecosystem.sort_key('1.4.0-r1'), ecosystem.sort_key('1.4.0-r0'))
+    self.assertGreater(
+        ecosystem.sort_key('invalid'), ecosystem.sort_key('1.4.0-r0'))

--- a/osv/ecosystems/wolfi.py
+++ b/osv/ecosystems/wolfi.py
@@ -22,7 +22,7 @@ class Wolfi(Ecosystem):
   """Wolfi packages ecosystem"""
 
   def sort_key(self, version):
-    # Wolfi uses apk package format
+    # Wolfi uses `apk` package format
     if not AlpineLinuxVersion.is_valid(version):
       # If version is not valid, it is most likely an invalid input
       # version then sort it to the last/largest element

--- a/osv/ecosystems/wolfi.py
+++ b/osv/ecosystems/wolfi.py
@@ -1,0 +1,38 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Wolfi ecosystem helper."""
+
+from ..third_party.univers.alpine import AlpineLinuxVersion
+
+from .helper_base import Ecosystem
+
+
+class Wolfi(Ecosystem):
+  """Wolfi packages ecosystem"""
+
+  def sort_key(self, version):
+    # Wolfi uses apk package format
+    if not AlpineLinuxVersion.is_valid(version):
+      # If version is not valid, it is most likely an invalid input
+      # version then sort it to the last/largest element
+      return AlpineLinuxVersion('999999')
+    return AlpineLinuxVersion(version)
+
+  def enumerate_versions(self,
+                         package,
+                         introduced,
+                         fixed=None,
+                         last_affected=None,
+                         limits=None):
+    raise NotImplementedError('Ecosystem helper does not support enumeration')

--- a/osv/ecosystems/wolfi_test.py
+++ b/osv/ecosystems/wolfi_test.py
@@ -1,0 +1,36 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Wolfi ecosystem helper tests."""
+
+import unittest
+from .. import ecosystems
+
+
+class WolfiEcosystemTest(unittest.TestCase):
+  """Wolfi ecosystem helper tests."""
+
+  def test_wolfi(self):
+    """Test sort_key"""
+    ecosystem = ecosystems.get('Wolfi')
+    self.assertGreater(
+        ecosystem.sort_key('38.52.0-r0'),
+        ecosystem.sort_key('37.52.0-r0'))
+    self.assertLess(
+        ecosystem.sort_key('453'),
+        ecosystem.sort_key('453-r1'))
+    self.assertGreater(ecosystem.sort_key('5.4.13-r1'), ecosystem.sort_key('0'))
+    self.assertGreater(
+        ecosystem.sort_key('1.4.0-r1'), ecosystem.sort_key('1.4.0-r0'))
+    self.assertGreater(
+        ecosystem.sort_key('invalid'), ecosystem.sort_key('1.4.0-r0'))

--- a/osv/ecosystems/wolfi_test.py
+++ b/osv/ecosystems/wolfi_test.py
@@ -24,11 +24,8 @@ class WolfiEcosystemTest(unittest.TestCase):
     """Test sort_key"""
     ecosystem = ecosystems.get('Wolfi')
     self.assertGreater(
-        ecosystem.sort_key('38.52.0-r0'),
-        ecosystem.sort_key('37.52.0-r0'))
-    self.assertLess(
-        ecosystem.sort_key('453'),
-        ecosystem.sort_key('453-r1'))
+        ecosystem.sort_key('38.52.0-r0'), ecosystem.sort_key('37.52.0-r0'))
+    self.assertLess(ecosystem.sort_key('453'), ecosystem.sort_key('453-r1'))
     self.assertGreater(ecosystem.sort_key('5.4.13-r1'), ecosystem.sort_key('0'))
     self.assertGreater(
         ecosystem.sort_key('1.4.0-r1'), ecosystem.sort_key('1.4.0-r0'))


### PR DESCRIPTION
Both Chainguard and Wolfi [use the Alpine Package format](https://github.com/wolfi-dev#wolfi-features). Implement the `sort_key()` function for both, using the Alpine version library.
Related to https://github.com/google/osv.dev/issues/2401