### PR TITLE
fix(nvd-mirror): increase deadline to 2h

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/nvd-mirror.yaml
+++ b/deployment/clouddeploy/gke-workers/base/nvd-mirror.yaml
@@ -8,7 +8,7 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
-      activeDeadlineSeconds: 2100
+      activeDeadlineSeconds: 7200
       template:
         spec:
           tolerations:


### PR DESCRIPTION
Given the cron job runs every 2 hours, there's nothing gained by arbitrarily terminating it before that. At 260K records over 130 pages, the best case scenario for *retrieval* alone is ~780 seconds (and growing) and with intermittent failures and retries, could exceed an hour.

And that's before the time taken to split by year.