### PR TITLE
fix: Fix android ignore pattern subtle regex error

### DIFF
--- a/source.yaml
+++ b/source.yaml
@@ -44,7 +44,7 @@
 - name: 'android'
   versions_from_repo: False
   type: 1
-  ignore_patterns: ['^(?!(ASB|PUB|A))-.*$']
+  ignore_patterns: ['^(?!(ASB|PUB|A)-).*$']
   detect_cherrypicks: False
   extension: '.json'
   bucket: 'android-osv'

--- a/source_test.yaml
+++ b/source_test.yaml
@@ -44,7 +44,7 @@
 - name: 'android'
   versions_from_repo: False
   type: 1
-  ignore_patterns: ['^(?!(ASB|PUB|A))-.*$']
+  ignore_patterns: ['^(?!(ASB|PUB|A)-).*$']
   detect_cherrypicks: False
   extension: '.json'
   bucket: 'android-osv-test'


### PR DESCRIPTION
One of the patterns is just slightly different than the others 🥷 , complete coincidence that android also added some new irrelevant json files. 