### PR TITLE
docs: update integration test command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,12 +73,12 @@ make all-tests
 
 To run integration tests for the API is a separate command
 ```shell
-make integration-tests
+make api-server-tests
 ```
 
 By default, this skips long tests, enable them by setting the `LONG_TESTS` variable
 ```shell
-LONG_TESTS=1 make integration-tests
+LONG_TESTS=1 make api-server-tests
 ```
 
 #### Test result generation


### PR DESCRIPTION
Update integration test command to the correct one ([`api-server-tests`](https://github.com/google/osv.dev/blob/7ec31bd721f63790ceea0028388d065249b272e4/Makefile#L37))