### PR TITLE
fix(deps): let renovate open more PRs per week

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,8 @@
   ],
   "timezone": "Australia/Sydney",
   "schedule": ["before 6am on wednesday"],
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 20,
   "labels": ["dependencies"],
   "postUpdateOptions": ["gomodTidy"],
   "osvVulnerabilityAlerts": true,


### PR DESCRIPTION
Remove the [`prHourlyLimit`](https://docs.renovatebot.com/configuration-options/#prhourlylimit) to let renovate open as many PRs as needed in its runs on Wednesday mornings.

Also, bumped the [`prConcurrentLimit`](https://docs.renovatebot.com/configuration-options/#prconcurrentlimit) to 20 (from the default of 10), since we seem to currently have 17 pending updates.

Hopefully, this won't be too noisy / too much backlog.