### PR TITLE
feat: combine more Debian security tracker data into OSV

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/main_test.go
+++ b/vulnfeeds/cmd/combine-to-osv/main_test.go
@@ -36,7 +36,7 @@ func loadTestData2(cveName string) cves.Vulnerability {
 
 func TestLoadParts(t *testing.T) {
 	allParts, _ := loadParts("../../test_data/parts")
-	expectedPartCount := 14
+	expectedPartCount := 15
 	actualPartCount := len(allParts)
 
 	if actualPartCount != expectedPartCount {

--- a/vulnfeeds/cmd/debian/main.go
+++ b/vulnfeeds/cmd/debian/main.go
@@ -105,13 +105,9 @@ func updateOSVPkgInfos(pkgName string, cveId string, releases map[string]Release
 	}
 
 	for _, releaseName := range releaseNames {
-		// Skips 'not yet assigned' entries because their status may change in the future.
 		// For reference on urgency levels, see: https://security-team.debian.org/security_tracker.html#severity-levels
 		release, ok := releases[releaseName]
 		if !ok {
-			continue
-		}
-		if release.Urgency == "not yet assigned" {
 			continue
 		}
 		debianVersion, ok := debianReleaseMap[releaseName]

--- a/vulnfeeds/cmd/debian/main_test.go
+++ b/vulnfeeds/cmd/debian/main_test.go
@@ -26,7 +26,7 @@ func Test_generateDebianSecurityTrackerOSV(t *testing.T) {
 	debianReleaseMap["trixie"] = "13"
 
 	osvPkgInfos := generateDebianSecurityTrackerOSV(decodedDebianData, debianReleaseMap)
-	expectedCount := 2
+	expectedCount := 3
 	if len(osvPkgInfos) != expectedCount {
 		t.Errorf("Expected %v Debian OSV entries , got %v", expectedCount, osvPkgInfos)
 	}

--- a/vulnfeeds/test_data/parts/debian/CVE-2017-6507.debian.json
+++ b/vulnfeeds/test_data/parts/debian/CVE-2017-6507.debian.json
@@ -1,0 +1,70 @@
+[
+  {
+    "pkg_name": "apparmor",
+    "ecosystem": "Debian:10",
+    "fixed_version": {
+      "affected_versions": [
+        {
+          "introduced": "0"
+        },
+        {
+          "fixed": "2.11.0-3"
+        }
+      ]
+    },
+    "ecosystem_specific": {
+      "urgency": "not yet assigned"
+    }
+  },
+  {
+    "pkg_name": "apparmor",
+    "ecosystem": "Debian:11",
+    "fixed_version": {
+      "affected_versions": [
+        {
+          "introduced": "0"
+        },
+        {
+          "fixed": "2.11.0-3"
+        }
+      ]
+    },
+    "ecosystem_specific": {
+      "urgency": "not yet assigned"
+    }
+  },
+  {
+    "pkg_name": "apparmor",
+    "ecosystem": "Debian:12",
+    "fixed_version": {
+      "affected_versions": [
+        {
+          "introduced": "0"
+        },
+        {
+          "fixed": "2.11.0-3"
+        }
+      ]
+    },
+    "ecosystem_specific": {
+      "urgency": "not yet assigned"
+    }
+  },
+  {
+    "pkg_name": "apparmor",
+    "ecosystem": "Debian:13",
+    "fixed_version": {
+      "affected_versions": [
+        {
+          "introduced": "0"
+        },
+        {
+          "fixed": "2.11.0-3"
+        }
+      ]
+    },
+    "ecosystem_specific": {
+      "urgency": "not yet assigned"
+    }
+  }
+]


### PR DESCRIPTION
Combine Debian security issues without an urgency tag into OSV. Details: https://github.com/google/osv.dev/issues/2482

This will significantly increase entries to combine-to-osv, and should be merged only after [SDK performance testing](https://github.com/google/osv.dev/pull/2546).


