### PR TITLE
feat: add SUSE/openSUSE source to test instance

### DIFF
--- a/source_test.yaml
+++ b/source_test.yaml
@@ -204,19 +204,6 @@
   link: 'https://github.com/ossf/malicious-packages/blob/main/'
   editable: False
 
-  - name: 'open-suse'
-  versions_from_repo: False
-  rest_api_url: 'https://ftp.suse.com/pub/projects/security/osv/all.json'
-  type: 2
-  ignore_patterns: ['^(?!openSUSE-(RU|FU|SU)-).*$']  # NOTE: Not currently supported for REST sources
-  directory_path: 'pub/projects/security/osv'
-  detect_cherrypicks: False
-  extension: '.json'
-  db_prefix: ['openSUSE-SU-']
-  ignore_git: True
-  link: 'https://ftp.suse.com/pub/projects/security/osv/'
-  editable: False
-
 - name: 'test-oss-fuzz'
   versions_from_repo: True
   type: 0
@@ -307,6 +294,19 @@
   link: 'https://github.com/rustsec/advisory-db/blob/osv/'
   editable: False
   repo_username: 'git'
+
+- name: 'suse'
+  versions_from_repo: False
+  rest_api_url: 'https://ftp.suse.com/pub/projects/security/osv/all.json'
+  type: 2
+  ignore_patterns: ['^(?!(?:open)?SUSE-[FORS]U-).*$']  # NOTE: Not currently supported for REST sources
+  directory_path: 'pub/projects/security/osv'
+  detect_cherrypicks: False
+  extension: '.json'
+  db_prefix: ['openSUSE-SU', 'SUSE-FU-', 'SUSE-OU-', 'SUSE-RU-', 'SUSE-SU-']
+  ignore_git: True
+  link: 'https://ftp.suse.com/pub/projects/security/osv/'
+  editable: False
 
 - name: 'ubuntu'
   versions_from_repo: False

--- a/source_test.yaml
+++ b/source_test.yaml
@@ -78,6 +78,7 @@
   ignore_git: True
   link: 'https://packages.cgr.dev/chainguard/osv/'
   editable: False
+
 - name: 'curl'
   versions_from_repo: False
   rest_api_url: 'https://curl.se/docs/vuln.json'
@@ -201,6 +202,19 @@
   db_prefix: ['MAL-']
   ignore_git: False
   link: 'https://github.com/ossf/malicious-packages/blob/main/'
+  editable: False
+
+  - name: 'open-suse'
+  versions_from_repo: False
+  rest_api_url: 'https://ftp.suse.com/pub/projects/security/osv/all.json'
+  type: 2
+  ignore_patterns: ['^(?!openSUSE-(RU|FU|SU)-).*$']  # NOTE: Not currently supported for REST sources
+  directory_path: 'pub/projects/security/osv'
+  detect_cherrypicks: False
+  extension: '.json'
+  db_prefix: ['openSUSE-SU-']
+  ignore_git: True
+  link: 'https://ftp.suse.com/pub/projects/security/osv/'
   editable: False
 
 - name: 'test-oss-fuzz'

--- a/source_test.yaml
+++ b/source_test.yaml
@@ -303,7 +303,7 @@
   directory_path: 'pub/projects/security/osv'
   detect_cherrypicks: False
   extension: '.json'
-  db_prefix: ['openSUSE-SU', 'SUSE-FU-', 'SUSE-OU-', 'SUSE-RU-', 'SUSE-SU-']
+  db_prefix: ['openSUSE-SU-', 'SUSE-FU-', 'SUSE-OU-', 'SUSE-RU-', 'SUSE-SU-']
   ignore_git: True
   link: 'https://ftp.suse.com/pub/projects/security/osv/'
   editable: False


### PR DESCRIPTION
Add SUSE and openSUSE source (around 20k records), details: https://github.com/google/osv.dev/issues/2543
SUSE prefixes: `SUSE-SU-` (most records), `SUSE-OU-`, `SUSE-FU-` and `SUSE-RU-`
openSUSE prefixes: `openSUSE-SU-`

Merge after https://github.com/google/osv.dev/pull/2571