### PR TITLE
fix(sources): switch oss-fuzz to https

### DIFF
--- a/source_test.yaml
+++ b/source_test.yaml
@@ -209,6 +209,7 @@
   type: 0
   ignore_patterns: ['^(?!OSV-).*$']
   directory_path: 'vulns'
+  # deliberately HTTPS due to lack of SSH credentials in Staging.
   repo_url: 'https://github.com/google/oss-fuzz-vulns'
   detect_cherrypicks: True
   db_prefix: ['OSV-']

--- a/source_test.yaml
+++ b/source_test.yaml
@@ -210,7 +210,7 @@
   ignore_patterns: ['^(?!OSV-).*$']
   directory_path: 'vulns'
   # deliberately HTTPS due to lack of SSH credentials in Staging.
-  repo_url: 'https://github.com/google/oss-fuzz-vulns'
+  repo_url: 'https://github.com/google/oss-fuzz-vulns.git'
   detect_cherrypicks: True
   db_prefix: ['OSV-']
   ignore_git: False

--- a/source_test.yaml
+++ b/source_test.yaml
@@ -209,7 +209,7 @@
   type: 0
   ignore_patterns: ['^(?!OSV-).*$']
   directory_path: 'vulns'
-  repo_url: 'ssh://github.com/google/oss-fuzz-vulns'
+  repo_url: 'https://github.com/google/oss-fuzz-vulns'
   detect_cherrypicks: True
   db_prefix: ['OSV-']
   ignore_git: False


### PR DESCRIPTION
The staging instance has no SSH credentials and we aren't writing anything back so don't need to authenticate