### PR TITLE
fix(importer): correctly handle deleted GCS records with colons in ID

### DIFF
--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -565,7 +565,7 @@ class Importer:
     result.sort(key=lambda r: r.id())
     VulnAndSource = namedtuple('VulnAndSource', ['id', 'path'])
     vuln_ids_for_source = [
-        VulnAndSource(id=r.id(), path=r.source_id.split(':')[1])
+        VulnAndSource(id=r.id(), path=r.source_id.partition(':')[2])
         for r in result
         if not r.withdrawn
     ]

--- a/docker/importer/importer_test.py
+++ b/docker/importer/importer_test.py
@@ -462,6 +462,37 @@ class BucketImporterTest(unittest.TestCase):
         import_last_modified=datetime.datetime(2018, 2, 9, 3, 29, 0, 0),
     ).put()
 
+    # Preexisting Bug (with a colon in the ID) that does not exist in GCS.
+    osv.Bug(
+        id='RXSA-2023:0101',
+        db_id='RXSA-2023:0101',
+        status=1,
+        source='test',
+        source_id='test:RXSA-2023:0101.json',
+        public=True,
+        affected_packages=[{
+            'package': {
+                'ecosystem':
+                    'Rocky Linux:8',
+                'name':
+                    'kernel',
+                'purl': ('pkg:rpm/rocky-linux/kernel'
+                         '?distro=rocky-linux-8-sig-cloud&epoch=0'),
+            },
+            'ranges': [{
+                'events': [{
+                    'value': '0',
+                    'type': 'introduced'
+                }, {
+                    'value': '0:4.18.0-425.10.1.el8_7.cloud',
+                    'type': 'fixed'
+                }],
+                'type': 'ECOSYSTEM',
+            }],
+        }],
+        import_last_modified=datetime.datetime(2018, 2, 9, 3, 29, 0, 0),
+    ).put()
+
     self.tasks_topic = f'projects/{tests.TEST_PROJECT_ID}/topics/tasks'
 
   def tearDown(self):
@@ -580,6 +611,20 @@ class BucketImporterTest(unittest.TestCase):
         req_timestamp='12345')
     mock_publish.assert_has_calls([deletion_call])
 
+    # Test existing record in Datastore with an ID containing a colon and no
+    # longer present in GCS has been requested to be deleted and is correctly
+    # formed.
+    deletion_call = mock.call(
+        self.tasks_topic,
+        data=b'',
+        type='update',
+        source='test',
+        path='RXSA-2023:0101.json',
+        original_sha256='',
+        deleted='true',
+        req_timestamp='12345')
+    mock_publish.assert_has_calls([deletion_call])
+
     # Run again with a 10% threshold and confirm the safeguards work as
     # intended.
     imp = importer.Importer(
@@ -601,7 +646,7 @@ class BucketImporterTest(unittest.TestCase):
     # _process_deletions_bucket() causes, plus an extra one from the safeguard.
     self.assertEqual(4, len(logs.output))
     self.assertEqual(
-        "ERROR:root:Cowardly refusing to delete 1 missing records from GCS for: test",  # pylint: disable=line-too-long
+        "ERROR:root:Cowardly refusing to delete 2 missing records from GCS for: test",  # pylint: disable=line-too-long
         logs.output[-1])
 
     # No deletions should have been requested.


### PR DESCRIPTION
Some deleted rockylinux-rxsa records surfaced a bug with the handling of deleted GCS records with colons in their ID.