### PR TITLE
refactor(combine-to-osv): update only changed files in `output/` dir

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
+++ b/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
@@ -34,6 +34,9 @@ if [[ -n "$CVELIST" ]]; then
     git clone --quiet https://github.com/CVEProject/cvelistV5
 fi
 
+echo "Get output files modified time"
+cloud storage cp "gs://${OUTPUT_BUCKET}/osv-output/modified_time.csv" $OSV_OUTPUT
+
 echo "Run combine-to-osv"
 ./combine-to-osv -cvePath "$CVE_OUTPUT" -partsPath "$OSV_PARTS_ROOT" -osvOutputPath "$OSV_OUTPUT" -cveListPath "$CVELIST"
 
@@ -41,5 +44,5 @@ echo "Override"
 gcloud --no-user-output-enabled storage rsync "gs://${INPUT_BUCKET}/osv-output-overrides/" $OSV_OUTPUT
 
 echo "Begin syncing output to GCS bucket ${OUTPUT_BUCKET}"
-gcloud --no-user-output-enabled storage rsync "$OSV_OUTPUT" "gs://${OUTPUT_BUCKET}/osv-output/" --checksums-only -c --delete-unmatched-destination-objects -q
+gcloud --no-user-output-enabled storage rsync "$OSV_OUTPUT" "gs://${OUTPUT_BUCKET}/osv-output/" --checksums-only -c -q
 echo "Successfully synced to GCS bucket"


### PR DESCRIPTION
- Create a `modified_time.csv` file to track the last modified time of all output files.
- Generate output files only when any `parts/` or CVE content is modified after the last recorded output modification time.
- Update `modified_time.csv` after rewriting any files.