### PR TITLE
refactor(combine-to-osv): attempt to change `gcloud` to `gsutil`

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
+++ b/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
@@ -41,5 +41,5 @@ echo "Override"
 gcloud --no-user-output-enabled storage rsync "gs://${INPUT_BUCKET}/osv-output-overrides/" $OSV_OUTPUT
 
 echo "Begin syncing output to GCS bucket ${OUTPUT_BUCKET}"
-gcloud --no-user-output-enabled storage rsync "$OSV_OUTPUT" "gs://${OUTPUT_BUCKET}/osv-output/" --checksums-only -c --delete-unmatched-destination-objects -q
+gsutil -q -m rsync -c -d "${OSV_OUTPUT}" "gs://${OUTPUT_BUCKET}/osv-output/"
 echo "Successfully synced to GCS bucket"


### PR DESCRIPTION
The `combine-to-osv` job takes more than 1 hour to write files to the cloud, while `debian-cve-convert` (around 40k files) takes less than 1 minute. Although `combine-to-osv` processes more files than `debian-cve-convert`, the time difference is excessive.  `debian-cve-convert` uses `gsutil`, and  `combine-to-osv` uses gcloud SDK. 

Attempt to replace `gcloud` with `gsutil` in `combine-to-osv` and conduct performance testing to determine if this improves performance.

The `importer` relies on `blob.time_created` to determine if GSC records need to be re-imported. Updating to `gsutil` should not affect the creation time; only the modification time will remain the same if there are no changes.