### PR TITLE
ci: pin `actions/stale` to a commit

### DIFF
--- a/.github/workflows/staleness.yml
+++ b/.github/workflows/staleness.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
           days-before-stale: 60
           days-before-close: 14


### PR DESCRIPTION
I noticed that this hasn't been pinned, which it should be to make scorecard happier