### PR TITLE
feat(data source): add SUSE/openSUSE source to prod instance

### DIFF
--- a/source.yaml
+++ b/source.yaml
@@ -297,6 +297,19 @@
   editable: False
   repo_username: 'git'
 
+- name: 'suse'
+  versions_from_repo: False
+  rest_api_url: 'https://ftp.suse.com/pub/projects/security/osv/all.json'
+  type: 2
+  ignore_patterns: ['^(?!(?:open)?SUSE-[FORS]U-).*$']  # NOTE: Not currently supported for REST sources
+  directory_path: 'pub/projects/security/osv'
+  detect_cherrypicks: False
+  extension: '.json'
+  db_prefix: ['openSUSE-', 'SUSE-']
+  ignore_git: True
+  link: 'https://ftp.suse.com/pub/projects/security/osv/'
+  editable: False
+
 - name: 'ubuntu'
   versions_from_repo: False
   type: 0


### PR DESCRIPTION
Add SUSE and openSUSE source (around 20k records), details: https://github.com/google/osv.dev/issues/2543
SUSE prefixes: `SUSE-SU-` (most records), `SUSE-OU-`, `SUSE-FU-` and `SUSE-RU-`
openSUSE prefixes: `openSUSE-SU-`

Test instance PR: https://github.com/google/osv.dev/pull/2570