### PR TITLE
chore(sources): convert Red Hat temporary staging to GCS

### DIFF
--- a/source_test.yaml
+++ b/source_test.yaml
@@ -258,14 +258,13 @@
 
 - name: 'redhat-stage'
   versions_from_repo: False
-  type: 0
+  type: 1
+  bucket: 'osv-test-cve-osv-conversion'
+  directory_path: 'redhat-temporary'
   ignore_patterns: ['^(?!RH[BES]{1}A-).*$']
-  repo_url: 'https://github.com/jasinner/redhat-osv.git'
-  detect_cherrypicks: False
   extension: '.json'
   db_prefix: ['RHBA-', 'RHEA-', 'RHSA-']
-  ignore_git: False
-  link: 'https://github.com/jasinner/redhat-osv/blob/main/'
+  link: 'https://storage.googleapis.com/osv-test-cve-osv-conversion/'
   editable: False
 
 - name: 'rockylinux'


### PR DESCRIPTION
The temporary GitHub repo set up for ingestion is using [LFS](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github), which the Importer does not support, so I have copied the repo's contents to an existing GCS bucket for a one-time test import.