### PR TITLE
fix(ecosystems): treat Red Hat as supported

### DIFF
--- a/osv/ecosystems/_ecosystems.py
+++ b/osv/ecosystems/_ecosystems.py
@@ -64,7 +64,7 @@ _ecosystems = {
     'Linux': OrderingUnsupportedEcosystem(),
     'OSS-Fuzz': OrderingUnsupportedEcosystem(),
     'Photon OS': OrderingUnsupportedEcosystem(),
-    'Red Hat': OrderingUnsupportedEcosystem,
+    'Red Hat': OrderingUnsupportedEcosystem(),
 }
 
 # Semver-based ecosystems, should correspond to _ecosystems above.
@@ -134,7 +134,7 @@ def get(name: str) -> Ecosystem:
   if name.startswith('SUSE'):
     return SUSE()
 
-  return _ecosystems.get(name)
+  return _ecosystems.get(normalize(name))
 
 
 def normalize(ecosystem_name: str):


### PR DESCRIPTION
Correct a typo and also a thinko with normalizing fall-through ecosystem names

We'll need to reimport the Red Hat source in Staging once this change is live there.