### PR TITLE
fix(importer): retry oss-fuzz GCS exports

### DIFF
--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -836,13 +836,13 @@ class Importer:
       try:
         blob = bucket.blob(f'testcase/{testcase_id}.json')
         data = json.dumps(osv.vulnerability_to_dict(vulnerability))
-        blob.upload_from_string(data)
+        blob.upload_from_string(data, retry=retry.DEFAULT_RETRY)
 
         if not issue_id:
           return
 
         blob = bucket.blob(f'issue/{issue_id}.json')
-        blob.upload_from_string(data)
+        blob.upload_from_string(data, retry=retry.DEFAULT_RETRY)
       except Exception as e:
         logging.error('Failed to export: %s', e)
 

--- a/docker/importer/importer_test.py
+++ b/docker/importer/importer_test.py
@@ -25,6 +25,7 @@ from unittest import mock
 import warnings
 
 from google.cloud import ndb
+from google.cloud.storage import retry
 import pygit2
 from docker.mock_test.mock_test_handler import MockDataHandler
 import importer
@@ -205,9 +206,11 @@ class ImporterTest(unittest.TestCase, tests.ExpectationTest(TEST_DATA_DIR)):
 
     bucket.blob.assert_has_calls([
         mock.call('testcase/5417710252982272.json'),
-        mock.call().upload_from_string(expected_json),
+        mock.call().upload_from_string(
+            expected_json, retry=retry.DEFAULT_RETRY),
         mock.call('issue/1064.json'),
-        mock.call().upload_from_string(expected_json),
+        mock.call().upload_from_string(
+            expected_json, retry=retry.DEFAULT_RETRY),
     ])
 
   @mock.patch('google.cloud.pubsub_v1.PublisherClient.publish')


### PR DESCRIPTION
I noticed evidence of GCS upload failures from this while I was scrutinizing an importer run's logs.