### PR TITLE
fix: Set `last_update_date` to the time reported by the REST endpoint

### DIFF
--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -732,7 +732,7 @@ class Importer:
     vulns = osv.parse_vulnerabilities_from_data(
         request.text, source_repo.extension, strict=self._strict_validation)
 
-    vulns_last_modified = datetime.datetime.min
+    vulns_last_modified = last_update_date
     # Create tasks for changed files.
     for vuln in vulns:
       import_failure_logs = []

--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -727,8 +727,8 @@ class Importer:
     adapter = HTTPAdapter(
         max_retries=Retry(
             total=3, status_forcelist=[502, 503, 504], backoff_factor=1))
-    s.mount(source_repo.rest_api_url, adapter)
-    s.mount(source_repo.link, adapter)
+    s.mount('http://', adapter)
+    s.mount('https://', adapter)
 
     try:
       request = s.head(source_repo.rest_api_url, timeout=_TIMEOUT_SECONDS)

--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -701,7 +701,18 @@ class Importer:
                          self._public_log_bucket, import_failure_logs)
 
   def _process_updates_rest(self, source_repo: osv.SourceRepository):
-    """Process updates from REST API."""
+    """Process updates from REST API.
+    
+    To find new updates, first makes a HEAD request to check the 'Last-Modified'
+    header, and skips processing if it's before the source's last_modified_date
+    (and ignore_last_import_time isn't set).
+
+    Otherwise, GETs the list of vulnerabilities and requests updates for
+    vulnerabilities modified after last_modified_date.
+
+    last_modified_date is updated to the HEAD's 'Last-Modified' time, or the
+    latest vulnerability's modified date if 'Last-Modified' was missing/invalid.
+    """
     logging.info('Begin processing REST: %s', source_repo.name)
 
     last_update_date = source_repo.last_update_date or datetime.datetime.min

--- a/docker/importer/importer_test.py
+++ b/docker/importer/importer_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Importer tests."""
+import contextlib
 import datetime
 import os
 import shutil
@@ -22,6 +23,7 @@ import logging
 import threading
 
 from unittest import mock
+from urllib3.exceptions import SystemTimeWarning
 import warnings
 
 from google.cloud import ndb
@@ -66,6 +68,7 @@ class ImporterTest(unittest.TestCase, tests.ExpectationTest(TEST_DATA_DIR)):
     self.tmp_dir = tempfile.mkdtemp()
 
     tests.mock_datetime(self)
+    warnings.filterwarnings('ignore', category=SystemTimeWarning)
     self.mock_repo = tests.mock_repository(self)
 
     storage_patcher = mock.patch('google.cloud.storage.Client')
@@ -407,6 +410,7 @@ class BucketImporterTest(unittest.TestCase):
     self.tmp_dir = tempfile.mkdtemp()
 
     tests.mock_datetime(self)
+    warnings.filterwarnings('ignore', category=SystemTimeWarning)
 
     self.source_repo = osv.SourceRepository(
         type=osv.SourceRepositoryType.BUCKET,
@@ -821,7 +825,7 @@ class RESTImporterTest(unittest.TestCase):
     self.tmp_dir = tempfile.mkdtemp()
 
     tests.mock_datetime(self)
-    warnings.filterwarnings("ignore", "unclosed", ResourceWarning)
+    warnings.filterwarnings('ignore', category=SystemTimeWarning)
 
     storage_patcher = mock.patch('google.cloud.storage.Client')
     self.addCleanup(storage_patcher.stop)
@@ -841,7 +845,19 @@ class RESTImporterTest(unittest.TestCase):
 
   def tearDown(self):
     shutil.rmtree(self.tmp_dir, ignore_errors=True)
-    self.httpd.shutdown()
+
+  @contextlib.contextmanager
+  def server(self, handler_class):
+    """REST mock server context manager."""
+    httpd = http.server.HTTPServer(SERVER_ADDRESS, handler_class)
+    thread = threading.Thread(target=httpd.serve_forever)
+    thread.start()
+    try:
+      yield httpd
+    finally:
+      httpd.shutdown()
+      httpd.server_close()
+      thread.join()
 
   @mock.patch('google.cloud.pubsub_v1.PublisherClient.publish')
   @mock.patch('time.time', return_value=12345.0)
@@ -851,15 +867,13 @@ class RESTImporterTest(unittest.TestCase):
     data_handler = MockDataHandler
     data_handler.last_modified = 'Mon, 01 Jan 2024 00:00:00 GMT'
     data_handler.load_file(data_handler, 'rest_test.json')
-    self.httpd = http.server.HTTPServer(SERVER_ADDRESS, data_handler)
-    thread = threading.Thread(target=self.httpd.serve_forever)
-    thread.start()
     self.source_repo.last_update_date = datetime.datetime(2020, 1, 1)
     repo = self.source_repo.put()
     imp = importer.Importer('fake_public_key', 'fake_private_key', self.tmp_dir,
                             importer.DEFAULT_PUBLIC_LOGGING_BUCKET, 'bucket',
                             False, False)
-    imp.run()
+    with self.server(data_handler):
+      imp.run()
     self.assertEqual(mock_publish.call_count, data_handler.cve_count)
     self.assertEqual(
         repo.get().last_update_date,
@@ -874,16 +888,14 @@ class RESTImporterTest(unittest.TestCase):
     data_handler = MockDataHandler
     data_handler.last_modified = 'Mon, 01 Jan 2024 00:00:00 GMT'
     data_handler.load_file(data_handler, 'rest_test.json')
-    self.httpd = http.server.HTTPServer(SERVER_ADDRESS, data_handler)
-    thread = threading.Thread(target=self.httpd.serve_forever)
-    thread.start()
     self.source_repo.last_update_date = datetime.datetime(2023, 6, 6)
     self.source_repo.ignore_last_import_time = True
     repo = self.source_repo.put()
     imp = importer.Importer('fake_public_key', 'fake_private_key', self.tmp_dir,
                             importer.DEFAULT_PUBLIC_LOGGING_BUCKET, 'bucket',
                             False, False)
-    imp.run()
+    with self.server(data_handler):
+      imp.run()
     self.assertEqual(mock_publish.call_count, data_handler.cve_count)
     self.assertEqual(
         repo.get().last_update_date,
@@ -896,15 +908,12 @@ class RESTImporterTest(unittest.TestCase):
                       mock_publish: mock.MagicMock):
     """Testing none last modified"""
     MockDataHandler.last_modified = 'Fri, 01 Jan 2021 00:00:00 GMT'
-    self.httpd = http.server.HTTPServer(SERVER_ADDRESS, MockDataHandler)
-    thread = threading.Thread(target=self.httpd.serve_forever)
-    thread.start()
     self.source_repo.last_update_date = datetime.datetime(2024, 2, 1)
     repo = self.source_repo.put()
     imp = importer.Importer('fake_public_key', 'fake_private_key', self.tmp_dir,
                             importer.DEFAULT_PUBLIC_LOGGING_BUCKET, 'bucket',
                             True, False)
-    with self.assertLogs() as logs:
+    with self.assertLogs() as logs, self.server(MockDataHandler):
       imp.run()
     mock_publish.assert_not_called()
     self.assertIn('INFO:root:No changes since last update.', logs.output[1])
@@ -920,15 +929,13 @@ class RESTImporterTest(unittest.TestCase):
     """Testing from date between entries - 
     only entries after 6/6/2023 should be called"""
     MockDataHandler.last_modified = 'Mon, 01 Jan 2024 00:00:00 GMT'
-    self.httpd = http.server.HTTPServer(SERVER_ADDRESS, MockDataHandler)
-    thread = threading.Thread(target=self.httpd.serve_forever)
-    thread.start()
     self.source_repo.last_update_date = datetime.datetime(2023, 6, 6)
     repo = self.source_repo.put()
     imp = importer.Importer('fake_public_key', 'fake_private_key', self.tmp_dir,
                             importer.DEFAULT_PUBLIC_LOGGING_BUCKET, 'bucket',
                             False, False)
-    imp.run()
+    with self.server(MockDataHandler):
+      imp.run()
     mock_publish.assert_has_calls([
         mock.call(
             self.tasks_topic,
@@ -1005,6 +1012,7 @@ class ImportFindingsTest(unittest.TestCase):
     tests.reset_emulator()
 
     tests.mock_datetime(self)
+    warnings.filterwarnings('ignore', category=SystemTimeWarning)
 
   def test_add_finding(self):
     """Test that creating an import finding works."""

--- a/docker/importer/importer_test.py
+++ b/docker/importer/importer_test.py
@@ -861,7 +861,10 @@ class RESTImporterTest(unittest.TestCase):
                             False, False)
     imp.run()
     self.assertEqual(mock_publish.call_count, data_handler.cve_count)
-    self.assertEqual(repo.get().last_update_date, datetime.datetime(2024, 1, 1))
+    self.assertEqual(
+        repo.get().last_update_date,
+        datetime.datetime(2024, 1, 1),
+        msg='Expected last_update_date to equal REST Last-Modified date')
 
   @mock.patch('google.cloud.pubsub_v1.PublisherClient.publish')
   @mock.patch('time.time', return_value=12345.0)
@@ -882,7 +885,10 @@ class RESTImporterTest(unittest.TestCase):
                             False, False)
     imp.run()
     self.assertEqual(mock_publish.call_count, data_handler.cve_count)
-    self.assertEqual(repo.get().last_update_date, datetime.datetime(2024, 1, 1))
+    self.assertEqual(
+        repo.get().last_update_date,
+        datetime.datetime(2024, 1, 1),
+        msg='Expected last_update_date to equal REST Last-Modified date')
 
   @mock.patch('google.cloud.pubsub_v1.PublisherClient.publish')
   @mock.patch('time.time', return_value=12345.0)
@@ -902,7 +908,10 @@ class RESTImporterTest(unittest.TestCase):
       imp.run()
     mock_publish.assert_not_called()
     self.assertIn('INFO:root:No changes since last update.', logs.output[1])
-    self.assertEqual(repo.get().last_update_date, datetime.datetime(2024, 2, 1))
+    self.assertEqual(
+        repo.get().last_update_date,
+        datetime.datetime(2024, 2, 1),
+        msg='last_update_date should not have been updated')
 
   @mock.patch('google.cloud.pubsub_v1.PublisherClient.publish')
   @mock.patch('time.time', return_value=12345.0)
@@ -982,7 +991,10 @@ class RESTImporterTest(unittest.TestCase):
             deleted='false',
             req_timestamp='12345')
     ])
-    self.assertEqual(repo.get().last_update_date, datetime.datetime(2024, 1, 1))
+    self.assertEqual(
+        repo.get().last_update_date,
+        datetime.datetime(2024, 1, 1),
+        msg='Expected last_update_date to equal REST Last-Modified date')
 
 
 @mock.patch('importer.utcnow', lambda: datetime.datetime(2024, 1, 1))

--- a/docker/mock_test/mock_test_handler.py
+++ b/docker/mock_test/mock_test_handler.py
@@ -8,7 +8,7 @@ TEST_DATA_DIR = os.path.dirname(os.path.abspath(__file__))
 
 class MockDataHandler(http.server.BaseHTTPRequestHandler):
   """Mock data handler for testing."""
-  last_modified = 'Tue, 13 Jun 2023 00:00:00 GMT'
+  last_modified = 'Mon, 01 Jan 2024 00:00:00 GMT'
   file_path = 'rest_test.json'
   cve_count = -1
   data = None


### PR DESCRIPTION
Use the `Last-Modified` header (or the latest `modified` vuln date if the header is missing) to set the REST SourceRepository's `last_update_date`, instead of using the time when the importer ran.

Should alleviate #2670 for well-behaved REST sources, though it still doesn't handle cases where the source itself adds a record with date before the previous updated date.

While I was here, I also tidied up the `ignore_last_import_time` logic a bit (because the long line splitting was annoying).