### PR TITLE
fix(blog): include future-dated content when generating blog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,12 @@ lint:
 
 run-appengine:
 	cd gcp/appengine/frontend3 && npm install && npm run build
-	cd gcp/appengine/blog && hugo -d ../dist/static/blog
+	cd gcp/appengine/blog && hugo --buildFuture -d ../dist/static/blog
 	cd gcp/appengine && $(install-cmd) && GOOGLE_CLOUD_PROJECT=oss-vdb $(run-cmd) python main.py
 
 run-appengine-staging:
 	cd gcp/appengine/frontend3 && npm install && npm run build
-	cd gcp/appengine/blog && hugo -d ../dist/static/blog
+	cd gcp/appengine/blog && hugo --buildFuture -d ../dist/static/blog
 	cd gcp/appengine && $(install-cmd) && GOOGLE_CLOUD_PROJECT=oss-vdb-test $(run-cmd) python main.py
 
 run-api-server:

--- a/gcp/appengine/Dockerfile
+++ b/gcp/appengine/Dockerfile
@@ -19,7 +19,7 @@ FROM gcr.io/oss-vdb/ci AS HUGO_BUILD
 WORKDIR /build/blog
 COPY gcp/appengine/blog ./
 
-RUN hugo -d ../dist/static/blog
+RUN hugo --buildFuture -d ../dist/static/blog
 
 # OSV.dev site image
 # Adapted from https://cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-python-service#writing

--- a/gcp/appengine/blog/content/posts/announcing-data-quality-initiatives/index.md
+++ b/gcp/appengine/blog/content/posts/announcing-data-quality-initiatives/index.md
@@ -1,6 +1,6 @@
 ---
 title: "OSV's approach to data quality"
-date: 2023-09-30T09:00:00Z
+date: 2024-09-30T09:00:00Z
 draft: false
 author: Andrew Pollock and Charl de Nysschen
 ---


### PR DESCRIPTION
Invoke hugo with the `--buildFuture` flag

Also fix year typo in blog post for data quality