### PR TITLE
fix(data source): update human_link for UBUNTU CVEs

### DIFF
--- a/source_test.yaml
+++ b/source_test.yaml
@@ -320,20 +320,6 @@
   link: 'https://ftp.suse.com/pub/projects/security/osv/'
   editable: False
 
-- name: 'ubuntu-usn'
-  versions_from_repo: False
-  type: 0
-  ignore_patterns: ['^(?!(USN)-).*$']
-  directory_path: 'osv'
-  repo_url: 'https://github.com/canonical/ubuntu-security-notices.git'
-  detect_cherrypicks: False
-  extension: '.json'
-  db_prefix: ['USN-']
-  ignore_git: False
-  human_link: 'https://ubuntu.com/security/notices/{{ BUG_ID }}'
-  link: 'https://github.com/canonical/ubuntu-security-notices/blob/main/'
-  editable: False
-
 - name: 'ubuntu-cve'
   versions_from_repo: False
   type: 0
@@ -345,6 +331,20 @@
   db_prefix: ['UBUNTU-']
   ignore_git: False
   human_link: 'https://ubuntu.com/security/{{ BUG_ID | replace("UBUNTU-", "") }}'
+  link: 'https://github.com/canonical/ubuntu-security-notices/blob/main/'
+  editable: False
+
+- name: 'ubuntu-usn'
+  versions_from_repo: False
+  type: 0
+  ignore_patterns: ['^(?!(USN)-).*$']
+  directory_path: 'osv'
+  repo_url: 'https://github.com/canonical/ubuntu-security-notices.git'
+  detect_cherrypicks: False
+  extension: '.json'
+  db_prefix: ['USN-']
+  ignore_git: False
+  human_link: 'https://ubuntu.com/security/notices/{{ BUG_ID }}'
   link: 'https://github.com/canonical/ubuntu-security-notices/blob/main/'
   editable: False
 

--- a/source_test.yaml
+++ b/source_test.yaml
@@ -323,7 +323,7 @@
 - name: 'ubuntu-cve'
   versions_from_repo: False
   type: 0
-  ignore_patterns: ['^(?!(UBUNTU)-).*$']
+  ignore_patterns: ['^(?!UBUNTU-).*$']
   directory_path: 'osv'
   repo_url: 'https://github.com/canonical/ubuntu-security-notices.git'
   detect_cherrypicks: False
@@ -337,7 +337,7 @@
 - name: 'ubuntu-usn'
   versions_from_repo: False
   type: 0
-  ignore_patterns: ['^(?!(USN)-).*$']
+  ignore_patterns: ['^(?!USN-).*$']
   directory_path: 'osv'
   repo_url: 'https://github.com/canonical/ubuntu-security-notices.git'
   detect_cherrypicks: False

--- a/source_test.yaml
+++ b/source_test.yaml
@@ -320,17 +320,31 @@
   link: 'https://ftp.suse.com/pub/projects/security/osv/'
   editable: False
 
-- name: 'ubuntu'
+- name: 'ubuntu-usn'
   versions_from_repo: False
   type: 0
-  ignore_patterns: ['^(?!(USN|UBUNTU)-).*$']
+  ignore_patterns: ['^(?!(USN)-).*$']
   directory_path: 'osv'
   repo_url: 'https://github.com/canonical/ubuntu-security-notices.git'
   detect_cherrypicks: False
   extension: '.json'
-  db_prefix: ['USN-', 'UBUNTU-']
+  db_prefix: ['USN-']
   ignore_git: False
   human_link: 'https://ubuntu.com/security/notices/{{ BUG_ID }}'
+  link: 'https://github.com/canonical/ubuntu-security-notices/blob/main/'
+  editable: False
+
+- name: 'ubuntu-cve'
+  versions_from_repo: False
+  type: 0
+  ignore_patterns: ['^(?!(UBUNTU)-).*$']
+  directory_path: 'osv'
+  repo_url: 'https://github.com/canonical/ubuntu-security-notices.git'
+  detect_cherrypicks: False
+  extension: '.json'
+  db_prefix: ['UBUNTU-']
+  ignore_git: False
+  human_link: 'https://ubuntu.com/security/{{ BUG_ID | replace("UBUNTU-", "") }}'
   link: 'https://github.com/canonical/ubuntu-security-notices/blob/main/'
   editable: False
 


### PR DESCRIPTION
Ubuntu CVEs have different URLs than USNs. Separate them into two sources with different human-readable links.
UBUNTU-CVE URL: https://ubuntu.com/security/CVE-2024-47076
USN URL: https://ubuntu.com/security/notices/USN-7045-1