### PR TITLE
fix(sourcerepo-sync): improve debugability

### DIFF
--- a/tools/sourcerepo-sync/README.md
+++ b/tools/sourcerepo-sync/README.md
@@ -26,5 +26,5 @@ See [`run_source_update.sh`](run_source_update.sh):
 ## Operational matters
 
 * Triggered by Cloud Build on pushes of `source.yaml` or `source_test.yaml` to
-  `master`, using [source\_build.yaml](source_build.yaml)
+  `master`, using [`source\_build.yaml`](source_build.yaml)
 * Can fail non-prominently post-merge

--- a/tools/sourcerepo-sync/README.md
+++ b/tools/sourcerepo-sync/README.md
@@ -1,0 +1,30 @@
+# sourcerepo-sync
+
+## What
+
+Synchronise the contents of [`source.yaml`](../../source.yaml) (for Production) and
+[`source_test.yaml`](../../source_test.yaml) (for Staging) with Cloud Datastore.
+
+## Why
+
+To reduce the need for unilateral editing of
+[`SourceRepository`](https://github.com/google/osv.dev/blob/fe6155f7cfa0e5df0ae1ef20c7b16f5c20bebed1/osv/models.py#L814)
+kind contents in Cloud Datastore (with attendant fat-fingering risks) and
+generally best-practices around config-as-code and transparency around data
+sources.
+
+## How
+
+See [`run_source_update.sh`](run_source_update.sh):
+
+* Uses the `gcr.io/oss-vdb/ci` Docker image
+* Validates both [the YAML contents of the pull
+  request](https://github.com/google/osv.dev/blob/fe6155f7cfa0e5df0ae1ef20c7b16f5c20bebed1/tools/sourcerepo-sync/source_sync.py#L125) *and* [the existing
+  content in Cloud
+  Datastore](https://github.com/google/osv.dev/blob/fe6155f7cfa0e5df0ae1ef20c7b16f5c20bebed1/tools/sourcerepo-sync/source_sync.py#L134)
+* Can fail non-prominently post-merge
+
+## Operational matters
+
+* Triggered by Cloud Build on pushes of `source.yaml` or `source_test.yaml` to
+  `master`, using [source\_build.yaml](source_build.yaml)

--- a/tools/sourcerepo-sync/README.md
+++ b/tools/sourcerepo-sync/README.md
@@ -22,9 +22,9 @@ See [`run_source_update.sh`](run_source_update.sh):
   request](https://github.com/google/osv.dev/blob/fe6155f7cfa0e5df0ae1ef20c7b16f5c20bebed1/tools/sourcerepo-sync/source_sync.py#L125) *and* [the existing
   content in Cloud
   Datastore](https://github.com/google/osv.dev/blob/fe6155f7cfa0e5df0ae1ef20c7b16f5c20bebed1/tools/sourcerepo-sync/source_sync.py#L134)
-* Can fail non-prominently post-merge
 
 ## Operational matters
 
 * Triggered by Cloud Build on pushes of `source.yaml` or `source_test.yaml` to
   `master`, using [source\_build.yaml](source_build.yaml)
+* Can fail non-prominently post-merge

--- a/tools/sourcerepo-sync/source_sync.py
+++ b/tools/sourcerepo-sync/source_sync.py
@@ -60,6 +60,8 @@ def main() -> None:
     """Check the attributes of the source repo."""
     sourcerepo_names = []
     for repo in repository:
+      if args.verbose:
+        print(f'Validating: {repo}')
       if repo['name'] == '' or repo['name'] is None or repo['name'] == 'null':
         raise ValueError(f'Empty sourcerepo name in {file}')
       if repo['name'] in sourcerepo_names:


### PR DESCRIPTION
Problem:

```
+ poetry run python source_sync.py --kind SourceRepository --project oss-vdb-test --file ../../source_test.yaml --no-dry-run --verbose
Loaded 26 local source repositories
Validated 26 source repositories
Retrieved 26 source repositories from datastore
Traceback (most recent call last):
  File "/workspace/tools/sourcerepo-sync/source_sync.py", line 162, in <module>
    main()
  File "/workspace/tools/sourcerepo-sync/source_sync.py", line 134, in main
    validate_repository(ds_repos, False)
  File "/workspace/tools/sourcerepo-sync/source_sync.py", line 69, in validate_repository
    if 'link' in repo and repo['link'][-1] != '/':
                          ~~~~~~~~~~~~^^^^
TypeError: 'NoneType' object is not subscriptable
```

happening on https://github.com/google/osv.dev/pull/2699 was harder to get to the bottom of than I'd have liked...

Capture some of the knowledge gained as part of debugging this in some basic service documentation to help the next person