### PR TITLE
chore(frontend): improve frontend vuln debuggability

### DIFF
--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -380,13 +380,16 @@ def add_links(bug):
 
 
 def add_source_info(bug, response):
-  """Add source information to `response`."""
+  """Add upstream provenance information to `response`."""
   if bug.source_of_truth == osv.SourceOfTruth.INTERNAL:
     response['source'] = 'INTERNAL'
     return
 
   source_repo = osv.get_source_repository(bug.source)
   if not source_repo or not source_repo.link:
+    logging.error(
+        'Unexpected state for "%s": source repository/link not found for "%s"',
+        bug.id, bug.source)
     return
 
   source_path = osv.source_path(source_repo, bug)


### PR DESCRIPTION
I hit weirdness with an incomplete vulnerability page, which took longer than I'd have liked to get to the bottom of. It was because the source `redhat-stage` was renamed to `redhat` AND the particular record I was looking at had failed to import successfully from the newly named `redhat` source.

This scenario is unexpected enough that it shouldn't be something that happens silently.