### PR TITLE
feat: add an EMPTY ecosystem for withdrawn records

### DIFF
--- a/osv/models.py
+++ b/osv/models.py
@@ -397,9 +397,9 @@ class Bug(ndb.Model):
           break
 
     # If a withdrawn record has no affected package,
-    # assign an 'EMPTY' ecosystem value for export.
+    # assign an '[EMPTY]' ecosystem value for export.
     if not ecosystems_set:
-      ecosystems_set.add('EMPTY')
+      ecosystems_set.add('[EMPTY]')
 
     # For all ecosystems that specify a specific version with colon,
     # also add the base name

--- a/osv/models.py
+++ b/osv/models.py
@@ -396,6 +396,11 @@ class Bug(ndb.Model):
         if 'GIT' in ecosystems_set:
           break
 
+    # If a withdrawn record has no affected package,
+    # assign an 'EMPTY' ecosystem value for export.
+    if not ecosystems_set:
+      ecosystems_set.add('EMPTY')
+
     # For all ecosystems that specify a specific version with colon,
     # also add the base name
     ecosystems_set.update({ecosystems.normalize(x) for x in ecosystems_set})


### PR DESCRIPTION
Some records will be withdrawn from upstream and may also have their affected package information deleted. These records currently cannot be exported and may cause confusion for our customers due to missing records.  Adding an "EMPTY" ecosystem will represent these records for exporting.