### PR TITLE
fix(nvd-cve-osv): check for nil when logging `VendorProduct`

### DIFF
--- a/vulnfeeds/cmd/nvd-cve-osv/main.go
+++ b/vulnfeeds/cmd/nvd-cve-osv/main.go
@@ -436,7 +436,7 @@ func loadCPEDictionary(ProductToRepo *VendorProductToRepoMap, f string) error {
 
 // Adds the repo to the cache for the Vendor/Product combination if not already present.
 func maybeUpdateVPRepoCache(cache VendorProductToRepoMap, vp *VendorProduct, repo string) {
-	if cache == nil {
+	if cache == nil || vp == nil {
 		return
 	}
 	if slices.Contains(cache[*vp], repo) {
@@ -450,7 +450,7 @@ func maybeUpdateVPRepoCache(cache VendorProductToRepoMap, vp *VendorProduct, rep
 
 // Removes the repo from the cache for the Vendor/Product combination if already present.
 func maybeRemoveFromVPRepoCache(cache VendorProductToRepoMap, vp *VendorProduct, repo string) {
-	if cache == nil {
+	if cache == nil || vp == nil {
 		return
 	}
 	cacheEntry, ok := cache[*vp]

--- a/vulnfeeds/cmd/nvd-cve-osv/main.go
+++ b/vulnfeeds/cmd/nvd-cve-osv/main.go
@@ -219,7 +219,12 @@ func ReposFromReferences(CVE string, cache VendorProductToRepoMap, vp *VendorPro
 		repos = append(repos, repo)
 		maybeUpdateVPRepoCache(cache, vp, repo)
 	}
-	Logger.Infof("[%s]: Derived %q for %q %q using references", CVE, repos, vp.Vendor, vp.Product)
+	if vp != nil {
+		Logger.Infof("[%s]: Derived %q for %q %q using references", CVE, repos, vp.Vendor, vp.Product)
+	} else {
+		Logger.Infof("[%s]: Derived %q (no CPEs) using references", CVE, repos)
+	}
+
 	return repos
 }
 

--- a/vulnfeeds/cmd/nvd-cve-osv/run_cve_to_osv_generation.sh
+++ b/vulnfeeds/cmd/nvd-cve-osv/run_cve_to_osv_generation.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Copyright 2023 Google LLC
 #


### PR DESCRIPTION
The log line added in #2678 was causing a panic when `vp` is nil (that we didn't notice :facepalm:).

I believe it's causing processing to stop early, so we end up missing records and marking them as 'withdrawn' #2704
Also adding some checks elsewhere where vp might be dereferenced.

Also added the `-e` flag to the run bash script so any other failures stop it from uploading (thanks @another-rex for pointing this out)