### PR TITLE
feat: skip exporting data into subdirectories

### DIFF
--- a/docker/exporter/export_runner.py
+++ b/docker/exporter/export_runner.py
@@ -54,6 +54,9 @@ def main():
   with concurrent.futures.ThreadPoolExecutor(
       max_workers=args.processes) as executor:
     for eco in ecosystems:
+      # Skip exporting data for child ecosystems (e.g., 'Debian:11').
+      if ':' in eco:
+        continue
       executor.submit(spawn_ecosystem_exporter, args.work_dir, args.bucket, eco)
 
 

--- a/docker/exporter/exporter.py
+++ b/docker/exporter/exporter.py
@@ -47,7 +47,11 @@ class Exporter:
     """Run exporter."""
     if self._ecosystem == "list":
       query = osv.Bug.query(projection=[osv.Bug.ecosystem], distinct=True)
-      ecosystems = [bug.ecosystem[0] for bug in query if bug.ecosystem]
+      ecosystems = [
+          bug.ecosystem[0]
+          for bug in query
+          if bug.ecosystem and ':' not in bug.ecosystem[0]
+      ]
       with tempfile.TemporaryDirectory() as tmp_dir:
         self._export_ecosystem_list_to_bucket(ecosystems, tmp_dir)
     else:


### PR DESCRIPTION
Linux distributions have a large number of releases and products. Exporting each release into a subdirectory wastes a lot of memory and reduces exporter performance. Skipping the exporting of these subdirectories and keeping one directory for each ecosystem will improve exporter performance.

This PR will be merged after the weekly release, and performance will be tested on the test instance. If all looks good, an announcement email will be sent before moving this into production.