### PR TITLE
fix(exporter): revert ecosystem.txt changes

### DIFF
--- a/docker/exporter/exporter.py
+++ b/docker/exporter/exporter.py
@@ -47,11 +47,9 @@ class Exporter:
     """Run exporter."""
     if self._ecosystem == "list":
       query = osv.Bug.query(projection=[osv.Bug.ecosystem], distinct=True)
-      ecosystems = [
-          bug.ecosystem[0]
-          for bug in query
-          if bug.ecosystem and ':' not in bug.ecosystem[0]
-      ]
+      #TODO(gongh@): remove all ecosystem releases from ecosystem.txt
+      # after notifying users.
+      ecosystems = [bug.ecosystem[0] for bug in query if bug.ecosystem]
       with tempfile.TemporaryDirectory() as tmp_dir:
         self._export_ecosystem_list_to_bucket(ecosystems, tmp_dir)
     else:


### PR DESCRIPTION
https://github.com/google/osv.dev/pull/2707 removed subdirectories from both the ecosystem export functionality and the `ecosystem.txt` list. To ensure a smooth transition for users, keep the `ecosystem.txt` file unchanged for now and then announce this change.

TODO:
- Announce the removal of subdirectories to users
- Remove all ecosystem releases from `ecosystem.txt`
- Update exporter doc