### PR TITLE
fix: catch exception parsing CVSS scores on frontend

### DIFF
--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -316,8 +316,14 @@ def calculate_severity_details(
   if not (type_ and score):
     return None, None
 
-  c = cvss_calculator[type_](score)
-  severity_rating = c.severities()[0]
+  try:
+    c = cvss_calculator[type_](score)
+    severity_rating = c.severities()[0]
+  except Exception as e:
+    logging.error('Exception raised when parsing "%s" severity "%s": %s',
+                  type_, score, e)
+    return None, None
+
   severity_score = c.base_score
   return severity_score, severity_rating
 

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -320,8 +320,8 @@ def calculate_severity_details(
     c = cvss_calculator[type_](score)
     severity_rating = c.severities()[0]
   except Exception as e:
-    logging.error('Exception raised when parsing "%s" severity "%s": %s',
-                  type_, score, e)
+    logging.error('Exception raised when parsing "%s" severity "%s": %s', type_,
+                  score, e)
     return None, None
 
   severity_score = c.base_score


### PR DESCRIPTION
The CVSS calculators throw exceptions when parsing fails, which were uncaught and causing 500's on our website.