### PR TITLE
fix(importer-deleter): use a 10x lower safety threshold

### DIFF
--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/importer-deleter.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/importer-deleter.yaml
@@ -15,5 +15,5 @@ spec:
             image: importer
             args:
               - --delete
-              - --delete_threshold_pct=20
+              - --delete_threshold_pct=2
               - --public_log_bucket=osv-test-public-import-logs

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/importer-deleter.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/importer-deleter.yaml
@@ -15,5 +15,5 @@ spec:
             image: importer
             args:
               - --delete
-              - --delete_threshold_pct=20
+              - --delete_threshold_pct=2
               - --public_log_bucket=osv-public-import-logs


### PR DESCRIPTION
Reviewing the logs in staging from the aftermath of #2678, it looks like we need a much lower safety threshold for it provide any value.

```
Counted 53432 parsed vulnerabilities (from 55198 blobs) for cve-osv
1736 Bugs in Datastore considered deleted from GCS for cve-osv
```

20% is still way too high to consider as a normal level of churn.