### PR TITLE
feat(exporter): add a unified all.zip

### DIFF
--- a/docker/exporter/export_runner.py
+++ b/docker/exporter/export_runner.py
@@ -47,6 +47,8 @@ def main():
       default=os.cpu_count() or DEFAULT_EXPORT_PROCESSES)
   args = parser.parse_args()
 
+  # Clean up the work directory, in case other job didn't clean it properly.
+  clean_work_dir(args.work_dir)
   query = osv.Bug.query(projection=[osv.Bug.ecosystem], distinct=True)
   ecosystems = [bug.ecosystem[0] for bug in query if bug.ecosystem] + ['list']
 

--- a/docker/exporter/export_runner.py
+++ b/docker/exporter/export_runner.py
@@ -87,15 +87,16 @@ def aggregate_all_vulnerabilities(work_dir: str, export_bucket: str):
   Aggregates vulnerability records from each ecosystem into a single zip
   file and uploads it to the export bucket.
   """
+  logging.info('Generating unified all.zip archive.')
   zip_file_name = 'all.zip'
   output_zip = os.path.join(work_dir, zip_file_name)
   all_vulns = {}
 
   for file_path in glob.glob(
-      os.path.join(work_dir, '**/*.json', recursive=True)):
+      os.path.join(work_dir, '**/*.json'), recursive=True):
     all_vulns[os.path.basename(file_path)] = file_path
 
-  with z.ZipFile(output_zip, 'a') as all_zip:
+  with z.ZipFile(output_zip, 'a', z.ZIP_DEFLATED) as all_zip:
     for vuln_filename in sorted(all_vulns):
       file_path = all_vulns[vuln_filename]
       all_zip.write(file_path, os.path.basename(file_path))
@@ -103,6 +104,7 @@ def aggregate_all_vulnerabilities(work_dir: str, export_bucket: str):
   storage_client = storage.Client()
   bucket = storage_client.get_bucket(export_bucket)
   upload_single(bucket, output_zip, zip_file_name)
+  logging.info('Unified all.zip uploaded successfully.')
 
 
 if __name__ == '__main__':

--- a/docker/exporter/exporter.py
+++ b/docker/exporter/exporter.py
@@ -23,6 +23,7 @@ from typing import List
 from google.cloud import ndb
 from google.cloud import storage
 from google.cloud.storage import retry
+from google.cloud.storage.bucket import Bucket
 
 import osv
 import osv.logs
@@ -119,14 +120,14 @@ class Exporter:
 
     with concurrent.futures.ThreadPoolExecutor(
         max_workers=_EXPORT_WORKERS) as executor:
-      # Note: all.zip is included here
+      # Note: the individual ecosystem all.zip is included here
       for filename in os.listdir(ecosystem_dir):
         executor.submit(upload_single, bucket,
                         os.path.join(ecosystem_dir, filename),
                         f'{ecosystem}/{filename}')
 
 
-def upload_single(bucket, source_path, target_path):
+def upload_single(bucket: Bucket, source_path: str, target_path: str):
   """Upload a single file to a GCS bucket."""
   logging.info('Uploading %s', target_path)
   try:


### PR DESCRIPTION
Add a ZIP file containing records from all ecosystems to solve https://github.com/google/osv.dev/issues/2423.  Write everything to the default work directory for reuse by the new unified all.zip (instead of using temporary directories). Clean up the work directory afterward.