### PR TITLE
feat(importer): instrument REST API importing

### DIFF
--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -711,6 +711,7 @@ class Importer:
         request.text, source_repo.extension, strict=self._strict_validation)
 
     vulns_last_modified = last_update_date
+    logging.info('%d records to consider', len(vulns))
     # Create tasks for changed files.
     for vuln in vulns:
       import_failure_logs = []
@@ -730,6 +731,8 @@ class Importer:
         _ = osv.parse_vulnerability_from_dict(single_vuln.json(),
                                               source_repo.key_path,
                                               self._strict_validation)
+        logging.info('Requesting analysis of REST record: %s',
+                     vuln.id + source_repo.extension)
         self._request_analysis_external(
             source_repo, osv.sha256_bytes(single_vuln.text.encode()),
             vuln.id + source_repo.extension)


### PR DESCRIPTION
Currently the REST API is entirely silent about what records it is processing. This commit addresses that and makes the instrumentation more in line with the Git and GCS sources, for easier debugging.