### PR TITLE
fix(worker): handle Datastore exceptions

### DIFF
--- a/docker/worker/worker.py
+++ b/docker/worker/worker.py
@@ -530,7 +530,12 @@ class TaskRunner:
       logging.info('%s does not affect any packages. Marking as invalid.',
                    vulnerability.id)
       bug.status = osv.BugStatus.INVALID
-    bug.put()
+    try:
+      bug.put()
+    except ndb.exceptions.Error as e:
+      e.add_note(f'Happened on {vulnerability.id}')
+      logging.exception('Unexpected expection while writing %s to Datastore',
+                        vulnerability.id)
 
     osv.update_affected_commits(bug.key.id(), result.commits, bug.public)
     self._notify_ecosystem_bridge(vulnerability)


### PR DESCRIPTION
Pathologically large records can be too big for Datastore, resulting in "entity is too big" errors and unhandled exceptions. This is happening for a few of the Red Hat records at present.

This commit handles failures to `put()` the bug in Datastore, and logs the exception with context as to the offending record, to ease debugging.