### PR TITLE
chore(nvd-cve-osv): Run twice a day

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/nvd-cve-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/nvd-cve-osv.yaml
@@ -4,7 +4,7 @@ metadata:
   name: nvd-cve-osv
 spec:
   timeZone: Australia/Sydney
-  schedule: "0 6 * * *"
+  schedule: "0 6,13 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:


### PR DESCRIPTION
The NVD CVE conversion currently takes about 4 hours to run. This commit adds an afternoon run as well, mostly for the benefit of Staging, where it gives another opportunity for changes to be exercised in the same business day.