### PR TITLE
docs(faq): signpost alias calculation impact on modified time

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -130,7 +130,7 @@ If you work on a project (like a Linux distribution) and would like to contribut
 1. Version enumeration (for non-SemVer ecosystems where [supporting version enumeration code](https://github.com/google/osv.dev/tree/master/osv/ecosystems) exists)
 2. [Package URL](https://github.com/package-url/purl-spec) [computation](https://github.com/google/osv.dev/blob/a751ceb26522f093edf26c0ad167cfd0967716d9/osv/models.py#L361-L365) (if necessary)
 3. [Git affected commit enumeration and commit to tag mapping](https://github.com/google/osv.dev/blob/a751ceb26522f093edf26c0ad167cfd0967716d9/osv/impact.py#L422)
-4. [Batch](https://github.com/google/osv.dev/blob/master/deployment/clouddeploy/gke-workers/base/alias-computation.yaml) [computation](https://github.com/google/osv.dev/tree/master/docker/alias) of [aliases](https://ossf.github.io/osv-schema/#aliases-field)
+4. Repeat [batch](https://github.com/google/osv.dev/blob/master/deployment/clouddeploy/gke-workers/base/alias-computation.yaml) [computation](https://github.com/google/osv.dev/tree/master/docker/alias) of [aliases](https://ossf.github.io/osv-schema/#aliases-field) (**Note**: any time the `aliases` field changes, the record's [`modified`](https://ossf.github.io/osv-schema/#id-modified-fields) field is updated)
 
 Both version and commit enumeration populate the [`affected.versions[]`](https://ossf.github.io/osv-schema/#affectedversions-field) field, which assists with precise version matching.
 

--- a/osv/models.py
+++ b/osv/models.py
@@ -680,6 +680,8 @@ class Bug(ndb.Model):
 
     details = self.details
 
+    # Note that there is further possible mutation of this field below when
+    # `include_alias` is True
     if self.last_modified:
       modified = timestamp_pb2.Timestamp()
       modified.FromDatetime(self.last_modified)
@@ -735,7 +737,7 @@ class Bug(ndb.Model):
         schema_version=SCHEMA_VERSION,
         id=self.id(),
         published=published,
-        modified=modified,
+        modified=modified,  # Note the two places above where this can be set.
         aliases=aliases,
         related=related,
         withdrawn=withdrawn,


### PR DESCRIPTION
There was some some recent confusion around `modified` time behaviour.

This commit makes it more clear that any future alias group recalculation will result in a change to the record's `modified` time.