### PR TITLE
feat(nvd-cve-osv): rename log name

### DIFF
--- a/vulnfeeds/cmd/nvd-cve-osv/main.go
+++ b/vulnfeeds/cmd/nvd-cve-osv/main.go
@@ -508,7 +508,7 @@ func main() {
 	Metrics.Outcomes = make(map[cves.CVEID]ConversionOutcome)
 
 	var logCleanup func()
-	Logger, logCleanup = utility.CreateLoggerWrapper("cpp-osv")
+	Logger, logCleanup = utility.CreateLoggerWrapper("nvd-cve-osv")
 	defer logCleanup()
 
 	data, err := os.ReadFile(*jsonPath)


### PR DESCRIPTION
This commit harmonizes the Cloud Logging log name with the previous naming tidy up done in #1936