### PR TITLE
fix(data source): update human_link for UBUNTU CVEs in prod

### DIFF
--- a/source.yaml
+++ b/source.yaml
@@ -310,15 +310,29 @@
   link: 'https://ftp.suse.com/pub/projects/security/osv/'
   editable: False
 
-- name: 'ubuntu'
+- name: 'ubuntu-cve'
   versions_from_repo: False
   type: 0
-  ignore_patterns: ['^(?!(USN|UBUNTU)-).*$']
+  ignore_patterns: ['^(?!UBUNTU-).*$']
   directory_path: 'osv'
   repo_url: 'https://github.com/canonical/ubuntu-security-notices.git'
   detect_cherrypicks: False
   extension: '.json'
-  db_prefix: ['USN-', 'UBUNTU-']
+  db_prefix: ['UBUNTU-']
+  ignore_git: False
+  human_link: 'https://ubuntu.com/security/{{ BUG_ID | replace("UBUNTU-", "") }}'
+  link: 'https://github.com/canonical/ubuntu-security-notices/blob/main/'
+  editable: False
+
+- name: 'ubuntu-usn'
+  versions_from_repo: False
+  type: 0
+  ignore_patterns: ['^(?!USN-).*$']
+  directory_path: 'osv'
+  repo_url: 'https://github.com/canonical/ubuntu-security-notices.git'
+  detect_cherrypicks: False
+  extension: '.json'
+  db_prefix: ['USN-']
   ignore_git: False
   human_link: 'https://ubuntu.com/security/notices/{{ BUG_ID }}'
   link: 'https://github.com/canonical/ubuntu-security-notices/blob/main/'


### PR DESCRIPTION
Ubuntu CVEs have different URLs than USNs. Separate them into two sources with different human-readable links.
UBUNTU-CVE URL: https://ubuntu.com/security/CVE-2024-47076
USN URL: https://ubuntu.com/security/notices/USN-7045-1

Test instance changes: https://github.com/google/osv.dev/pull/2684