### PR TITLE
fix(staging-api-test): increase memory limit

### DIFF
--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/staging-api-test.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/staging-api-test.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: staging-api-test
 spec:
-  schedule: "50 9 * * *"
+  schedule: "50 21 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
@@ -19,8 +19,8 @@ spec:
             resources:
               requests:
                 cpu: 1.5
-                memory: "4G"
+                memory: "10G"
               limits:
                 cpu: 2
-                memory: "10G"
+                memory: "30G"
           restartPolicy: Never

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/staging-api-test.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/staging-api-test.yaml
@@ -3,7 +3,8 @@ kind: CronJob
 metadata:
   name: staging-api-test
 spec:
-  schedule: "50 21 * * *"
+  # Runs at 10:00 PM UTC (9:00 AM AEST) every day.
+  schedule: "0 22 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/staging-api-test.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/staging-api-test.yaml
@@ -3,8 +3,8 @@ kind: CronJob
 metadata:
   name: staging-api-test
 spec:
-  # Runs at 10:00 PM UTC (9:00 AM AEST) every day.
-  schedule: "0 22 * * *"
+  timeZone: Australia/Sydney
+  schedule: "0 9 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/docker/staging_api_test/perform_api_calls.py
+++ b/docker/staging_api_test/perform_api_calls.py
@@ -36,7 +36,7 @@ GCP_PROJECT = 'oss-vdb-test'
 BUG_DIR = './all_bugs'
 
 # Total run time in seconds
-TOTAL_RUNTIME = 3600
+TOTAL_RUNTIME = 3600 * 5    # 5 hours
 # Execute all pending batch size requests within the specified time interval.
 FREQUENCY_IN_SECONDS = 1
 

--- a/docker/staging_api_test/perform_api_calls.py
+++ b/docker/staging_api_test/perform_api_calls.py
@@ -36,7 +36,7 @@ GCP_PROJECT = 'oss-vdb-test'
 BUG_DIR = './all_bugs'
 
 # Total run time in seconds
-TOTAL_RUNTIME = 3600 * 5    # 5 hours
+TOTAL_RUNTIME = 3600 * 5  # 5 hours
 # Execute all pending batch size requests within the specified time interval.
 FREQUENCY_IN_SECONDS = 1
 

--- a/source.yaml
+++ b/source.yaml
@@ -310,15 +310,29 @@
   link: 'https://ftp.suse.com/pub/projects/security/osv/'
   editable: False
 
-- name: 'ubuntu'
+- name: 'ubuntu-cve'
   versions_from_repo: False
   type: 0
-  ignore_patterns: ['^(?!(USN|UBUNTU)-).*$']
+  ignore_patterns: ['^(?!UBUNTU-).*$']
   directory_path: 'osv'
   repo_url: 'https://github.com/canonical/ubuntu-security-notices.git'
   detect_cherrypicks: False
   extension: '.json'
-  db_prefix: ['USN-', 'UBUNTU-']
+  db_prefix: ['UBUNTU-']
+  ignore_git: False
+  human_link: 'https://ubuntu.com/security/{{ BUG_ID | replace("UBUNTU-", "") }}'
+  link: 'https://github.com/canonical/ubuntu-security-notices/blob/main/'
+  editable: False
+
+- name: 'ubuntu-usn'
+  versions_from_repo: False
+  type: 0
+  ignore_patterns: ['^(?!USN-).*$']
+  directory_path: 'osv'
+  repo_url: 'https://github.com/canonical/ubuntu-security-notices.git'
+  detect_cherrypicks: False
+  extension: '.json'
+  db_prefix: ['USN-']
   ignore_git: False
   human_link: 'https://ubuntu.com/security/notices/{{ BUG_ID }}'
   link: 'https://github.com/canonical/ubuntu-security-notices/blob/main/'


### PR DESCRIPTION
We recently added more Linux ecosystem records, and the original memory limit is not enough to fetch all vulnerabilities. Increase the memory limit and the runtime."