### PR TITLE
fix: use projection for related queries

### DIFF
--- a/osv/models.py
+++ b/osv/models.py
@@ -965,6 +965,7 @@ def get_aliases_async(bug_id) -> ndb.Future:
 @ndb.tasklet
 def get_related_async(bug_id) -> ndb.Future:
   """Gets related bugs asynchronously."""
-  related_bugs = yield Bug.query(Bug.related == bug_id).fetch_async(keys_only=True)
+  related_bugs = yield Bug.query(Bug.related == bug_id).fetch_async(
+      keys_only=True)
   related_bug_ids = [bug.id() for bug in related_bugs]
   return related_bug_ids

--- a/osv/models.py
+++ b/osv/models.py
@@ -722,8 +722,8 @@ class Bug(ndb.Model):
     aliases = []
 
     if include_alias:
-      related_bugs = Bug.query(Bug.related == self.db_id).fetch()
-      related_bug_ids = [bug.db_id for bug in related_bugs]
+      related_bugs = Bug.query(Bug.related == self.db_id).fetch(keys_only=True)
+      related_bug_ids = [bug.id() for bug in related_bugs]
       related = sorted(list(set(related_bug_ids + self.related)))
 
       alias_group = AliasGroup.query(AliasGroup.bug_ids == self.db_id).get()
@@ -965,6 +965,6 @@ def get_aliases_async(bug_id) -> ndb.Future:
 @ndb.tasklet
 def get_related_async(bug_id) -> ndb.Future:
   """Gets related bugs asynchronously."""
-  related_bugs = yield Bug.query(Bug.related == bug_id).fetch_async()
-  related_bug_ids = [bug.db_id for bug in related_bugs]
+  related_bugs = yield Bug.query(Bug.related == bug_id).fetch_async(keys_only=True)
+  related_bug_ids = [bug.id() for bug in related_bugs]
   return related_bug_ids

--- a/osv/models.py
+++ b/osv/models.py
@@ -722,8 +722,9 @@ class Bug(ndb.Model):
     aliases = []
 
     if include_alias:
-      related_bugs = Bug.query(Bug.related == self.db_id).fetch(keys_only=True)
-      related_bug_ids = [bug.id() for bug in related_bugs]
+      related_bugs = Bug.query(
+          Bug.related == self.db_id, projection=[Bug.db_id]).fetch()
+      related_bug_ids = [bug.db_id for bug in related_bugs]
       related = sorted(list(set(related_bug_ids + self.related)))
 
       alias_group = AliasGroup.query(AliasGroup.bug_ids == self.db_id).get()
@@ -965,7 +966,7 @@ def get_aliases_async(bug_id) -> ndb.Future:
 @ndb.tasklet
 def get_related_async(bug_id) -> ndb.Future:
   """Gets related bugs asynchronously."""
-  related_bugs = yield Bug.query(Bug.related == bug_id).fetch_async(
-      keys_only=True)
-  related_bug_ids = [bug.id() for bug in related_bugs]
+  related_bugs = yield Bug.query(
+      Bug.related == bug_id, projection=[Bug.db_id]).fetch_async()
+  related_bug_ids = [bug.db_id for bug in related_bugs]
   return related_bug_ids


### PR DESCRIPTION
The addition queries to find the related bugs was querying for the whole record, even though it only needs the id.
Changed the queries to grab only the db_id.