### PR TITLE
fix: Specify memory and CPU limits for osv-website.

### DIFF
--- a/deployment/clouddeploy/osv-website/run-prod.yaml
+++ b/deployment/clouddeploy/osv-website/run-prod.yaml
@@ -22,3 +22,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /_ah/warmup
+        resources:
+          limits:
+            cpu: 1
+            memory: 1024Mi

--- a/deployment/clouddeploy/osv-website/run-staging.yaml
+++ b/deployment/clouddeploy/osv-website/run-staging.yaml
@@ -22,3 +22,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /_ah/warmup
+        resources:
+          limits:
+            cpu: 1
+            memory: 1024Mi


### PR DESCRIPTION
The actual change to staging and prod is that memory is bumped to 1024Mi from 512Mi.