### PR TITLE
fix: Double memory for API server

### DIFF
--- a/deployment/clouddeploy/osv-api/run.yaml
+++ b/deployment/clouddeploy/osv-api/run.yaml
@@ -12,7 +12,7 @@ spec:
       - image: osv-server
         resources:
           limits:
-            memory: 4Gi
+            memory: 8Gi
         startupProbe:
           grpc:
             service: osv.v1.OSV


### PR DESCRIPTION
We are already using 8GB for the past week in prod, this change makes the release not replace it back down to 4GB. 

After this is merged double check staging to see if it correctly updates.