### PR TITLE
fix(api): double the CPU for API server

### DIFF
--- a/deployment/clouddeploy/osv-api/run.yaml
+++ b/deployment/clouddeploy/osv-api/run.yaml
@@ -12,6 +12,7 @@ spec:
       - image: osv-server
         resources:
           limits:
+            cpu: 2000m
             memory: 8Gi
         startupProbe:
           grpc:

--- a/deployment/clouddeploy/osv-api/run.yaml
+++ b/deployment/clouddeploy/osv-api/run.yaml
@@ -12,7 +12,7 @@ spec:
       - image: osv-server
         resources:
           limits:
-            cpu: 2000m
+            cpu: 2
             memory: 8Gi
         startupProbe:
           grpc:


### PR DESCRIPTION
https://github.com/google/osv.dev/pull/2799 increased the memory usage from 4Gi to 8Gi, but the deployment failed due to 

> Invalid value specified for container memory. For 1.0 CPU, memory must be between 128Mi and 4Gi inclusive.
> For more troubleshooting guidance, see https://cloud.google.com/run/docs/configuring/memory-limits


Bumps CPU to 2, matches with the current prod setting. 