### PR TITLE
fix: Upgrade the website's memory limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/lib
 .history/*
 **/.history/*
 */datastore-helper/
+hurl-scripts/

--- a/deployment/clouddeploy/osv-website/run-prod.yaml
+++ b/deployment/clouddeploy/osv-website/run-prod.yaml
@@ -25,4 +25,4 @@ spec:
         resources:
           limits:
             cpu: 1
-            memory: 1024Mi
+            memory: 4Gi

--- a/deployment/clouddeploy/osv-website/run-staging.yaml
+++ b/deployment/clouddeploy/osv-website/run-staging.yaml
@@ -25,4 +25,4 @@ spec:
         resources:
           limits:
             cpu: 1
-            memory: 1024Mi
+            memory: 4Gi


### PR DESCRIPTION
Some big records were still causing a memory outage for osv.dev, this increases it up to 4Gb's, the maximum memory limit on one core.

The osv.dev website only uses around ~1-2 instances, compared to our API which uses 20 instances, and is also using 8Gb per instance, so this is pretty small increase in relative cost. 

(The gitignore is for the hurl tool, which allows me to send http requests for testing)