### PR TITLE
feat: Make it easier to launch the api server locally without the backend.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ run-appengine-staging:
 run-api-server:
 	test -f $(HOME)/.config/gcloud/application_default_credentials.json || (echo "GCP Application Default Credentials not set, try 'gcloud auth login --update-adc'"; exit 1)
 	cd gcp/api && docker build -f Dockerfile.esp -t osv/esp:latest .
-	cd gcp/api && $(install-cmd) && GOOGLE_CLOUD_PROJECT=oss-vdb $(run-cmd) python test_server.py $(HOME)/.config/gcloud/application_default_credentials.json
+	cd gcp/api && $(install-cmd) && GOOGLE_CLOUD_PROJECT=oss-vdb $(run-cmd) python test_server.py $(HOME)/.config/gcloud/application_default_credentials.json $(NOBACKUP)
 
 # TODO: API integration tests.
 all-tests: lib-tests worker-tests importer-tests alias-tests appengine-tests vulnfeed-tests

--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,11 @@ run-appengine-staging:
 	cd gcp/appengine/blog && hugo --buildFuture -d ../dist/static/blog
 	cd gcp/appengine && $(install-cmd) && GOOGLE_CLOUD_PROJECT=oss-vdb-test $(run-cmd) python main.py
 
+# Run with `make run-api-server ARGS=--no-backend` to launch esp without backend.
 run-api-server:
 	test -f $(HOME)/.config/gcloud/application_default_credentials.json || (echo "GCP Application Default Credentials not set, try 'gcloud auth login --update-adc'"; exit 1)
 	cd gcp/api && docker build -f Dockerfile.esp -t osv/esp:latest .
-	cd gcp/api && $(install-cmd) && GOOGLE_CLOUD_PROJECT=oss-vdb $(run-cmd) python test_server.py $(HOME)/.config/gcloud/application_default_credentials.json $(NOBACKUP)
+	cd gcp/api && $(install-cmd) && GOOGLE_CLOUD_PROJECT=oss-vdb $(run-cmd) python test_server.py $(HOME)/.config/gcloud/application_default_credentials.json $(ARGS)
 
 # TODO: API integration tests.
 all-tests: lib-tests worker-tests importer-tests alias-tests appengine-tests vulnfeed-tests

--- a/gcp/api/test_server.py
+++ b/gcp/api/test_server.py
@@ -183,11 +183,11 @@ if __name__ == '__main__':
     print(f'Usage: {sys.argv[0]} path/to/credential.json')
     sys.exit(1)
 
-  no_backend = False
+  no_backend_flag = False
   if len(sys.argv) == 3:
-    no_backend = sys.argv[2] == '--no-backend'
+    no_backend_flag = sys.argv[2] == '--no-backend'
 
-  server = start(sys.argv[1], no_backend=no_backend)
+  server = start(sys.argv[1], no_backend=no_backend_flag)
   try:
     while True:
       server.check()

--- a/gcp/api/test_server.py
+++ b/gcp/api/test_server.py
@@ -32,7 +32,7 @@ class ServerInstance:
 
   def check(self):
     """Check that the server is still up."""
-    if self.backend.poll():
+    if self.backend and self.backend.poll():
       raise RuntimeError('Backend process died.')
 
     if self.esp.poll():
@@ -41,7 +41,8 @@ class ServerInstance:
   def stop(self):
     """Stop the server."""
     self.esp.kill()
-    self.backend.kill()
+    if self.backend:
+      self.backend.kill()
 
 
 def start_backend(port, log_path):
@@ -154,12 +155,16 @@ def start_esp(port, backend_port, credential_path, log_path):
   return esp_proc
 
 
-def start(credential_path, port=_ESP_PORT, backend_port=_BACKEND_PORT):
+def start(credential_path,
+          no_backend=False,
+          port=_ESP_PORT,
+          backend_port=_BACKEND_PORT):
   """Start the test server."""
   backend = None
   esp = None
   try:
-    backend = start_backend(_BACKEND_PORT, 'backend.log')
+    if not no_backend:
+      backend = start_backend(_BACKEND_PORT, 'backend.log')
     esp = start_esp(port, backend_port, credential_path, 'esp.log')
   except Exception:
     if esp:
@@ -178,7 +183,11 @@ if __name__ == '__main__':
     print(f'Usage: {sys.argv[0]} path/to/credential.json')
     sys.exit(1)
 
-  server = start(sys.argv[1])
+  no_backend = False
+  if len(sys.argv) == 3:
+    no_backend = sys.argv[2] == '--no-backend'
+
+  server = start(sys.argv[1], no_backend=no_backend)
   try:
     while True:
       server.check()


### PR DESCRIPTION
Commonly when testing changes for the backend, we want to keep the ESP translation layer up continuously, while rapidly restarting the python code with changes.

This makes it easier to launch just the translation layer. 