### PR TITLE
feat(frontend): improve record feedback user journey

### DIFF
--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -18,12 +18,12 @@
             Suggest an improvement
           </a>
         {% elif vulnerability.human_source_link -%}
-          <div>
-          <a class="vulnerability-improvement-link" href="https://google.github.io/osv.dev/faq/#ive-found-something-wrong-with-the-data" title="Follow the Source link below and use its record feedback reporting mechanism">
+          <div class="vulnerability-improvement-link">
+          <a href="https://google.github.io/osv.dev/faq/#ive-found-something-wrong-with-the-data" title="Follow the Source link below and use its record feedback reporting mechanism">
             See a problem?
           </a>
           <br/>
-          Please try reporting it to <a class="vulnerability-improvement-link" href="{{ vulnerability.human_source_link}}" target="_blank" rel="noopener noreferrer">the source</a> first.
+          Please try reporting it <a href="{{ vulnerability.human_source_link}}" target="_blank" rel="noopener noreferrer">to the source</a> first.
         </div>
         {% else -%}
           <a class="vulnerability-improvement-link" href="https://google.github.io/osv.dev/faq/#ive-found-something-wrong-with-the-data">

--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -17,6 +17,14 @@
           <a class="vulnerability-improvement-link" href="{{ vulnerability.human_source_link }}/improve">
             Suggest an improvement
           </a>
+        {% elif vulnerability.human_source_link -%}
+          <div>
+          <a class="vulnerability-improvement-link" href="https://google.github.io/osv.dev/faq/#ive-found-something-wrong-with-the-data" title="Follow the Source link below and use its record feedback reporting mechanism">
+            See a problem?
+          </a>
+          <br/>
+          Please try reporting it to <a class="vulnerability-improvement-link" href="{{ vulnerability.human_source_link}}" target="_blank" rel="noopener noreferrer">the source</a> first.
+        </div>
         {% else -%}
           <a class="vulnerability-improvement-link" href="https://google.github.io/osv.dev/faq/#ive-found-something-wrong-with-the-data">
             See a problem?


### PR DESCRIPTION
This commit improves the user journey for providing record feedback, by removing the round-trip through the FAQ (when possible) and making the callout to report it directly to the record's source more self-evident.

![image](https://github.com/user-attachments/assets/fd825b95-5bc2-4e86-bec6-a32845731320)

Part of #2191

Co-authored-by: Rex Pan <rexpan@google.com>