### PR TITLE
fix(frontend): open FAQ in a new tab/window

### DIFF
--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -19,14 +19,14 @@
           </a>
         {% elif vulnerability.human_source_link -%}
           <div class="vulnerability-improvement-link">
-          <a href="https://google.github.io/osv.dev/faq/#ive-found-something-wrong-with-the-data" title="Follow the Source link below and use its record feedback reporting mechanism">
+          <a href="https://google.github.io/osv.dev/faq/#ive-found-something-wrong-with-the-data" target="_blank" rel="noopener noreferrer" title="Follow the Source link below and use its record feedback reporting mechanism">
             See a problem?
           </a>
           <br/>
           Please try reporting it <a href="{{ vulnerability.human_source_link}}" target="_blank" rel="noopener noreferrer">to the source</a> first.
         </div>
         {% else -%}
-          <a class="vulnerability-improvement-link" href="https://google.github.io/osv.dev/faq/#ive-found-something-wrong-with-the-data">
+          <a class="vulnerability-improvement-link" href="https://google.github.io/osv.dev/faq/#ive-found-something-wrong-with-the-data" target="_blank" rel="noopener noreferrer">
             See a problem?
           </a>
         {% endif -%}


### PR DESCRIPTION
This commit addresses post-merge feedback on #2821 and opens the link to the FAQ entry in a new window/tab