### PR TITLE
feat: make critical batch jobs fail more noisily

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
+++ b/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
@@ -6,6 +6,14 @@
 ## This script is intended to be the entrypoint of the docker image.
 ## with the working directory being the root of the repository
 
+function __error_handing__() {
+     local last_status_code=$1;
+     local error_line_number=$2;
+     echo 1>&2 "Error - exited with status $last_status_code at line $error_line_number";
+}
+
+trap  '__error_handing__ $? $LINENO' ERR
+
 set -eu
 
 INPUT_BUCKET="${INPUT_GCS_BUCKET:=cve-osv-conversion}"

--- a/vulnfeeds/cmd/download-cves/mirror_nvd.sh
+++ b/vulnfeeds/cmd/download-cves/mirror_nvd.sh
@@ -19,6 +19,14 @@
 # discontinued by the NVD.
 # They are saved to GCS for use by combine-to-osv and the NVD to OSV conversion.
 
+function __error_handing__() {
+     local last_status_code=$1;
+     local error_line_number=$2;
+     echo 1>&2 "Error - exited with status $last_status_code at line $error_line_number";
+}
+
+trap  '__error_handing__ $? $LINENO' ERR
+
 set -e
 
 echo "Downloading the entire NVD"

--- a/vulnfeeds/cmd/nvd-cve-osv/run_cve_to_osv_generation.sh
+++ b/vulnfeeds/cmd/nvd-cve-osv/run_cve_to_osv_generation.sh
@@ -19,6 +19,14 @@
 # specified.
 # It assumes it is running in a Docker container
 
+function __error_handing__() {
+     local last_status_code=$1;
+     local error_line_number=$2;
+     echo 1>&2 "Error - exited with status $last_status_code at line $error_line_number";
+}
+
+trap  '__error_handing__ $? $LINENO' ERR
+
 set -e
 set -u
 


### PR DESCRIPTION
This commit adds an error handler to the wrapper script that runs the batch job workload, so that if it fails unexpectedly due to being run with `set -e`/`set -u` we stand a better chance of GCP's error reporting alerting us to it, or at least having additional context in the logs when investigating.

This is because until we get proper k8s job monitoring implemented, we're solely dependent on error reporting alerting us to job failures.