### PR TITLE
feat(importer): prepare for selective strict mode enablement (staging)

### DIFF
--- a/source_test.yaml
+++ b/source_test.yaml
@@ -12,6 +12,7 @@
   human_link: 'https://errata.almalinux.org/{{ ECOSYSTEMS[1].split(":")[1] }}/{{ BUG_ID | replace(":", "-", 1) }}.html'
   link: 'https://github.com/AlmaLinux/osv-database/blob/master/'
   editable: False
+  strict_validation: False
 
 - name: 'almalinux-alea'
   versions_from_repo: False
@@ -26,6 +27,7 @@
   human_link: 'https://errata.almalinux.org/{{ ECOSYSTEMS[1].split(":")[1] }}/{{ BUG_ID | replace(":", "-", 1) }}.html'
   link: 'https://github.com/AlmaLinux/osv-database/blob/master/'
   editable: False
+  strict_validation: False
 
 - name: 'almalinux-alsa'
   versions_from_repo: False
@@ -40,6 +42,7 @@
   human_link: 'https://errata.almalinux.org/{{ ECOSYSTEMS[1].split(":")[1] }}/{{ BUG_ID | replace(":", "-", 1) }}.html'
   link: 'https://github.com/AlmaLinux/osv-database/blob/master/'
   editable: False
+  strict_validation: False
 
 - name: 'android'
   versions_from_repo: False
@@ -52,6 +55,7 @@
   ignore_git: True
   link: 'https://storage.googleapis.com/android-osv-test/'
   editable: False
+  strict_validation: False
 
 - name: 'bitnami'
   versions_from_repo: False
@@ -65,6 +69,7 @@
   ignore_git: False
   link: 'https://github.com/bitnami/vulndb/tree/main/'
   editable: False
+  strict_validation: False
 
 - name: 'chainguard'
   versions_from_repo: False
@@ -78,6 +83,7 @@
   ignore_git: True
   link: 'https://packages.cgr.dev/chainguard/osv/'
   editable: False
+  strict_validation: False
 
 - name: 'curl'
   versions_from_repo: False
@@ -92,6 +98,7 @@
   human_link: 'https://curl.se/docs/{{ BUG_ID | replace("CURL-", "") }}.html'
   link: 'https://curl.se/docs/'
   editable: False
+  strict_validation: False
 
 - name: 'cve-osv'
   versions_from_repo: True
@@ -106,6 +113,7 @@
   human_link: 'https://nvd.nist.gov/vuln/detail/{{ BUG_ID }}'
   link: 'https://storage.googleapis.com/osv-test-cve-osv-conversion/'
   editable: False
+  strict_validation: True
 
 - name: 'debian-dla'
   versions_from_repo: False
@@ -120,6 +128,7 @@
   human_link: 'https://security-tracker.debian.org/tracker/{{ BUG_ID }}'
   link: 'https://storage.googleapis.com/debian-osv/'
   editable: False
+  strict_validation: False
 
 - name: 'debian-dsa'
   versions_from_repo: False
@@ -134,6 +143,7 @@
   human_link: 'https://security-tracker.debian.org/tracker/{{ BUG_ID }}'
   link: 'https://storage.googleapis.com/debian-osv/'
   editable: False
+  strict_validation: False
 
 - name: 'debian-dtsa'
   versions_from_repo: False
@@ -148,6 +158,7 @@
   human_link: 'https://security-tracker.debian.org/tracker/{{ BUG_ID }}'
   link: 'https://storage.googleapis.com/debian-osv/'
   editable: False
+  strict_validation: False
 
 - name: 'ghsa'
   versions_from_repo: False
@@ -162,6 +173,7 @@
   human_link: 'https://github.com/advisories/{{ BUG_ID }}'
   link: 'https://github.com/github/advisory-database/blob/main/'
   editable: False
+  strict_validation: False
 
 - name: 'go'
   versions_from_repo: True
@@ -176,6 +188,7 @@
   human_link: 'https://pkg.go.dev/vuln/{{ BUG_ID }}'
   link: 'https://vuln.go.dev/'
   editable: False
+  strict_validation: False
 
 - name: 'haskell'
   versions_from_repo: False
@@ -190,6 +203,7 @@
   link: 'https://github.com/haskell/security-advisories/blob/generated/osv-export/'
   editable: False
   repo_username: 'git'
+  strict_validation: False
 
 - name: 'malicious-packages'
   versions_from_repo: False
@@ -203,6 +217,7 @@
   ignore_git: False
   link: 'https://github.com/ossf/malicious-packages/blob/main/'
   editable: False
+  strict_validation: False
 
 - name: 'test-oss-fuzz'
   versions_from_repo: True
@@ -216,6 +231,7 @@
   ignore_git: False
   link: 'https://github.com/google/oss-fuzz-vulns/blob/main/'
   editable: False
+  strict_validation: False
 
 - name: 'psf'
   versions_from_repo: True
@@ -229,6 +245,7 @@
   ignore_git: False
   link: 'https://github.com/psf/advisory-database/blob/main/'
   editable: False
+  strict_validation: False
 
 - name: 'python'
   versions_from_repo: False
@@ -242,6 +259,7 @@
   ignore_git: False
   link: 'https://github.com/pypa/advisory-database/blob/main/'
   editable: False
+  strict_validation: False
 
 - name: 'r'
   versions_from_repo: False
@@ -255,6 +273,7 @@
   ignore_git: False
   link: 'https://github.com/RConsortium/r-advisory-database/blob/main/'
   editable: False
+  strict_validation: False
 
 - name: 'redhat'
   versions_from_repo: False
@@ -269,6 +288,7 @@
   human_link: 'https://access.redhat.com/errata/{{ BUG_ID }}'
   link: 'https://security.access.redhat.com/data/osv/'
   editable: False
+  strict_validation: False
 
 - name: 'rockylinux'
   versions_from_repo: False
@@ -282,6 +302,7 @@
   human_link: 'https://errata.rockylinux.org/{{ BUG_ID }}'
   link: 'https://storage.googleapis.com/resf-osv-data/'
   editable: False
+  strict_validation: False
 
 - name: 'rockylinux-rxsa'
   versions_from_repo: False
@@ -295,6 +316,7 @@
   human_link: 'https://errata.rockylinux.org/{{ BUG_ID }}'
   link: 'https://storage.googleapis.com/resf-osv-data/'
   editable: False
+  strict_validation: False
 
 - name: 'rust'
   versions_from_repo: True
@@ -311,6 +333,7 @@
   link: 'https://github.com/rustsec/advisory-db/blob/osv/'
   editable: False
   repo_username: 'git'
+  strict_validation: False
 
 - name: 'suse'
   versions_from_repo: False
@@ -325,6 +348,7 @@
   human_link: 'https://www.suse.com/support/update/announcement/{{ BUG_ID.split(":")[0].split("-")[2] }}/{{ BUG_ID | replace(":", "") | lower }}/'
   link: 'https://ftp.suse.com/pub/projects/security/osv/'
   editable: False
+  strict_validation: False
 
 - name: 'ubuntu-cve'
   versions_from_repo: False
@@ -339,6 +363,7 @@
   human_link: 'https://ubuntu.com/security/{{ BUG_ID | replace("UBUNTU-", "") }}'
   link: 'https://github.com/canonical/ubuntu-security-notices/blob/main/'
   editable: False
+  strict_validation: False
 
 - name: 'ubuntu-usn'
   versions_from_repo: False
@@ -353,6 +378,7 @@
   human_link: 'https://ubuntu.com/security/notices/{{ BUG_ID }}'
   link: 'https://github.com/canonical/ubuntu-security-notices/blob/main/'
   editable: False
+  strict_validation: False
 
 - name: 'uvi'
   versions_from_repo: True
@@ -368,4 +394,5 @@
   editable: False
   key_path: 'OSV'
   repo_username: 'git'
+  strict_validation: False
 


### PR DESCRIPTION
This commit explicitly sets strict mode on a per-repository basis. This change is a no-op until the importer's `--strict_validation` flag is also set to True, which will still then be a no-op for all sources other than `cve-osv` where we can trial having it enabled.

Part of #2188