### PR TITLE
feat(importer): enable strict validation in staging

### DIFF
--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/importer.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/importer.yaml
@@ -16,3 +16,7 @@ spec:
               # TODO(michaelkedar): ssh secrets
               # TODO(michaelkedar): single source of truth w/ terraform config
               - "--public_log_bucket=osv-test-public-import-logs"
+              # Note that with https://github.com/google/osv.dev/pull/2766
+              # addition per-repository settings make this *really* take effect, see
+              # https://github.com/google/osv.dev/pull/2837
+              - "--strict_validation=True"


### PR DESCRIPTION
This only impacts sources that have `strict_validation` enabled for them, such as in #2837

Part of #2188