### PR TITLE
feat(sources): add more human_links to production

### DIFF
--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -17,7 +17,7 @@
           <a class="vulnerability-improvement-link" href="{{ vulnerability.human_source_link }}/improve">
             Suggest an improvement
           </a>
-        {% elif vulnerability.human_source_link -%}
+        {% elif vulnerability.human_source_link and not vulnerability.id.startswith("openSUSE-") -%}
           <div class="vulnerability-improvement-link">
           <a href="https://google.github.io/osv.dev/faq/#ive-found-something-wrong-with-the-data" target="_blank" rel="noopener noreferrer" title="Follow the Source link below and use its record feedback reporting mechanism">
             See a problem?
@@ -42,7 +42,7 @@
           <dt>Import Source</dt>
           <dd><a href="{{ vulnerability.source_link }}" target="_blank" rel="noopener noreferrer">{{
               vulnerability.source }}</a></dd>
-          
+
           <dt>JSON Data</dt>
           <dd><a href="https://{{ api_url }}/v1/vulns/{{ vulnerability.id }}" target="_blank" rel="noopener noreferrer">
             https://{{ api_url }}/v1/vulns/{{ vulnerability.id }}</a>

--- a/source.yaml
+++ b/source.yaml
@@ -280,6 +280,7 @@
   bucket: 'resf-osv-data'
   db_prefix: ['RLSA-']
   ignore_git: False
+  human_link: 'https://errata.rockylinux.org/{{ BUG_ID }}'
   link: 'https://storage.googleapis.com/resf-osv-data/'
   editable: False
 
@@ -292,6 +293,7 @@
   bucket: 'resf-osv-data'
   db_prefix: ['RXSA-']
   ignore_git: False
+  human_link: 'https://errata.rockylinux.org/{{ BUG_ID }}'
   link: 'https://storage.googleapis.com/resf-osv-data/'
   editable: False
 
@@ -321,6 +323,7 @@
   extension: '.json'
   db_prefix: ['openSUSE-', 'SUSE-']
   ignore_git: True
+  human_link: 'https://www.suse.com/support/update/announcement/{{ BUG_ID.split(":")[0].split("-")[2] }}/{{ BUG_ID | replace(":", "") | lower }}/'
   link: 'https://ftp.suse.com/pub/projects/security/osv/'
   editable: False
 

--- a/source.yaml
+++ b/source.yaml
@@ -323,7 +323,6 @@
   extension: '.json'
   db_prefix: ['openSUSE-', 'SUSE-']
   ignore_git: True
-  human_link: 'https://www.suse.com/support/update/announcement/{{ BUG_ID.split(":")[0].split("-")[2] }}/{{ BUG_ID | replace(":", "") | lower }}/'
   link: 'https://ftp.suse.com/pub/projects/security/osv/'
   editable: False
 


### PR DESCRIPTION
This commit partially replicates the changes from https://github.com/google/osv.dev/pull/2822 to production, adding
additional human_links for records for Rocky Linux (but not yet SuSE), to improve signposting around the desired user journey for data feedback going directly to the source.

It also modifies the frontend to not link out for `openSUSE`-prefixed records, because the approach taken in #2822 doesn't seem to work.

Part of #2191