### PR TITLE
feat(frontend): improved UX for missing vulnerabilities

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -91,6 +91,16 @@ If you have any questions, please feel free to create an issue!
 
 ## Data
 
+### Why isn't a record available?
+
+If you are unable to retrieve a record you are expecting to be able to find, it
+may be because it has not imported successfully, due to there being a quality issue with it.
+
+If a record has not met [OSV.dev's quality bar](data_quality.md), the 404 page
+for the vulnerability will state this.
+
+You should raise this with the home database responsible for the record.
+
 ### I've found something wrong with the data
 
 Data quality is very important to us. Please remember that OSV.dev is an

--- a/gcp/appengine/frontend3/src/templates/404.html
+++ b/gcp/appengine/frontend3/src/templates/404.html
@@ -12,6 +12,27 @@
 {% block top_bar %} {% endblock %}
 
 {% block content %}
+{% if vuln_id %}
+<div class="mdc-layout-grid not-found-page">
+    <div class="mdc-layout-grid__inner">
+        <div class="mdc-layout-grid__cell--span-12 text-info">
+            <h2 class="heading">{{ vuln_id }} Not Found!</h2>
+            <p class="description">
+            {% if has_importfindings %}
+            The record has not imported successfully from its source<br/>
+            {% endif %}
+                Please see our
+                <a href="https://google.github.io/osv.dev/faq/">FAQ</a> for more information.
+            </p>
+            <div class="cta">
+                <a class="cta-primary link-button" href="{{ url_for('frontend_handlers.index') }}"
+                    aria-label="Get me back Home!">Back to Home</a>
+            </div>
+        </div>
+    </div>
+    <footer></footer>
+</div>
+{% else %}
 <div class="mdc-layout-grid not-found-page">
     <div class="mdc-layout-grid__inner">
         <div class="mdc-layout-grid__cell--span-12 text-info">
@@ -29,4 +50,5 @@
     </div>
     <footer></footer>
 </div>
+{% endif %}
 {% endblock %}

--- a/gcp/appengine/frontend3/src/templates/404.html
+++ b/gcp/appengine/frontend3/src/templates/404.html
@@ -19,7 +19,7 @@
             <h2 class="heading">{{ vuln_id }} Not Found!</h2>
             <p class="description">
             {% if has_importfindings %}
-            The record has not imported successfully from its source<br/>
+            The record has not been successfully imported from its source<br/>
             {% endif %}
                 Please see our
                 <a href="https://google.github.io/osv.dev/faq/">FAQ</a> for more information.

--- a/gcp/appengine/frontend3/src/templates/list.html
+++ b/gcp/appengine/frontend3/src/templates/list.html
@@ -128,7 +128,7 @@
           </div>
           {%- endfor -%}
           {%- if vulnerabilities | length == 0 -%}
-          <span class="no-results">No results</span>
+          <span class="no-results">No results (check our <a href="https://google.github.io/osv.dev/faq/">FAQ</a> if this is unexpected)</span>
           {%- endif -%}
           {%- if page < total_pages -%} <turbo-frame id="vulnerability-table-page{{ page + 1 }}"
             data-turbo-action="advance" target="_top" class="next-page-frame">

--- a/gcp/appengine/frontend_handlers.py
+++ b/gcp/appengine/frontend_handlers.py
@@ -273,9 +273,9 @@ def vulnerability_redirector(potential_vuln_id):
     return None
 
   # This may raise an exception directly or via abort() for failed retrievals.
-  _ = osv_get_by_id(potential_vuln_id)
+  bug = osv_get_by_id(potential_vuln_id)
 
-  return redirect(f'/vulnerability/{potential_vuln_id}')
+  return redirect(f'/vulnerability/{bug["id"]}')
 
 
 @blueprint.route('/<potential_vuln_id>.json')
@@ -289,13 +289,13 @@ def vulnerability_json_redirector(potential_vuln_id):
     return None
 
   # This calls abort() on failed retrievals.
-  _ = osv_get_by_id(potential_vuln_id)
+  bug = osv_get_by_id(potential_vuln_id)
 
   if utils.is_prod():
     api_url = 'api.osv.dev'
   else:
     api_url = 'api.test.osv.dev'
-  return redirect(f'https://{api_url}/v1/vulns/{potential_vuln_id}')
+  return redirect(f'https://{api_url}/v1/vulns/{bug["id"]}')
 
 
 def bug_to_response(bug, detailed=True):


### PR DESCRIPTION
This commit modifies the 404 flow so that:
- when a request for a non-existent vulnerability is received, the 404 page reflects the nature of the failed request
- when it is known that the vulnerability failed to import, this is explicitly surfaced

A new FAQ entry discussing this is also added.

Additionally, the 404 generation was tidied up to make it easier to understand where the 404 comes from. There were many unreachable paths that called `abort()`, which made the code unnecessarily unreadable.

It also addresses requests for `/favicon.ico` generating 404's from the redirector by adding an explicit handler for it.

![127 0 0 1_8000_USN-2001-1](https://github.com/user-attachments/assets/5ec0c6cc-9826-4220-852c-cc1a7e274141)

![127 0 0 1_8000_foo_bar_baz](https://github.com/user-attachments/assets/1005d0bc-3253-48d8-bb56-8ac4ddb9a065)

![127 0 0 1_8000_list_q=USN-2001-1 ecosystem=](https://github.com/user-attachments/assets/1b82bbd7-7ad4-4b68-9b92-ee99f1777c0e)

Part of #2190