### PR TITLE
fix(importer): correctly specific strict validation flag

### DIFF
--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/importer.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/importer.yaml
@@ -19,4 +19,4 @@ spec:
               # Note that with https://github.com/google/osv.dev/pull/2766
               # addition per-repository settings make this *really* take effect, see
               # https://github.com/google/osv.dev/pull/2837
-              - "--strict_validation=True"
+              - "--strict_validation"


### PR DESCRIPTION
This commit fixes the specification of the `--strict_validation` flag for the importer in staging. It seems #2841 had it wrong, based on:

```
importer.py: error: argument --strict_validation: ignored explicit argument 'True'
```