### PR TITLE
fix(frontend): add missing special-case for openSuSE human links

### DIFF
--- a/gcp/appengine/frontend3/src/templates/vulnerability.html
+++ b/gcp/appengine/frontend3/src/templates/vulnerability.html
@@ -33,7 +33,7 @@
       </div>
       <div class="mdc-layout-grid__cell--span-12">
         <dl class="vulnerability-details">
-          {%- if vulnerability.human_source_link -%}
+          {%- if vulnerability.human_source_link and not vulnerability.id.startswith("openSUSE-") -%}
           <dt>Source</dt>
           <dd><a href="{{ vulnerability.human_source_link }}" target="_blank" rel="noopener noreferrer">{{
               vulnerability.human_source_link }}</a>


### PR DESCRIPTION
This commit addresses the other (more important) location where special casing for openSuSE `human_link` that was overlooked in #2844

Thanks to @hogo6002 for picking up on this.