### PR TITLE
fix(importer): avoid raising an exception when handling invalid data

### DIFF
--- a/docker/importer/importer.py
+++ b/docker/importer/importer.py
@@ -206,6 +206,10 @@ class Importer:
     except RuntimeError:
       # Happens if filename extension is unsupported.
       pass
+    except Exception:
+      # This function is called from an Exception handler.
+      # Do not cause further exceptions.
+      pass
 
     # TODO(apollock): Then try by poking around at the data.
 


### PR DESCRIPTION
This commit makes record ID inference more exception-proof by handling all exceptions. Because this function is already being called by the exception handler for a previous failed attempt parsing a record, it is guaranteed to struggle to successfully parse the record under a variety of unknown circumstances, and so raising another exception is not desired.