### PR TITLE
feat(sources): add human_link for chainguard to staging

### DIFF
--- a/source_test.yaml
+++ b/source_test.yaml
@@ -82,6 +82,7 @@
   db_prefix: ['CGA-']
   ignore_git: True
   link: 'https://packages.cgr.dev/chainguard/osv/'
+  human_link: 'https://images.chainguard.dev/security/{{ BUG_ID }}'
   editable: False
   strict_validation: False
 


### PR DESCRIPTION
I discovered a human-friendly upstream link for Chainguard's advisories

Part of #2191