### PR TITLE
pypi vulnfeeds: Support ignoring unbounded vulnerabilities.

### DIFF
--- a/vulnfeeds/cmd/pypi/main.go
+++ b/vulnfeeds/cmd/pypi/main.go
@@ -171,7 +171,7 @@ func main() {
 			}
 
 			if *excludeUnbounded && anyUnbounded(v) {
-				log.Printf("Skipping %s as we could not find a fixed version.", cve.CVE.ID)
+				log.Printf("Skipping %s as we could not find an upperbound version.", cve.CVE.ID)
 				continue
 			}
 


### PR DESCRIPTION
This is to reduce the chance of introducing false positive matches.

Refs:
- https://github.com/pypa/advisory-database/issues/207
- https://github.com/pypa/advisory-database/issues/205