### PR TITLE
feat: include record source in machine readable record feedback Datas…

### DIFF
--- a/docker/importer/importer_test.py
+++ b/docker/importer/importer_test.py
@@ -1116,6 +1116,7 @@ class ImportFindingsTest(unittest.TestCase):
     """Test that creating an import finding works."""
     expected = osv.ImportFinding(
         bug_id='CVE-2024-1234',
+        source='cve-osv',
         findings=[
             osv.ImportFindings.INVALID_VERSION,
         ],
@@ -1124,9 +1125,8 @@ class ImportFindingsTest(unittest.TestCase):
     )
     expected.put()
 
-    for actual in osv.ImportFinding.query(
-        osv.ImportFinding.bug_id == expected.bug_id):
-      self.assertEqual(expected, actual)
+    actual = osv.ImportFinding.get_by_id(expected.bug_id)
+    self.assertEqual(expected, actual)
 
 
 if __name__ == '__main__':

--- a/osv/models.py
+++ b/osv/models.py
@@ -917,6 +917,7 @@ class ImportFindings(enum.IntEnum):
 class ImportFinding(ndb.Model):
   """Quality findings about an individual record."""
   bug_id: str = ndb.StringProperty()
+  source: str = ndb.StringProperty()
   findings: list[ImportFindings] = ndb.IntegerProperty(repeated=True)
   first_seen: datetime = ndb.DateTimeProperty()
   last_attempt: datetime = ndb.DateTimeProperty()


### PR DESCRIPTION
…tore model

This commit extends #2582 to include the source of a record. This is so it's possible to search for all records from a specific source.

Part of #2189