### PR TITLE
chore: remove duplicate index

### DIFF
--- a/gcp/datastore/index.yaml
+++ b/gcp/datastore/index.yaml
@@ -40,13 +40,6 @@ indexes:
       - name: purl
       - name: semver_fixed_indexes
 
-  - kind: Bug
-    properties:
-      - name: status
-      - name: public
-      - name: purl
-      - name: semver_fixed_indexes
-
   # Is used in importer to look for not fixed bug entries
   # Specifically specified since merged index has a slight performance hit
   - kind: Bug


### PR DESCRIPTION
https://github.com/google/osv.dev/issues/2790

There are identical indexes defined (L36-L41 and L43-L48) and this PR removes the duplicate one.