### PR TITLE
fix(worker): raise an exception for invalid source

### DIFF
--- a/docker/worker/worker.py
+++ b/docker/worker/worker.py
@@ -334,8 +334,7 @@ class TaskRunner:
 
     source_repo = osv.get_source_repository(source)
     if source_repo is None:
-      logging.error('Failed to get source repository %s', source)
-      return
+      raise Exception('Failed to get source repository %s', source)
 
     if source_repo.type == osv.SourceRepositoryType.GIT:
       repo = osv.ensure_updated_checkout(

--- a/docker/worker/worker.py
+++ b/docker/worker/worker.py
@@ -334,7 +334,7 @@ class TaskRunner:
 
     source_repo = osv.get_source_repository(source)
     if source_repo is None:
-      raise Exception('Failed to get source repository %s', source)
+      raise ValueError('Failed to get source repository %s' % source)
 
     if source_repo.type == osv.SourceRepositoryType.GIT:
       repo = osv.ensure_updated_checkout(


### PR DESCRIPTION
Follow up on https://github.com/google/osv.dev/pull/2928

Instead of logging the error, raise an exception so that caller is able to add record ID to the error.