### PR TITLE
fix(faq): Revert custom header color and text settings for better contrast

### DIFF
--- a/docs/_sass/color_schemes/custom_dark.scss
+++ b/docs/_sass/color_schemes/custom_dark.scss
@@ -7,8 +7,6 @@ $new-body-background-color: #292929;
 // Overriding dark default for just-the-docs styles
 $color-scheme: dark;
 $body-background-color: $new-body-background-color; // Replacing default $grey-dk-300
-$body-heading-color: $white; // Replacing default $grey-lt-000
-$body-text-color: $white; //Replacing default $grey-lt-300
 $link-color: #C9F5F7;
 $nav-child-link-color: $white; // Replacing default $grey-dk-000
 $sidebar-color: $new-body-background-color; //Replacing default $grey-dk-300


### PR DESCRIPTION
Our FAQ uses [Just the Docs](https://just-the-docs.com/docs/configuration/) dark mode, but we overwrote the default text and header colour, changing two slightly different colours to all white. This makes our `h3` tags difficult to find. This PR reverts the color scheme settings for headers and body text to improve visibility (slightly different colours between headers and body text).
![image](https://github.com/user-attachments/assets/6fb1bc14-5219-49ae-aaa5-e51d02f37a77)
