### PR TITLE
feat: add more purl converters

### DIFF
--- a/osv/purl_helpers.py
+++ b/osv/purl_helpers.py
@@ -18,47 +18,48 @@ from urllib.parse import quote
 
 from packageurl import PackageURL
 
+ParsedPURL = namedtuple('ParsedPURL', ['ecosystem', 'package', 'version'])
+EcosystemPURL = namedtuple('EcosystemPURL', ['type', 'namespace'])
+
 # PURL spec:
 # https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst
 ECOSYSTEM_PURL_DATA = {
-    'AlmaLinux': ('rpm', 'almalinux'),
-    'Alpine': ('apk', 'alpine'),
+    'AlmaLinux': EcosystemPURL('rpm', 'almalinux'),
+    'Alpine': EcosystemPURL('apk', 'alpine'),
     # Android
-    'Bitnami': ('bitnami', None),
-    'Chainguard': ('apk', 'chainguard'),
-    'CRAN': ('cran', None),
-    'crates.io': ('cargo', None),
-    'Debian': ('deb', 'debian'),
+    'Bitnami': EcosystemPURL('bitnami', None),
+    'Chainguard': EcosystemPURL('apk', 'chainguard'),
+    'CRAN': EcosystemPURL('cran', None),
+    'crates.io': EcosystemPURL('cargo', None),
+    'Debian': EcosystemPURL('deb', 'debian'),
     # GIT
-    'GitHub Actions': ('github', None),
-    'Go': ('golang', None),
-    'Hackage': ('hackage', None),
-    'Hex': ('hex', None),
+    'GitHub Actions': EcosystemPURL('github', None),
+    'Go': EcosystemPURL('golang', None),
+    'Hackage': EcosystemPURL('hackage', None),
+    'Hex': EcosystemPURL('hex', None),
     # Linux
-    'Maven': ('maven', None),
-    'npm': ('npm', None),
-    'NuGet': ('nuget', None),
-    'openSUSE': ('rpm', 'opensuse'),
-    'OSS-Fuzz': ('generic', None),
-    'Packagist': ('composer', None),
-    'Pub': ('pub', None),
-    'PyPI': ('pypi', None),
-    'Red Hat': ('rpm', 'redhat'),
-    'Rocky Linux': ('rpm', 'rocky-linux'),
-    'RubyGems': ('gem', None),
-    'SUSE': ('rpm', 'suse'),
-    'SwiftURL': ('swift', None),
-    'Ubuntu': ('deb', 'ubuntu'),
-    'Wolfi': ('apk', 'wolfi'),
+    'Maven': EcosystemPURL('maven', None),
+    'npm': EcosystemPURL('npm', None),
+    'NuGet': EcosystemPURL('nuget', None),
+    'openSUSE': EcosystemPURL('rpm', 'opensuse'),
+    'OSS-Fuzz': EcosystemPURL('generic', None),
+    'Packagist': EcosystemPURL('composer', None),
+    'Pub': EcosystemPURL('pub', None),
+    'PyPI': EcosystemPURL('pypi', None),
+    'Red Hat': EcosystemPURL('rpm', 'redhat'),
+    'Rocky Linux': EcosystemPURL('rpm', 'rocky-linux'),
+    'RubyGems': EcosystemPURL('gem', None),
+    'SUSE': EcosystemPURL('rpm', 'suse'),
+    'SwiftURL': EcosystemPURL('swift', None),
+    'Ubuntu': EcosystemPURL('deb', 'ubuntu'),
+    'Wolfi': EcosystemPURL('apk', 'wolfi'),
 }
 
 # Create the reverse lookup hash map
 PURL_ECOSYSTEM_MAP = {
-    (purl_type, purl_namespace): ecosystem
-    for ecosystem, (purl_type, purl_namespace) in ECOSYSTEM_PURL_DATA.items()
+    purl_data: ecosystem
+    for ecosystem, purl_data in ECOSYSTEM_PURL_DATA.items()
 }
-
-Purl = namedtuple('Purl', ['ecosystem', 'package', 'version'])
 
 
 def _url_encode(package_name):
@@ -74,9 +75,10 @@ def package_to_purl(ecosystem: str, package_name: str) -> str | None:
     return None
 
   purl_type, purl_namespace = purl_data
-  purl_ecosystem = purl_type
   if purl_namespace:
     purl_ecosystem = f'{purl_type}/{purl_namespace}'
+  else:
+    purl_ecosystem = purl_type
 
   suffix = ''
 
@@ -93,7 +95,7 @@ def package_to_purl(ecosystem: str, package_name: str) -> str | None:
   return f'pkg:{purl_ecosystem}/{_url_encode(package_name)}{suffix}'
 
 
-def parse_purl(purl_str: str) -> Purl | None:
+def parse_purl(purl_str: str) -> ParsedPURL | None:
   """Parses a PURL string and extracts
   ecosystem, package, and version information.
 
@@ -111,28 +113,26 @@ def parse_purl(purl_str: str) -> Purl | None:
   package = purl.name
   version = purl.version
 
-  ecosystem = PURL_ECOSYSTEM_MAP.get((purl.type, purl.namespace))
-  if not ecosystem:
-    # check for matching ecosystems without using the namespace (special cases)
-    ecosystem = PURL_ECOSYSTEM_MAP.get((purl.type, None))
-    if not ecosystem:
-      raise ValueError('Invalid ecosystem.')
-    # Handle special cases for package name construction
-    if purl.type == 'golang' and purl.namespace:
-      # Go uses the combined purl.namespace and purl.name for Go package names
-      # Example:
-      #   pkg:golang/github.com/cri-o/cri-o
-      #   -> namespace: github.com/cri-o
-      #   -> name: cri-o
-      #   -> package name in OSV: github.com/cri-o/cri-o
-      package = purl.namespace + '/' + purl.name
-    elif purl.type in ('hex', 'npm', 'swift') and purl.namespace:
-      package = purl.namespace + '/' + purl.name
-    elif purl.type == 'maven' and purl.namespace:
-      package = purl.namespace + ':' + purl.name
-    elif purl.type == 'composer' and purl.namespace:
-      package = purl.namespace + '/' + purl.name
-    else:
-      raise ValueError('Invalid ecosystem.')
+  # Find a matching ecosystem using both type and namespace.
+  ecosystem = PURL_ECOSYSTEM_MAP.get(EcosystemPURL(purl.type, purl.namespace))
+  if ecosystem:
+    return ParsedPURL(ecosystem, package, version)
 
-  return Purl(ecosystem, package, version)
+  # If no match is found, try again using only the type.
+  # Some ecosystems may use the namespace to represent additional
+  # information (like vendors) and the namespace might be optional.
+  ecosystem = PURL_ECOSYSTEM_MAP.get(EcosystemPURL(purl.type, None))
+  if not ecosystem:
+    raise ValueError('Invalid ecosystem.')
+
+  # For ecosystems with optional namespaces, the namespace might need to be
+  # included as part of the package name.
+  if purl.type in ('composer', 'golang', 'hex', 'npm',
+                   'swift') and purl.namespace:
+    package = purl.namespace + '/' + purl.name
+  elif purl.type == 'maven' and purl.namespace:
+    package = purl.namespace + ':' + purl.name
+  else:
+    raise ValueError('Invalid ecosystem.')
+
+  return ParsedPURL(ecosystem, package, version)

--- a/osv/purl_helpers_test.py
+++ b/osv/purl_helpers_test.py
@@ -21,46 +21,115 @@ from . import purl_helpers
 class PurlHelpersTest(unittest.TestCase):
   """purl_helpers tests."""
 
-  def test_pypi(self):
-    """Test PURL generation for PyPI."""
+  def tests_package_to_purl(self):
+    """Test PURL generation."""
+    self.assertEqual('pkg:rpm/almalinux/libvpx',
+                     purl_helpers.package_to_purl('AlmaLinux', 'libvpx'))
+
+    self.assertEqual('pkg:apk/alpine/postgresql14?arch=source',
+                     purl_helpers.package_to_purl('Alpine', 'postgresql14'))
+
+    self.assertEqual('pkg:apk/chainguard/solr',
+                     purl_helpers.package_to_purl('Chainguard', 'solr'))
+
+    self.assertEqual('pkg:cran/commonmark',
+                     purl_helpers.package_to_purl('CRAN', 'commonmark'))
+
     self.assertEqual('pkg:pypi/django',
                      purl_helpers.package_to_purl('PyPI', 'django'))
 
-  def test_maven(self):
-    """Test PURL generation for Maven."""
     self.assertEqual(
         'pkg:maven/org.apache.struts/struts2-core',
         purl_helpers.package_to_purl('Maven', 'org.apache.struts:struts2-core'))
 
-  def test_npm(self):
-    """Test PURL generation for npm."""
     self.assertEqual('pkg:npm/%40hapi/hoek',
                      purl_helpers.package_to_purl('npm', '@hapi/hoek'))
 
-  def test_debian(self):
-    """Test PURL generation for npm."""
     self.assertEqual('pkg:deb/debian/nginx?arch=source',
                      purl_helpers.package_to_purl('Debian', 'nginx'))
 
-  def test_alpine(self):
-    """Test PURL generation for alpine."""
     self.assertEqual('pkg:apk/alpine/nginx?arch=source',
                      purl_helpers.package_to_purl('Alpine', 'nginx'))
 
-  def test_pub(self):
-    """Test PURL generation for Pub."""
     self.assertEqual('pkg:pub/characters',
                      purl_helpers.package_to_purl('Pub', 'characters'))
 
-  def test_swift(self):
-    """Test PURL generation for Swift."""
     self.assertEqual(
         'pkg:swift/github.com/Alamofire/Alamofire',
         purl_helpers.package_to_purl('SwiftURL',
                                      'github.com/Alamofire/Alamofire'))
 
+    # Reverted tests based on test_parse_purl (without parse_purl calls)
+    self.assertEqual('pkg:bitnami/moodl',
+                     purl_helpers.package_to_purl('Bitnami', 'moodl'))
+
+    self.assertEqual('pkg:cargo/surrealdb',
+                     purl_helpers.package_to_purl('crates.io', 'surrealdb'))
+
+    self.assertEqual(
+        'pkg:golang/github.com/treeverse/lakefs',
+        purl_helpers.package_to_purl('Go', 'github.com/treeverse/lakefs'))
+
+    self.assertEqual('pkg:hackage/process',
+                     purl_helpers.package_to_purl('Hackage', 'process'))
+
+    self.assertEqual('pkg:hex/test-package',
+                     purl_helpers.package_to_purl('Hex', 'test-package'))
+
+    self.assertEqual('pkg:hex/acme/foo',
+                     purl_helpers.package_to_purl('Hex', 'acme/foo'))
+
+    self.assertEqual('pkg:npm/test-package',
+                     purl_helpers.package_to_purl('npm', 'test-package'))
+
+    self.assertEqual('pkg:nuget/test-package',
+                     purl_helpers.package_to_purl('NuGet', 'test-package'))
+
+    self.assertEqual('pkg:rpm/opensuse/test-package',
+                     purl_helpers.package_to_purl('openSUSE', 'test-package'))
+
+    self.assertEqual('pkg:generic/test-package',
+                     purl_helpers.package_to_purl('OSS-Fuzz', 'test-package'))
+
+    self.assertEqual(
+        'pkg:composer/spencer14420/sp-php-email-handler',
+        purl_helpers.package_to_purl('Packagist',
+                                     'spencer14420/sp-php-email-handler'))
+
+    self.assertEqual('pkg:pub/test-package',
+                     purl_helpers.package_to_purl('Pub', 'test-package'))
+
+    self.assertEqual('pkg:rpm/redhat/test-package',
+                     purl_helpers.package_to_purl('Red Hat', 'test-package'))
+
+    self.assertEqual(
+        'pkg:rpm/rocky-linux/test-package',
+        purl_helpers.package_to_purl('Rocky Linux', 'test-package'))
+
+    self.assertEqual('pkg:gem/test-package',
+                     purl_helpers.package_to_purl('RubyGems', 'test-package'))
+
+    self.assertEqual('pkg:rpm/suse/test-package',
+                     purl_helpers.package_to_purl('SUSE', 'test-package'))
+
+    self.assertEqual(
+        'pkg:swift/github.com/shareup/wasm-interpreter-apple',
+        purl_helpers.package_to_purl(
+            'SwiftURL', 'github.com/shareup/wasm-interpreter-apple'))
+
+    self.assertEqual('pkg:deb/ubuntu/pygments',
+                     purl_helpers.package_to_purl('Ubuntu', 'pygments'))
+
+    self.assertEqual('pkg:apk/wolfi/test-package',
+                     purl_helpers.package_to_purl('Wolfi', 'test-package'))
+
+    self.assertIsNone(purl_helpers.package_to_purl('Invalid', 'test-package'))
+
   def test_parse_purl(self):
     """Test parse purl"""
+    self.assertEqual(('AlmaLinux', 'libvpx', None),
+                     purl_helpers.parse_purl('pkg:rpm/almalinux/libvpx'))
+
     self.assertEqual(
         ('Alpine', 'postgresql14', None),
         purl_helpers.parse_purl('pkg:apk/alpine/postgresql14?arch=source'))
@@ -73,6 +142,9 @@ class PurlHelpersTest(unittest.TestCase):
 
     self.assertEqual(('crates.io', 'surrealdb', '2.1.0'),
                      purl_helpers.parse_purl('pkg:cargo/surrealdb@2.1.0'))
+
+    self.assertEqual(('CRAN', 'commonmark', None),
+                     purl_helpers.parse_purl('pkg:cran/commonmark'))
 
     self.assertEqual(('Debian', 'mpg123', '1.26.4-1+deb11u1'),
                      purl_helpers.parse_purl(


### PR DESCRIPTION
- Refactored `purl_helper.py` to store ecosystem to PURL mapping in one dictionary.
- Implemented PURL converters for all ecosystems mentioned in the issue https://github.com/google/osv.dev/issues/2402 except for Android, Git, Linux, and those not currently shown in OSV (such as Photon OS).
  - Android package names (e.g. `/platform/packages/modules/Bluetooth`) can't be converted to PURL
  - Git and Linux aren't explicitly mentioned in the standard [PURL spec](https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst) (let me know if I've missed any).
- New added PURL converters:
  - AlmaLinux, Chainguard, CRAN, GitHub Actions, openSUSE, Red Hat, Rocky Linux, SUSE, Ubuntu, Wolfi