### PR TITLE
fix(api): only start cloud profiler for test instance

### DIFF
--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -1397,12 +1397,13 @@ def main():
     setup_gcp_logging('api-backend')
     logging.getLogger().addFilter(trace_filter)
 
-    # Profiler initialization. It starts a daemon thread which continuously
-    # collects and uploads profiles. Best done as early as possible.
-    try:
-      googlecloudprofiler.start(service="osv-api-profiler")
-    except (ValueError, NotImplementedError) as e:
-      logging.error(e)
+    if get_gcp_project() == _TEST_INSTANCE:
+      # Profiler initialization. It starts a daemon thread which continuously
+      # collects and uploads profiles. Best done as early as possible.
+      try:
+        googlecloudprofiler.start(service="osv-api-profiler")
+      except (ValueError, NotImplementedError) as e:
+        logging.error(e)
 
   logging.getLogger().setLevel(logging.INFO)
 


### PR DESCRIPTION
Only start the cloud profiler for test instance so that we can continue our investigation on this without interrupting production release.