### PR TITLE
feat: pilot enabling strict mode on all JSON Schema compliant sources

### DIFF
--- a/source_test.yaml
+++ b/source_test.yaml
@@ -12,7 +12,7 @@
   human_link: 'https://errata.almalinux.org/{{ ECOSYSTEMS[1].split(":")[1] }}/{{ BUG_ID | replace(":", "-", 1) }}.html'
   link: 'https://github.com/AlmaLinux/osv-database/blob/master/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'almalinux-alea'
   versions_from_repo: False
@@ -27,7 +27,7 @@
   human_link: 'https://errata.almalinux.org/{{ ECOSYSTEMS[1].split(":")[1] }}/{{ BUG_ID | replace(":", "-", 1) }}.html'
   link: 'https://github.com/AlmaLinux/osv-database/blob/master/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'almalinux-alsa'
   versions_from_repo: False
@@ -42,7 +42,7 @@
   human_link: 'https://errata.almalinux.org/{{ ECOSYSTEMS[1].split(":")[1] }}/{{ BUG_ID | replace(":", "-", 1) }}.html'
   link: 'https://github.com/AlmaLinux/osv-database/blob/master/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'android'
   versions_from_repo: False
@@ -55,7 +55,7 @@
   ignore_git: True
   link: 'https://storage.googleapis.com/android-osv-test/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'bitnami'
   versions_from_repo: False
@@ -69,7 +69,7 @@
   ignore_git: False
   link: 'https://github.com/bitnami/vulndb/tree/main/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'chainguard'
   versions_from_repo: False
@@ -84,7 +84,7 @@
   link: 'https://packages.cgr.dev/chainguard/osv/'
   human_link: 'https://images.chainguard.dev/security/{{ BUG_ID }}'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'curl'
   versions_from_repo: False
@@ -99,7 +99,7 @@
   human_link: 'https://curl.se/docs/{{ BUG_ID | replace("CURL-", "") }}.html'
   link: 'https://curl.se/docs/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'cve-osv'
   versions_from_repo: True
@@ -129,7 +129,7 @@
   human_link: 'https://security-tracker.debian.org/tracker/{{ BUG_ID }}'
   link: 'https://storage.googleapis.com/debian-osv/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'debian-dsa'
   versions_from_repo: False
@@ -144,7 +144,7 @@
   human_link: 'https://security-tracker.debian.org/tracker/{{ BUG_ID }}'
   link: 'https://storage.googleapis.com/debian-osv/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'debian-dtsa'
   versions_from_repo: False
@@ -159,7 +159,7 @@
   human_link: 'https://security-tracker.debian.org/tracker/{{ BUG_ID }}'
   link: 'https://storage.googleapis.com/debian-osv/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'ghsa'
   versions_from_repo: False
@@ -174,7 +174,7 @@
   human_link: 'https://github.com/advisories/{{ BUG_ID }}'
   link: 'https://github.com/github/advisory-database/blob/main/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'go'
   versions_from_repo: True
@@ -189,7 +189,7 @@
   human_link: 'https://pkg.go.dev/vuln/{{ BUG_ID }}'
   link: 'https://vuln.go.dev/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'haskell'
   versions_from_repo: False
@@ -204,7 +204,7 @@
   link: 'https://github.com/haskell/security-advisories/blob/generated/osv-export/'
   editable: False
   repo_username: 'git'
-  strict_validation: False
+  strict_validation: True
 
 - name: 'malicious-packages'
   versions_from_repo: False
@@ -218,7 +218,7 @@
   ignore_git: False
   link: 'https://github.com/ossf/malicious-packages/blob/main/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'test-oss-fuzz'
   versions_from_repo: True
@@ -233,7 +233,7 @@
   ignore_git: False
   link: 'https://github.com/google/oss-fuzz-vulns/blob/main/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'psf'
   versions_from_repo: True
@@ -247,7 +247,7 @@
   ignore_git: False
   link: 'https://github.com/psf/advisory-database/blob/main/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'python'
   versions_from_repo: False
@@ -261,7 +261,7 @@
   ignore_git: False
   link: 'https://github.com/pypa/advisory-database/blob/main/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'r'
   versions_from_repo: False
@@ -275,7 +275,7 @@
   ignore_git: False
   link: 'https://github.com/RConsortium/r-advisory-database/blob/main/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'redhat'
   versions_from_repo: False
@@ -290,7 +290,7 @@
   human_link: 'https://access.redhat.com/errata/{{ BUG_ID }}'
   link: 'https://security.access.redhat.com/data/osv/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'rockylinux'
   versions_from_repo: False
@@ -304,7 +304,7 @@
   human_link: 'https://errata.rockylinux.org/{{ BUG_ID }}'
   link: 'https://storage.googleapis.com/resf-osv-data/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'rockylinux-rxsa'
   versions_from_repo: False
@@ -318,7 +318,7 @@
   human_link: 'https://errata.rockylinux.org/{{ BUG_ID }}'
   link: 'https://storage.googleapis.com/resf-osv-data/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'rust'
   versions_from_repo: True
@@ -350,7 +350,7 @@
   human_link: 'https://www.suse.com/support/update/announcement/{{ BUG_ID.split(":")[0].split("-")[2] }}/{{ BUG_ID | replace(":", "") | lower }}/'
   link: 'https://ftp.suse.com/pub/projects/security/osv/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'ubuntu-cve'
   versions_from_repo: False
@@ -365,7 +365,7 @@
   human_link: 'https://ubuntu.com/security/{{ BUG_ID | replace("UBUNTU-", "") }}'
   link: 'https://github.com/canonical/ubuntu-security-notices/blob/main/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'ubuntu-usn'
   versions_from_repo: False
@@ -380,7 +380,7 @@
   human_link: 'https://ubuntu.com/security/notices/{{ BUG_ID }}'
   link: 'https://github.com/canonical/ubuntu-security-notices/blob/main/'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'uvi'
   versions_from_repo: True
@@ -396,5 +396,5 @@
   editable: False
   key_path: 'OSV'
   repo_username: 'git'
-  strict_validation: False
+  strict_validation: True
 


### PR DESCRIPTION
This enables strict mode in the OSV.dev staging environment for all sources in staging that have been deemed already be publishing 100% OSV JSON Schema compliant records, with the notable exception of the RustSec Advisory Database due to https://github.com/rustsec/advisory-db/issues/2135 and the inclusion of PyPA despite https://github.com/pypa/advisory-database/issues/217 (because of https://github.com/pypa/advisory-database/pull/208)

Part of #2188