### PR TITLE
fix(api): install build-essential for cloud profiler

### DIFF
--- a/gcp/api/Dockerfile
+++ b/gcp/api/Dockerfile
@@ -14,6 +14,9 @@
 
 FROM python:3.11-slim@sha256:ad5dadd957a398226996bc4846e522c39f2a77340b531b28aaab85b2d361210b
 
+# Install build-essential which is required by Cloud Profiler
+RUN apt-get update && apt-get install -y build-essential
+
 # Generation 1 of cloud run overrides the HOME environment variable, causing
 # poetry to run in the incorrect environment, as it defaults to using $HOME/.cache/virtualenvs/...
 # 


### PR DESCRIPTION
Install build-essential for Cloud Profiler based on the [instructions](https://cloud.google.com/profiler/docs/profiling-python)