### PR TITLE
fix(api): allow Alpine queries without a release number

### DIFF
--- a/osv/ecosystems/_ecosystems.py
+++ b/osv/ecosystems/_ecosystems.py
@@ -112,7 +112,7 @@ def get(name: str) -> Ecosystem:
   if name.startswith('Debian'):
     return Debian(name.partition(':')[2])
 
-  if name.startswith('Alpine:'):
+  if name.startswith('Alpine'):
     return Alpine(name.partition(':')[2])
 
   if name.startswith('AlmaLinux'):


### PR DESCRIPTION
The [OSV spec](https://ossf.github.io/osv-schema/#affectedpackage-field) requires Alpine packages to have a `:v<RELEASE-NUMBER>` suffix. Currently, our API has inconsistencies regarding Alpine queries:
- It returns a 400 status code with the error message "Invalid ecosystem" for all Alpine package/ecosystem queries without a release number.
- However, for Alpine PURL queries (e.g. 
`pkg:apk/alpine/postgresql14?arch=source`), it returns all matching vulnerabilities across all releases.

Also we recently switched our PURL query from PURL string matching to package/ecosystem matching (https://github.com/google/osv.dev/pull/2900). This change causes all Alpine-related PURL API queries to fail because PURL string doesn't contain any release info and the PURL spec doesn't define how to include release numbers.

Since OSV-generated Alpine PURLs (e.g. 
`pkg:apk/alpine/postgresql14?arch=source`) don't contain release numbers, we should allow Alpine queries without a release number for consistency. This change would return all matching vulnerabilities across different releases when no release number is specified. 