### PR TITLE
fix(ui): set dark colour for FAQ text

### DIFF
--- a/docs/_sass/color_schemes/custom_dark.scss
+++ b/docs/_sass/color_schemes/custom_dark.scss
@@ -7,6 +7,8 @@ $new-body-background-color: #292929;
 // Overriding dark default for just-the-docs styles
 $color-scheme: dark;
 $body-background-color: $new-body-background-color; // Replacing default $grey-dk-300
+$body-heading-color: $grey-lt-000;
+$body-text-color: $grey-lt-300;
 $link-color: #C9F5F7;
 $nav-child-link-color: $white; // Replacing default $grey-dk-000
 $sidebar-color: $new-body-background-color; //Replacing default $grey-dk-300


### PR DESCRIPTION
[previous](https://github.com/google/osv.dev/pull/2934) reverted the custom text colour, but because it didn't specify a replacement colour, the text reverted to the default light mode colour. This change sets the default text colour for dark mode.