### PR TITLE
fix(api): remove all purl ecosystem validation

### DIFF
--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -422,10 +422,7 @@ class IntegrationTests(unittest.TestCase,
         }),
         timeout=_TIMEOUT)
 
-    self.assert_results_equal({
-        'code': 3,
-        'message': 'Unknown PURL ecosystem.'
-    }, response.json())
+    self.assert_results_equal({}, response.json())
 
   def test_query_semver_no_vulns(self):
     """Test queries by SemVer with no vulnerabilities."""

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -735,8 +735,13 @@ def do_query(query: osv_service_v1_pb2.Query,
       )
 
     if purl is None:
-      context.service_context.abort(grpc.StatusCode.INVALID_ARGUMENT,
-                                    'Unknown PURL ecosystem.')
+      # TODO(gongh@): Previously, we didn't perform any PURL validation.
+      # All unsupported PURL queries would simply return a 200
+      # status code with an empty response.
+      # To avoid breaking existing behavior,
+      # we return an empty response here with no error.
+      # This needs to be revisited with a more considerate design.
+      return [], None
 
     if package_name:  # Purls already include the package name
       context.service_context.abort(

--- a/osv/purl_helpers.py
+++ b/osv/purl_helpers.py
@@ -36,7 +36,7 @@ ECOSYSTEM_PURL_DATA = {
     'Debian': EcosystemPURL('deb', 'debian'),
     # GHC
     # GIT
-    'GitHub Actions': EcosystemPURL('github', None),
+    # GitHub Actions
     'Go': EcosystemPURL('golang', None),
     'Hackage': EcosystemPURL('hackage', None),
     'Hex': EcosystemPURL('hex', None),
@@ -138,6 +138,6 @@ def parse_purl(purl_str: str) -> ParsedPURL | None:
   elif purl.type == 'maven' and purl.namespace:
     package = purl.namespace + ':' + purl.name
   else:
-    raise ValueError('Invalid ecosystem.')
+    return None
 
   return ParsedPURL(ecosystem, package, version)


### PR DESCRIPTION
We didn't have any PURL ecosystem validation until [PR 2900](https://github.com/google/osv.dev/pull/2900) was merged.  [PR 2900](https://github.com/google/osv.dev/pull/2900) introduced some [breaking changes](https://github.com/google/osv.dev/issues/2960#issuecomment-2518943142) that affect users querying ecosystems for which we currently lack a PURL converter, especially those not specified in the PURL specification.

This PR changes the response from a 400 error code to a 200 status code with an empty response unblock users. A more considered design will be discussed later with the team and implemented.