### PR TITLE
fix(api): handle golang subpath

### DIFF
--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -734,6 +734,19 @@ def do_query(query: osv_service_v1_pb2.Query,
           'Invalid PURL.',
       )
 
+    if package_name:  # Purls already include the package name
+      context.service_context.abort(
+          grpc.StatusCode.INVALID_ARGUMENT,
+          'name specified in a PURL query',
+      )
+
+    if ecosystem:
+      # Purls already include the ecosystem inside
+      context.service_context.abort(
+          grpc.StatusCode.INVALID_ARGUMENT,
+          'ecosystem specified in a PURL query',
+      )
+
     if purl is None:
       # TODO(gongh@): Previously, we didn't perform any PURL validation.
       # All unsupported PURL queries would simply return a 200
@@ -743,17 +756,6 @@ def do_query(query: osv_service_v1_pb2.Query,
       # This needs to be revisited with a more considerate design.
       return [], None
 
-    if package_name:  # Purls already include the package name
-      context.service_context.abort(
-          grpc.StatusCode.INVALID_ARGUMENT,
-          'name specified in a PURL query',
-      )
-    if ecosystem:
-      # Purls already include the ecosystem inside
-      context.service_context.abort(
-          grpc.StatusCode.INVALID_ARGUMENT,
-          'ecosystem specified in a PURL query',
-      )
     if purl.version and version:
       # version included both in purl and query
       context.service_context.abort(
@@ -763,7 +765,8 @@ def do_query(query: osv_service_v1_pb2.Query,
 
     ecosystem = purl.ecosystem
     package_name = purl.package
-    version = purl.version
+    if purl.version:
+      version = purl.version
 
   if ecosystem and not ecosystems.get(ecosystem):
     context.service_context.abort(grpc.StatusCode.INVALID_ARGUMENT,

--- a/osv/purl_helpers.py
+++ b/osv/purl_helpers.py
@@ -132,12 +132,20 @@ def parse_purl(purl_str: str) -> ParsedPURL | None:
 
   # For ecosystems with optional namespaces, the namespace might need to be
   # included as part of the package name.
-  if purl.type in ('composer', 'golang', 'hex', 'npm',
-                   'swift') and purl.namespace:
-    package = purl.namespace + '/' + purl.name
-  elif purl.type == 'maven' and purl.namespace:
-    package = purl.namespace + ':' + purl.name
+  if purl.namespace:
+    if purl.type == 'golang':
+      package = purl.namespace + '/' + purl.name
+      if purl.subpath:
+        package = package + '/' + purl.subpath
+    elif purl.type in ('composer', 'hex', 'npm', 'swift'):
+      package = purl.namespace + '/' + purl.name
+    elif purl.type == 'maven':
+      package = purl.namespace + ':' + purl.name
+    else:
+      # Handle the case where the ecosystem shouldn't have a namespace.
+      return None
   else:
+    # Handle the case where the namespace is not supported.
     return None
 
   return ParsedPURL(ecosystem, package, version)

--- a/osv/purl_helpers_test.py
+++ b/osv/purl_helpers_test.py
@@ -163,6 +163,10 @@ class PurlHelpersTest(unittest.TestCase):
                      purl_helpers.parse_purl(
                          'pkg:golang/github.com/treeverse/lakefs@1.33.0'))
 
+    self.assertEqual(
+        ('Go', 'github.com/jackc/pgx/v5', 'v5.6.0'),
+        purl_helpers.parse_purl('pkg:golang/github.com/jackc/pgx@v5.6.0#v5'))
+
     self.assertEqual(('Hackage', 'process', None),
                      purl_helpers.parse_purl('pkg:hackage/process'))
 


### PR DESCRIPTION
Related issue: https://github.com/google/osv-scanner/issues/1428
Added support for Go module PURL strings containing `subpath`