### PR TITLE
feat: expand Ubuntu ecosystem to include more variants

### DIFF
--- a/osv/ecosystems/_ecosystems.py
+++ b/osv/ecosystems/_ecosystems.py
@@ -144,6 +144,31 @@ def normalize(ecosystem_name: str):
   return ecosystem_name.split(':')[0]
 
 
+def add_matching_ecosystems(original_set: set[str]) -> set[str]:
+  """
+  For Linux distributions, some release versions may have different variants.
+  For example, Ubuntu:22.04 is equivalent to Ubuntu:22.04:LTS.
+  This function adds all matching ecosystems
+  to the datastore to facilitate API queries.
+
+  For example:
+  - "Ubuntu:Pro:18.04:LTS" would also be "Ubuntu:18.04"
+
+  Args:
+    original_set: The original ecosystem set
+
+  Returns:
+    A new set with the added matching ecosystems.
+  """
+  new_set = set(original_set)
+  for ecosystem in original_set:
+    # For Ubuntu, remove ":Pro" and ":LTS"
+    if ecosystem.startswith("Ubuntu"):
+      new_item = ecosystem.replace(":Pro", "").replace(":LTS", "")
+      new_set.add(new_item)
+  return new_set
+
+
 def is_supported_in_deps_dev(ecosystem_name: str) -> bool:
   return ecosystem_name in _OSV_TO_DEPS_ECOSYSTEMS_MAP
 

--- a/osv/ecosystems/_ecosystems.py
+++ b/osv/ecosystems/_ecosystems.py
@@ -163,8 +163,8 @@ def add_matching_ecosystems(original_set: set[str]) -> set[str]:
   new_set = set(original_set)
   for ecosystem in original_set:
     # For Ubuntu, remove ":Pro" and ":LTS"
-    if ecosystem.startswith("Ubuntu"):
-      new_item = ecosystem.replace(":Pro", "").replace(":LTS", "")
+    if ecosystem.startswith('Ubuntu'):
+      new_item = ecosystem.replace(':Pro', '').replace(':LTS', '')
       new_set.add(new_item)
   return new_set
 

--- a/osv/ecosystems/_ecosystems_test.py
+++ b/osv/ecosystems/_ecosystems_test.py
@@ -1,0 +1,46 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Ecosystem helper tests."""
+
+import unittest
+from .. import ecosystems
+
+
+class EcosystemTest(unittest.TestCase):
+  """Ecosystem helper tests."""
+
+  def test_add_matching_ecosystems(self):
+    """Test sort key"""
+    # Test Ubuntu
+    ubuntu_ecosystem = {
+        "Ubuntu", "Ubuntu:20.04:LTS", "Ubuntu:22.04:LTS", "Ubuntu:24.04:LTS",
+        "Ubuntu:24.10", "Ubuntu:Pro:14.04:LTS", "Ubuntu:Pro:16.04:LTS",
+        "Ubuntu:Pro:18.04:LTS"
+    }
+    actual_output = list(ecosystems.add_matching_ecosystems(ubuntu_ecosystem))
+    expected_output = [
+        'Ubuntu', 'Ubuntu:14.04', 'Ubuntu:16.04', 'Ubuntu:18.04',
+        'Ubuntu:20.04', 'Ubuntu:20.04:LTS', 'Ubuntu:22.04', 'Ubuntu:22.04:LTS',
+        'Ubuntu:24.04', 'Ubuntu:24.04:LTS', 'Ubuntu:24.10',
+        'Ubuntu:Pro:14.04:LTS', 'Ubuntu:Pro:16.04:LTS', 'Ubuntu:Pro:18.04:LTS'
+    ]
+    actual_output.sort()
+    self.assertEqual(list(actual_output), expected_output)
+
+    #Test Debian (it should be no change)
+    debian_ecosystem = {"Debian", "Debian:11", "Debian:12", "Debian:13"}
+    actual_output = list(ecosystems.add_matching_ecosystems(debian_ecosystem))
+    expected_output = ["Debian", "Debian:11", "Debian:12", "Debian:13"]
+    actual_output.sort()
+    self.assertEqual(list(actual_output), expected_output)

--- a/osv/ecosystems/_ecosystems_test.py
+++ b/osv/ecosystems/_ecosystems_test.py
@@ -24,9 +24,9 @@ class EcosystemTest(unittest.TestCase):
     """Test sort key"""
     # Test Ubuntu
     ubuntu_ecosystem = {
-        "Ubuntu", "Ubuntu:20.04:LTS", "Ubuntu:22.04:LTS", "Ubuntu:24.04:LTS",
-        "Ubuntu:24.10", "Ubuntu:Pro:14.04:LTS", "Ubuntu:Pro:16.04:LTS",
-        "Ubuntu:Pro:18.04:LTS"
+        'Ubuntu', 'Ubuntu:20.04:LTS', 'Ubuntu:22.04:LTS', 'Ubuntu:24.04:LTS',
+        'Ubuntu:24.10', 'Ubuntu:Pro:14.04:LTS', 'Ubuntu:Pro:16.04:LTS',
+        'Ubuntu:Pro:18.04:LTS'
     }
     actual_output = list(ecosystems.add_matching_ecosystems(ubuntu_ecosystem))
     expected_output = [
@@ -39,8 +39,8 @@ class EcosystemTest(unittest.TestCase):
     self.assertEqual(list(actual_output), expected_output)
 
     #Test Debian (it should be no change)
-    debian_ecosystem = {"Debian", "Debian:11", "Debian:12", "Debian:13"}
+    debian_ecosystem = {'Debian', 'Debian:11', 'Debian:12', 'Debian:13'}
     actual_output = list(ecosystems.add_matching_ecosystems(debian_ecosystem))
-    expected_output = ["Debian", "Debian:11", "Debian:12", "Debian:13"]
+    expected_output = ['Debian', 'Debian:11', 'Debian:12', 'Debian:13']
     actual_output.sort()
     self.assertEqual(list(actual_output), expected_output)

--- a/osv/models.py
+++ b/osv/models.py
@@ -405,6 +405,9 @@ class Bug(ndb.Model):
     # also add the base name
     ecosystems_set.update({ecosystems.normalize(x) for x in ecosystems_set})
 
+    # Expand the set to include all ecosystem variants.
+    ecosystems_set = ecosystems.add_matching_ecosystems(ecosystems_set)
+
     self.ecosystem = list(ecosystems_set)
     self.ecosystem.sort()
 


### PR DESCRIPTION
Related issue https://github.com/google/osv.dev/issues/2963

OSV-Scanner mismatches Ubuntu vulnerabilities due to variations in ecosystem naming (e.g., :LTS, :Pro). 
Adds a function to expand the Ubuntu ecosystem list with all possible variants, ensuring accurate vulnerability matching.

TODO:

- [ ] reput all Ubuntu vulnerabilities
- [ ] support naming variations in API query