### PR TITLE
feat(api): match ecosystem names without variants

### DIFF
--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -983,7 +983,7 @@ def _is_version_affected(affected_packages,
 
     if ecosystem:
       # If package ecosystem has a :, also try ignoring parts after it.
-      if is_matching_package_ecosystem(affected_package.package, ecosystem):
+      if not is_matching_package_ecosystem(affected_package.package, ecosystem):
         continue
 
     if normalize:
@@ -1237,9 +1237,6 @@ def _query_by_comparing_versions(context: QueryContext, query: ndb.Query,
 
   it: ndb.QueryIterator = query.iter(start_cursor=context.cursor_at_current())
 
-  # Checks if the query specifies a release (e.g., "Debian:12")
-  has_release = ':' in ecosystem
-
   while (yield it.has_next_async()):
     if context.should_break_page(len(bugs)):
       context.save_cursor_at_page_break(it)
@@ -1255,14 +1252,9 @@ def _query_by_comparing_versions(context: QueryContext, query: ndb.Query,
       # compare against packages in all releases (e.g., "Debian:X").
       # Otherwise, only compare within
       # the specified release (e.g., "Debian:11").
-      package_ecosystem: str = package.ecosystem  # type: ignore
-      if not has_release:
-        # Extracts ecosystem name for broader comparison (e.g., "Debian")
-        package_ecosystem = package_ecosystem.split(':')[0]
-
       # Skips if the affected package ecosystem does not match
       # the queried ecosystem.
-      if package_ecosystem != ecosystem:
+      if not is_matching_package_ecosystem(affected_package, ecosystem):
         continue
 
       # Skips if the affected package name does not match

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -52,8 +52,6 @@ from gcp.api.cursor import QueryCursor
 
 import googlecloudprofiler
 
-from osv.models import AffectedPackage
-
 _SHUTDOWN_GRACE_DURATION = 5
 
 _MAX_SINGLE_QUERY_TIME = timedelta(seconds=20)
@@ -983,7 +981,8 @@ def _is_version_affected(affected_packages,
 
     if ecosystem:
       # If package ecosystem has a :, also try ignoring parts after it.
-      if not is_matching_package_ecosystem(affected_package.package, ecosystem):
+      if not is_matching_package_ecosystem(affected_package.package.ecosystem,
+                                           ecosystem):
         continue
 
     if normalize:
@@ -1254,7 +1253,7 @@ def _query_by_comparing_versions(context: QueryContext, query: ndb.Query,
       # the specified release (e.g., "Debian:11").
       # Skips if the affected package ecosystem does not match
       # the queried ecosystem.
-      if not is_matching_package_ecosystem(affected_package, ecosystem):
+      if not is_matching_package_ecosystem(package.ecosystem, ecosystem):
         continue
 
       # Skips if the affected package name does not match
@@ -1395,12 +1394,11 @@ def _is_affected(ecosystem: str, version: str,
   return False
 
 
-def is_matching_package_ecosystem(affected_package: AffectedPackage,
+def is_matching_package_ecosystem(package_ecosystem: str,
                                   ecosystem: str) -> bool:
   """Checks if the queried ecosystem matches the affected package's ecosystem,
   considering potential variations in the package's ecosystem.
   """
-  package_ecosystem = affected_package.package.ecosystem
   return any(eco == ecosystem for eco in (
       package_ecosystem,
       ecosystems.normalize(package_ecosystem),

--- a/osv/ecosystems/_ecosystems.py
+++ b/osv/ecosystems/_ecosystems.py
@@ -144,6 +144,15 @@ def normalize(ecosystem_name: str):
   return ecosystem_name.split(':')[0]
 
 
+def remove_variants(ecosystem_name: str) -> str | None:
+  result = None
+  # For Ubuntu, remove ":Pro" and ":LTS"
+  if ecosystem_name.startswith('Ubuntu'):
+    result = ecosystem_name.replace(':Pro', '').replace(':LTS', '')
+
+  return result
+
+
 def add_matching_ecosystems(original_set: set[str]) -> set[str]:
   """
   For Linux distributions, some release versions may have different variants.
@@ -163,9 +172,9 @@ def add_matching_ecosystems(original_set: set[str]) -> set[str]:
   new_set = set(original_set)
   for ecosystem in original_set:
     # For Ubuntu, remove ":Pro" and ":LTS"
-    if ecosystem.startswith('Ubuntu'):
-      new_item = ecosystem.replace(':Pro', '').replace(':LTS', '')
-      new_set.add(new_item)
+    new_ecosystem = remove_variants(ecosystem)
+    if new_ecosystem:
+      new_set.add(new_ecosystem)
   return new_set
 
 


### PR DESCRIPTION
Resolves https://github.com/google/osv.dev/issues/2963

Updates the API query to support variant-insensitive matching of affected package ecosystem names. A match is found if the package ecosystem name, after removing all variants, is the same as the queried ecosystem name.

TODO:
- [ ] Add integration tests after reput Ubuntu records on prod (after the end-of-year release freeze)