### PR TITLE
chore: ignore `docker/poetry/requirements.txt` in renovatebot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -135,5 +135,6 @@
       ],
       "enabled": false
     }
-  ]
+  ],
+  "ignorePaths": ["docker/poetry/requirements.txt"]
 }


### PR DESCRIPTION
`docker/poetry/requirements.txt` is autogenerated and dependencies are pinned, we probably should not ask renovatebot to update the dependencies in it. 