### PR TITLE
chore(deps): revert "update dependency urllib3 to v2.3.0"

### DIFF
--- a/docker/poetry/requirements.txt
+++ b/docker/poetry/requirements.txt
@@ -579,9 +579,9 @@ trove-classifiers==2024.10.21.16 \
     --hash=sha256:0fb11f1e995a757807a8ef1c03829fbd4998d817319abcef1f33165750f103be \
     --hash=sha256:17cbd055d67d5e9d9de63293a8732943fabc21574e4c7b74edf112b4928cf5f3
     # via poetry
-urllib3==2.3.0 \
-    --hash=sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df \
-    --hash=sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d
+urllib3==2.2.3 \
+    --hash=sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac \
+    --hash=sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9
     # via
     #   dulwich
     #   requests


### PR DESCRIPTION
Reverts google/osv.dev#3012

though this PR didn't trigger build failure, but we should not update this `requirements.txt`