### PR TITLE
fix: define resource limits on api frontend & update espv2 version

### DIFF
--- a/deployment/terraform/environments/oss-vdb-test/main.tf
+++ b/deployment/terraform/environments/oss-vdb-test/main.tf
@@ -16,7 +16,7 @@ module "osv_test" {
 
   website_domain = "test.osv.dev"
   api_url        = "api.test.osv.dev"
-  esp_version    = "2.49.0"
+  esp_version    = "2.51.0"
 }
 
 import {

--- a/deployment/terraform/environments/oss-vdb/main.tf
+++ b/deployment/terraform/environments/oss-vdb/main.tf
@@ -16,7 +16,7 @@ module "osv" {
 
   website_domain = "osv.dev"
   api_url        = "api.osv.dev"
-  esp_version    = "2.49.0"
+  esp_version    = "2.51.0"
 }
 
 import {

--- a/deployment/terraform/modules/osv/osv_api.tf
+++ b/deployment/terraform/modules/osv/osv_api.tf
@@ -128,6 +128,12 @@ resource "google_cloud_run_service" "api" {
           name  = "ESPv2_ARGS"
           value = "^++^--transcoding_preserve_proto_field_names++--envoy_connection_buffer_limit_bytes=104857600"
         }
+        resources {
+          limits = {
+            "cpu"    = "1000m"
+            "memory" = "2Gi"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
The memory of the API 'frontend' (the ESPv2) was bumped to 2GB manually. Adjusted the terraform configs to do this.
Also updated the ESPv2 base image to the latest version.