### PR TITLE
fix(nvd-mirror): remove limit on cve references field

### DIFF
--- a/vulnfeeds/cves/nvd2.go
+++ b/vulnfeeds/cves/nvd2.go
@@ -342,9 +342,10 @@ func (j *CVE) UnmarshalJSON(b []byte) error {
 	if plain.Descriptions != nil && len(plain.Descriptions) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "descriptions", 1)
 	}
-	if len(plain.References) > 500 {
-		return fmt.Errorf("field %s length: must be <= %d", "references", 500)
-	}
+	// (hand-modified), CVE-2009-3555 from NVD has more than 500 references
+	// if len(plain.References) > 500 {
+	// 	return fmt.Errorf("field %s length: must be <= %d", "references", 500)
+	// }
 	*j = CVE(plain)
 	return nil
 }

--- a/vulnfeeds/cves/nvd2.go
+++ b/vulnfeeds/cves/nvd2.go
@@ -339,10 +339,11 @@ func (j *CVE) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &plain); err != nil {
 		return err
 	}
-	if plain.Descriptions != nil && len(plain.Descriptions) < 1 {
-		return fmt.Errorf("field %s length: must be >= %d", "descriptions", 1)
-	}
-	// (hand-modified), CVE-2009-3555 from NVD has more than 500 references
+	// (hand-modified), being more permissive in case of odd records
+	// e.g. CVE-2009-3555 from NVD has more than 500 references
+	// if plain.Descriptions != nil && len(plain.Descriptions) < 1 {
+	// 	return fmt.Errorf("field %s length: must be >= %d", "descriptions", 1)
+	// }
 	// if len(plain.References) > 500 {
 	// 	return fmt.Errorf("field %s length: must be <= %d", "references", 500)
 	// }


### PR DESCRIPTION
Even though the NVD CVE API v2 schema says there's a maximum of 500 references, the response given for [CVE-2009-3555](https://nvd.nist.gov/vuln/detail/cve-2009-3555) has 620.
This was causing a fatal error decoding the JSON response, stopping `nvd-mirror` from completing.

I've just manually commented-out the auto-generated length check to remediate this - not sure what the better long-term solution is for this.