### PR TITLE
fix: invalid debian versions causing comparison exceptions

### DIFF
--- a/osv/ecosystems/debian.py
+++ b/osv/ecosystems/debian.py
@@ -86,7 +86,7 @@ class Debian(Ecosystem):
     if not DebianVersion.is_valid(version):
       # If debian version is not valid, it is most likely an invalid fixed
       # version then sort it to the last/largest element
-      return DebianVersion(999999, 999999)
+      return DebianVersion(999999, '999999')
     return DebianVersion.from_string(version)
 
   def enumerate_versions(self,

--- a/osv/ecosystems/ubuntu.py
+++ b/osv/ecosystems/ubuntu.py
@@ -23,7 +23,7 @@ class Ubuntu(Ecosystem):
 
   def sort_key(self, version):
     if not UbuntuVersion.is_valid(version):
-      return UbuntuVersion(999999, 999999)
+      return UbuntuVersion(999999, '999999')
     return UbuntuVersion.from_string(version)
 
   def enumerate_versions(self,


### PR DESCRIPTION
The second argument of a Debian `Version` is supposed to be a string, but we were setting it to an int for invalid versions.

This was causing an exception when comparing two invalid versions against each other in query_by_comparing_versions.