### PR TITLE
fix: manually install poetry in debian-convert

### DIFF
--- a/deployment/build-and-stage.yaml
+++ b/deployment/build-and-stage.yaml
@@ -178,8 +178,7 @@ steps:
   
 # Build/push debian converter image
 - name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/oss-vdb/debian-convert:latest', '-t', 'gcr.io/oss-vdb/debian-convert:$COMMIT_SHA', '.']
-  dir: 'vulnfeeds/tools/debian'
+  args: ['build', '-t', 'gcr.io/oss-vdb/debian-convert:latest', '-t', 'gcr.io/oss-vdb/debian-convert:$COMMIT_SHA', '-f', 'vulnfeeds/tools/debian/Dockerfile', '.']
   id: 'build-debian-convert'
   waitFor: ['setup']
 - name: gcr.io/cloud-builders/docker
@@ -187,7 +186,6 @@ steps:
   waitFor: ['build-debian-convert', 'cloud-build-queue']
 
 # Build/push api backend
-# TODO(michaelkedar): This is also done in staging.yaml. They should end up pushing identical images.
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'gcr.io/oss-vdb/osv-server:latest', '-t', 'gcr.io/oss-vdb/osv-server:$COMMIT_SHA', '-f', 'gcp/api/Dockerfile', '.']
   id: 'build-osv-server'

--- a/vulnfeeds/tools/debian/Dockerfile
+++ b/vulnfeeds/tools/debian/Dockerfile
@@ -14,17 +14,25 @@
 
 FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:485.0.0-alpine@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
 
+# Setup Poetry in its own virtual environment.
+# So when poetry changes the system dependencies, it doesn't mess with its own dependencies
+# when managing our dependencies.
+# See: https://python-poetry.org/docs/#installation 
+ENV POETRY_HOME "/opt/poetry"
+COPY docker/poetry/requirements.txt ./poetry-requirements.txt
+RUN python3 -m venv $POETRY_HOME && \
+    $POETRY_HOME/bin/pip install --require-hashes -r ./poetry-requirements.txt && \
+    ln -s $POETRY_HOME/bin/poetry /usr/local/bin/poetry
+
 # Keep the virtualenv directly in the project directory. This isn't strictly neccesary for
 # this project as it runs on kubernetes, but it keeps it consistent with other cloud run images
 ENV POETRY_VIRTUALENVS_IN_PROJECT=true
-
-RUN apk --no-cache add poetry
 
 RUN mkdir /src
 WORKDIR /src
 
 ENV PIP_NO_BINARY ""
-COPY . /src
+COPY vulnfeeds/tools/debian /src
 
 ENV LANG en_US.UTF-8
 RUN cd debian_converter && poetry install


### PR DESCRIPTION
I missed this in #3003, and looks like poetry on apk is version 1, which broke when we updated to v2

Had to change the debian-convert image to build from the root of the repo to be able to grab the poetry requirements.txt from the docker directory.