### PR TITLE
fix: failing vulnfeeds test

### DIFF
--- a/vulnfeeds/git/versions_test.go
+++ b/vulnfeeds/git/versions_test.go
@@ -85,8 +85,8 @@ func TestVersionToCommit(t *testing.T) {
 			description:    "An RC version that should match to one of many prefixed release candidates",
 			inputRepoURL:   "https://github.com/apache/inlong",
 			cache:          cache,
-			inputVersion:   "1.8.0-RC0",
-			expectedResult: "15d9fd922ef314977c7ce47c1fdf5e1655efd945",
+			inputVersion:   "1.8.0-RC1",
+			expectedResult: "91368c4b61d0dc4284092e497a1c1a2eceb5c2ad",
 			expectedOk:     false,
 		},
 	}


### PR DESCRIPTION
This test started failing recently.
I *think* it's because the tag it was checking against was deleted from the repo, so I've changed it to point to a new, existing tag & commit.

It now passes the tests, but I'm not sure if the test is still testing what it's intending to.
@andrewpollock if you want to take a look when you're back.