### PR TITLE
fix(sources): add ignore_pattern for Mageia

### DIFF
--- a/source_test.yaml
+++ b/source_test.yaml
@@ -210,6 +210,7 @@
   versions_from_repo: False
   rest_api_url: 'https://advisories.mageia.org/vulns.json'
   type: 2
+  ignore_patterns: ['^(?!MGASA-).*$']
   directory_path: .
   detect_cherrypicks: False
   extension: '.json'


### PR DESCRIPTION
The original commit lacked an `ignore_pattern`, this commit adds one for consistency with other sources.