### PR TITLE
fix(blog): update executive order link

### DIFF
--- a/gcp/website/blog/content/posts/automating-and-scaling-vex-generation/index.md
+++ b/gcp/website/blog/content/posts/automating-and-scaling-vex-generation/index.md
@@ -5,7 +5,7 @@ draft: false
 author: Brandon Lum, Oliver Chang, and Meder Kydyraliev
 ---
 
-If you've recently been in the space of vulnerability management and the discussions around the White House [Executive Order on Improving the Nation's Cybersecurity (EO)](https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/), you're probably familiar with concepts such as Software Bill of Materials (SBOM) and Vulnerability Exploitability eXchange (VEX).
+If you've recently been in the space of vulnerability management and the discussions around the White House [Executive Order on Improving the Nation's Cybersecurity (EO)](https://bidenwhitehouse.archives.gov/), you're probably familiar with concepts such as Software Bill of Materials (SBOM) and Vulnerability Exploitability eXchange (VEX).
 
 A VEX document/statement—a form of a security advisory that indicates whether a product or products are affected by a known vulnerability or vulnerabilities—provides a great starting point in prioritizing vulnerability response and automating risk evaluation of software, especially for software consumers. There has already been a lot of coverage on consuming and using VEX for vulnerability management. However, there has not been much conversation around the generation of VEX documents. For producers, the process of creating a VEX statement today is largely a manual and cost-intensive process.
 <!--more-->

--- a/gcp/website/blog/content/posts/automating-and-scaling-vex-generation/index.md
+++ b/gcp/website/blog/content/posts/automating-and-scaling-vex-generation/index.md
@@ -5,7 +5,7 @@ draft: false
 author: Brandon Lum, Oliver Chang, and Meder Kydyraliev
 ---
 
-If you've recently been in the space of vulnerability management and the discussions around the White House [Executive Order on Improving the Nation's Cybersecurity (EO)](https://bidenwhitehouse.archives.gov/), you're probably familiar with concepts such as Software Bill of Materials (SBOM) and Vulnerability Exploitability eXchange (VEX).
+If you've recently been in the space of vulnerability management and the discussions around the White House [Executive Order on Improving the Nation's Cybersecurity (EO)](https://bidenwhitehouse.archives.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/), you're probably familiar with concepts such as Software Bill of Materials (SBOM) and Vulnerability Exploitability eXchange (VEX).
 
 A VEX document/statement—a form of a security advisory that indicates whether a product or products are affected by a known vulnerability or vulnerabilities—provides a great starting point in prioritizing vulnerability response and automating risk evaluation of software, especially for software consumers. There has already been a lot of coverage on consuming and using VEX for vulnerability management. However, there has not been much conversation around the generation of VEX documents. For producers, the process of creating a VEX statement today is largely a manual and cost-intensive process.
 <!--more-->


### PR DESCRIPTION
This commit adjusts the link to the executive order to the Biden administration's archive.

The new administration's clean out of whitehouse.gov broke it.