### PR TITLE
fix: labels are strings

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/alias-computation.yaml
+++ b/deployment/clouddeploy/gke-workers/base/alias-computation.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: alias-computation
   labels:
-    cronLastSuccessfulTimeMins: 45
+    cronLastSuccessfulTimeMins: "45"
 spec:
   schedule: "10/15 * * * *"
   concurrencyPolicy: Forbid

--- a/deployment/clouddeploy/gke-workers/base/alpine-cve-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/base/alpine-cve-convert.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: alpine-cve-convert
   labels:
-    cronLastSuccessfulTimeMins: 180
+    cronLastSuccessfulTimeMins: "180"
 spec:
   schedule: "0 */1 * * *"
   concurrencyPolicy: Forbid

--- a/deployment/clouddeploy/gke-workers/base/backup.yaml
+++ b/deployment/clouddeploy/gke-workers/base/backup.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: backup
   labels:
-    cronLastSuccessfulTimeMins: 2880
+    cronLastSuccessfulTimeMins: "2880"
 spec:
   schedule: "0 18 * * *"
   concurrencyPolicy: Forbid

--- a/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: combine-to-osv
   labels:
-    cronLastSuccessfulTimeMins: 90
+    cronLastSuccessfulTimeMins: "90"
 spec:
   schedule: "30 */1 * * *"
   concurrencyPolicy: Forbid

--- a/deployment/clouddeploy/gke-workers/base/cpe-repo-gen.yaml
+++ b/deployment/clouddeploy/gke-workers/base/cpe-repo-gen.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: cpe-repo-gen
   labels:
-    cronLastSuccessfulTimeMins: 2880
+    cronLastSuccessfulTimeMins: "2880"
 spec:
   schedule: "0 6 */1 * *"
   concurrencyPolicy: Forbid

--- a/deployment/clouddeploy/gke-workers/base/debian-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/base/debian-convert.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: debian-convert
   labels:
-    cronLastSuccessfulTimeMins: 180
+    cronLastSuccessfulTimeMins: "180"
 spec:
   schedule: "0 */1 * * *"
   concurrencyPolicy: Forbid

--- a/deployment/clouddeploy/gke-workers/base/debian-copyright-mirror.yaml
+++ b/deployment/clouddeploy/gke-workers/base/debian-copyright-mirror.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: debian-copyright-mirror
   labels:
-    cronLastSuccessfulTimeMins: 2880
+    cronLastSuccessfulTimeMins: "2880"
 spec:
   schedule: "0 6 */1 * *"
   concurrencyPolicy: Forbid

--- a/deployment/clouddeploy/gke-workers/base/debian-cve-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/base/debian-cve-convert.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: debian-cve-convert
   labels:
-    cronLastSuccessfulTimeMins: 120
+    cronLastSuccessfulTimeMins: "120"
 spec:
   schedule: "0 */1 * * *"
   concurrencyPolicy: Forbid

--- a/deployment/clouddeploy/gke-workers/base/debian-first-version.yaml
+++ b/deployment/clouddeploy/gke-workers/base/debian-first-version.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: debian-first-version
   labels:
-    cronLastSuccessfulTimeMins: 120
+    cronLastSuccessfulTimeMins: "120"
 spec:
   schedule: "0 1 * * *"
   concurrencyPolicy: Forbid

--- a/deployment/clouddeploy/gke-workers/base/exporter.yaml
+++ b/deployment/clouddeploy/gke-workers/base/exporter.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: exporter
   labels:
-    cronLastSuccessfulTimeMins: 90
+    cronLastSuccessfulTimeMins: "90"
 spec:
   schedule: "*/30 * * * *"
   concurrencyPolicy: Forbid

--- a/deployment/clouddeploy/gke-workers/base/generate-sitemap.yaml
+++ b/deployment/clouddeploy/gke-workers/base/generate-sitemap.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: generate-sitemap
   labels:
-    cronLastSuccessfulTimeMins: 2880
+    cronLastSuccessfulTimeMins: "2880"
 spec:
   schedule: "30 8 * * *"
   concurrencyPolicy: Forbid

--- a/deployment/clouddeploy/gke-workers/base/importer-deleter.yaml
+++ b/deployment/clouddeploy/gke-workers/base/importer-deleter.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: importer-deleter
   labels:
-    cronLastSuccessfulTimeMins: 360
+    cronLastSuccessfulTimeMins: "360"
 spec:
   schedule: "* */3 * * *"
   concurrencyPolicy: Forbid

--- a/deployment/clouddeploy/gke-workers/base/importer.yaml
+++ b/deployment/clouddeploy/gke-workers/base/importer.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: importer
   labels:
-    cronLastSuccessfulTimeMins: 90
+    cronLastSuccessfulTimeMins: "90"
 spec:
   schedule: "*/15 * * * *"
   concurrencyPolicy: Forbid

--- a/deployment/clouddeploy/gke-workers/base/nvd-cve-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/nvd-cve-osv.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: nvd-cve-osv
   labels:
-    cronLastSuccessfulTimeMins: 86400
+    cronLastSuccessfulTimeMins: "86400"
 spec:
   timeZone: Australia/Sydney
   schedule: "0 6,13 * * *"

--- a/deployment/clouddeploy/gke-workers/base/nvd-mirror.yaml
+++ b/deployment/clouddeploy/gke-workers/base/nvd-mirror.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: nvd-mirror
   labels:
-    cronLastSuccessfulTimeMins: 240
+    cronLastSuccessfulTimeMins: "240"
 spec:
   schedule: "0 */2 * * *"
   concurrencyPolicy: Forbid

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/staging-api-test.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/staging-api-test.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: staging-api-test
   labels:
-    cronLastSuccessfulTimeMins: 2880
+    cronLastSuccessfulTimeMins: "2880"
 spec:
   timeZone: Australia/Sydney
   schedule: "0 9 * * *"


### PR DESCRIPTION
This fixes what was introduced in #3118

Labels must be strings not ints. Based on `terraform plan`, this is no-op, but is intended to address the Cloud Deploy failure encountered.