### PR TITLE
fix(monitoring): correct expected threshold for debian-first-version

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/debian-first-version.yaml
+++ b/deployment/clouddeploy/gke-workers/base/debian-first-version.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: debian-first-version
   labels:
-    cronLastSuccessfulTimeMins: "120"
+    cronLastSuccessfulTimeMins: "2880"
 spec:
   schedule: "0 1 * * *"
   concurrencyPolicy: Forbid


### PR DESCRIPTION
This corrects the threshold for the debian-first-version k8s CronJob to be two days, given it it is a daily CronJob.