### PR TITLE
feat(monitoring): add k8s CronJob monitoring to Production terraform

### DIFF
--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/make-bugs-public.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/make-bugs-public.yaml
@@ -2,6 +2,8 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: make-bugs-public
+  labels:
+    cronLastSuccessfulTimeMins: "2160"
 spec:
   schedule: "0 12 * * *"
   concurrencyPolicy: Forbid

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/process-results.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/process-results.yaml
@@ -2,6 +2,8 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: process-results
+  labels:
+    cronLastSuccessfulTimeMins: "2880"
 spec:
   schedule: "0 0 * * *"
   concurrencyPolicy: Forbid

--- a/deployment/terraform/environments/oss-vdb/main.tf
+++ b/deployment/terraform/environments/oss-vdb/main.tf
@@ -1,3 +1,22 @@
+locals {
+  env_kustomization_path  = "../../../clouddeploy/gke-workers/environments/oss-vdb"
+  base_kustomization_path = "../../../clouddeploy/gke-workers/base"
+  env_kustomization       = yamldecode(file("${local.env_kustomization_path}/kustomization.yaml"))
+  base_kustomization      = yamldecode(file("${local.base_kustomization_path}/kustomization.yaml"))
+
+  all_resources = concat(
+    [for resource in local.env_kustomization.resources : "${local.env_kustomization_path}/${resource}" if can(regex("\\.yaml$", resource))],
+    [for resource in local.base_kustomization.resources : "${local.base_kustomization_path}/${resource}" if can(regex("\\.yaml$", resource))],
+  )
+
+  # Iterate of each yaml configuration and create a key based on kind and name in the yaml file.
+  kube_manifests = {
+    for manifest in flatten([for file in local.all_resources : yamldecode(file(file))]) :
+    "${try(manifest.kind, "")}--${try(manifest.metadata.name, "")}" => manifest
+    if try(manifest.kind, "") == "CronJob"
+  }
+}
+
 module "osv" {
   source = "../../modules/osv"
 
@@ -17,6 +36,14 @@ module "osv" {
   website_domain = "osv.dev"
   api_url        = "api.osv.dev"
   esp_version    = "2.51.0"
+}
+
+module "k8s_cron_alert" {
+  for_each                         = local.kube_manifests
+  source                           = "../../modules/k8s_cron_alert"
+  project_id                       = module.osv.project_id
+  cronjob_name                     = each.value.metadata.name
+  cronjob_expected_latency_minutes = lookup(each.value.metadata.labels, "cronLastSuccessfulTimeMins", null)
 }
 
 import {


### PR DESCRIPTION
This commit replicates the terraform configuration previously applied to Staging to Production as well.

The addition of notifications will be in a followup change.

Relevant `terraform plan` output:

```
Terraform will perform the following actions:

  # module.k8s_cron_alert["CronJob--alias-computation"].google_monitoring_alert_policy.cron_alert_policy will be created
  + resource "google_monitoring_alert_policy" "cron_alert_policy" {
      + combiner        = "OR"
      + creation_record = (known after apply)
      + display_name    = "Cronjob: alias-computation has not run recently."
      + enabled         = true
      + id              = (known after apply)
      + name            = (known after apply)
      + project         = "oss-vdb"

      + conditions {
          + display_name = "Cronjob: alias-computation has not run recently."
          + name         = (known after apply)

          + condition_prometheus_query_language {
              + alert_rule          = "AlwaysOn"
              + duration            = "60s"
              + evaluation_interval = "60s"
              + query               = "((time() - kube_cronjob_status_last_successful_time{cronjob=\"alias-computation\"})/60) > 45"
              + rule_group          = "cronjob alias-computation"
            }
        }
    }

  # module.k8s_cron_alert["CronJob--alpine-cve-convert"].google_monitoring_alert_policy.cron_alert_policy will be created
  + resource "google_monitoring_alert_policy" "cron_alert_policy" {
      + combiner        = "OR"
      + creation_record = (known after apply)
      + display_name    = "Cronjob: alpine-cve-convert has not run recently."
      + enabled         = true
      + id              = (known after apply)
      + name            = (known after apply)
      + project         = "oss-vdb"

      + conditions {
          + display_name = "Cronjob: alpine-cve-convert has not run recently."
          + name         = (known after apply)

          + condition_prometheus_query_language {
              + alert_rule          = "AlwaysOn"
              + duration            = "60s"
              + evaluation_interval = "60s"
              + query               = "((time() - kube_cronjob_status_last_successful_time{cronjob=\"alpine-cve-convert\"})/60) > 180"
              + rule_group          = "cronjob alpine-cve-convert"
            }
        }
    }

  # module.k8s_cron_alert["CronJob--backup"].google_monitoring_alert_policy.cron_alert_policy will be created
  + resource "google_monitoring_alert_policy" "cron_alert_policy" {
      + combiner        = "OR"
      + creation_record = (known after apply)
      + display_name    = "Cronjob: backup has not run recently."
      + enabled         = true
      + id              = (known after apply)
      + name            = (known after apply)
      + project         = "oss-vdb"

      + conditions {
          + display_name = "Cronjob: backup has not run recently."
          + name         = (known after apply)

          + condition_prometheus_query_language {
              + alert_rule          = "AlwaysOn"
              + duration            = "60s"
              + evaluation_interval = "60s"
              + query               = "((time() - kube_cronjob_status_last_successful_time{cronjob=\"backup\"})/60) > 2880"
              + rule_group          = "cronjob backup"
            }
        }
    }

  # module.k8s_cron_alert["CronJob--combine-to-osv"].google_monitoring_alert_policy.cron_alert_policy will be created
  + resource "google_monitoring_alert_policy" "cron_alert_policy" {
      + combiner        = "OR"
      + creation_record = (known after apply)
      + display_name    = "Cronjob: combine-to-osv has not run recently."
      + enabled         = true
      + id              = (known after apply)
      + name            = (known after apply)
      + project         = "oss-vdb"

      + conditions {
          + display_name = "Cronjob: combine-to-osv has not run recently."
          + name         = (known after apply)

          + condition_prometheus_query_language {
              + alert_rule          = "AlwaysOn"
              + duration            = "60s"
              + evaluation_interval = "60s"
              + query               = "((time() - kube_cronjob_status_last_successful_time{cronjob=\"combine-to-osv\"})/60) > 90"
              + rule_group          = "cronjob combine-to-osv"
            }
        }
    }

  # module.k8s_cron_alert["CronJob--cpe-repo-gen"].google_monitoring_alert_policy.cron_alert_policy will be created
  + resource "google_monitoring_alert_policy" "cron_alert_policy" {
      + combiner        = "OR"
      + creation_record = (known after apply)
      + display_name    = "Cronjob: cpe-repo-gen has not run recently."
      + enabled         = true
      + id              = (known after apply)
      + name            = (known after apply)
      + project         = "oss-vdb"

      + conditions {
          + display_name = "Cronjob: cpe-repo-gen has not run recently."
          + name         = (known after apply)

          + condition_prometheus_query_language {
              + alert_rule          = "AlwaysOn"
              + duration            = "60s"
              + evaluation_interval = "60s"
              + query               = "((time() - kube_cronjob_status_last_successful_time{cronjob=\"cpe-repo-gen\"})/60) > 2880"
              + rule_group          = "cronjob cpe-repo-gen"
            }
        }
    }

  # module.k8s_cron_alert["CronJob--debian-convert"].google_monitoring_alert_policy.cron_alert_policy will be created
  + resource "google_monitoring_alert_policy" "cron_alert_policy" {
      + combiner        = "OR"
      + creation_record = (known after apply)
      + display_name    = "Cronjob: debian-convert has not run recently."
      + enabled         = true
      + id              = (known after apply)
      + name            = (known after apply)
      + project         = "oss-vdb"

      + conditions {
          + display_name = "Cronjob: debian-convert has not run recently."
          + name         = (known after apply)

          + condition_prometheus_query_language {
              + alert_rule          = "AlwaysOn"
              + duration            = "60s"
              + evaluation_interval = "60s"
              + query               = "((time() - kube_cronjob_status_last_successful_time{cronjob=\"debian-convert\"})/60) > 180"
              + rule_group          = "cronjob debian-convert"
            }
        }
    }

  # module.k8s_cron_alert["CronJob--debian-copyright-mirror"].google_monitoring_alert_policy.cron_alert_policy will be created
  + resource "google_monitoring_alert_policy" "cron_alert_policy" {
      + combiner        = "OR"
      + creation_record = (known after apply)
      + display_name    = "Cronjob: debian-copyright-mirror has not run recently."
      + enabled         = true
      + id              = (known after apply)
      + name            = (known after apply)
      + project         = "oss-vdb"

      + conditions {
          + display_name = "Cronjob: debian-copyright-mirror has not run recently."
          + name         = (known after apply)

          + condition_prometheus_query_language {
              + alert_rule          = "AlwaysOn"
              + duration            = "60s"
              + evaluation_interval = "60s"
              + query               = "((time() - kube_cronjob_status_last_successful_time{cronjob=\"debian-copyright-mirror\"})/60) > 2880"
              + rule_group          = "cronjob debian-copyright-mirror"
            }
        }
    }

  # module.k8s_cron_alert["CronJob--debian-cve-convert"].google_monitoring_alert_policy.cron_alert_policy will be created
  + resource "google_monitoring_alert_policy" "cron_alert_policy" {
      + combiner        = "OR"
      + creation_record = (known after apply)
      + display_name    = "Cronjob: debian-cve-convert has not run recently."
      + enabled         = true
      + id              = (known after apply)
      + name            = (known after apply)
      + project         = "oss-vdb"

      + conditions {
          + display_name = "Cronjob: debian-cve-convert has not run recently."
          + name         = (known after apply)

          + condition_prometheus_query_language {
              + alert_rule          = "AlwaysOn"
              + duration            = "60s"
              + evaluation_interval = "60s"
              + query               = "((time() - kube_cronjob_status_last_successful_time{cronjob=\"debian-cve-convert\"})/60) > 120"
              + rule_group          = "cronjob debian-cve-convert"
            }
        }
    }

  # module.k8s_cron_alert["CronJob--debian-first-version"].google_monitoring_alert_policy.cron_alert_policy will be created
  + resource "google_monitoring_alert_policy" "cron_alert_policy" {
      + combiner        = "OR"
      + creation_record = (known after apply)
      + display_name    = "Cronjob: debian-first-version has not run recently."
      + enabled         = true
      + id              = (known after apply)
      + name            = (known after apply)
      + project         = "oss-vdb"

      + conditions {
          + display_name = "Cronjob: debian-first-version has not run recently."
          + name         = (known after apply)

          + condition_prometheus_query_language {
              + alert_rule          = "AlwaysOn"
              + duration            = "60s"
              + evaluation_interval = "60s"
              + query               = "((time() - kube_cronjob_status_last_successful_time{cronjob=\"debian-first-version\"})/60) > 2880"
              + rule_group          = "cronjob debian-first-version"
            }
        }
    }

  # module.k8s_cron_alert["CronJob--exporter"].google_monitoring_alert_policy.cron_alert_policy will be created
  + resource "google_monitoring_alert_policy" "cron_alert_policy" {
      + combiner        = "OR"
      + creation_record = (known after apply)
      + display_name    = "Cronjob: exporter has not run recently."
      + enabled         = true
      + id              = (known after apply)
      + name            = (known after apply)
      + project         = "oss-vdb"

      + conditions {
          + display_name = "Cronjob: exporter has not run recently."
          + name         = (known after apply)

          + condition_prometheus_query_language {
              + alert_rule          = "AlwaysOn"
              + duration            = "60s"
              + evaluation_interval = "60s"
              + query               = "((time() - kube_cronjob_status_last_successful_time{cronjob=\"exporter\"})/60) > 90"
              + rule_group          = "cronjob exporter"
            }
        }
    }

  # module.k8s_cron_alert["CronJob--generate-sitemap"].google_monitoring_alert_policy.cron_alert_policy will be created
  + resource "google_monitoring_alert_policy" "cron_alert_policy" {
      + combiner        = "OR"
      + creation_record = (known after apply)
      + display_name    = "Cronjob: generate-sitemap has not run recently."
      + enabled         = true
      + id              = (known after apply)
      + name            = (known after apply)
      + project         = "oss-vdb"

      + conditions {
          + display_name = "Cronjob: generate-sitemap has not run recently."
          + name         = (known after apply)

          + condition_prometheus_query_language {
              + alert_rule          = "AlwaysOn"
              + duration            = "60s"
              + evaluation_interval = "60s"
              + query               = "((time() - kube_cronjob_status_last_successful_time{cronjob=\"generate-sitemap\"})/60) > 2880"
              + rule_group          = "cronjob generate-sitemap"
            }
        }
    }

  # module.k8s_cron_alert["CronJob--importer"].google_monitoring_alert_policy.cron_alert_policy will be created
  + resource "google_monitoring_alert_policy" "cron_alert_policy" {
      + combiner        = "OR"
      + creation_record = (known after apply)
      + display_name    = "Cronjob: importer has not run recently."
      + enabled         = true
      + id              = (known after apply)
      + name            = (known after apply)
      + project         = "oss-vdb"

      + conditions {
          + display_name = "Cronjob: importer has not run recently."
          + name         = (known after apply)

          + condition_prometheus_query_language {
              + alert_rule          = "AlwaysOn"
              + duration            = "60s"
              + evaluation_interval = "60s"
              + query               = "((time() - kube_cronjob_status_last_successful_time{cronjob=\"importer\"})/60) > 90"
              + rule_group          = "cronjob importer"
            }
        }
    }

  # module.k8s_cron_alert["CronJob--importer-deleter"].google_monitoring_alert_policy.cron_alert_policy will be created
  + resource "google_monitoring_alert_policy" "cron_alert_policy" {
      + combiner        = "OR"
      + creation_record = (known after apply)
      + display_name    = "Cronjob: importer-deleter has not run recently."
      + enabled         = true
      + id              = (known after apply)
      + name            = (known after apply)
      + project         = "oss-vdb"

      + conditions {
          + display_name = "Cronjob: importer-deleter has not run recently."
          + name         = (known after apply)

          + condition_prometheus_query_language {
              + alert_rule          = "AlwaysOn"
              + duration            = "60s"
              + evaluation_interval = "60s"
              + query               = "((time() - kube_cronjob_status_last_successful_time{cronjob=\"importer-deleter\"})/60) > 360"
              + rule_group          = "cronjob importer-deleter"
            }
        }
    }

  # module.k8s_cron_alert["CronJob--make-bugs-public"].google_monitoring_alert_policy.cron_alert_policy will be created
  + resource "google_monitoring_alert_policy" "cron_alert_policy" {
      + combiner        = "OR"
      + creation_record = (known after apply)
      + display_name    = "Cronjob: make-bugs-public has not run recently."
      + enabled         = true
      + id              = (known after apply)
      + name            = (known after apply)
      + project         = "oss-vdb"

      + conditions {
          + display_name = "Cronjob: make-bugs-public has not run recently."
          + name         = (known after apply)

          + condition_prometheus_query_language {
              + alert_rule          = "AlwaysOn"
              + duration            = "60s"
              + evaluation_interval = "60s"
              + query               = "((time() - kube_cronjob_status_last_successful_time{cronjob=\"make-bugs-public\"})/60) > 2160"
              + rule_group          = "cronjob make-bugs-public"
            }
        }
    }

  # module.k8s_cron_alert["CronJob--nvd-cve-osv"].google_monitoring_alert_policy.cron_alert_policy will be created
  + resource "google_monitoring_alert_policy" "cron_alert_policy" {
      + combiner        = "OR"
      + creation_record = (known after apply)
      + display_name    = "Cronjob: nvd-cve-osv has not run recently."
      + enabled         = true
      + id              = (known after apply)
      + name            = (known after apply)
      + project         = "oss-vdb"

      + conditions {
          + display_name = "Cronjob: nvd-cve-osv has not run recently."
          + name         = (known after apply)

          + condition_prometheus_query_language {
              + alert_rule          = "AlwaysOn"
              + duration            = "60s"
              + evaluation_interval = "60s"
              + query               = "((time() - kube_cronjob_status_last_successful_time{cronjob=\"nvd-cve-osv\"})/60) > 2160"
              + rule_group          = "cronjob nvd-cve-osv"
            }
        }
    }

  # module.k8s_cron_alert["CronJob--nvd-mirror"].google_monitoring_alert_policy.cron_alert_policy will be created
  + resource "google_monitoring_alert_policy" "cron_alert_policy" {
      + combiner        = "OR"
      + creation_record = (known after apply)
      + display_name    = "Cronjob: nvd-mirror has not run recently."
      + enabled         = true
      + id              = (known after apply)
      + name            = (known after apply)
      + project         = "oss-vdb"

      + conditions {
          + display_name = "Cronjob: nvd-mirror has not run recently."
          + name         = (known after apply)

          + condition_prometheus_query_language {
              + alert_rule          = "AlwaysOn"
              + duration            = "60s"
              + evaluation_interval = "60s"
              + query               = "((time() - kube_cronjob_status_last_successful_time{cronjob=\"nvd-mirror\"})/60) > 240"
              + rule_group          = "cronjob nvd-mirror"
            }
        }
    }

  # module.k8s_cron_alert["CronJob--process-results"].google_monitoring_alert_policy.cron_alert_policy will be created
  + resource "google_monitoring_alert_policy" "cron_alert_policy" {
      + combiner        = "OR"
      + creation_record = (known after apply)
      + display_name    = "Cronjob: process-results has not run recently."
      + enabled         = true
      + id              = (known after apply)
      + name            = (known after apply)
      + project         = "oss-vdb"

      + conditions {
          + display_name = "Cronjob: process-results has not run recently."
          + name         = (known after apply)

          + condition_prometheus_query_language {
              + alert_rule          = "AlwaysOn"
              + duration            = "60s"
              + evaluation_interval = "60s"
              + query               = "((time() - kube_cronjob_status_last_successful_time{cronjob=\"process-results\"})/60) > 2880"
              + rule_group          = "cronjob process-results"
            }
        }
    }

Plan: 17 to add, 0 to change, 0 to destroy.
```