### PR TITLE
chore: update Go version to 1.23.6

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: '>=1.23.5'
+          go-version: '>=1.23.6'
       - name: Set up terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
       - name: Run pylint and yapf, go vet

--- a/docker/ci/install_go.sh
+++ b/docker/ci/install_go.sh
@@ -19,4 +19,4 @@ set -eux
 
 # Download and install Go
 # https://go.dev/doc/install
-curl https://go.dev/dl/go1.23.5.linux-amd64.tar.gz -LO && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.23.5.linux-amd64.tar.gz
+curl https://go.dev/dl/go1.23.6.linux-amd64.tar.gz -LO && rm -rf /usr/local/go && tar -C /usr/local -xzf go1.23.6.linux-amd64.tar.gz

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,6 +1,6 @@
 module osv.dev/tools
 
-go 1.23.5
+go 1.23.6
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.1

--- a/gcp/indexer/go.mod
+++ b/gcp/indexer/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/osv.dev/gcp/indexer
 
-go 1.23.5
+go 1.23.6
 
 require (
 	cloud.google.com/go/datastore v1.20.0

--- a/tools/datastore-remover/go.mod
+++ b/tools/datastore-remover/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/datastore-remover
 
-go 1.23.5
+go 1.23.6
 
 require (
 	cloud.google.com/go/datastore v1.20.0

--- a/tools/indexer-api-caller/go.mod
+++ b/tools/indexer-api-caller/go.mod
@@ -1,3 +1,3 @@
 module github.com/google/indexer-api-caller
 
-go 1.23.5
+go 1.23.6

--- a/vulnfeeds/go.mod
+++ b/vulnfeeds/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/osv/vulnfeeds
 
-go 1.23.5
+go 1.23.6
 
 require (
 	cloud.google.com/go/logging v1.13.0


### PR DESCRIPTION
Fixes the reported vulnerability [GO-2025-3447](https://osv.dev/vulnerability/GO-2025-3447)

Is there a way to get renovate/dependabot to do this?