### PR TITLE
feat(monitoring): add notifications to k8s CronJob monitoring in production

### DIFF
--- a/deployment/terraform/environments/oss-vdb/main.tf
+++ b/deployment/terraform/environments/oss-vdb/main.tf
@@ -44,6 +44,7 @@ module "k8s_cron_alert" {
   project_id                       = module.osv.project_id
   cronjob_name                     = each.value.metadata.name
   cronjob_expected_latency_minutes = lookup(each.value.metadata.labels, "cronLastSuccessfulTimeMins", null)
+  notification_channel             = "projects/oss-vdb/notificationChannels/17648103713296264012"
 }
 
 import {


### PR DESCRIPTION
This builds on #3123 and incorporates #3124 and will be applied as part of the next release of Production.