### PR TITLE
test(vulnfeeds): emit external IP for troubleshooting

### DIFF
--- a/vulnfeeds/run_tests.sh
+++ b/vulnfeeds/run_tests.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+echo !!!
+echo !!! FYI external IP is: $(curl -s https://ipinfo.io/ip)
+echo !!!
+
 set -e
 
 go test ./...


### PR DESCRIPTION
This adds the external IP of the environment executing vulnfeeds tests to assist with troubleshooting test failures that have remote network dependencies.