### PR TITLE
fix(vulnfeeds): correct version normalization for tags with a v prefix

### DIFF
--- a/vulnfeeds/git/repository.go
+++ b/vulnfeeds/git/repository.go
@@ -161,7 +161,7 @@ func RepoTags(repoURL string, repoTagsCache RepoTagsCache) (tags Tags, e error) 
 // finally, it is run through the standard version normalizing treatment
 func normalizeRepoTag(tag string, reponame string) (normalizedTag string, err error) {
 	// Match the likes of "org.apache.sling.i18n-2.0.2" as seen in github.com/apache/sling-org-apache-sling-i18n
-	var javaPackageRegex = regexp.MustCompile(`(?i)^(?:[a-z][a-z0-9_]*(?:\.[a-z0-9_]+)+[0-9a-z_])(.*)$`)
+	var javaPackageRegex = regexp.MustCompile(`(?i)^(?:[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]+)+[a-z0-9_])-(.*)$`)
 	// Opportunistically remove parts determined to match the repo name,
 	// to ease particularly difficult to normalize cases like 'openj9-0.38.0'.
 	prenormalizedTag := strings.TrimPrefix(strings.ToLower(tag), reponame)

--- a/vulnfeeds/git/repository_test.go
+++ b/vulnfeeds/git/repository_test.go
@@ -225,6 +225,13 @@ func TestNormalizeRepoTag(t *testing.T) {
 			expectedResult: "2-0-2",
 			expectedOk:     true,
 		},
+		{
+			description:    "A tag with a v prefix",
+			inputTag:       "v0.0.245",
+			repoName:       "langchain",
+			expectedResult: "0-0-245",
+			expectedOk:     true,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
This fixes a bug discovered in the pre-normalization of tags with a v prefix, they were incorrectly running through the Java package treatment and being completely wiped out :-(

Discovered while investigating the unexpected withdrawal of CVE-2023-39631