### PR TITLE
refactor(monitoring): add a severity to k8s CronJob alerting

### DIFF
--- a/deployment/terraform/modules/k8s_cron_alert/k8s_cron_alert.tf
+++ b/deployment/terraform/modules/k8s_cron_alert/k8s_cron_alert.tf
@@ -35,4 +35,5 @@ resource "google_monitoring_alert_policy" "cron_alert_policy" {
   }
 
   notification_channels = var.notification_channel != null ? toset([var.notification_channel]) : toset([])
+  severity              = "ERROR"
 }


### PR DESCRIPTION
This adds a severity of ERROR to the generated alerting policies so that the incidents opened have this severity, rather than none at all.