### PR TITLE
feat(vulnfeeds): better validate repos found in references

### DIFF
--- a/vulnfeeds/cmd/nvd-cve-osv/main.go
+++ b/vulnfeeds/cmd/nvd-cve-osv/main.go
@@ -210,10 +210,13 @@ func ReposFromReferences(CVE string, cache VendorProductToRepoMap, vp *VendorPro
 			// Failed to parse as a valid repo.
 			continue
 		}
-		if !git.ValidRepo(repo) {
+		if slices.Contains(repos, repo) {
 			continue
 		}
-		if slices.Contains(repos, repo) {
+		// If the reference is a commit URL, the repo is inherently useful.
+		// If it's any other repo-shaped URL, it's only useful if it has tags.
+		_, err = cves.Commit(ref.Url)
+		if !git.ValidRepoAndHasUsableRefs(repo) && err != nil {
 			continue
 		}
 		repos = append(repos, repo)

--- a/vulnfeeds/cmd/nvd-cve-osv/main_test.go
+++ b/vulnfeeds/cmd/nvd-cve-osv/main_test.go
@@ -21,7 +21,7 @@ func TestReposFromReferences(t *testing.T) {
 		wantRepos []string
 	}{
 		{
-			name: "A CVE with a repo not already present in the VendorRepo cache",
+			name: "A CVE with a repo not already present in the VendorRepo cache (that happens to have no useful references)",
 			args: args{
 				CVE:   "CVE-2023-0327",
 				cache: nil,
@@ -36,11 +36,27 @@ func TestReposFromReferences(t *testing.T) {
 			},
 			wantRepos: []string{"https://github.com/saemorris/TheRadSystem"},
 		},
+		{
+			name: "A CVE with a useless (vulnerability researcher) repo",
+			args: args{
+				CVE:   "CVE-2025-0211",
+				cache: nil,
+				vp:    &VendorProduct{"campcodes", "school_faculty_scheduling_system"},
+				refs: []cves.Reference{
+					{
+						Source: "cna@vuldb.com",
+						Tags:   []string{"Exploit", "Third Party Advisory"},
+						Url:    "https://github.com/shaturo1337/POCs/blob/main/LFI%20in%20School%20Faculty%20Scheduling%20System.md"},
+				},
+				tagDenyList: RefTagDenyList,
+			},
+			wantRepos: []string(nil),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if gotRepos := ReposFromReferences(tt.args.CVE, tt.args.cache, tt.args.vp, tt.args.refs, tt.args.tagDenyList); !reflect.DeepEqual(gotRepos, tt.wantRepos) {
-				t.Errorf("ReposFromReferences() = %v, want %v", gotRepos, tt.wantRepos)
+				t.Errorf("ReposFromReferences() = %#v, want %#v", gotRepos, tt.wantRepos)
 			}
 		})
 	}

--- a/vulnfeeds/git/repository_test.go
+++ b/vulnfeeds/git/repository_test.go
@@ -301,12 +301,11 @@ func TestValidRepo(t *testing.T) {
 			repoURL:        "https://github.com/torvalds/linux",
 			expectedResult: true,
 		},
-		// Seems to be having an outage at 2024-06-19
-		// {
-		// 	description:    "Valid repository with a git:// protocol URL",
-		// 	repoURL:        "git://git.infradead.org/mtd-utils.git",
-		// 	expectedResult: true,
-		// },
+		{
+			description:    "Valid repository with a git:// protocol URL",
+			repoURL:        "git://git.infradead.org/mtd-utils.git",
+			expectedResult: true,
+		},
 		{
 			description:    "Invalid repository",
 			repoURL:        "https://github.com/andrewpollock/mybogusrepo",
@@ -320,6 +319,11 @@ func TestValidRepo(t *testing.T) {
 		{
 			description:    "Legitimate repository with no tags and one branch",
 			repoURL:        "https://github.com/active-labs/Advisories",
+			expectedResult: false,
+		},
+		{
+			description:    "Unusable repo that seems to be slipping past",
+			repoURL:        "https://github.com/shaturo1337/POCs",
 			expectedResult: false,
 		},
 	}


### PR DESCRIPTION
This commit tightens up the repo validation to exclude repos that don't have any usable tags, unless the reference URL is obviously a commit.

The primary benefit here is that useless repos don't cause CVEs to be in-scope for attempting conversion that shouldn't, while not disregarding CVEs that have a potential fix commit as a reference, but a repo that is otherwise useless for version-to-commit mapping.

In other words, it improves the overall conversion metrics by firming up the denominator some more.

Last staging run against 2025 NVD data:

```
nvdcve-2.0-2025.json Metrics: {TotalCVEs:2870 CVEsForApplications:205 CVEsForKnownRepos:420 OSVRecordsGenerated:188 Outcomes:map[]} 
```

Local regression test:

```
nvdcve-2.0-2025.json Metrics: {TotalCVEs:2876 CVEsForApplications:205 CVEsForKnownRepos:302 OSVRecordsGenerated:189 Outcomes:map[]}
```

This change reduces the CVEs in scope by 118, while increasing records converted by 1. (There _are_ 6 more CVEs in the latest NVD snapshot)