### PR TITLE
fix(worker): only log import latency for non-time outs

### DIFF
--- a/gcp/workers/worker/worker.py
+++ b/gcp/workers/worker/worker.py
@@ -653,8 +653,9 @@ class TaskRunner:
 
       done = done_event.wait(timeout=MAX_LEASE_DURATION)
       logging.info('Returned from task thread')
-      self._log_task_latency(message)
-      if not done:
+      if done:
+        self._log_task_latency(message)
+      else:
         self.handle_timeout(subscriber, subscription, ack_id, message)
         logging.warning('Timed out processing task')
 


### PR DESCRIPTION
This adjusts the latency logging behaviour so that it only happens when a task completes successfully (as opposed to times out, and is subject to being retried).

Fixes: #1871