### PR TITLE
feat: add support for an 'upstream' field in the models

### DIFF
--- a/gcp/workers/alias/upstream_computation.py
+++ b/gcp/workers/alias/upstream_computation.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OSV Upstream relation computation."""
+
+import datetime
+from google.cloud import ndb
+
+import osv
+import osv.logs
+
+import logging
+
+
+def _compute_upstream(target_bug_id, bugs):
+  """Computes all upstream vulnerabilities for the given bug ID.
+  The returned list contains all of the bug IDs that are upstream of the
+  target bug ID, including transitive upstreams."""
+  visited = set()
+  target_bug_upstream = bugs[target_bug_id]
+  if not target_bug_upstream:
+    return []
+  to_visit = set(target_bug_upstream)
+  bug_ids = []
+  while to_visit:
+    bug_id = to_visit.pop()
+    if bug_id in visited:
+      continue
+    visited.add(bug_id)
+    bug_ids.append(bug_id)
+    upstreams = set()
+    if bug_id in bugs.keys():
+      upstreams = set(bugs[bug_id])
+    to_visit.update(upstreams - visited)
+
+  # Returns a sorted list of bug IDs, which ensures deterministic behaviour
+  # and avoids unnecessary updates.
+  return sorted(bug_ids)
+
+def _create_group(bug_id, upstream_ids):
+  """Creates a new upstream group in the datastore."""
+
+  new_group = osv.UpstreamGroup(db_id=bug_id)
+  new_group.upstream_ids = upstream_ids
+  new_group.last_modified = datetime.datetime.now()
+  new_group.put()
+
+
+def _update_group(upstream_group, upstream_ids: list):
+  """Updates the alias group in the datastore."""
+  if len(upstream_ids) < 1:
+    logging.info('Deleting alias group due to too few bugs: %s', upstream_ids)
+    upstream_group.key.delete()
+    return
+
+  if upstream_ids == upstream_group.upstream_ids:
+    return
+
+  upstream_group.upstream_ids = upstream_ids
+  upstream_group.last_modified = datetime.datetime.now()
+  upstream_group.put()
+
+
+def main():
+  """Updates all upstream groups in the datastore by re-computing existing
+  UpstreamGroups and creating new UpstreamGroups for un-computed bugs."""
+
+  # Query for all bugs that have upstreams.
+  # Use (> '' OR < '') instead of (!= '') / (> '') to de-duplicate results
+  # and avoid datastore emulator problems, see issue #2093
+  bugs = osv.Bug.query(ndb.OR(osv.Bug.upstream > '', osv.Bug.upstream < ''))
+
+  all_upstream_group = osv.UpstreamGroup.query()
+
+  # for every bug, check if it has an UpstreamGroup.
+  for bug in bugs:
+    # check if the db key is also a db_id in all_upstream_group
+    b = all_upstream_group.filter(osv.UpstreamGroup.db_id == bug.db_id)
+    if b:
+      #recompute the transitive upstreams and compare with the existing group
+      upstream_ids = _compute_upstream(bug.db_id, bugs)
+      _update_group(b, upstream_ids)
+    else:
+      # Create a new UpstreamGroup
+      upstream_ids = _compute_upstream(bug.db_id, bugs)
+      _create_group(bug, upstream_ids)
+
+
+if __name__ == '__main__':
+  _ndb_client = ndb.Client()
+  osv.logs.setup_gcp_logging('upstream')
+  with _ndb_client.context():
+    main()

--- a/gcp/workers/alias/upstream_computation_test.py
+++ b/gcp/workers/alias/upstream_computation_test.py
@@ -1,0 +1,389 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Upstream computation tests."""
+import datetime
+import os
+import unittest
+import logging
+from google.cloud import ndb
+
+import osv
+import upstream_computation
+from osv import tests
+
+TEST_DATA_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), 'testdata')
+
+
+class UpstreamTest(unittest.TestCase, tests.ExpectationTest(TEST_DATA_DIR)):
+  """Upstream tests."""
+
+  def setUp(self):
+    self.maxDiff = None  # pylint: disable=invalid-name
+    tests.reset_emulator()
+    osv.Bug(
+        id='CVE-1',
+        db_id='CVE-1',
+        status=1,
+        upstream=[],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1),
+    ).put()
+    osv.Bug(
+        id='CVE-2',
+        db_id='CVE-2',
+        status=1,
+        upstream=['CVE-1'],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1),
+    ).put()
+    osv.Bug(
+        id='CVE-3',
+        db_id='CVE-3',
+        status=1,
+        upstream=['CVE-1', 'CVE-2'],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1),
+    ).put()
+
+    osv.Bug(
+        id='CVE-2023-21400',
+        db_id='CVE-2023-21400',
+        status=1,
+        upstream=[],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2025, 1, 14),
+    ).put()
+    osv.Bug(
+        id='UBUNTU-CVE-2023-21400',
+        db_id='UBUNTU-CVE-2023-21400',
+        status=1,
+        upstream=['CVE-2023-21400'],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2025, 1, 14),
+    ).put()
+
+    osv.Bug(
+        id='UBUNTU-CVE-2023-4004',
+        db_id='UBUNTU-CVE-2023-4004',
+        status=1,
+        upstream=['CVE-2023-4004'],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2025, 2, 10),
+    ).put()
+
+    osv.Bug(
+        id='UBUNTU-CVE-2023-4015',
+        db_id='UBUNTU-CVE-2023-4015',
+        status=1,
+        upstream=['CVE-2023-4015'],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2025, 2, 10),
+    ).put()
+
+    osv.Bug(
+        id='USN-6315-1',
+        db_id='USN-6315-1',
+        status=1,
+        upstream=[
+            "CVE-2022-40982", "CVE-2023-20593", "CVE-2023-21400",
+            "CVE-2023-3609", "CVE-2023-3610", "CVE-2023-3611", "CVE-2023-3776",
+            "CVE-2023-3777", "CVE-2023-4004", "CVE-2023-4015",
+            "UBUNTU-CVE-2022-40982", "UBUNTU-CVE-2023-20593",
+            "UBUNTU-CVE-2023-21400", "UBUNTU-CVE-2023-3609",
+            "UBUNTU-CVE-2023-3610", "UBUNTU-CVE-2023-3611",
+            "UBUNTU-CVE-2023-3776", "UBUNTU-CVE-2023-3777",
+            "UBUNTU-CVE-2023-4004", "UBUNTU-CVE-2023-4015"
+        ],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 8, 29),
+    ).put()
+
+    osv.Bug(
+        id='USN-6325-1',
+        db_id='USN-6325-1',
+        status=1,
+        upstream=[
+            "CVE-2022-40982", "CVE-2023-20593", "CVE-2023-21400",
+            "CVE-2023-3609", "CVE-2023-3610", "CVE-2023-3611", "CVE-2023-3776",
+            "CVE-2023-3777", "CVE-2023-4004", "CVE-2023-4015",
+            "UBUNTU-CVE-2022-40982", "UBUNTU-CVE-2023-20593",
+            "UBUNTU-CVE-2023-21400", "UBUNTU-CVE-2023-3609",
+            "UBUNTU-CVE-2023-3610", "UBUNTU-CVE-2023-3611",
+            "UBUNTU-CVE-2023-3776", "UBUNTU-CVE-2023-3777",
+            "UBUNTU-CVE-2023-4004", "UBUNTU-CVE-2023-4015"
+        ],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 8, 31),
+    ).put()
+
+    osv.Bug(
+        id='USN-6330-1',
+        db_id='USN-6330-1',
+        status=1,
+        upstream=[
+            "CVE-2022-40982", "CVE-2023-20593", "CVE-2023-21400",
+            "CVE-2023-3609", "CVE-2023-3610", "CVE-2023-3611", "CVE-2023-3776",
+            "CVE-2023-3777", "CVE-2023-4004", "CVE-2023-4015",
+            "UBUNTU-CVE-2022-40982", "UBUNTU-CVE-2023-20593",
+            "UBUNTU-CVE-2023-21400", "UBUNTU-CVE-2023-3609",
+            "UBUNTU-CVE-2023-3610", "UBUNTU-CVE-2023-3611",
+            "UBUNTU-CVE-2023-3776", "UBUNTU-CVE-2023-3777",
+            "UBUNTU-CVE-2023-4004", "UBUNTU-CVE-2023-4015"
+        ],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 8, 31),
+    ).put()
+
+    osv.Bug(
+        id='USN-6332-1',
+        db_id='USN-6332-1',
+        status=1,
+        upstream=[
+            "CVE-2022-40982", "CVE-2022-4269", "CVE-2022-48502",
+            "CVE-2023-0597", "CVE-2023-1611", "CVE-2023-1855", "CVE-2023-1990",
+            "CVE-2023-2002", "CVE-2023-20593", "CVE-2023-2124",
+            "CVE-2023-21400", "CVE-2023-2163", "CVE-2023-2194", "CVE-2023-2235",
+            "CVE-2023-2269", "CVE-2023-23004", "CVE-2023-28466",
+            "CVE-2023-30772", "CVE-2023-3141", "CVE-2023-32248",
+            "CVE-2023-3268", "CVE-2023-33203", "CVE-2023-33288",
+            "CVE-2023-35823", "CVE-2023-35824", "CVE-2023-35828",
+            "CVE-2023-35829", "CVE-2023-3609", "CVE-2023-3610", "CVE-2023-3611",
+            "CVE-2023-3776", "CVE-2023-3777", "CVE-2023-4004", "CVE-2023-4015",
+            "UBUNTU-CVE-2022-40982", "UBUNTU-CVE-2022-4269",
+            "UBUNTU-CVE-2022-48502", "UBUNTU-CVE-2023-0597",
+            "UBUNTU-CVE-2023-1611", "UBUNTU-CVE-2023-1855",
+            "UBUNTU-CVE-2023-1990", "UBUNTU-CVE-2023-2002",
+            "UBUNTU-CVE-2023-20593", "UBUNTU-CVE-2023-2124",
+            "UBUNTU-CVE-2023-21400", "UBUNTU-CVE-2023-2163",
+            "UBUNTU-CVE-2023-2194", "UBUNTU-CVE-2023-2235",
+            "UBUNTU-CVE-2023-2269", "UBUNTU-CVE-2023-23004",
+            "UBUNTU-CVE-2023-28466", "UBUNTU-CVE-2023-30772",
+            "UBUNTU-CVE-2023-3141", "UBUNTU-CVE-2023-32248",
+            "UBUNTU-CVE-2023-3268", "UBUNTU-CVE-2023-33203",
+            "UBUNTU-CVE-2023-33288", "UBUNTU-CVE-2023-35823",
+            "UBUNTU-CVE-2023-35824", "UBUNTU-CVE-2023-35828",
+            "UBUNTU-CVE-2023-35829", "UBUNTU-CVE-2023-3609",
+            "UBUNTU-CVE-2023-3610", "UBUNTU-CVE-2023-3611",
+            "UBUNTU-CVE-2023-3776", "UBUNTU-CVE-2023-3777",
+            "UBUNTU-CVE-2023-4004", "UBUNTU-CVE-2023-4015"
+        ],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 8, 31),
+    ).put()
+
+    osv.Bug(
+        id='USN-6348-1',
+        db_id='USN-6348-1',
+        status=1,
+        upstream=[
+            "CVE-2022-40982", "CVE-2023-20593", "CVE-2023-21400",
+            "CVE-2023-3609", "CVE-2023-3610", "CVE-2023-3611", "CVE-2023-3776",
+            "CVE-2023-3777", "CVE-2023-4004", "CVE-2023-4015",
+            "UBUNTU-CVE-2022-40982", "UBUNTU-CVE-2023-20593",
+            "UBUNTU-CVE-2023-21400", "UBUNTU-CVE-2023-3609",
+            "UBUNTU-CVE-2023-3610", "UBUNTU-CVE-2023-3611",
+            "UBUNTU-CVE-2023-3776", "UBUNTU-CVE-2023-3777",
+            "UBUNTU-CVE-2023-4004", "UBUNTU-CVE-2023-4015"
+        ],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 9, 6),
+    ).put()
+
+    osv.Bug(
+        id='USN-7234-1',
+        db_id='USN-7234-1',
+        status=1,
+        upstream=[
+            "CVE-2023-21400", "CVE-2024-40967", "CVE-2024-53103",
+            "CVE-2024-53141", "CVE-2024-53164", "UBUNTU-CVE-2023-21400",
+            "UBUNTU-CVE-2024-40967", "UBUNTU-CVE-2024-53103",
+            "UBUNTU-CVE-2024-53141", "UBUNTU-CVE-2024-53164"
+        ],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 8, 31),
+    ).put()
+
+    osv.Bug(
+        id='USN-7234-3',
+        db_id='USN-7234-3',
+        status=1,
+        upstream=[
+            "CVE-2023-21400", "CVE-2024-40967", "CVE-2024-53103",
+            "CVE-2024-53141", "CVE-2024-53164", "UBUNTU-CVE-2023-21400",
+            "UBUNTU-CVE-2024-40967", "UBUNTU-CVE-2024-53103",
+            "UBUNTU-CVE-2024-53141", "UBUNTU-CVE-2024-53164"
+        ],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2025, 2, 4),
+    ).put()
+
+    osv.Bug(
+        id='USN-7234-2',
+        db_id='USN-7234-2',
+        status=1,
+        upstream=[
+            "CVE-2023-21400", "CVE-2024-40967", "CVE-2024-53103",
+            "CVE-2024-53141", "CVE-2024-53164", "UBUNTU-CVE-2023-21400",
+            "UBUNTU-CVE-2024-40967", "UBUNTU-CVE-2024-53103",
+            "UBUNTU-CVE-2024-53141", "UBUNTU-CVE-2024-53164"
+        ],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 8, 31),
+    ).put()
+
+    osv.Bug(
+        id='DLA-3623-1',
+        db_id='DLA-3623-1',
+        status=1,
+        upstream=[
+            "CVE-2022-39189", "CVE-2022-4269", "CVE-2023-1206", "CVE-2023-1380",
+            "CVE-2023-2002", "CVE-2023-2007", "CVE-2023-20588", "CVE-2023-2124",
+            "CVE-2023-21255", "CVE-2023-21400", "CVE-2023-2269",
+            "CVE-2023-2898", "CVE-2023-3090", "CVE-2023-31084", "CVE-2023-3111",
+            "CVE-2023-3141", "CVE-2023-3212", "CVE-2023-3268", "CVE-2023-3338",
+            "CVE-2023-3389", "CVE-2023-34256", "CVE-2023-34319",
+            "CVE-2023-35788", "CVE-2023-35823", "CVE-2023-35824",
+            "CVE-2023-3609", "CVE-2023-3611", "CVE-2023-3772", "CVE-2023-3773",
+            "CVE-2023-3776", "CVE-2023-3863", "CVE-2023-4004", "CVE-2023-40283",
+            "CVE-2023-4132", "CVE-2023-4147", "CVE-2023-4194", "CVE-2023-4244",
+            "CVE-2023-4273", "CVE-2023-42753", "CVE-2023-42755",
+            "CVE-2023-42756", "CVE-2023-4622", "CVE-2023-4623", "CVE-2023-4921"
+        ],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2024, 1, 9),
+    ).put()
+
+    osv.Bug(
+        id='SUSE-SU-2023:3313-1',
+        db_id='SUSE-SU-2023:3313-1',
+        status=1,
+        upstream=[
+            "CVE-2022-40982", "CVE-2023-0459", "CVE-2023-20569",
+            "CVE-2023-21400", "CVE-2023-2156", "CVE-2023-2166",
+            "CVE-2023-31083", "CVE-2023-3268", "CVE-2023-3567", "CVE-2023-3609",
+            "CVE-2023-3611", "CVE-2023-3776", "CVE-2023-4004"
+        ],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 8, 14),
+    ).put()
+
+  def test_compute_upstream_basic(self):
+    """Tests basic case.
+    CVE-1-> CVE-2 -> CVE-3
+    Upstream of CVE-3 is CVE-2 & CVE-1
+    """
+
+    bugs_query = osv.Bug.query(
+        ndb.OR(osv.Bug.upstream > '', osv.Bug.upstream < ''))
+
+    bugs = {}
+    for bug in bugs_query:
+      bugs[bug.db_id] = bug.upstream
+    bug_ids = upstream_computation._compute_upstream('CVE-3', bugs)
+    self.assertEqual(['CVE-1', 'CVE-2'], bug_ids)
+
+  def test_compute_upstream_example(self):
+    """Test real world case with multiple levels"""
+
+    bugs_query = osv.Bug.query(
+        ndb.OR(osv.Bug.upstream > '', osv.Bug.upstream < ''))
+
+    bugs = {}
+    for bug in bugs_query:
+      bugs[bug.db_id] = bug.upstream
+    bug_ids = upstream_computation._compute_upstream('USN-7234-3', bugs)
+    self.assertEqual(["CVE-2023-21400", "CVE-2024-40967", "CVE-2024-53103",
+            "CVE-2024-53141", "CVE-2024-53164", "UBUNTU-CVE-2023-21400",
+            "UBUNTU-CVE-2024-40967", "UBUNTU-CVE-2024-53103",
+            "UBUNTU-CVE-2024-53141", "UBUNTU-CVE-2024-53164"], bug_ids)
+
+  def test_incomplete_compute_upstream(self):
+    """ Test when incomplete upstream information is given 
+         VULN-1 -> VULN-2, VULN-3 -> VULN-4
+    """
+    osv.Bug(
+        id='VULN-1',
+        db_id='VULN-1',
+        status=1,
+        upstream=[],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 8, 14),
+    ).put()
+    osv.Bug(
+        id='VULN-2',
+        db_id='VULN-2',
+        status=1,
+        upstream=['VULN-1'],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 8, 14),
+    ).put()
+    osv.Bug(
+        id='VULN-3',
+        db_id='VULN-3',
+        status=1,
+        upstream=['VULN-1'],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 8, 14),
+    ).put()
+    osv.Bug(
+        id='VULN-4',
+        db_id='VULN-4',
+        status=1,
+        upstream=['VULN-3'],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 8, 14),
+    ).put()
+    bugs_query = osv.Bug.query(
+    ndb.OR(osv.Bug.upstream > '', osv.Bug.upstream < ''))
+
+    bugs = {}
+    for bug in bugs_query:
+      bugs[bug.db_id] = bug.upstream
+    bug_ids = upstream_computation._compute_upstream('VULN-4', bugs)
+    self.assertEqual(['VULN-1', 'VULN-3'], bug_ids)
+
+
+if __name__ == '__main__':
+  ds_emulator = tests.start_datastore_emulator()
+  try:
+    with ndb.Client().context() as context:
+      context.set_memcache_policy(False)
+      context.set_cache_policy(False)
+      logging.getLogger("UpstreamTest.test_compute_upstream").setLevel(
+          logging.DEBUG)
+      unittest.main()
+  finally:
+    tests.stop_emulator()


### PR DESCRIPTION
 This PR aims to prepare the models.py file to support the 'upstream' field to be introduced by https://github.com/ossf/osv-schema/pull/312.  Part of addressing #3052

This will calculate all of the transitive upstream dependencies of a given CVE. Hierarchy will be calculated and determined by the frontend in a later PR. 
