### PR TITLE
fix: importer not importing upstream values from sources 

### DIFF
--- a/osv/models.py
+++ b/osv/models.py
@@ -542,7 +542,7 @@ class Bug(ndb.Model):
 
     self.aliases = list(vulnerability.aliases)
     self.related = list(vulnerability.related)
-    self.upstream = list(vulnerability.upstream)
+    self.upstream_raw = list(vulnerability.upstream)
 
     self.affected_packages = []
     for affected_package in vulnerability.affected:


### PR DESCRIPTION
As the internal data store name for upstream from external sources is 'upstream_raw', it needs to be set properly when received from the sources.