### PR TITLE
fix(exporter): accept the current reality of run length

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/exporter.yaml
+++ b/deployment/clouddeploy/gke-workers/base/exporter.yaml
@@ -3,9 +3,9 @@ kind: CronJob
 metadata:
   name: exporter
   labels:
-    cronLastSuccessfulTimeMins: "90"
+    cronLastSuccessfulTimeMins: "180"
 spec:
-  schedule: "*/30 * * * *"
+  schedule: "*/60 * * * *"
   concurrencyPolicy: Forbid
   # If the previous job overruns by more than a minute,
   # Don't try to immediately queue up the next job

--- a/deployment/clouddeploy/gke-workers/base/exporter.yaml
+++ b/deployment/clouddeploy/gke-workers/base/exporter.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "180"
 spec:
-  schedule: "*/60 * * * *"
+  schedule: "*/30 * * * *"
   concurrencyPolicy: Forbid
   # If the previous job overruns by more than a minute,
   # Don't try to immediately queue up the next job


### PR DESCRIPTION
The exporter is reliably taking >50m to complete, based on recent runs.

This adjusts the monitoring accordingly.