### PR TITLE
fix(cron): added logging to differentiate alias vs upstream computation in cron

### DIFF
--- a/gcp/workers/alias/run_cron.sh
+++ b/gcp/workers/alias/run_cron.sh
@@ -12,6 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+echo "Starting alias computation"
 python3 ./alias_computation.py
+echo "Completed alias computation"
+
+echo "Starting upstream computation"
 python3 ./upstream_computation.py
+echo "Completed upstream computation"

--- a/gcp/workers/alias/run_cron.sh
+++ b/gcp/workers/alias/run_cron.sh
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 echo "Starting alias computation"
-python3 ./alias_computation.py
+python3 alias_computation.py
 echo "Completed alias computation"
 
 echo "Starting upstream computation"
-python3 ./upstream_computation.py
+python3 upstream_computation.py
 echo "Completed upstream computation"


### PR DESCRIPTION
Indicate when alias computation starts/ends and when upstream computation starts/ends