### PR TITLE
feat(exporter): add a safe_upload_single function

### DIFF
--- a/gcp/workers/exporter/export_runner.py
+++ b/gcp/workers/exporter/export_runner.py
@@ -24,7 +24,7 @@ import zipfile as z
 
 from google.cloud import ndb, storage
 
-from exporter import upload_single
+from exporter import safe_upload_single
 import osv
 import osv.logs
 
@@ -103,7 +103,7 @@ def aggregate_all_vulnerabilities(work_dir: str, export_bucket: str):
 
   storage_client = storage.Client()
   bucket = storage_client.get_bucket(export_bucket)
-  upload_single(bucket, output_zip, zip_file_name)
+  safe_upload_single(bucket, output_zip, zip_file_name)
   logging.info('Unified all.zip uploaded successfully.')
 
 

--- a/gcp/workers/exporter/exporter.py
+++ b/gcp/workers/exporter/exporter.py
@@ -31,6 +31,7 @@ import osv.logs
 DEFAULT_WORK_DIR = '/work'
 
 DEFAULT_EXPORT_BUCKET = 'osv-vulnerabilities'
+DEFAULT_SAFE_DELTA_PCT = 10
 _EXPORT_WORKERS = 32
 ECOSYSTEMS_FILE = 'ecosystems.txt'
 
@@ -154,7 +155,7 @@ def upload_single(bucket: Bucket, source_path: str, target_path: str):
 def safe_upload_single(bucket: Bucket,
                        source_path: str,
                        target_path: str,
-                       safe_delta_pct: int = 10):
+                       safe_delta_pct: int = DEFAULT_SAFE_DELTA_PCT):
   """Upload a single file to a GCS bucket, with a size check.
 
   This refuses to overwrite the GCS object if the file size difference is

--- a/osv/models.py
+++ b/osv/models.py
@@ -1046,4 +1046,6 @@ def get_related_async(bug_id: str) -> ndb.Future:
 @ndb.tasklet
 def get_upstream_async(bug_id: str) -> ndb.Future:
   """Gets upstream bugs asynchronously."""
-  return UpstreamGroup.query(UpstreamGroup.db_id == bug_id).get_async()
+  upstream_group = yield UpstreamGroup.query(
+      UpstreamGroup.db_id == bug_id).get_async()
+  return upstream_group

--- a/osv/models.py
+++ b/osv/models.py
@@ -542,7 +542,7 @@ class Bug(ndb.Model):
 
     self.aliases = list(vulnerability.aliases)
     self.related = list(vulnerability.related)
-    self.upstream = list(vulnerability.upstream)
+    self.upstream_raw = list(vulnerability.upstream)
 
     self.affected_packages = []
     for affected_package in vulnerability.affected:


### PR DESCRIPTION
This adds a file size delta function to prevent the unintended overwriting of a file with a significantly smaller one.

It only uses it for the unified all.zip upload at present, as I'm not sure how to identify when to use it for the ecosystem-specific zip files as they seem to be bundled in with the individual record files.