### PR TITLE
fix(exporter): correctly retrieve blob metadata

### DIFF
--- a/gcp/workers/exporter/exporter.py
+++ b/gcp/workers/exporter/exporter.py
@@ -177,8 +177,8 @@ def safe_upload_single(bucket: Bucket,
   source_size = os.stat(source_path).st_size
   logging.info('Uploading %s', target_path)
   try:
-    blob = bucket.blob(target_path)
-    if (source_size / blob.size) * 100 < safe_delta_pct:
+    blob = bucket.get_blob(target_path)
+    if blob.size and (source_size / blob.size) * 100 < safe_delta_pct:
       raise (Error(
           f'Cowardly refusing to overwrite {blob.name} ({blob.size} bytes) '
           f'with {source_path} ({source_size} bytes)'))


### PR DESCRIPTION
This fixes a bug in `safe_upload_single` where the existing blob metadata was not available for size calculation.

`bucket.blob()` is just a constructor, `bucket.get_blob()` actually retrieves the existing blob's metadata.