### PR TITLE
feat(test): add V8 advisory to test environment.

### DIFF
--- a/source_test.yaml
+++ b/source_test.yaml
@@ -425,6 +425,5 @@
   human_link: 'https://github.com/google/chromium-policy-vulnfeed/blob/main/advisories/V8-advisory.json'
   link: 'https://github.com/google/chromium-policy-vulnfeed/blob/main/advisories/V8-advisory.json'
   editable: False
-  key_path: 'OSV'
   repo_username: 'git'
   strict_validation: True

--- a/source_test.yaml
+++ b/source_test.yaml
@@ -418,12 +418,13 @@
   type: 0
   ignore_patterns: [ '^(?!V8-advisory).*$' ]
   repo_url: 'https://github.com/google/chromium-policy-vulnfeed.git'
-  detect_cherrypicks: False
+  detect_cherrypicks: True
   extension: '.json'
   db_prefix: ['V8-']
   ignore_git: False
-  human_link: 'https://github.com/google/chromium-policy-vulnfeed/blob/main/advisories/V8-advisory.json'
-  link: 'https://github.com/google/chromium-policy-vulnfeed/blob/main/advisories/V8-advisory.json'
+  human_link: 'https://github.com/google/chromium-policy-vulnfeed/blob/main/advisories/'
+  
+  link: 'https://github.com/google/chromium-policy-vulnfeed/blob/main/advisories/'
   editable: False
   repo_username: 'git'
   strict_validation: True

--- a/source_test.yaml
+++ b/source_test.yaml
@@ -413,3 +413,18 @@
   repo_username: 'git'
   strict_validation: True
 
+- name: 'V8'
+  versions_from_repo: True
+  type: 0
+  ignore_patterns: [ '^(?!V8-advisory).*$' ]
+  repo_url: 'https://github.com/google/chromium-policy-vulnfeed.git'
+  detect_cherrypicks: False
+  extension: '.json'
+  db_prefix: ['V8-']
+  ignore_git: False
+  human_link: 'https://github.com/google/chromium-policy-vulnfeed/blob/main/advisories/V8-advisory.json'
+  link: 'https://github.com/google/chromium-policy-vulnfeed/blob/main/advisories/V8-advisory.json'
+  editable: False
+  key_path: 'OSV'
+  repo_username: 'git'
+  strict_validation: True


### PR DESCRIPTION
Add V8 advisory to the test environment.

As per internal discussions, we are adding a V8 advisory to OSV.
The Chromium team has a [policy](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/security/updates.md) that states that direct embedders of Chromium packages such as V8 are responsible for using an up-to-date version of V8 packages. The definition of that is that the V8 package is at most one week old.

Since these types of packages do not have their own identifiers and therefore no advisory could be created, enforcement of such policies was not possible. We now created a synthetic advisory generator that takes such time-based policies and converts them into regularily updated advisories that OSV can read:
https://github.com/google/chromium-policy-vulnfeed/blob/main/advisories/V8-advisory.json