### PR TITLE
fix(vulnfeeds): correctly handle commit extraction for CPE-less CVE e…

### DIFF
--- a/vulnfeeds/cmd/nvd-cve-osv/main.go
+++ b/vulnfeeds/cmd/nvd-cve-osv/main.go
@@ -213,10 +213,10 @@ func ReposFromReferences(CVE string, cache VendorProductToRepoMap, vp *VendorPro
 		if slices.Contains(repos, repo) {
 			continue
 		}
-		// If the reference is a commit URL, the repo is inherently useful.
-		// If it's any other repo-shaped URL, it's only useful if it has tags.
+		// If the reference is a commit URL, the repo is inherently useful (but only if the repo still ultimately works).
 		_, err = cves.Commit(ref.Url)
-		if !git.ValidRepoAndHasUsableRefs(repo) && err != nil {
+		// If it's any other repo-shaped URL, it's only useful if it has tags.
+		if err != nil || !git.ValidRepo(repo) {
 			continue
 		}
 		repos = append(repos, repo)

--- a/vulnfeeds/cmd/nvd-cve-osv/main_test.go
+++ b/vulnfeeds/cmd/nvd-cve-osv/main_test.go
@@ -21,7 +21,7 @@ func TestReposFromReferences(t *testing.T) {
 		wantRepos []string
 	}{
 		{
-			name: "A CVE with a repo not already present in the VendorRepo cache (that happens to have no useful references)",
+			name: "A CVE with a repo not already present in the VendorRepo cache (that happens to have a useful commit and a repo that has no tags)",
 			args: args{
 				CVE:   "CVE-2023-0327",
 				cache: nil,
@@ -51,6 +51,23 @@ func TestReposFromReferences(t *testing.T) {
 				tagDenyList: RefTagDenyList,
 			},
 			wantRepos: []string(nil),
+		},
+		{
+			name: "A CVE with a cgit repo reference that does not work without transformation",
+			args: args{
+				CVE:   "CVE-2025-26519",
+				cache: nil,
+				vp:    nil,
+				refs: []cves.Reference{
+					{
+						Source: "cna@mitre.org",
+						Tags:   nil,
+						Url:    "https://git.musl-libc.org/cgit/musl/commit/?id=c47ad25ea3b484e10326f933e927c0bc8cded3da",
+					},
+				},
+				tagDenyList: RefTagDenyList,
+			},
+			wantRepos: []string{"https://git.musl-libc.org/git/musl"},
 		},
 	}
 	for _, tt := range tests {

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -385,6 +385,7 @@ func Repo(u string) (string, error) {
 
 		case "git.savannah.gnu.org":
 		case "git.savannah.nongnu.org":
+		case "git.musl-libc.org":
 			repo = strings.Replace(repo, "/cgit", "/git", 1)
 		}
 

--- a/vulnfeeds/git/repository_test.go
+++ b/vulnfeeds/git/repository_test.go
@@ -326,6 +326,11 @@ func TestValidRepo(t *testing.T) {
 			repoURL:        "https://github.com/shaturo1337/POCs",
 			expectedResult: false,
 		},
+		{
+			description:    "Unusable repo (without remapping) that seems to be slipping past",
+			repoURL:        "https://git.musl-libc.org/cgit/musl",
+			expectedResult: false,
+		},
 	}
 	for _, tc := range tests {
 		// This tests against Internet hosts and may have intermittent failures.


### PR DESCRIPTION
…dge cases

This fixes some edge cases:

- a CVE with no CPEs (and therefore no known repos)
- another cGit repo that requires rewriting to get a valid cloneable repo

Seen on CVE-2025-26519, where an invalid repo was being extracted, resulting in a record that does not successfully import.