### PR TITLE
fix(test): Fix V8 source link.

### DIFF
--- a/source_test.yaml
+++ b/source_test.yaml
@@ -424,8 +424,7 @@
   db_prefix: ['V8-']
   ignore_git: False
   human_link: 'https://github.com/google/chromium-policy-vulnfeed/blob/main/advisories/'
-  
-  link: 'https://github.com/google/chromium-policy-vulnfeed/blob/main/advisories/'
+  link: 'https://github.com/google/chromium-policy-vulnfeed/blob/main/'
   editable: False
   repo_username: 'git'
   strict_validation: True


### PR DESCRIPTION
I noticed that the import source link has "advisories" twice, which breaks the link. I suppose this is because it appends the whole path to the advisory file instead of just the file name, so I removed the advisories subfolder from the link field.

https://test.osv.dev/vulnerability/V8-FRESHNESS