### PR TITLE
feat: add Ubuntu LSN to staging instance

### DIFF
--- a/source_test.yaml
+++ b/source_test.yaml
@@ -382,6 +382,21 @@
   editable: False
   strict_validation: True
 
+- name: 'ubuntu-lsn'
+  versions_from_repo: False
+  type: 0
+  ignore_patterns: ['^(?!LSN-).*$']
+  directory_path: 'osv'
+  repo_url: 'https://github.com/canonical/ubuntu-security-notices.git'
+  detect_cherrypicks: False
+  extension: '.json'
+  db_prefix: ['LSN-']
+  ignore_git: False
+  human_link: 'https://ubuntu.com/security/notices/{{ BUG_ID }}'
+  link: 'https://github.com/canonical/ubuntu-security-notices/blob/main/'
+  editable: False
+  strict_validation: True
+
 - name: 'ubuntu-usn'
   versions_from_repo: False
   type: 0


### PR DESCRIPTION
add Ubuntu LSN to OSV with record prefix `UBUNTU-LSN`

Related: https://github.com/google/osv.dev/issues/3204