### PR TITLE
feat(worker): include vulnerability ID in more logs

### DIFF
--- a/gcp/workers/worker/worker.py
+++ b/gcp/workers/worker/worker.py
@@ -489,6 +489,7 @@ class TaskRunner:
   def _do_update(self, source_repo, repo, vulnerability, relative_path,
                  original_sha256):
     """Process updates on a vulnerability."""
+    _state.bug_id = vulnerability.id
     logging.info('Processing update for vulnerability %s', vulnerability.id)
     vulnerability = maybe_normalize_package_names(vulnerability)
     if source_repo.name == 'ghsa' and not fix_invalid_ghsa(vulnerability):


### PR DESCRIPTION
This commit includes the record's vulnerability ID in a structured log field for the worker's code path that imports updates to vulnerability records.

After reviewing the current logger behaviour, it was determined that the opportunity exists to add this existing structured log field in more places, to aid with tracing the path of a specific record through the worker.

This is intended to enable filtering logs emitted from `_do_update()` for a specific vulnerability ID by using `jsonPayload.bug_id`