### PR TITLE
fix(nvd-cve-osv): do not restart on failures

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/nvd-cve-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/nvd-cve-osv.yaml
@@ -31,7 +31,7 @@ spec:
                 value: /tmp
               - name: FIRST_INSCOPE_YEAR
                 value: "2016"
-          restartPolicy: OnFailure
+          restartPolicy: Never
           volumes:
             - name: "ssd"
               hostPath:


### PR DESCRIPTION
This job takes around 6h to complete on a good run, so restarting it multiple times just delays the next regularly scheduled run (which potentially already has a fix in it)