### PR TITLE
fix(importer): adjust GCS client to reduce HTTP connection exhaustion

### DIFF
--- a/gcp/workers/exporter/exporter.py
+++ b/gcp/workers/exporter/exporter.py
@@ -133,8 +133,7 @@ class Exporter:
     (including the zip file) are uploaded to the GCS bucket.
     """
     logging.info('Exporting vulnerabilities for ecosystem %s', ecosystem)
-    storage_client = storage.Client()
-    storage_client = modify_storage_client_adapters(storage_client)
+    storage_client = modify_storage_client_adapters(storage.Client())
     bucket = storage_client.get_bucket(self._export_bucket)
 
     ecosystem_dir = os.path.join(work_dir, ecosystem)


### PR DESCRIPTION
This uses the same technique as #3248 to increase the HTTP connection pool, retries and blocking behaviour on exhaustion for the GCS client used in the importer.

The importer (at least running in deletion mode) is experiencing the same exhaustion issues the exporter was, with lengthy increases in runtime.