### PR TITLE
fix(nvd-cve-osv): regression in reference repo extraction

### DIFF
--- a/vulnfeeds/cmd/nvd-cve-osv/main.go
+++ b/vulnfeeds/cmd/nvd-cve-osv/main.go
@@ -216,7 +216,7 @@ func ReposFromReferences(CVE string, cache VendorProductToRepoMap, vp *VendorPro
 		// If the reference is a commit URL, the repo is inherently useful (but only if the repo still ultimately works).
 		_, err = cves.Commit(ref.Url)
 		// If it's any other repo-shaped URL, it's only useful if it has tags.
-		if err != nil || !git.ValidRepo(repo) {
+		if (err == nil && !git.ValidRepo(repo)) || (err != nil && !git.ValidRepoAndHasUsableRefs(repo)) {
 			continue
 		}
 		repos = append(repos, repo)

--- a/vulnfeeds/cmd/nvd-cve-osv/main_test.go
+++ b/vulnfeeds/cmd/nvd-cve-osv/main_test.go
@@ -69,6 +69,23 @@ func TestReposFromReferences(t *testing.T) {
 			},
 			wantRepos: []string{"https://git.musl-libc.org/git/musl"},
 		},
+		{
+			name: "A CVE with a valid GitHub repo that stopped working",
+			args: args{
+				CVE:   "CVE-2016-10525",
+				cache: nil,
+				vp:    nil,
+				refs: []cves.Reference{
+					{
+						Source: "support@hackerone.com",
+						Tags:   []string{"Patch", "Third Party Advisory"},
+						Url:    "https://github.com/dwyl/hapi-auth-jwt2/issues/111",
+					},
+				},
+				tagDenyList: RefTagDenyList,
+			},
+			wantRepos: []string{"https://github.com/dwyl/hapi-auth-jwt2"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This fixes a logic error introduced in #3162

That previously was not correctly handling the independent scenarios of the reference containing an extractable commit hash OR the reference being derivable as a valid and usable repository, and was causing CVEs that previously had a valid and usable repository in a reference to no longer have that repository derived for it.