### PR TITLE
chore: log exception

### DIFF
--- a/osv/repos.py
+++ b/osv/repos.py
@@ -176,7 +176,7 @@ def ensure_updated_checkout(git_url,
       if isinstance(e, subprocess.CalledProcessError):
         # add the git output to the log
         err_str = f'{err_str}\n{e.stderr.decode()}'
-      logging.error('Failed to load existing checkout: %s', err_str)
+      logging.exception('Failed to load existing checkout: %s', err_str)
       shutil.rmtree(checkout_dir)
 
   repo = clone_with_retries(


### PR DESCRIPTION
This upgrades the logging to capture the entire exception to assist with future debugging.

Seeing
`Failed to load existing checkout: reference 'refs/heads/master' not found` being logged in conjunction with processing for the `ghsa` source, which seems nonsensical given there's no branch configured anywhere.