### PR TITLE
fix: use the amd64 python 3.12.8-slim digest

### DIFF
--- a/gcp/api/Dockerfile
+++ b/gcp/api/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.12.8-slim@sha256:143496c4e492ee45436fb1ac222714990b58a02f2eafe5eb2622b1427a8301c6
+FROM python:3.12.8-slim@sha256:8859bd6ca943079262c27e38b7119cdacede77c463139a15651dd340087a6cc9
 
 # Install build-essential which is required by Cloud Profiler
 RUN apt-get update && apt-get install -y build-essential

--- a/gcp/website/Dockerfile
+++ b/gcp/website/Dockerfile
@@ -23,7 +23,7 @@ RUN hugo --buildFuture -d ../dist/static/blog
 
 # OSV.dev site image
 # Adapted from https://cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-python-service#writing
-FROM python:3.12.8-slim@sha256:143496c4e492ee45436fb1ac222714990b58a02f2eafe5eb2622b1427a8301c6
+FROM python:3.12.8-slim@sha256:8859bd6ca943079262c27e38b7119cdacede77c463139a15651dd340087a6cc9
 
 # Generation 1 of cloud run overrides the HOME environment variable, causing
 # poetry to run in the incorrect environment, as it defaults to using $HOME/.cache/virtualenvs/...


### PR DESCRIPTION
This corrects the image digest hash to be the amd64 instead of i386 one, accidentally used in #3260