### PR TITLE
fix(source_sync): correct output for exceptions

### DIFF
--- a/tools/source-sync/source_sync.py
+++ b/tools/source-sync/source_sync.py
@@ -203,7 +203,7 @@ def main() -> None:
       print(f'Still in flight: {pprint.pformat(inflight, width=1)}')
       source = future_to_source[future]
       if exc := future.exception():
-        print(f"source['name'] raised {exc}")
+        print(f"{source['name']} raised {exc}")
       else:
         print(f"{source['name']} completed")
 


### PR DESCRIPTION
This fixes the f-string so the source name is emitted as intended