### PR TITLE
feat(api): update maven query method

### DIFF
--- a/osv/ecosystems/maven.py
+++ b/osv/ecosystems/maven.py
@@ -249,3 +249,7 @@ class Maven(DepsDevMixin):
     """Enumerate versions."""
     return self._deps_dev_enumerate(
         package, introduced, fixed, last_affected, limits=limits)
+
+  @property
+  def supports_comparing(self):
+    return True


### PR DESCRIPTION
Range matching gives more accurate results than only checking affected versions. In some cases, versions may fail to enumerate and cause false negative query results for users.

same as https://github.com/google/osv.dev/pull/2971