### PR TITLE
chore(vulnfeeds): resume tracking the latest google-cloud-cli image

### DIFF
--- a/vulnfeeds/cmd/alpine/Dockerfile
+++ b/vulnfeeds/cmd/alpine/Dockerfile
@@ -25,7 +25,7 @@ COPY ./ /src/
 RUN go build -o alpine-osv ./cmd/alpine/
 
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:485.0.0-alpine@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@sha256:5b9ce432f4f2230e7bfd02f51d6c97ec952456a6910c33c1542dc7cffbb80dcf
 
 WORKDIR /root/
 COPY --from=GO_BUILD /src/alpine-osv ./

--- a/vulnfeeds/cmd/combine-to-osv/Dockerfile
+++ b/vulnfeeds/cmd/combine-to-osv/Dockerfile
@@ -26,7 +26,7 @@ RUN go build -o combine-to-osv ./cmd/combine-to-osv/
 RUN go build -o download-cves ./cmd/download-cves/
 
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:485.0.0-alpine@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@sha256:5b9ce432f4f2230e7bfd02f51d6c97ec952456a6910c33c1542dc7cffbb80dcf
 RUN apk --no-cache add jq
 
 WORKDIR /root/

--- a/vulnfeeds/cmd/cpe-repo-gen/Dockerfile
+++ b/vulnfeeds/cmd/cpe-repo-gen/Dockerfile
@@ -24,7 +24,7 @@ RUN go mod download
 COPY ./ /src/
 RUN CGO_ENABLED=0 go build -o cpe-repo-gen ./cmd/cpe-repo-gen
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:485.0.0-alpine@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@sha256:5b9ce432f4f2230e7bfd02f51d6c97ec952456a6910c33c1542dc7cffbb80dcf
 
 COPY --from=GO_BUILD /src/cpe-repo-gen ./
 COPY ./cmd/cpe-repo-gen/cpe-repo-gen_map.sh ./

--- a/vulnfeeds/cmd/debian-copyright-mirror/Dockerfile
+++ b/vulnfeeds/cmd/debian-copyright-mirror/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:485.0.0-alpine@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@sha256:5b9ce432f4f2230e7bfd02f51d6c97ec952456a6910c33c1542dc7cffbb80dcf
 
 RUN apk add py3-yaml
 

--- a/vulnfeeds/cmd/debian/Dockerfile
+++ b/vulnfeeds/cmd/debian/Dockerfile
@@ -25,7 +25,7 @@ COPY ./ /src/
 RUN go build -o debian-osv ./cmd/debian/
 
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:485.0.0-alpine@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@sha256:5b9ce432f4f2230e7bfd02f51d6c97ec952456a6910c33c1542dc7cffbb80dcf
 
 WORKDIR /root/
 COPY --from=GO_BUILD /src/debian-osv ./

--- a/vulnfeeds/cmd/download-cves/Dockerfile
+++ b/vulnfeeds/cmd/download-cves/Dockerfile
@@ -24,7 +24,7 @@ RUN go mod download
 COPY ./ /src/
 RUN go build -o download-cves ./cmd/download-cves/
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:485.0.0-alpine@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@sha256:5b9ce432f4f2230e7bfd02f51d6c97ec952456a6910c33c1542dc7cffbb80dcf
 RUN apk --no-cache add jq
 
 WORKDIR /usr/local/bin

--- a/vulnfeeds/cmd/nvd-cve-osv/Dockerfile
+++ b/vulnfeeds/cmd/nvd-cve-osv/Dockerfile
@@ -22,7 +22,7 @@ RUN go mod download && go mod verify
 COPY . .
 RUN CGO_ENABLED=0 go build -v -o /usr/local/bin ./cmd/nvd-cve-osv ./cmd/download-cves
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:485.0.0-alpine@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@sha256:5b9ce432f4f2230e7bfd02f51d6c97ec952456a6910c33c1542dc7cffbb80dcf
 RUN apk --no-cache add jq
 
 COPY --from=GO_BUILD /usr/local/bin/ ./usr/local/bin/

--- a/vulnfeeds/tools/debian/Dockerfile
+++ b/vulnfeeds/tools/debian/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:485.0.0-alpine@sha256:d5da0344b23d03a6f2728657732c7a60300a91acaad9b8076c6fd30b1dfe1ff4
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine@sha256:5b9ce432f4f2230e7bfd02f51d6c97ec952456a6910c33c1542dc7cffbb80dcf
 
 # Setup Poetry in its own virtual environment.
 # So when poetry changes the system dependencies, it doesn't mess with its own dependencies


### PR DESCRIPTION
Returning to the generic `alpine` tag will enable Renovate to be able to upgrade this image periodically.

This pins to the current latest Alpine google-cloud-cli Docker image (515.0.0, from 2025-03-18).

We had previously pinned to 485.0.0 (from 2024-07-23), due to performance regressions between `gcloud storage rsync` versus `gsutil rsync`.

That version is:

- getting very old
- showing signs of bitrotting with newer Python runtimes
- potentially hiding deprecations that may surprise us

I believe we have re-converged back on `gsutil` for everything currently, and with the additional k8s CronJob monitoring now in place, we should pick up any future upgrades that introduce any new performance regressions.