### PR TITLE
chore(workflows): exempt autoclosing of backlog tagged PRs

### DIFF
--- a/.github/workflows/staleness.yml
+++ b/.github/workflows/staleness.yml
@@ -20,6 +20,7 @@ jobs:
           operations-per-run: 100
           remove-stale-when-updated: true
           exempt-issue-labels: "good first issue,backlog"
+          exempt-pr-labels: "backlog"
           exempt-all-assignees: true
           ignore-updates: false
           stale-issue-label: stale


### PR DESCRIPTION
This also treats `backlog` tagged PRs as exempt from auto-closure as stale, just like how issues are treated.