### PR TITLE
fix(exporter): increase CPU limit for exporter

### DIFF
--- a/.github/workflows/staleness.yml
+++ b/.github/workflows/staleness.yml
@@ -20,6 +20,7 @@ jobs:
           operations-per-run: 100
           remove-stale-when-updated: true
           exempt-issue-labels: "good first issue,backlog"
+          exempt-pr-labels: "backlog"
           exempt-all-assignees: true
           ignore-updates: false
           stale-issue-label: stale

--- a/deployment/clouddeploy/gke-workers/base/exporter.yaml
+++ b/deployment/clouddeploy/gke-workers/base/exporter.yaml
@@ -32,7 +32,7 @@ spec:
                 cpu: "6"
                 memory: "48G"
               limits:
-                cpu: "6"
+                cpu: "32"
                 memory: "128G"
           restartPolicy: OnFailure
           volumes:

--- a/deployment/clouddeploy/gke-workers/base/exporter.yaml
+++ b/deployment/clouddeploy/gke-workers/base/exporter.yaml
@@ -29,10 +29,10 @@ spec:
                 name: "ssd"
             resources:
               requests:
-                cpu: "6"
+                cpu: "12"
                 memory: "48G"
               limits:
-                cpu: "32"
+                cpu: "24"
                 memory: "128G"
           restartPolicy: OnFailure
           volumes:


### PR DESCRIPTION
I *think* the exporter is running into its CPU limit and getting evicted as a result, and the CPU limit seems to be unnecessarily low, given it's running on a highend node with 32 CPUs?