### PR TITLE
feat: Add go vanity metadata

### DIFF
--- a/gcp/website/frontend_handlers.py
+++ b/gcp/website/frontend_handlers.py
@@ -55,6 +55,8 @@ _VALID_VULN_ID = _WORD_CHARACTERS_OR_DASH_OR_COLON
 _BLOG_CONTENTS_DIR = 'blog'
 _DEPS_BASE_URL = 'https://deps.dev'
 _FIRST_CVSS_CALCULATOR_BASE_URL = 'https://www.first.org/cvss/calculator'
+_GO_VANITY_METADATA = '<meta name="go-import" content="osv.dev/bindings/go git https://github.com/google/osv.dev/bindings/go">'
+
 _ndb_client = ndb.Client()
 
 
@@ -123,6 +125,13 @@ def index_v2():
 def index_v2_with_subpath(subpath):
   return redirect('/' + subpath)
 
+
+@blueprint.route('/bindings/go')
+def go_bindings_vanity():
+  if request.args.get('go-get', 0) == 1:
+    return _GO_VANITY_METADATA
+
+  abort(404)
 
 @blueprint.route('/')
 def index():

--- a/gcp/website/frontend_handlers.py
+++ b/gcp/website/frontend_handlers.py
@@ -130,7 +130,7 @@ def index_v2_with_subpath(subpath):
 
 @blueprint.route('/bindings/go')
 def go_bindings_vanity():
-  if request.args.get('go-get', 0) == 1:
+  if request.args.get('go-get', 0) == '1':
     return _GO_VANITY_METADATA
 
   abort(404)
@@ -140,7 +140,7 @@ def go_bindings_vanity():
 @blueprint.route('/')
 def index():
   # Go will request the root url to make sure we own this domain
-  if request.args.get('go-get', 0) == 1:
+  if request.args.get('go-get', 0) == '1':
     return _GO_VANITY_METADATA
 
   return render_template(

--- a/gcp/website/frontend_handlers.py
+++ b/gcp/website/frontend_handlers.py
@@ -55,7 +55,9 @@ _VALID_VULN_ID = _WORD_CHARACTERS_OR_DASH_OR_COLON
 _BLOG_CONTENTS_DIR = 'blog'
 _DEPS_BASE_URL = 'https://deps.dev'
 _FIRST_CVSS_CALCULATOR_BASE_URL = 'https://www.first.org/cvss/calculator'
-_GO_VANITY_METADATA = '<meta name="go-import" content="osv.dev git https://github.com/google/osv.dev">'
+_GO_VANITY_METADATA = \
+  ('<meta name="go-import" '
+   'content="osv.dev git https://github.com/google/osv.dev">')
 
 _ndb_client = ndb.Client()
 
@@ -132,6 +134,7 @@ def go_bindings_vanity():
     return _GO_VANITY_METADATA
 
   abort(404)
+  return None
 
 
 @blueprint.route('/')

--- a/gcp/website/frontend_handlers.py
+++ b/gcp/website/frontend_handlers.py
@@ -133,6 +133,7 @@ def go_bindings_vanity():
 
   abort(404)
 
+
 @blueprint.route('/')
 def index():
   # Go will request the root url to make sure we own this domain

--- a/gcp/website/frontend_handlers.py
+++ b/gcp/website/frontend_handlers.py
@@ -55,7 +55,7 @@ _VALID_VULN_ID = _WORD_CHARACTERS_OR_DASH_OR_COLON
 _BLOG_CONTENTS_DIR = 'blog'
 _DEPS_BASE_URL = 'https://deps.dev'
 _FIRST_CVSS_CALCULATOR_BASE_URL = 'https://www.first.org/cvss/calculator'
-_GO_VANITY_METADATA = '<meta name="go-import" content="osv.dev/bindings/go git https://github.com/google/osv.dev/bindings/go">'
+_GO_VANITY_METADATA = '<meta name="go-import" content="osv.dev git https://github.com/google/osv.dev">'
 
 _ndb_client = ndb.Client()
 
@@ -135,6 +135,10 @@ def go_bindings_vanity():
 
 @blueprint.route('/')
 def index():
+  # Go will request the root url to make sure we own this domain
+  if request.args.get('go-get', 0) == 1:
+    return _GO_VANITY_METADATA
+
   return render_template(
       'home.html', ecosystem_counts=osv_get_ecosystem_counts_cached())
 


### PR DESCRIPTION
Add vanity URL metadata to return when go gets a package from osv.dev.

I think this is set up in a way where in the future we can also add osv-scanner to the vanity URL by putting it on a sub path.

Needs to be merged before #3299 for it to work.