### PR TITLE
chore(k8s): don't restart failing high-frequency CronJobs

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/alias-computation.yaml
+++ b/deployment/clouddeploy/gke-workers/base/alias-computation.yaml
@@ -17,9 +17,9 @@ spec:
             imagePullPolicy: Always
             resources:
               requests:
-                cpu: 1
+                cpu: "1"
                 memory: "3G"
               limits:
-                cpu: 1
+                cpu: "1"
                 memory: "4G"
-          restartPolicy: OnFailure
+          restartPolicy: Never

--- a/deployment/clouddeploy/gke-workers/base/alpine-cve-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/base/alpine-cve-convert.yaml
@@ -20,12 +20,12 @@ spec:
               privileged: true
             resources:
               requests:
-                cpu: 1
+                cpu: "1"
                 memory: "1G"
               limits:
-                cpu: 1
+                cpu: "1"
                 memory: "2G"
-          restartPolicy: OnFailure
+          restartPolicy: Never
           volumes:
             - name: "ssd"
               hostPath:

--- a/deployment/clouddeploy/gke-workers/base/backup.yaml
+++ b/deployment/clouddeploy/gke-workers/base/backup.yaml
@@ -18,9 +18,9 @@ spec:
             command: ["/usr/local/bin/backup/backup.py"]
             resources:
               requests:
-                cpu: 1
+                cpu: "1"
                 memory: "3G"
               limits:
-                cpu: 1
+                cpu: "1"
                 memory: "4G"
           restartPolicy: OnFailure

--- a/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
@@ -25,10 +25,10 @@ spec:
               privileged: true
             resources:
               requests:
-                cpu: 30
+                cpu: "30"
                 memory: "4G"
               limits:
-                cpu: 30
+                cpu: "30"
                 memory: "8G"
           nodeSelector:
             cloud.google.com/gke-nodepool: highend

--- a/deployment/clouddeploy/gke-workers/base/cpe-repo-gen.yaml
+++ b/deployment/clouddeploy/gke-workers/base/cpe-repo-gen.yaml
@@ -20,15 +20,15 @@ spec:
               privileged: true
             resources:
               requests:
-                cpu: 1
+                cpu: "1"
                 memory: "2G"
               limits:
-                cpu: 1
+                cpu: "1"
                 memory: "4G"
             env:
               - name: WORK_DIR
                 value: /scratch
-          restartPolicy: OnFailure
+          restartPolicy: Never
           volumes:
             - name: "ssd"
               hostPath:

--- a/deployment/clouddeploy/gke-workers/base/debian-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/base/debian-convert.yaml
@@ -25,12 +25,12 @@ spec:
               privileged: true
             resources:
               requests:
-                cpu: 1
+                cpu: "1"
                 memory: "1G"
               limits:
-                cpu: 1
+                cpu: "1"
                 memory: "2G"
-          restartPolicy: OnFailure
+          restartPolicy: Never
           volumes:
             - name: "ssd"
               hostPath:

--- a/deployment/clouddeploy/gke-workers/base/debian-copyright-mirror.yaml
+++ b/deployment/clouddeploy/gke-workers/base/debian-copyright-mirror.yaml
@@ -20,15 +20,15 @@ spec:
               privileged: true
             resources:
               requests:
-                cpu: 1
+                cpu: "1"
                 memory: "1G"
               limits:
-                cpu: 1
+                cpu: "1"
                 memory: "2G"
             env:
               - name: WORK_DIR
                 value: /scratch
-          restartPolicy: OnFailure
+          restartPolicy: Never
           volumes:
             - name: "ssd"
               hostPath:

--- a/deployment/clouddeploy/gke-workers/base/debian-cve-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/base/debian-cve-convert.yaml
@@ -20,12 +20,12 @@ spec:
               privileged: true
             resources:
               requests:
-                cpu: 1
+                cpu: "1"
                 memory: "1G"
               limits:
-                cpu: 1
+                cpu: "1"
                 memory: "2G"
-          restartPolicy: OnFailure
+          restartPolicy: Never
           volumes:
             - name: "ssd"
               hostPath:

--- a/deployment/clouddeploy/gke-workers/base/debian-first-version.yaml
+++ b/deployment/clouddeploy/gke-workers/base/debian-first-version.yaml
@@ -25,10 +25,10 @@ spec:
               privileged: true
             resources:
               requests:
-                cpu: 1
+                cpu: "1"
                 memory: "1G"
               limits:
-                cpu: 1
+                cpu: "1"
                 memory: "2G"
           restartPolicy: OnFailure
           volumes:

--- a/deployment/clouddeploy/gke-workers/base/exporter.yaml
+++ b/deployment/clouddeploy/gke-workers/base/exporter.yaml
@@ -34,7 +34,7 @@ spec:
               limits:
                 cpu: "24"
                 memory: "128G"
-          restartPolicy: OnFailure
+          restartPolicy: Never
           volumes:
             - name: "ssd"
               emptyDir:

--- a/deployment/clouddeploy/gke-workers/base/generate-sitemap.yaml
+++ b/deployment/clouddeploy/gke-workers/base/generate-sitemap.yaml
@@ -18,9 +18,9 @@ spec:
             command: ["/usr/local/bin/generate_sitemap/generate_and_upload.sh"]
             resources:
               requests:
-                cpu: 1
+                cpu: "1"
                 memory: "4G"
               limits:
-                cpu: 1
+                cpu: "1"
                 memory: "6G"
           restartPolicy: OnFailure

--- a/deployment/clouddeploy/gke-workers/base/importer-deleter.yaml
+++ b/deployment/clouddeploy/gke-workers/base/importer-deleter.yaml
@@ -22,12 +22,12 @@ spec:
               privileged: true
             resources:
               requests:
-                cpu: 1
+                cpu: "1"
                 memory: "10G"
               limits:
-                cpu: 1
+                cpu: "1"
                 memory: "11G"
-          restartPolicy: OnFailure
+          restartPolicy: Never
           volumes:
             - name: "ssd"
               hostPath:

--- a/deployment/clouddeploy/gke-workers/base/importer.yaml
+++ b/deployment/clouddeploy/gke-workers/base/importer.yaml
@@ -26,14 +26,14 @@ spec:
               privileged: true
             resources:
               requests:
-                cpu: 1
+                cpu: "1"
                 memory: "1G"
               limits:
-                cpu: 1
+                cpu: "1"
                 memory: "2G"
           nodeSelector:
             cloud.google.com/gke-nodepool: importer-pool
-          restartPolicy: OnFailure
+          restartPolicy: Never
           volumes:
             - name: "ssd"
               hostPath:

--- a/deployment/clouddeploy/gke-workers/base/nvd-cve-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/nvd-cve-osv.yaml
@@ -21,10 +21,10 @@ spec:
               privileged: true
             resources:
               requests:
-                cpu: 1
+                cpu: "1"
                 memory: "2G"
               limits:
-                cpu: 1
+                cpu: "1"
                 memory: "4G"
             env:
               - name: WORK_DIR


### PR DESCRIPTION
This adjusts the restart policy for high(ish) frequency CronJobs from `OnFailure` to `Never`

The thinking here is that restarting a failing pod with the exact same container image (and therefore build of the binary) is unlikely to be helpful in the cases where the problem is a runtime bug in that binary, and it just delays the next scheduled run of what is potentially a newer container image with a fix for the aforementioned bug (or possibly a different k8s specification).

If the problem is transient, the next scheduled run will be "soon enough" to be morally equivalent to just restarting the same pod.

And we have monitoring to still catch any longer-term crash looping that prevents a successful completion.

It also fixes a string quoting issue that the linter was complaining about