### PR TITLE
docs(nvd-cve-osv): how to do CSV-based analysis of conversion

### DIFF
--- a/vulnfeeds/cmd/nvd-cve-osv/README.md
+++ b/vulnfeeds/cmd/nvd-cve-osv/README.md
@@ -58,3 +58,56 @@ $ gcloud --project oss-vdb logging read --freshness=12h --format=json 'logName="
 2023 73.034
 2024 52.2844
 ```
+
+# Specific conversion treatment examination
+
+## Prerequisites
+
+- [Office Editing for Docs, Sheets & Slides](https://chromewebstore.google.com/detail/office-editing-for-docs-s/gbkeegbaiigmenfmjfclcdgdpimamgkj) (Please note: This extension is already installed on Chrome OS by default.)
+- [JSON Formatter](https://chromewebstore.google.com/detail/json-formatter/gpmodmeblccallcadopbcoeoejepgpnb) for easier viewing of JSON output
+
+## Process
+
+### Retrieve latest per-year-per-record CSV report
+
+1. Decide the year of NVD conversion data to review (2016 to the current year)
+1. Visit [https://storage.googleapis.com/cve-osv-conversion/index.html?prefix=parts/nvd/nvd-conversion-outcomes-$YEAR](https://storage.googleapis.com/cve-osv-conversion/index.html?prefix=parts/nvd/nvd-conversion-outcomes-$YEAR) (for production) or [https://storage.googleapis.com/osv-test-cve-osv-conversion/index.html?prefix=parts/nvd/nvd-conversion-outcomes-$YEAR](https://storage.googleapis.com/osv-test-cve-osv-conversion/index.html?prefix=parts/nvd/nvd-conversion-outcomes-$YEAR) (for staging) based on the desired environment (note that this removes the prefixes of the filenames, making them look a bit weird).
+1. Open the downloaded file. The CSV should open in a browser tab, but it’s not really a Google Sheet (yet)
+
+### Convert to a Google Sheet
+
+1. `File > Save as Google Sheets`
+1. At this point, it's now a bonafide Google Sheet in a new tab. You can close the previous tab.
+
+- Consider renaming the Google Sheet to remove the `parts_nvd_` prefix that was added by the magic of the `index.html` JavaScript from step #2 in the previous section.
+
+## Potential analyses
+
+### General conversion metrics
+
+- Create a pivot table to summarize a count of each outcome by outcome
+  - Add a Row for outcome, sorted descending by COUNTA of outcome
+  - Add a Values for outcome, summarized by COUNTA
+- Interpretation
+  - `Successful` is Successful
+  - In-scope (i.e. attempted): is `NoRepos` + `Successful` + `FixUnresolvable` + `NoRanges`
+
+### Record conversion failures with `NoRepos`
+
+- Manually review the CVE record (particularly the references) for canonical software Git repository indications
+- Manually review the existing [NVD CPE Dictionary](https://nvd.nist.gov/products/cpe) entry for canonical software Git repository indications
+- [Review the logs](https://cloudlogging.app.goo.gl/o5hZGnH3km33enzH7) for the latest run of `cpe-repo-gen` and filter by the CPE Vendor and Product concatenated with a colon, e.g. `gnu:glibc`
+
+### Record conversion failures with `NoRanges`
+
+- Manually review the CVE record (particularly the description) for version hints
+  - Desk check against the derived repository for resolvability to commits
+    - `git ls-remote -t` or reviewing the repo in a browser
+- Flag with the NVD (CVE Configuration Update Request) *and* the owning CNA
+  - If the NVD fixes it first, great
+  - If the CNA fixes it first, the update will trigger reeanalysis by the NVD
+
+### Record conversion failures with `FixUnresolvable`
+
+- Create a pivot table to look for any repository clustering that stands out
+  - Add **repos** to Rows (order descending, sorted by COUNTA of repos), summarize by COUNTA and filter on the `FixUnresolvable` outcome


### PR DESCRIPTION
This adds documentation on how to access the CSV reports for the latest conversion run from `nvd-cve-osv` and some possible analyses that can be performed on that data