### PR TITLE
fix: make importer-deleter cron schedule run only once within the hour

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/alpine-cve-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/base/alpine-cve-convert.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "180"
 spec:
-  schedule: "0 */1 * * *"
+  schedule: "0 * * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/combine-to-osv.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "90"
 spec:
-  schedule: "30 */1 * * *"
+  schedule: "30 * * * *"
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 3
   jobTemplate:

--- a/deployment/clouddeploy/gke-workers/base/cpe-repo-gen.yaml
+++ b/deployment/clouddeploy/gke-workers/base/cpe-repo-gen.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "2880"
 spec:
-  schedule: "0 6 */1 * *"
+  schedule: "0 6 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/deployment/clouddeploy/gke-workers/base/debian-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/base/debian-convert.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "180"
 spec:
-  schedule: "0 */1 * * *"
+  schedule: "0 * * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/deployment/clouddeploy/gke-workers/base/debian-copyright-mirror.yaml
+++ b/deployment/clouddeploy/gke-workers/base/debian-copyright-mirror.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "2880"
 spec:
-  schedule: "0 6 */1 * *"
+  schedule: "0 6 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/deployment/clouddeploy/gke-workers/base/debian-cve-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/base/debian-cve-convert.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "120"
 spec:
-  schedule: "0 */1 * * *"
+  schedule: "0 * * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/deployment/clouddeploy/gke-workers/base/importer-deleter.yaml
+++ b/deployment/clouddeploy/gke-workers/base/importer-deleter.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "360"
 spec:
-  schedule: "* */3 * * *"
+  schedule: "0 */3 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:


### PR DESCRIPTION
The `importer-deleter` had a cron schedule of `"* */3 * * *"`, so it was trying to run at every minute of each 3rd hour (`00:00`, `00:01`, `00:02`, ..., `00:59`, `03:00`, `03:01`, ...). Changed this to the intended once every three hours `"0 */3 * * *"`.

Also replaced `*/1` in our cron schedules with `*`, which means the same thing.