### PR TITLE
docs: Update osv-scanner install instructions on osv.dev to V2

### DIFF
--- a/gcp/website/frontend3/src/templates/home.html
+++ b/gcp/website/frontend3/src/templates/home.html
@@ -186,7 +186,7 @@
         <div class="code-card mdc-layout-grid__cell--span-6 mdc-layout-grid__cell--span-12-tablet">
           <h3 class="code-card-title">Install OSV&#8209;Scanner</h3>
           <pre class="code-card-content" id="example-scanner-install">
-go install github.com/google/osv-scanner/cmd/osv-scanner@v1
+go install github.com/google/osv-scanner/v2/cmd/osv-scanner@v2
           </pre>
           <clipboard-copy class="code-card-copy" for="example-scanner-install">
             <md-icon-button class="icon"><md-icon>content_copy</md-icon></md-icon-button>


### PR DESCRIPTION
Turns out we never updated the website to have v2 install instructions.