### PR TITLE
fix: analyze git commits from curl on test instance

### DIFF
--- a/source_test.yaml
+++ b/source_test.yaml
@@ -95,7 +95,7 @@
   detect_cherrypicks: False
   extension: '.json'
   db_prefix: ['CURL-']
-  ignore_git: True
+  ignore_git: False
   human_link: 'https://curl.se/docs/{{ BUG_ID | replace("CURL-", "") }}.html'
   link: 'https://curl.se/docs/'
   editable: False


### PR DESCRIPTION
Looking into #3353, testing analyzing these on the test instance.
I believe this requires a re-import of all the CURL records.