### PR TITLE
feat(frontend): Added weighted search results

### DIFF
--- a/gcp/website/frontend_handlers.py
+++ b/gcp/website/frontend_handlers.py
@@ -535,17 +535,21 @@ def osv_query(search_string, page, affected_only, ecosystem):
   bugs, _, _ = query.fetch_page(
       page_size=_PAGE_SIZE, offset=(page - 1) * _PAGE_SIZE)
 
+  # The following only works 100% as intended if all of these results appear in
+  # the first page
   if _VALID_VULN_ID.match(search_string):
     sorting_bugs = list(bugs)
+    # yapf: disable
     bugs = sorted(
         sorting_bugs,
         key=lambda bug: (
-            0 if bug.db_id == search_string else 1
-            if search_string in bug.aliases else 2
-            if search_string in bug.upstream_raw else 3
-            if search_string in bug.related else
+            0 if bug.db_id == search_string else
+            1 if search_string in bug.aliases else
+            2 if search_string in bug.upstream_raw else
+            3 if search_string in bug.related else
             4,  # Default priority for items not matching specific criteria
             -bug.timestamp.timestamp()))
+    # yapf: enable
   result_items = [bug_to_response(bug, detailed=False) for bug in bugs]
 
   results = {

--- a/gcp/website/frontend_handlers.py
+++ b/gcp/website/frontend_handlers.py
@@ -534,8 +534,19 @@ def osv_query(search_string, page, affected_only, ecosystem):
 
   bugs, _, _ = query.fetch_page(
       page_size=_PAGE_SIZE, offset=(page - 1) * _PAGE_SIZE)
-  for bug in bugs:
-    result_items.append(bug_to_response(bug, detailed=False))
+
+  if _VALID_VULN_ID.match(search_string):
+    sorting_bugs = list(bugs)
+    bugs = sorted(
+        sorting_bugs,
+        key=lambda bug: (
+            0 if bug.db_id == search_string else 1
+            if search_string in bug.aliases else 2
+            if search_string in bug.upstream_raw else 3
+            if search_string in bug.related else
+            4,  # Default priority for items not matching specific criteria
+            -bug.timestamp.timestamp()))
+  result_items = [bug_to_response(bug, detailed=False) for bug in bugs]
 
   results = {
       'total': total_future.get_result(),

--- a/osv/models.py
+++ b/osv/models.py
@@ -427,6 +427,8 @@ class Bug(ndb.Model):
     for alias in self.aliases:
       search_indices.update(self._tokenize(alias))
 
+    # Please note this will not include exhaustive transitive upstream
+    # so may not appear for all cases.
     for upstream in self.upstream_raw:
       search_indices.update(self._tokenize(upstream))
 


### PR DESCRIPTION
When a user searches for a specific vulnerability ID, that should be the first record that shows up, not just the most recently updated record. 

As such we added some extra ordering on record results: the ID given > alias of the ID > in the ID's downstream > related to the ID.

May need to add functionality in the future for also including the ID's upstreams. Unfortunately, this only works 100% as intended with one page of results. 