### PR TITLE
fix: cap the length of string values in query

### DIFF
--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -671,7 +671,13 @@ def estimate_diff(num_bucket_change: int, file_count_diff: int) -> int:
 def determine_version(version_query: osv_service_v1_pb2.VersionQuery,
                       _: grpc.ServicerContext) -> ndb.Future:
   """Identify fitting commits based on a subset of hashes"""
-  req_list = [osv.FileResult(hash=x.hash) for x in version_query.file_hashes]
+  logging.info("DetermineVersion for %d hashes", len(version_query.file_hashes))
+
+  req_list = []
+  for x in version_query.file_hashes:
+    if x.hash is not None and len(x.hash) <= 100:
+      # We are expecting MD5 hashes which should not be super long.
+      req_list.append(osv.FileResult(hash=x.hash))
 
   # Build all the buckets and query the bucket hash
   buckets = process_buckets(req_list)

--- a/gcp/website/frontend3/src/templates/list.html
+++ b/gcp/website/frontend3/src/templates/list.html
@@ -36,7 +36,7 @@
             <div class="mdc-layout-grid__inner">
               <div class="query-container mdc-layout-grid__cell--span-8">
                 <md-textfield-with-enter label="Package or ID search" class="query-field" type="search" name="q"
-                  value="{{ query }}">
+                  value="{{ query }}" maxlength="300">
                   <md-icon slot="leading-icon" aria-hidden="false">search</md-icon>
                 </md-textfield-with-enter>
               </div>

--- a/gcp/website/frontend_handlers.py
+++ b/gcp/website/frontend_handlers.py
@@ -512,7 +512,10 @@ def osv_query(search_string, page, affected_only, ecosystem):
   query: ndb.Query = osv.Bug.query(osv.Bug.status == osv.BugStatus.PROCESSED,
                                    osv.Bug.public == True)  # pylint: disable=singleton-comparison
 
-  if search_string:
+  if search_string and len(search_string) <= 300:
+    # Indexed value can only be 1500 bytes at most.
+    # The search string length is capped at 300 characters which should be
+    # enough for package names or bug IDs.
     query = query.filter(osv.Bug.search_indices == search_string.lower())
 
   if affected_only:

--- a/gcp/website/frontend_handlers.py
+++ b/gcp/website/frontend_handlers.py
@@ -514,8 +514,8 @@ def osv_query(search_string, page, affected_only, ecosystem):
 
   if search_string and len(search_string) <= 300:
     # Indexed value can only be 1500 bytes at most.
-    # The search string length is capped at 300 characters which should be
-    # enough for package names or bug IDs.
+    # The search string length is capped at 300 which should be enough for
+    # package names or bug IDs.
     query = query.filter(osv.Bug.search_indices == search_string.lower())
 
   if affected_only:


### PR DESCRIPTION
There are bad value errors reported for some queries:
```
BadValueError: Indexed value must be at most 1500 bytes
```

To fix this, this PR caps the length of the string value reported to a reasonable length. 