### PR TITLE
fix(frontend): issue #3087 Collapse tabs by default when > ~7 affected packages

### DIFF
--- a/gcp/website/frontend3/src/templates/vulnerability.html
+++ b/gcp/website/frontend3/src/templates/vulnerability.html
@@ -170,8 +170,9 @@
   </div>
   <div class="vulnerability-packages-container">
     <h2 class="title">Affected packages</h2>
+    {% set collapse_threshold = 7 %}  
     <spicy-sections
-      class="vulnerability-packages{% if vulnerability.affected|should_collapse %} force-collapse{% endif %}">
+    class="vulnerability-packages{% if vulnerability.affected|length > collapse_threshold or vulnerability.affected|should_collapse %} force-collapse{% endif %}">
       {% for affected in vulnerability.affected -%}
       {% if 'package' in affected %}
       {% set ecosystem = affected.package.ecosystem %}


### PR DESCRIPTION
This PR introduces a dynamic collapse feature for the "Affected Packages" section. If the number of affected packages exceeds a predefined threshold (currently set to 7), the section will automatically collapse to enhance readability.

**Changes Implemented:**

- Defined a **collapse_threshold** variable set to 7.

- Updated the **spicy-sections** component to conditionally add the **force-collapse** class when the number of affected packages exceeds the threshold.

Displaying a large list of affected packages can overwhelm users. By introducing a collapse mechanism, we aim to provide a cleaner interface, allowing users to expand the section if they wish to view all affected packages.