### PR TITLE
fix: fatally error if NVD API returns less total results

### DIFF
--- a/vulnfeeds/cmd/download-cves/main.go
+++ b/vulnfeeds/cmd/download-cves/main.go
@@ -118,11 +118,16 @@ func downloadCVE2(APIKey string, CVEPath string) {
 	var vulnerabilities []cves.Vulnerability
 	page := &cves.CVEAPIJSON20Schema{}
 	offset := 0
+	prevTotal := 0
 	for {
 		page, err = downloadCVE2WithOffset(APIKey, offset)
 		if err != nil {
 			Logger.Fatalf("Failed to download at offset %d: %+v", offset, err)
 		}
+		if page.TotalResults < prevTotal {
+			Logger.Fatalf("TotalResults decreased from %d to %d", prevTotal, page.TotalResults)
+		}
+		prevTotal = page.TotalResults
 		vulnerabilities = append(vulnerabilities, page.Vulnerabilities...)
 		offset += PageSize
 		if offset > page.TotalResults {


### PR DESCRIPTION
Found this oddity in our logs:
```
INFO 2025-04-23T14:10:28.514799134Z Retrieved offset 118000 of 291146 total results
WARNING 2025-04-23T14:10:35.258238369Z Bad response for "https://services.nvd.nist.gov/rest/json/cves/2.0?startIndex=120000": "500 ", retrying
INFO 2025-04-23T14:10:41.302392482Z Retrieved offset 120000 of 770 total results
```
The NVD API returned many missing results, meaning we exit early. This propagates through our jobs and eventually makes us attempt to delete many CVE records.

As a simple fix, just error if the total number of results reduces during the nvd-mirror run, which should make the cron job fail and restart.