### PR TITLE
fix: temporarily disable some flaky tests

### DIFF
--- a/vulnfeeds/cves/versions_test.go
+++ b/vulnfeeds/cves/versions_test.go
@@ -513,9 +513,10 @@ func TestExtractGitCommit(t *testing.T) {
 			expectFailure:   true,
 		},
 		{
-			description:     "Valid GitHub commit URL with .patch extension",
-			inputLink:       "https://github.com/pimcore/customer-data-framework/commit/e3f333391582d9309115e6b94e875367d0ea7163.patch",
-			inputCommitType: Fixed,
+			description:       "Valid GitHub commit URL with .patch extension",
+			disableExpiryDate: time.Date(2025, 6, 1, 0, 0, 0, 0, time.Local),
+			inputLink:         "https://github.com/pimcore/customer-data-framework/commit/e3f333391582d9309115e6b94e875367d0ea7163.patch",
+			inputCommitType:   Fixed,
 			expectedAffectedCommit: AffectedCommit{
 				Repo:  "https://github.com/pimcore/customer-data-framework",
 				Fixed: "e3f333391582d9309115e6b94e875367d0ea7163",

--- a/vulnfeeds/cves/versions_test.go
+++ b/vulnfeeds/cves/versions_test.go
@@ -877,6 +877,7 @@ func TestExtractVersionInfo(t *testing.T) {
 		},
 		{
 			description:        "A CVE with fix commits in references and CPE match info",
+			disableExpiryDate:  time.Date(2025, 6, 1, 0, 0, 0, 0, time.Local),
 			inputCVEItem:       loadTestData2("CVE-2022-25929"),
 			inputValidVersions: []string{},
 			expectedVersionInfo: VersionInfo{
@@ -898,6 +899,7 @@ func TestExtractVersionInfo(t *testing.T) {
 		},
 		{
 			description:        "A CVE with fix commits in references and (more complex) CPE match info",
+			disableExpiryDate:  time.Date(2025, 6, 1, 0, 0, 0, 0, time.Local),
 			inputCVEItem:       loadTestData2("CVE-2022-29194"),
 			inputValidVersions: []string{},
 			expectedVersionInfo: VersionInfo{


### PR DESCRIPTION
These vulnfeeds tests have been inconsistently failing. I've temporarily skipped these until June so we don't block other PRs.
I think there's some rate limiting going on with GitHub. but I'm not sure what the long-term fix is for this.