### PR TITLE
fix(workers): bump memory limits on alias/upstream cron

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/alias-computation.yaml
+++ b/deployment/clouddeploy/gke-workers/base/alias-computation.yaml
@@ -18,8 +18,8 @@ spec:
             resources:
               requests:
                 cpu: "1"
-                memory: "3G"
+                memory: "16G"
               limits:
                 cpu: "1"
-                memory: "4G"
+                memory: "32G"
           restartPolicy: Never

--- a/deployment/clouddeploy/gke-workers/base/alias-computation.yaml
+++ b/deployment/clouddeploy/gke-workers/base/alias-computation.yaml
@@ -18,8 +18,8 @@ spec:
             resources:
               requests:
                 cpu: "1"
-                memory: "16G"
+                memory: "10G"
               limits:
                 cpu: "1"
-                memory: "32G"
+                memory: "13G"
           restartPolicy: Never


### PR DESCRIPTION
The upstream computation was being killed for using too much memory.

(For some reason, GKE does not consider this a failed cron...)