### PR TITLE
feat: add MinimOS ecosystem helper

### DIFF
--- a/osv/ecosystems/_ecosystems.py
+++ b/osv/ecosystems/_ecosystems.py
@@ -26,6 +26,7 @@ from .debian import Debian
 from .haskell import Hackage, GHC
 from .mageia import Mageia
 from .maven import Maven
+from .minimos import MinimOS
 from .nuget import NuGet
 from .packagist import Packagist
 from .pub import Pub
@@ -53,6 +54,7 @@ _ecosystems = {
     'GHC': GHC(),
     'Hackage': Hackage(),
     'Maven': Maven(),
+    'MinimOS': MinimOS(),
     'NuGet': NuGet(),
     'Packagist': Packagist(),
     'Pub': Pub(),

--- a/osv/ecosystems/minimos.py
+++ b/osv/ecosystems/minimos.py
@@ -1,0 +1,42 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""MinimOS ecosystem helper."""
+
+from ..third_party.univers.alpine import AlpineLinuxVersion
+
+from .helper_base import Ecosystem
+
+
+class MinimOS(Ecosystem):
+  """MinimOS packages ecosystem"""
+
+  def sort_key(self, version):
+    # MinimOS uses `apk` package format
+    if not AlpineLinuxVersion.is_valid(version):
+      # If version is not valid, it is most likely an invalid input
+      # version then sort it to the last/largest element
+      return AlpineLinuxVersion('999999')
+    return AlpineLinuxVersion(version)
+
+  def enumerate_versions(self,
+                         package,
+                         introduced,
+                         fixed=None,
+                         last_affected=None,
+                         limits=None):
+    raise NotImplementedError('Ecosystem helper does not support enumeration')
+
+  @property
+  def supports_comparing(self):
+    return True

--- a/osv/ecosystems/minimos_test.py
+++ b/osv/ecosystems/minimos_test.py
@@ -32,6 +32,6 @@ class MinimOSEcosystemTest(unittest.TestCase):
     self.assertGreater(
         ecosystem.sort_key('invalid'), ecosystem.sort_key('1.4.0-r0'))
     self.assertGreater(
-      ecosystem.sort_key('13.0.14.5-r1'), ecosystem.sort_key('7.64.3-r2'))
+        ecosystem.sort_key('13.0.14.5-r1'), ecosystem.sort_key('7.64.3-r2'))
     self.assertLess(
-      ecosystem.sort_key('13.0.14.5-r1'), ecosystem.sort_key('16.6-r0'))
+        ecosystem.sort_key('13.0.14.5-r1'), ecosystem.sort_key('16.6-r0'))

--- a/osv/ecosystems/minimos_test.py
+++ b/osv/ecosystems/minimos_test.py
@@ -1,0 +1,37 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""MinimOS ecosystem helper tests."""
+
+import unittest
+from .. import ecosystems
+
+
+class MinimOSEcosystemTest(unittest.TestCase):
+  """MinimOS ecosystem helper tests."""
+
+  def test_minimos(self):
+    """Test sort_key"""
+    ecosystem = ecosystems.get('MinimOS')
+    self.assertGreater(
+        ecosystem.sort_key('38.52.0-r0'), ecosystem.sort_key('37.52.0-r0'))
+    self.assertLess(ecosystem.sort_key('453'), ecosystem.sort_key('453-r1'))
+    self.assertGreater(ecosystem.sort_key('5.4.13-r1'), ecosystem.sort_key('0'))
+    self.assertGreater(
+        ecosystem.sort_key('1.4.0-r1'), ecosystem.sort_key('1.4.0-r0'))
+    self.assertGreater(
+        ecosystem.sort_key('invalid'), ecosystem.sort_key('1.4.0-r0'))
+    self.assertGreater(
+      ecosystem.sort_key('13.0.14.5-r1'), ecosystem.sort_key('7.64.3-r2'))
+    self.assertLess(
+      ecosystem.sort_key('13.0.14.5-r1'), ecosystem.sort_key('16.6-r0'))


### PR DESCRIPTION
ref: #3400 
Adding a ecosystem helper for the new `MinimOS` ecosystem, which appears to use standard APK-based versioning.
This is identical to the `Wolfi`/`Chainguard` helpers.

Also updated the osvschema submodule to pick up the `MinimOS` ecosystem.