### PR TITLE
fix(integration-tests): Update integration_tests.py

### DIFF
--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -632,7 +632,7 @@ class IntegrationTests(unittest.TestCase,
     response = requests.post(
         _api() + _BASE_QUERY,
         data=json.dumps({
-            'version': '1.1.1',
+            'version': '1.2.1',
             'package': {
                 'name': package,
                 'ecosystem': ecosystem,


### PR DESCRIPTION
A vuln appeared in the range for which a test assumed there would be no vulns. This should put it back into the range of non-existence.