### PR TITLE
test: split Cloud Build tests into multiple builds

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,2 @@
+# worker tests rely on this dir being a git repo
+!gcp/workers/worker/osv-test/.git

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,29 +13,33 @@
 # limitations under the License.
 
 steps:
+- name: 'gcr.io/cloud-builders/git'
+  id: 'init'
+  args: ['submodule', 'update', '--init']
+
 - name: 'gcr.io/cloud-builders/gcloud'
   id: 'lib-tests'
   args: ['builds', 'submit', '--region=${LOCATION}', '--config=osv/cloudbuild.yaml', '.']
-  waitFor: ['-']
+  waitFor: ['init']
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: 'worker-tests'
   args: ['builds', 'submit', '--region=${LOCATION}', '--config=gcp/workers/cloudbuild.yaml', '.']
-  waitFor: ['-']
+  waitFor: ['init']
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: 'website-tests'
   args: ['builds', 'submit', '--region=${LOCATION}', '--config=gcp/website/cloudbuild.yaml', '.']
-  waitFor: ['-']
+  waitFor: ['init']
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: 'api-tests'
   args: ['builds', 'submit', '--region=${LOCATION}', '--config=gcp/api/cloudbuild.yaml', '.']
-  waitFor: ['-']
+  waitFor: ['init']
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: 'vulnfeeds-tests'
   args: ['builds', 'submit', '--region=${LOCATION}', '--config=vulnfeeds/cloudbuild.yaml', '.']
-  waitFor: ['-']
+  waitFor: ['init']
 
 timeout: 7200s

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,90 +13,29 @@
 # limitations under the License.
 
 steps:
-# noop to pull the ci image once before the tests try to run concurrently
-- name: 'gcr.io/oss-vdb/ci'
-  args: ['echo']
-
-- name: 'gcr.io/cloud-builders/git'
-  id: 'init'
-  args: ['submodule', 'update', '--init']
-
-- name: 'gcr.io/oss-vdb/ci'
+- name: 'gcr.io/cloud-builders/gcloud'
   id: 'lib-tests'
-  args: ['bash', '-ex', 'run_tests.sh']
-  env:
-    # Each concurrent test that uses the datastore emulator must have a unique port number
-    # lib-tests is the first test that starts the emulator. The first emulator call creates the
-    # test project config. Every other datastore must wait till this finishes, otherwise
-    # we risk multiple attempts at creating the config directory, causing failure.
-    - DATASTORE_EMULATOR_PORT=8002
-  waitFor: ['init']
+  args: ['builds', 'submit', '--region=${LOCATION}', '--config=osv/cloudbuild.yaml', '.']
+  waitFor: []
 
-# Sourcerepo-sync-tests and lib-tests use the same env so have a race condition. 
-- name: 'gcr.io/oss-vdb/ci'
-  id: 'sourcerepo-sync-tests'
-  dir: 'tools/sourcerepo-sync'
-  args: ['bash', '-ex', 'run_tests.sh']
-  waitFor: ['init', 'lib-tests']
-
-- name: 'gcr.io/oss-vdb/ci'
+- name: 'gcr.io/cloud-builders/gcloud'
   id: 'worker-tests'
-  dir: gcp/workers/worker
-  args: ['bash', '-ex', 'run_tests.sh']
-  env:
-    # Each concurrent test that uses the datastore emulator must have a unique port number
-    # Wait for lib-tests to make sure the project directory is created
-    - DATASTORE_EMULATOR_PORT=8003
-  waitFor: ['init', 'lib-tests']
+  args: ['builds', 'submit', '--region=${LOCATION}', '--config=gcp/workers/cloudbuild.yaml', '.']
+  waitFor: []
 
-- name: 'gcr.io/oss-vdb/ci'
-  id: 'importer-tests'
-  dir: gcp/workers/importer
-  args: ['bash', '-ex', 'run_tests.sh']
-  env:
-    - CLOUD_BUILD=1
-    # same as worker
-    - DATASTORE_EMULATOR_PORT=8003
-  # importer uses same poetry as worker, 'poetry install' may break if run concurrently
-  waitFor: ['init', 'worker-tests']
-
-- name: 'gcr.io/oss-vdb/ci'
-  id: 'alias-tests'
-  dir: gcp/workers/alias
-  args: ['bash', '-ex', 'run_tests.sh']
-  env:
-    # same as worker/importer
-    - DATASTORE_EMULATOR_PORT=8003
-  # alias uses same poetry as worker, 'poetry install' may break if run concurrently
-  waitFor: ['init', 'importer-tests']
-
-- name: 'gcr.io/oss-vdb/ci'
+- name: 'gcr.io/cloud-builders/gcloud'
   id: 'website-tests'
-  dir: gcp/website
-  args: ['bash', '-ex', 'run_tests.sh']
-  env:
-    # Each concurrent test that uses the datastore emulator must have a unique port number
-    # Wait for lib-tests to make sure the project directory is created
-    - DATASTORE_EMULATOR_PORT=8004
-  waitFor: ['init', 'lib-tests']
+  args: ['builds', 'submit', '--region=${LOCATION}', '--config=gcp/website/cloudbuild.yaml', '.']
+  waitFor: []
 
-- name: 'gcr.io/oss-vdb/ci'
-  id: 'vulnfeed-tests'
-  dir: vulnfeeds
-  args: ['bash', '-ex', 'run_tests.sh']
-  env:
-    - 'BUILD_ID=$BUILD_ID'
-  waitFor: ['init']
-
-- name: 'gcr.io/oss-vdb/ci'
+- name: 'gcr.io/cloud-builders/gcloud'
   id: 'api-tests'
-  dir: gcp/api
-  #TODO: Update test scripts to support not supplying a credential.
-  args: ['bash', '-ex', 'run_tests.sh', '/workspace/dummy.json']
-  env:
-    - CLOUDBUILD=1
-  waitFor: ['init']
+  args: ['builds', 'submit', '--region=${LOCATION}', '--config=gcp/api/cloudbuild.yaml', '.']
+  waitFor: []
+
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: 'vulnfeeds-tests'
+  args: ['builds', 'submit', '--region=${LOCATION}', '--config=vulnfeeds/cloudbuild.yaml', '.']
+  waitFor: []
 
 timeout: 7200s
-options:
-  machineType: E2_HIGHCPU_8

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,26 +16,26 @@ steps:
 - name: 'gcr.io/cloud-builders/gcloud'
   id: 'lib-tests'
   args: ['builds', 'submit', '--region=${LOCATION}', '--config=osv/cloudbuild.yaml', '.']
-  waitFor: []
+  waitFor: ['-']
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: 'worker-tests'
   args: ['builds', 'submit', '--region=${LOCATION}', '--config=gcp/workers/cloudbuild.yaml', '.']
-  waitFor: []
+  waitFor: ['-']
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: 'website-tests'
   args: ['builds', 'submit', '--region=${LOCATION}', '--config=gcp/website/cloudbuild.yaml', '.']
-  waitFor: []
+  waitFor: ['-']
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: 'api-tests'
   args: ['builds', 'submit', '--region=${LOCATION}', '--config=gcp/api/cloudbuild.yaml', '.']
-  waitFor: []
+  waitFor: ['-']
 
 - name: 'gcr.io/cloud-builders/gcloud'
   id: 'vulnfeeds-tests'
   args: ['builds', 'submit', '--region=${LOCATION}', '--config=vulnfeeds/cloudbuild.yaml', '.']
-  waitFor: []
+  waitFor: ['-']
 
 timeout: 7200s

--- a/gcp/api/cloudbuild.yaml
+++ b/gcp/api/cloudbuild.yaml
@@ -25,6 +25,9 @@ steps:
 - name: 'gcr.io/cloud-builders/git'
   id: 'init'
   args: ['submodule', 'update', '--init']
+  # if this is invoked from another cloud build, this will fail as it is not a git repo
+  # the invoking cloud build file should run this step.
+  allowFailure: true
 - name: 'gcr.io/oss-vdb/ci'
   id: 'sync'
   dir: gcp/api

--- a/gcp/api/cloudbuild.yaml
+++ b/gcp/api/cloudbuild.yaml
@@ -12,25 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# vulnfeeds test runner
+# api test runner
 # This should be triggered on changes to the following:
-# vulnfeeds/go.mod
-# vulnfeeds/go.sum
-# vulnfeeds/run_tests.sh
-# vulnfeeds/*.go
-# vulnfeeds/**/*.go
+# gcp/api/poetry.lock
+# gcp/api/run_tests.sh
+# gcp/api/*.py
+# gcp/api/**/*.py
+# osv/*.py
+# osv/**/*.py
 
 steps:
 - name: 'gcr.io/cloud-builders/git'
   id: 'init'
   args: ['submodule', 'update', '--init']
+- name: 'gcr.io/oss-vdb/ci'
+  id: 'sync'
+  dir: gcp/api
+  args: ['poetry', 'sync']
 
 - name: 'gcr.io/oss-vdb/ci'
-  id: 'vulnfeed-tests'
-  dir: vulnfeeds
-  args: ['bash', '-ex', 'run_tests.sh']
+  id: 'api-tests'
+  dir: gcp/api
+  #TODO: Update test scripts to support not supplying a credential.
+  args: ['bash', '-ex', 'run_tests.sh', '/workspace/dummy.json']
   env:
-    - 'BUILD_ID=$BUILD_ID'
-  waitFor: ['init']
+    - CLOUDBUILD=1
+  waitFor: ['init', 'sync']
 
 timeout: 7200s

--- a/gcp/api/cloudbuild.yaml
+++ b/gcp/api/cloudbuild.yaml
@@ -32,6 +32,7 @@ steps:
   id: 'sync'
   dir: gcp/api
   args: ['poetry', 'sync']
+  waitFor: ['-']
 
 - name: 'gcr.io/oss-vdb/ci'
   id: 'api-tests'

--- a/gcp/website/cloudbuild.yaml
+++ b/gcp/website/cloudbuild.yaml
@@ -32,6 +32,7 @@ steps:
   id: 'sync'
   dir: gcp/website
   args: ['poetry', 'sync']
+  waitFor: ['-']
 
 - name: 'gcr.io/oss-vdb/ci'
   id: 'website-tests'

--- a/gcp/website/cloudbuild.yaml
+++ b/gcp/website/cloudbuild.yaml
@@ -12,25 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# vulnfeeds test runner
+# website test runner
 # This should be triggered on changes to the following:
-# vulnfeeds/go.mod
-# vulnfeeds/go.sum
-# vulnfeeds/run_tests.sh
-# vulnfeeds/*.go
-# vulnfeeds/**/*.go
+# gcp/website/poetry.lock
+# gcp/website/run_tests.sh
+# gcp/website/*.py
+# gcp/website/**/*.py
+# osv/*.py
+# osv/**/*.py
 
 steps:
 - name: 'gcr.io/cloud-builders/git'
   id: 'init'
   args: ['submodule', 'update', '--init']
+- name: 'gcr.io/oss-vdb/ci'
+  id: 'sync'
+  dir: gcp/website
+  args: ['poetry', 'sync']
 
 - name: 'gcr.io/oss-vdb/ci'
-  id: 'vulnfeed-tests'
-  dir: vulnfeeds
+  id: 'website-tests'
+  dir: gcp/website
   args: ['bash', '-ex', 'run_tests.sh']
   env:
-    - 'BUILD_ID=$BUILD_ID'
-  waitFor: ['init']
+    # Each concurrent test that uses the datastore emulator must have a unique port number
+    - DATASTORE_EMULATOR_PORT=8004
+  waitFor: ['init', 'sync']
 
 timeout: 7200s

--- a/gcp/website/cloudbuild.yaml
+++ b/gcp/website/cloudbuild.yaml
@@ -25,6 +25,9 @@ steps:
 - name: 'gcr.io/cloud-builders/git'
   id: 'init'
   args: ['submodule', 'update', '--init']
+  # if this is invoked from another cloud build, this will fail as it is not a git repo
+  # the invoking cloud build file should run this step.
+  allowFailure: true
 - name: 'gcr.io/oss-vdb/ci'
   id: 'sync'
   dir: gcp/website

--- a/gcp/workers/cloudbuild.yaml
+++ b/gcp/workers/cloudbuild.yaml
@@ -31,6 +31,7 @@ steps:
   id: 'sync'
   dir: gcp/workers/worker
   args: ['poetry', 'sync']
+  waitFor: ['-']
 
 - name: 'gcr.io/oss-vdb/ci'
   id: 'worker-tests'

--- a/gcp/workers/cloudbuild.yaml
+++ b/gcp/workers/cloudbuild.yaml
@@ -24,6 +24,9 @@ steps:
 - name: 'gcr.io/cloud-builders/git'
   id: 'init'
   args: ['submodule', 'update', '--init']
+  # if this is invoked from another cloud build, this will fail as it is not a git repo
+  # the invoking cloud build file should run this step.
+  allowFailure: true
 - name: 'gcr.io/oss-vdb/ci'
   id: 'sync'
   dir: gcp/workers/worker

--- a/gcp/workers/cloudbuild.yaml
+++ b/gcp/workers/cloudbuild.yaml
@@ -1,0 +1,60 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# workers test runner
+# This should be triggered on changes to the following:
+# gcp/workers/worker/poetry.lock
+# gcp/workers/**/run_tests.sh
+# gcp/workers/**/*.py
+# osv/*.py
+# osv/**/*.py
+
+steps:
+- name: 'gcr.io/cloud-builders/git'
+  id: 'init'
+  args: ['submodule', 'update', '--init']
+- name: 'gcr.io/oss-vdb/ci'
+  id: 'sync'
+  dir: gcp/workers/worker
+  args: ['poetry', 'sync']
+
+- name: 'gcr.io/oss-vdb/ci'
+  id: 'worker-tests'
+  dir: gcp/workers/worker
+  args: ['bash', '-ex', 'run_tests.sh']
+  env:
+    # Each concurrent test that uses the datastore emulator must have a unique port number
+    - DATASTORE_EMULATOR_PORT=8003
+  waitFor: ['init', 'sync']
+
+- name: 'gcr.io/oss-vdb/ci'
+  id: 'importer-tests'
+  dir: gcp/workers/importer
+  args: ['bash', '-ex', 'run_tests.sh']
+  env:
+    - CLOUD_BUILD=1
+    - DATASTORE_EMULATOR_PORT=8004
+  waitFor: ['init', 'sync']
+
+- name: 'gcr.io/oss-vdb/ci'
+  id: 'alias-tests'
+  dir: gcp/workers/alias
+  args: ['bash', '-ex', 'run_tests.sh']
+  env:
+    - DATASTORE_EMULATOR_PORT=8002
+  waitFor: ['init', 'sync']
+
+timeout: 7200s
+options:
+  machineType: E2_HIGHCPU_8

--- a/gcp/workers/worker/.gcloudignore
+++ b/gcp/workers/worker/.gcloudignore
@@ -1,1 +1,0 @@
-!osv-test/.git

--- a/gcp/workers/worker/.gcloudignore
+++ b/gcp/workers/worker/.gcloudignore
@@ -1,0 +1,1 @@
+!osv-test/.git

--- a/osv/cloudbuild.yaml
+++ b/osv/cloudbuild.yaml
@@ -34,6 +34,7 @@ steps:
   id: 'sync'
   dir: '.'
   args: ['poetry', 'sync']
+  waitFor: ['-']
 
 - name: 'gcr.io/oss-vdb/ci'
   id: 'lib-tests'

--- a/osv/cloudbuild.yaml
+++ b/osv/cloudbuild.yaml
@@ -12,25 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# vulnfeeds test runner
+# osv-lib test runner
 # This should be triggered on changes to the following:
-# vulnfeeds/go.mod
-# vulnfeeds/go.sum
-# vulnfeeds/run_tests.sh
-# vulnfeeds/*.go
-# vulnfeeds/**/*.go
+# poetry.lock
+# run_tests.sh
+# osv/*.py
+# osv/**/*.py
+# tools/source-sync/run_tests.sh
+# tools/source-sync/*.py
+# source.yaml
+# source_test.yaml
 
 steps:
 - name: 'gcr.io/cloud-builders/git'
   id: 'init'
   args: ['submodule', 'update', '--init']
+- name: 'gcr.io/oss-vdb/ci'
+  id: 'sync'
+  dir: '.'
+  args: ['poetry', 'sync']
 
 - name: 'gcr.io/oss-vdb/ci'
-  id: 'vulnfeed-tests'
-  dir: vulnfeeds
+  id: 'lib-tests'
   args: ['bash', '-ex', 'run_tests.sh']
   env:
-    - 'BUILD_ID=$BUILD_ID'
-  waitFor: ['init']
+    # Each concurrent test that uses the datastore emulator must have a unique port number
+    - DATASTORE_EMULATOR_PORT=8002
+  waitFor: ['init', 'sync']
+
+- name: 'gcr.io/oss-vdb/ci'
+  id: 'sourcerepo-sync-tests'
+  dir: 'tools/sourcerepo-sync'
+  args: ['bash', '-ex', 'run_tests.sh']
+  waitFor: ['init', 'sync']
 
 timeout: 7200s
+options:
+  machineType: E2_HIGHCPU_8

--- a/osv/cloudbuild.yaml
+++ b/osv/cloudbuild.yaml
@@ -27,6 +27,9 @@ steps:
 - name: 'gcr.io/cloud-builders/git'
   id: 'init'
   args: ['submodule', 'update', '--init']
+  # if this is invoked from another cloud build, this will fail as it is not a git repo
+  # the invoking cloud build file should run this step.
+  allowFailure: true
 - name: 'gcr.io/oss-vdb/ci'
   id: 'sync'
   dir: '.'

--- a/osv/tests.py
+++ b/osv/tests.py
@@ -105,7 +105,8 @@ class MockRepo:
 
 
 _ds_data_dir = None
-  
+
+
 def start_datastore_emulator():
   """Starts Datastore emulator."""
   port = os.environ.get('DATASTORE_EMULATOR_PORT', _DATASTORE_EMULATOR_PORT)

--- a/vulnfeeds/cloudbuild.yaml
+++ b/vulnfeeds/cloudbuild.yaml
@@ -24,6 +24,9 @@ steps:
 - name: 'gcr.io/cloud-builders/git'
   id: 'init'
   args: ['submodule', 'update', '--init']
+  # if this is invoked from another cloud build, this will fail as it is not a git repo
+  # the invoking cloud build file should run this step.
+  allowFailure: true
 
 - name: 'gcr.io/oss-vdb/ci'
   id: 'vulnfeed-tests'


### PR DESCRIPTION
#3452 Step 1 for running tests only on relevant PRs.
I've created a different `cloudbuild.yaml` file for a bunch of our components - basically each lockfile has its own file.

After this is merged, I'll split up the PR triggers to only run on the relevant files (that I've listed in the yaml files).

I've also made a slight change to the datastore emulator to allow the worker/importer tests to be run in parallel.