### PR TITLE
ci: bump JDK to version 21 in ci image

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ RUN apt-get update && \
     apt-get install -y \
     wget \
     google-cloud-sdk-datastore-emulator \
-    openjdk-11-jre  # Needed for Datastore emulator.
+    openjdk-21-jre  # Needed for Datastore emulator.
 
 COPY daemon.json /etc/docker/daemon.json
 COPY install_go.sh /tmp/install_go.sh


### PR DESCRIPTION
After spotting a deprecation warning the other day, I tried rebuilding the ci image and got:
```
ERROR: (gcloud.beta.emulators.datastore.start) The java executable on your PATH is not a Java 21+ JRE. The Google Cloud Datastore emulator requires a Java 21+ JRE installed and on your system PATH
```
So I'm bumping the jdk version (will manually push new image)