### PR TITLE
fix: Use correct timezone, and write timestamp directly

### DIFF
--- a/osv/sources.py
+++ b/osv/sources.py
@@ -215,7 +215,7 @@ def vulnerability_to_dict(vulnerability):
 
 
 def _write_vulnerability_dict(data, output_path,
-                              modified_date: datetime.datetime):
+                              modified_date_timestamp: float):
   """Write a vulnerability dict to disk."""
   with open(output_path, 'w') as f:
     ext = os.path.splitext(output_path)[1]
@@ -226,7 +226,7 @@ def _write_vulnerability_dict(data, output_path,
     else:
       raise RuntimeError('Unknown format ' + ext)
 
-  os.utime(output_path, (modified_date.timestamp(), modified_date.timestamp()))
+  os.utime(output_path, (modified_date_timestamp, modified_date_timestamp))
 
 
 def write_vulnerability(vulnerability: vulnerability_pb2.Vulnerability,
@@ -247,8 +247,11 @@ def write_vulnerability(vulnerability: vulnerability_pb2.Vulnerability,
   vuln_data = _get_nested_vulnerability(data, key_path)
   vuln_data.clear()
   vuln_data.update(vulnerability_to_dict(vulnerability))
-  _write_vulnerability_dict(data, output_path,
-                            vulnerability.modified.ToDatetime())
+  dt_timestamp = vulnerability.modified.seconds
+  if dt_timestamp == 0:
+    logging.warning('Record has no modified time: %s', vulnerability.id)
+
+  _write_vulnerability_dict(data, output_path, dt_timestamp)
 
 
 def vulnerability_has_range(vulnerability, introduced, fixed):

--- a/osv/sources.py
+++ b/osv/sources.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Importer sources."""
-import datetime
 import json
 import hashlib
 import logging

--- a/osv/sources.py
+++ b/osv/sources.py
@@ -250,6 +250,7 @@ def write_vulnerability(vulnerability: vulnerability_pb2.Vulnerability,
   dt_timestamp = vulnerability.modified.seconds
   if dt_timestamp == 0:
     logging.warning('Record has no modified time: %s', vulnerability.id)
+
   _write_vulnerability_dict(data, output_path, dt_timestamp)
 
 

--- a/osv/sources.py
+++ b/osv/sources.py
@@ -250,7 +250,6 @@ def write_vulnerability(vulnerability: vulnerability_pb2.Vulnerability,
   dt_timestamp = vulnerability.modified.seconds
   if dt_timestamp == 0:
     logging.warning('Record has no modified time: %s', vulnerability.id)
-
   _write_vulnerability_dict(data, output_path, dt_timestamp)
 
 


### PR DESCRIPTION
Use correct timezone, and write timestamp to avoid ValueError from records with no modified time. 