### PR TITLE
fix: Consolidate errors into one exception

### DIFF
--- a/osv/repos.py
+++ b/osv/repos.py
@@ -136,7 +136,8 @@ def clone_with_retries(git_url, checkout_dir, git_callbacks=None, branch=None):
     except GitCloneError as e:
       shutil.rmtree(checkout_dir, ignore_errors=True)
       if attempt == CLONE_TRIES - 1:
-        raise GitCloneError('Clone failed after %d attempts' % CLONE_TRIES) from e
+        raise GitCloneError('Clone failed after %d attempts' %
+                            CLONE_TRIES) from e
       time.sleep(RETRY_SLEEP_SECONDS)
     except NoBranchError as e:
       raise NoBranchError('Branch "%s" not found in repo "%s"' %


### PR DESCRIPTION
Rather than calling logging.error, then raising an exception, which creates two errors that are not linked to each other, put the context around the error directly in the exception.