### PR TITLE
fix: Set a default timestamp of year 2000

### DIFF
--- a/gcp/workers/exporter/export_runner.py
+++ b/gcp/workers/exporter/export_runner.py
@@ -79,7 +79,9 @@ def spawn_ecosystem_exporter(work_dir: str, bucket: str, eco: str):
   ])
   return_code = proc.wait()
   if return_code != 0:
-    logging.error('Export of %s failed with Exit Code: %d', eco, return_code)
+    logging.error(
+        'Export of %s failed with Exit Code: %d. See logs for related errors.',
+        eco, return_code)
 
 
 def aggregate_all_vulnerabilities(work_dir: str, export_bucket: str):

--- a/osv/sources.py
+++ b/osv/sources.py
@@ -37,6 +37,8 @@ PUSH_RETRY_SLEEP_SECONDS = 10
 YAML_EXTENSIONS = ('.yaml', '.yml')
 JSON_EXTENSIONS = ('.json',)
 
+DEFAULT_TIMESTAMP = 946684800  # Year 2000
+
 shared_cache = cache.InMemoryCache()
 
 
@@ -249,6 +251,7 @@ def write_vulnerability(vulnerability: vulnerability_pb2.Vulnerability,
   dt_timestamp = vulnerability.modified.seconds
   if dt_timestamp == 0:
     logging.warning('Record has no modified time: %s', vulnerability.id)
+    dt_timestamp = DEFAULT_TIMESTAMP
 
   _write_vulnerability_dict(data, output_path, dt_timestamp)
 


### PR DESCRIPTION
Apparently zips can't handle years before 1980, and unix epoch time is 1970