### PR TITLE
test(bindings): update vuln IDs in osvdev test

### DIFF
--- a/bindings/go/osvdev/osvdev_test.go
+++ b/bindings/go/osvdev/osvdev_test.go
@@ -98,6 +98,7 @@ func TestOSVClient_QueryBatch(t *testing.T) {
 					"GHSA-5w9c-rv96-fr7g",
 				},
 				{ // Commit
+					"CVE-2024-2002",
 					"OSV-2023-890",
 				},
 				// non-existent package
@@ -257,6 +258,7 @@ func TestOSVClient_Query(t *testing.T) {
 				Commit: "60e572dbf7b4ded66b488f54773f66aaf6184321",
 			},
 			wantIDs: []string{
+				"CVE-2024-2002",
 				"OSV-2023-890",
 			},
 		},


### PR DESCRIPTION
The osvdev test fails due to an extra vulnerability returned on the commit used in the test cases.

I think we are not running tests for the newly added Go bindings and we should add this to the workflow.