### PR TITLE
refactor(vulnfeeds): Refactor descriptions for better reusability and make versioning functions public

### DIFF
--- a/source.yaml
+++ b/source.yaml
@@ -235,6 +235,20 @@
   editable: False
   strict_validation: True
 
+- name: 'minimos'
+  versions_from_repo: False
+  rest_api_url: 'https://packages.mini.dev/advisories/osv/all.json'
+  type: 2
+  ignore_patterns: ['^(?!MINI-).*$']
+  directory_path: 'advisories/osv'
+  detect_cherrypicks: False
+  extension: '.json'
+  db_prefix: ['MINI-']
+  ignore_git: True
+  link: 'https://packages.mini.dev/advisories/osv/'
+  editable: False
+  strict_validation: True
+
 - name: 'oss-fuzz'
   versions_from_repo: True
   type: 0

--- a/vulnfeeds/cves/cve.go
+++ b/vulnfeeds/cves/cve.go
@@ -69,8 +69,8 @@ type CVE5 struct {
 	}
 }
 
-func EnglishDescription(cve CVE) string {
-	for _, desc := range cve.Descriptions {
+func EnglishDescription(descriptions []LangString) string {
+	for _, desc := range descriptions {
 		if desc.Lang == "en" {
 			return desc.Value
 		}

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -722,7 +722,7 @@ func ExtractVersionInfo(cve CVE, validVersions []string, httpClient *http.Client
 	}
 	if !gotVersions {
 		var extractNotes []string
-		v.AffectedVersions, extractNotes = extractVersionsFromDescription(validVersions, EnglishDescription(cve))
+		v.AffectedVersions, extractNotes = extractVersionsFromDescription(validVersions, EnglishDescription(cve.Descriptions))
 		notes = append(notes, extractNotes...)
 		if len(v.AffectedVersions) > 0 {
 			log.Printf("[%s] Extracted versions from description = %+v", cve.ID, v.AffectedVersions)

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -481,7 +481,7 @@ func ValidateAndCanonicalizeLink(link string, httpClient *http.Client) (canonica
 }
 
 // For URLs referencing commits in supported Git repository hosts, return a cloneable AffectedCommit.
-func extractGitCommit(link string, commitType models.CommitType, httpClient *http.Client) (ac models.AffectedCommit, err error) {
+func ExtractGitCommit(link string, commitType models.CommitType, httpClient *http.Client) (ac models.AffectedCommit, err error) {
 	r, err := Repo(link)
 	if err != nil {
 		return ac, err
@@ -502,7 +502,7 @@ func extractGitCommit(link string, commitType models.CommitType, httpClient *htt
 	// redirect to a completely different host, instead of a redirect within
 	// GitHub)
 	if possiblyDifferentLink != link {
-		return extractGitCommit(possiblyDifferentLink, commitType, httpClient)
+		return ExtractGitCommit(possiblyDifferentLink, commitType, httpClient)
 	}
 
 	ac.SetRepo(r)
@@ -629,7 +629,7 @@ func cleanVersion(version string) string {
 func ExtractVersionInfo(cve CVE, validVersions []string, httpClient *http.Client) (v models.VersionInfo, notes []string) {
 	for _, reference := range cve.References {
 		// (Potentially faulty) Assumption: All viable Git commit reference links are fix commits.
-		if commit, err := extractGitCommit(reference.Url, models.Fixed, httpClient); err == nil {
+		if commit, err := ExtractGitCommit(reference.Url, models.Fixed, httpClient); err == nil {
 			v.AffectedCommits = append(v.AffectedCommits, commit)
 		}
 	}

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -521,7 +521,7 @@ func ExtractGitCommit(link string, commitType models.CommitType, httpClient *htt
 	return ac, nil
 }
 
-func hasVersion(validVersions []string, version string) bool {
+func HasVersion(validVersions []string, version string) bool {
 	if len(validVersions) == 0 {
 		return true
 	}
@@ -561,7 +561,7 @@ func processExtractedVersion(version string) string {
 	return version
 }
 
-func extractVersionsFromDescription(validVersions []string, description string) ([]models.AffectedVersion, []string) {
+func ExtractVersionsFromDescription(validVersions []string, description string) ([]models.AffectedVersion, []string) {
 	// Match:
 	//  - x.x.x before x.x.x
 	//  - x.x.x through x.x.x
@@ -597,13 +597,13 @@ func extractVersionsFromDescription(validVersions []string, description string) 
 			continue
 		}
 
-		if introduced != "" && !hasVersion(validVersions, introduced) {
+		if introduced != "" && !HasVersion(validVersions, introduced) {
 			notes = append(notes, fmt.Sprintf("Extracted introduced version %s is not a valid version", introduced))
 		}
-		if fixed != "" && !hasVersion(validVersions, fixed) {
+		if fixed != "" && !HasVersion(validVersions, fixed) {
 			notes = append(notes, fmt.Sprintf("Extracted fixed version %s is not a valid version", fixed))
 		}
-		if lastaffected != "" && !hasVersion(validVersions, lastaffected) {
+		if lastaffected != "" && !HasVersion(validVersions, lastaffected) {
 			notes = append(notes, fmt.Sprintf("Extracted last_affected version %s is not a valid version", lastaffected))
 		}
 		// Favour fixed over last_affected for schema compliance.
@@ -698,11 +698,11 @@ func ExtractVersionInfo(cve CVE, validVersions []string, httpClient *http.Client
 					continue
 				}
 
-				if introduced != "" && !hasVersion(validVersions, introduced) {
+				if introduced != "" && !HasVersion(validVersions, introduced) {
 					notes = append(notes, fmt.Sprintf("Warning: %s is not a valid introduced version", introduced))
 				}
 
-				if fixed != "" && !hasVersion(validVersions, fixed) {
+				if fixed != "" && !HasVersion(validVersions, fixed) {
 					notes = append(notes, fmt.Sprintf("Warning: %s is not a valid fixed version", fixed))
 				}
 
@@ -722,7 +722,7 @@ func ExtractVersionInfo(cve CVE, validVersions []string, httpClient *http.Client
 	}
 	if !gotVersions {
 		var extractNotes []string
-		v.AffectedVersions, extractNotes = extractVersionsFromDescription(validVersions, EnglishDescription(cve.Descriptions))
+		v.AffectedVersions, extractNotes = ExtractVersionsFromDescription(validVersions, EnglishDescription(cve.Descriptions))
 		notes = append(notes, extractNotes...)
 		if len(v.AffectedVersions) > 0 {
 			log.Printf("[%s] Extracted versions from description = %+v", cve.ID, v.AffectedVersions)

--- a/vulnfeeds/cves/versions_test.go
+++ b/vulnfeeds/cves/versions_test.go
@@ -689,7 +689,7 @@ func TestExtractGitCommit(t *testing.T) {
 			if !tc.disableExpiryDate.IsZero() && time.Now().After(tc.disableExpiryDate) {
 				t.Logf("test %q: extractGitCommit(%q, %q) has been enabled on %s.", tc.description, tc.inputLink, tc.inputCommitType, tc.disableExpiryDate)
 			}
-			got, err := extractGitCommit(tc.inputLink, tc.inputCommitType, client)
+			got, err := ExtractGitCommit(tc.inputLink, tc.inputCommitType, client)
 			if err != nil && !tc.expectFailure {
 				t.Errorf("test %q: extractGitCommit for %q (%q) errored unexpectedly: %#v", tc.description, tc.inputLink, tc.inputCommitType, err)
 			}

--- a/vulnfeeds/pypi/pypi.go
+++ b/vulnfeeds/pypi/pypi.go
@@ -336,7 +336,7 @@ func (p *PyPI) packageExists(pkg string) bool {
 
 func (p *PyPI) finalPkgCheck(cve cves.CVE, pkg string, falsePositives *triage.FalsePositives) bool {
 	// To avoid false positives, check that the pkg name is mentioned in the description.
-	desc := strings.ToLower(cves.EnglishDescription(cve))
+	desc := strings.ToLower(cves.EnglishDescription(cve.Descriptions))
 	pkgNameParts := strings.Split(pkg, "-")
 
 	for _, part := range pkgNameParts {

--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -518,16 +518,16 @@ func ClassifyReferenceLink(link string, tag string) string {
 	return "WEB"
 }
 
-func extractReferencedVulns(id cves.CVEID, cve cves.CVE) ([]string, []string) {
+func extractReferencedVulns(id cves.CVEID, cveID cves.CVEID, references []cves.Reference) ([]string, []string) {
 	var aliases []string
 	var related []string
-	if id != cve.ID {
-		aliases = append(aliases, string(cve.ID))
+	if id != cves.CVEID(cveID) {
+		aliases = append(aliases, string(cves.CVEID(cveID)))
 	}
 
 	var GHSAs []string
 	var SYNKs []string
-	for _, reference := range cve.References {
+	for _, reference := range references {
 		u, err := url.Parse(reference.Url)
 		if err == nil {
 			pathParts := strings.Split(u.Path, "/")
@@ -613,7 +613,7 @@ func ClassifyReferences(refs []cves.Reference) (references References) {
 // FromCVE creates a minimal OSV object from a given CVEItem and id.
 // Leaves affected and version fields empty to be filled in later with AddPkgInfo
 func FromCVE(id cves.CVEID, cve cves.CVE) (*Vulnerability, []string) {
-	aliases, related := extractReferencedVulns(id, cve)
+	aliases, related := extractReferencedVulns(id, cve.ID, cve.References)
 	v := Vulnerability{
 		ID:      string(id),
 		Details: cves.EnglishDescription(cve.Descriptions),

--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -616,7 +616,7 @@ func FromCVE(id cves.CVEID, cve cves.CVE) (*Vulnerability, []string) {
 	aliases, related := extractReferencedVulns(id, cve)
 	v := Vulnerability{
 		ID:      string(id),
-		Details: cves.EnglishDescription(cve),
+		Details: cves.EnglishDescription(cve.Descriptions),
 		Aliases: aliases,
 		Related: related,
 	}

--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -518,7 +518,7 @@ func ClassifyReferenceLink(link string, tag string) string {
 	return "WEB"
 }
 
-func extractReferencedVulns(id cves.CVEID, cveID cves.CVEID, references []cves.Reference) ([]string, []string) {
+func ExtractReferencedVulns(id cves.CVEID, cveID cves.CVEID, references []cves.Reference) ([]string, []string) {
 	var aliases []string
 	var related []string
 	if id != cves.CVEID(cveID) {
@@ -613,7 +613,7 @@ func ClassifyReferences(refs []cves.Reference) (references References) {
 // FromCVE creates a minimal OSV object from a given CVEItem and id.
 // Leaves affected and version fields empty to be filled in later with AddPkgInfo
 func FromCVE(id cves.CVEID, cve cves.CVE) (*Vulnerability, []string) {
-	aliases, related := extractReferencedVulns(id, cve.ID, cve.References)
+	aliases, related := ExtractReferencedVulns(id, cve.ID, cve.References)
 	v := Vulnerability{
 		ID:      string(id),
 		Details: cves.EnglishDescription(cve.Descriptions),

--- a/vulnfeeds/vulns/vulns_test.go
+++ b/vulnfeeds/vulns/vulns_test.go
@@ -113,17 +113,17 @@ func loadTestData2(cveName string) cves.Vulnerability {
 func TestExtractAliases(t *testing.T) {
 	// TODO: convert to table based test
 	cveItem := loadTestData2("CVE-2022-36037")
-	aliases, related := extractReferencedVulns(cveItem.CVE.ID, cveItem.CVE.ID, cveItem.CVE.References)
+	aliases, related := ExtractReferencedVulns(cveItem.CVE.ID, cveItem.CVE.ID, cveItem.CVE.References)
 	if !utility.SliceEqual(aliases, []string{"GHSA-3f89-869f-5w76"}) || !utility.SliceEqual(related, []string{}) {
 		t.Errorf("Aliases not extracted, got %v, but expected %v.", aliases, []string{"GHSA-3f89-869f-5w76"})
 	}
 	cveItem = loadTestData2("CVE-2022-36749")
-	aliases, related = extractReferencedVulns(cveItem.CVE.ID, cveItem.CVE.ID, cveItem.CVE.References)
+	aliases, related = ExtractReferencedVulns(cveItem.CVE.ID, cveItem.CVE.ID, cveItem.CVE.References)
 	if !utility.SliceEqual(aliases, []string{}) || !utility.SliceEqual(related, []string{}) {
 		t.Errorf("Aliases not extracted, got %v, but expected %v.", aliases, []string{"GHSA-3f89-869f-5w76"})
 	}
 	cveItem = loadTestData2("CVE-2024-47177")
-	aliases, related = extractReferencedVulns(cveItem.CVE.ID, cveItem.CVE.ID, cveItem.CVE.References)
+	aliases, related = ExtractReferencedVulns(cveItem.CVE.ID, cveItem.CVE.ID, cveItem.CVE.References)
 	expectedRelated := []string{"GHSA-7xfx-47qg-grp6", "GHSA-p9rh-jxmq-gq47", "GHSA-rj88-6mr5-rcw8", "GHSA-w63j-6g73-wmg5"}
 	if !utility.SliceEqual(aliases, []string{}) || !utility.SliceEqualUnordered(related, expectedRelated) {
 		t.Errorf("Aliases not extracted, got %v, but expected %v.", aliases, []string{})

--- a/vulnfeeds/vulns/vulns_test.go
+++ b/vulnfeeds/vulns/vulns_test.go
@@ -113,17 +113,17 @@ func loadTestData2(cveName string) cves.Vulnerability {
 func TestExtractAliases(t *testing.T) {
 	// TODO: convert to table based test
 	cveItem := loadTestData2("CVE-2022-36037")
-	aliases, related := extractReferencedVulns(cveItem.CVE.ID, cveItem.CVE)
+	aliases, related := extractReferencedVulns(cveItem.CVE.ID, cveItem.CVE.ID, cveItem.CVE.References)
 	if !utility.SliceEqual(aliases, []string{"GHSA-3f89-869f-5w76"}) || !utility.SliceEqual(related, []string{}) {
 		t.Errorf("Aliases not extracted, got %v, but expected %v.", aliases, []string{"GHSA-3f89-869f-5w76"})
 	}
 	cveItem = loadTestData2("CVE-2022-36749")
-	aliases, related = extractReferencedVulns(cveItem.CVE.ID, cveItem.CVE)
+	aliases, related = extractReferencedVulns(cveItem.CVE.ID, cveItem.CVE.ID, cveItem.CVE.References)
 	if !utility.SliceEqual(aliases, []string{}) || !utility.SliceEqual(related, []string{}) {
 		t.Errorf("Aliases not extracted, got %v, but expected %v.", aliases, []string{"GHSA-3f89-869f-5w76"})
 	}
 	cveItem = loadTestData2("CVE-2024-47177")
-	aliases, related = extractReferencedVulns(cveItem.CVE.ID, cveItem.CVE)
+	aliases, related = extractReferencedVulns(cveItem.CVE.ID, cveItem.CVE.ID, cveItem.CVE.References)
 	expectedRelated := []string{"GHSA-7xfx-47qg-grp6", "GHSA-p9rh-jxmq-gq47", "GHSA-rj88-6mr5-rcw8", "GHSA-w63j-6g73-wmg5"}
 	if !utility.SliceEqual(aliases, []string{}) || !utility.SliceEqualUnordered(related, expectedRelated) {
 		t.Errorf("Aliases not extracted, got %v, but expected %v.", aliases, []string{})
@@ -133,7 +133,7 @@ func TestExtractAliases(t *testing.T) {
 
 func TestEnglishDescription(t *testing.T) {
 	cveItem := loadTestData2("CVE-2022-36037")
-	description := cves.EnglishDescription(cveItem.CVE)
+	description := cves.EnglishDescription(cveItem.CVE.Descriptions)
 	expectedDescription := "kirby is a content management system (CMS) that adapts to many different projects and helps you build your own ideal interface. Cross-site scripting (XSS) is a type of vulnerability that allows execution of any kind of JavaScript code inside the Panel session of the same or other users. In the Panel, a harmful script can for example trigger requests to Kirby's API with the permissions of the victim. If bad actors gain access to your group of authenticated Panel users they can escalate their privileges via the Panel session of an admin user. Depending on your site, other JavaScript-powered attacks are possible. The multiselect field allows selection of tags from an autocompleted list. Unfortunately, the Panel in Kirby 3.5 used HTML rendering for the raw option value. This allowed **attackers with influence on the options source** to store HTML code. The browser of the victim who visited a page with manipulated multiselect options in the Panel will then have rendered this malicious HTML code when the victim opened the autocomplete dropdown. Users are *not* affected by this vulnerability if you don't use the multiselect field or don't use it with options that can be manipulated by attackers. The problem has been patched in Kirby 3.5.8.1."
 	if description != expectedDescription {
 		t.Errorf("Description not extracted, got %v, but expected %v", description, expectedDescription)


### PR DESCRIPTION
These changes are done in preparation for CVEList ingestion 
- Refactor description logic to only require the array of descriptions rather than whole CVE, for better reusability
- Made a few functions public to use in other sections of the code.
- Updated tests