### PR TITLE
docs: add checking linter results step into new_source.md

### DIFF
--- a/docs/new_source.md
+++ b/docs/new_source.md
@@ -25,6 +25,8 @@ The step by step instructions are as follows:
         
 - [ ] Create a PR to start [importing the records you are publishing into our test instance of OSV.dev](https://github.com/google/osv.dev/blob/master/source_test.yaml) and validate everything is working as intended there.
 
+- [ ] After successful import, review the OSV-linter results by querying http://api.test.osv.dev/v1experimental/importfindings/{source_name} to identify and address any important record linting issues (allow up to a 1-day delay).
+
 - [ ] Create a PR to start [importing the records you are publishing into our production environment](https://github.com/google/osv.dev/blob/master/source.yaml)
 
 


### PR DESCRIPTION
I've seen some usage of our new data source doc, so I'm adding an extra step of linter checking before importing everything into production.