### PR TITLE
chore: add build-protos to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ lint:
 	tools/lint_and_format.sh
 
 build-protos:
-	osv/build_protos.sh
+	$(run-cmd) python -m grpc_tools.protoc --python_out=. --mypy_out=. --proto_path=. osv/*.proto
 
 run-website:
 	cd gcp/website/frontend3 && npm install && npm run build

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ api-server-tests:
 lint:
 	tools/lint_and_format.sh
 
+build-protos:
+	osv/build_protos.sh
+
 run-website:
 	cd gcp/website/frontend3 && npm install && npm run build
 	cd gcp/website/blog && hugo --buildFuture -d ../dist/static/blog


### PR DESCRIPTION
This PR adds `build-protos` to Makefile so we don't need to go to `osv` folder to run the script.