### PR TITLE
refactor(vulnfeeds): Remove redundant ByAffectedCommit code

### DIFF
--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -23,7 +23,6 @@ import (
 	"net/url"
 	"path"
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -627,33 +626,11 @@ func cleanVersion(version string) string {
 	return strings.TrimRight(version, ":")
 }
 
-type ByAffectedCommit []models.AffectedCommit
-
-func (a ByAffectedCommit) Len() int {
-	return len(a)
-}
-
-func (a ByAffectedCommit) Swap(i, j int) {
-	a[i], a[j] = a[j], a[i]
-}
-
-func (a ByAffectedCommit) Less(i, j int) bool {
-	if a[i].Repo != a[j].Repo {
-		return a[i].Repo < a[j].Repo
-	}
-	if a[i].Introduced != a[j].Introduced {
-		return a[i].Introduced < a[j].Introduced
-	}
-	if a[i].Fixed != a[j].Fixed {
-		return a[i].Fixed < a[j].Fixed
-	}
-	return a[i].LastAffected < a[j].LastAffected
-}
 func deduplicateAffectedCommits(commits []models.AffectedCommit) []models.AffectedCommit {
 	if len(commits) == 0 {
 		return []models.AffectedCommit{}
 	}
-	sort.Sort(ByAffectedCommit(commits))
+	slices.SortStableFunc(commits, models.AffectedCommitCompare)
 	uniqueCommits := slices.Compact(commits)
 	return uniqueCommits
 }

--- a/vulnfeeds/cves/versions_test.go
+++ b/vulnfeeds/cves/versions_test.go
@@ -6,13 +6,13 @@ import (
 	"log"
 	"os"
 	"reflect"
-	"sort"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/osv/vulnfeeds/internal/testutils"
 	"github.com/google/osv/vulnfeeds/models"
+	"golang.org/x/exp/slices"
 )
 
 func loadTestData2(cveName string) Vulnerability {
@@ -1074,8 +1074,8 @@ func TestDeduplicateAffectedCommits(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := deduplicateAffectedCommits(tt.input)
 
-			sort.Sort(ByAffectedCommit(got))
-			sort.Sort(ByAffectedCommit(tt.expected))
+			slices.SortStableFunc(got, models.AffectedCommitCompare)
+			slices.SortStableFunc(tt.expected, models.AffectedCommitCompare)
 			if diff := cmp.Diff(got, tt.expected); diff != "" {
 				t.Errorf("deduplicateAffectedCommits() got = %v, want %v", got, tt.expected)
 			}


### PR DESCRIPTION
Found an existing vulnfeeds commit compare function, so removing the redundant code. 