### PR TITLE
docs(README): Update README with Data Dump information

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ API documentation is available [here](https://google.github.io/osv.dev/api/).
 
 ## Data Dump
 
-We have data dumps available from a GCS bucket at `gs://osv-vulnerabilities`. For more information checkout [our documentation](https://google.github.io/osv.dev/data/#data-dumps).
+We have data dumps available from a GCS bucket at `gs://osv-vulnerabilities`. For more information check out [our documentation](https://google.github.io/osv.dev/data/#data-dumps).
 
 ## Viewing the web UI
 


### PR DESCRIPTION
It is a little bit buried that we supply a data dump along with the API so just surfacing in our README.