### PR TITLE
fix: 500 error on frontend rendering of some Ubuntu CVEs

### DIFF
--- a/gcp/website/frontend3/src/templates/vulnerability.html
+++ b/gcp/website/frontend3/src/templates/vulnerability.html
@@ -104,10 +104,14 @@
             <ul class="severity">
               {% for item in vulnerability.severity -%}
               <li>
-                <span class="severity-level severity-{{ item | severity_level }}">{{ item | display_severity_rating }}</span>
-                {{ item.type }} - {{ item.score }}
-                <a href="{{ item | cvss_calculator_url }}" target="_blank" rel="noopener noreferrer">
-                  CVSS Calculator</a>
+                {% if item | is_cvss %}
+                  <span class="severity-level severity-{{ item | severity_level }}">{{ item | display_severity_rating }}</span>
+                  {{ item.type }} - {{ item.score }}
+                  <a href="{{ item | cvss_calculator_url }}" target="_blank" rel="noopener noreferrer">
+                    CVSS Calculator</a>
+                {% else %}
+                  <span class="severity-level severity-invalid">{{ item.type }} - {{ item.score }}</span>
+                {% endif %}
               </li>
               {% endfor -%}
             </ul>
@@ -223,10 +227,14 @@
             <ul class="severity">
               {% for item in affected.severity -%}
               <li>
-                <span class="severity-level severity-{{ item | severity_level }}">{{ item | display_severity_rating }}</span>
-                {{ item.type }} - {{ item.score }}
-                <a href="{{ item | cvss_calculator_url }}" target="_blank" rel="noopener noreferrer">
-                  CVSS Calculator</a>
+                {% if item | is_cvss %}
+                  <span class="severity-level severity-{{ item | severity_level }}">{{ item | display_severity_rating }}</span>
+                  {{ item.type }} - {{ item.score }}
+                  <a href="{{ item | cvss_calculator_url }}" target="_blank" rel="noopener noreferrer">
+                    CVSS Calculator</a>
+                {% else %}
+                  <span class="severity-level severity-invalid">{{ item.type }} - {{ item.score }}</span>
+                {% endif %}
               </li>
               {% endfor -%}
             </ul>

--- a/gcp/website/frontend_handlers.py
+++ b/gcp/website/frontend_handlers.py
@@ -395,15 +395,15 @@ def add_stream_strings(bug: osv.Bug, response: dict[str, Any]):
         bug.db_id, computed, known_ids)
 
 
+cvss_calculator = {
+    'CVSS_V2': CVSS2,
+    'CVSS_V3': CVSS3,
+    'CVSS_V4': CVSS4,
+}
+
 def calculate_severity_details(
     severity: dict) -> tuple[float | None, str | None]:
   """Calculate score and rating of severity"""
-  cvss_calculator = {
-      'CVSS_V2': CVSS2,
-      'CVSS_V3': CVSS3,
-      'CVSS_V4': CVSS4,
-  }
-
   type_ = severity.get('type')
   score = severity.get('score')
 
@@ -904,9 +904,18 @@ def severity_level(severity: dict) -> str:
   return 'invalid' if rating is None else rating.lower()
 
 
+@blueprint.app_template_filter('is_cvss')
+def is_cvss(severity: dict) -> bool:
+  """Checks if severity is a CVSS score."""
+  return severity.get('type') in cvss_calculator
+
+
 @blueprint.app_template_filter('cvss_calculator_url')
 def cvss_calculator_url(severity):
   """Generate the FIRST CVSS calculator URL from a CVSS string."""
+  if not is_cvss(severity):
+    return None
+
   score = severity.get('score')
 
   # Extract CVSS version from the vector string


### PR DESCRIPTION
Remove assumption on the frontend where we assume that it's only CVSS scores.

This is a bit hacked together and on the frontend it'll look a bit weird because type doesn't actually exist right now:

![image](https://github.com/user-attachments/assets/e1b3e447-a7d6-4f59-aead-9ddd42be318b)
