### PR TITLE
fix(api): double backend concurrency

### DIFF
--- a/deployment/clouddeploy/osv-api/run.yaml
+++ b/deployment/clouddeploy/osv-api/run.yaml
@@ -26,4 +26,4 @@ spec:
           failureThreshold: 3
           periodSeconds: 10
       timeoutSeconds: 60
-      containerConcurrency: 5 # from-param: ${containerConcurrency}
+      containerConcurrency: 10 # from-param: ${containerConcurrency}

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -1383,7 +1383,7 @@ def query_by_package(
 
 def serve(port: int, local: bool):
   """Configures and runs the OSV API server."""
-  server = grpc.server(concurrent.futures.ThreadPoolExecutor(max_workers=5))
+  server = grpc.server(concurrent.futures.ThreadPoolExecutor(max_workers=10))
   servicer = OSVServicer()
   osv_service_v1_pb2_grpc.add_OSVServicer_to_server(servicer, server)
   health_pb2_grpc.add_HealthServicer_to_server(servicer, server)


### PR DESCRIPTION
Bump the max concurrent requests from 5 to 10 for the API backend, to help with container instance scaling.
This is not for the batch query backend, which still is just 1.

Hopefully this won't have a notable performance impact. I don't really want to change this and #3638 at the same time, since I want to be able to measure the individual impacts of both. We could probably push this out with the release this week, and let #3638 stage until next week.