### PR TITLE
fix(actions): Update osv-scanner-unified.yml with read permissions

### DIFF
--- a/.github/workflows/osv-scanner-unified.yml
+++ b/.github/workflows/osv-scanner-unified.yml
@@ -31,6 +31,8 @@ permissions:
 jobs:
   scan-scheduled:
     permissions:
+      contents: read
+      actions: read
       # Required for writing security events to upload SARIF file to security tab
       security-events: write
     if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
@@ -38,6 +40,8 @@ jobs:
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@main"
   scan-pr:
     permissions:
+      contents: read
+      actions: read
       # Required for writing security events to upload SARIF file to security tab
       security-events: write
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}


### PR DESCRIPTION
OSV-Scanner hasn't run on OSV.dev successfully in ~ 4 months. It seems to be missing read permissions. Hopefully this fixes it?