### PR TITLE
fix(website): prevent exceptions from parsing Ubuntu severities

### DIFF
--- a/gcp/website/frontend_handlers.py
+++ b/gcp/website/frontend_handlers.py
@@ -430,6 +430,8 @@ def add_cvss_score(bug):
   severity_type = None
 
   for severity in bug.get('severity', []):
+    if not is_cvss(severity):
+      continue
     type_ = severity.get('type')
     if type_ and (not severity_type or type_ > severity_type):
       severity_type = type_


### PR DESCRIPTION
Fixes #3675
Similar to #3637, skips parsing non-CVSS severities.

This PR mostly just gets rid of the error log - we'd still want to change the website rendering logic to gracefully handle other severity types.