### PR TITLE
feat(linter): add invalid schema error code

### DIFF
--- a/gcp/workers/linter/linter.py
+++ b/gcp/workers/linter/linter.py
@@ -38,6 +38,7 @@ TEST_DATA = '/linter/test_data'
 GCP_PROJECT = 'oss-vdb-test'
 
 ERROR_CODE_MAPPING = {
+    'SCH:001': osv.ImportFindings.INVALID_JSON,
     'REC:001': osv.ImportFindings.INVALID_RECORD,
     'REC:002': osv.ImportFindings.INVALID_ALIASES,
     'REC:003': osv.ImportFindings.INVALID_UPSTREAM,


### PR DESCRIPTION
https://github.com/ossf/osv-schema/pull/365 added a new check on JSON schema validation with new error code https://github.com/ossf/osv-schema/blob/b79744b3c60d0ccbd77e46adc1214dda7c547072/tools/osv-linter/internal/checks/schema.go#L18

adding this error code to linter cron job