### PR TITLE
perf: perform blobless clones in git enumeration

### DIFF
--- a/osv/impact.py
+++ b/osv/impact.py
@@ -636,14 +636,19 @@ def _analyze_git_ranges(repo_analyzer: RepoAnalyzer, checkout_path: str,
   package_repo = None
 
   with tempfile.TemporaryDirectory() as package_repo_dir:
+    # We'd prefer to only download the commit history, but detect_cherrypicks
+    # requires having the blobs available to function correctly.
+    blobless = not repo_analyzer.detect_cherrypicks
     if checkout_path:
       repo_name = os.path.basename(
           affected_range.repo.rstrip('/')).rstrip('.git')
       package_repo = repos.ensure_updated_checkout(
-          affected_range.repo, os.path.join(checkout_path, repo_name))
+          affected_range.repo,
+          os.path.join(checkout_path, repo_name),
+          blobless=blobless)
     else:
-      package_repo = repos.clone_with_retries(affected_range.repo,
-                                              package_repo_dir)
+      package_repo = repos.clone_with_retries(
+          affected_range.repo, package_repo_dir, blobless=blobless)
 
     all_introduced = []
     all_fixed = []


### PR DESCRIPTION
Since (in most cases), we do not actually need the repo contents to enumerate git commits, changed the impact analysis to not download blobs when cloning (via [`--filter=blob:none`](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt---filterfilter-spec)) if it can be avoided.

Testing locally on a few random-ish repos in OSV, seems to be a decent improvement:

|repo|full clone|blobless clone|
|:-:|:-:|:-:|
|https://github.com/v8/v8|360s|70s|
|https://github.com/curl/curl.git|12s|5s|
|https://github.com/mysql/mysql-server|430s|120s|
|https://github.com/libexif/exif|**2.5s**|**3.5s**|
|https://github.com/microsoft/chakracore|17s|7s|
|https://github.com/powerdns/pdns|12s|6s|

It seems like on small repos, it actually takes longer (maybe because git has to first check if the repo actually supports filters first?). This is only 1 extra second (locally), so I think it's probably an acceptable tradeoff.

I'll note that the majority of time spent for many repos is the cloning, though some repos (e.g. V8) of take a long time computing the enumeration, so the overall improvement is hard to say.