### PR TITLE
chore(linter): bump timeout limit

### DIFF
--- a/gcp/workers/linter/linter.py
+++ b/gcp/workers/linter/linter.py
@@ -232,7 +232,7 @@ def main():
       logging.info('Executing Go linter: %s', ' '.join(command))
 
       result = subprocess.run(
-          command, capture_output=True, text=True, check=False, timeout=600)
+          command, capture_output=True, text=True, check=False, timeout=2000)
 
       parse_and_record_linter_output(result.stdout)
 


### PR DESCRIPTION
OSV-schema added JSON schema checks which increased the runtime of OSV-linter. To address linter timeout issues, we can either increase the timeout limit or download all.zip files from different ecosystem buckets and run OSV-linter in multiple threads. 

For now, I will simply increase the timeout limit first, as the cron job only runs once a day and JSON schema checks should only increase the runtime slightly. Let's see how long it takes before splitting it into multiple threads.