### PR TITLE
fix(website): Correct search dropdown position on scroll

### DIFF
--- a/gcp/website/frontend3/src/search.js
+++ b/gcp/website/frontend3/src/search.js
@@ -296,13 +296,13 @@ export class SearchSuggestionsManager {
       // Use the designated suggestions container
       const containerRect = suggestionContainer.getBoundingClientRect();
       this.suggestionsElement.style.left = `${containerRect.left}px`;
-      this.suggestionsElement.style.top = `${containerRect.bottom}px`;
+      this.suggestionsElement.style.top = `${containerRect.bottom + window.scrollY}px`;
       this.suggestionsElement.style.width = `${containerRect.width}px`;
     } else {
       console.warn('No .search-suggestions-container found. Add this class to the desired parent element to control suggestions positioning.');
       // Fallback to input element positioning
       this.suggestionsElement.style.left = `${rect.left}px`;
-      this.suggestionsElement.style.top = `${rect.bottom}px`;
+      this.suggestionsElement.style.top = `${rect.bottom + window.scrollY}px`;
       this.suggestionsElement.style.width = `${rect.width}px`;
     }
   }


### PR DESCRIPTION
Fixes a bug where the search suggestions dropdown was misaligned when the page was scrolled.

The position calculation in `updatePosition()` now includes `window.scrollY` to ensure the dropdown's `top` position is always correct relative to the document, not the viewport.