### PR TITLE
refactor(vulnfeeds): Change FromCVE function back to taking whole CVE entry

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -155,14 +155,7 @@ func combineIntoOSV(loadedCves map[cves.CVEID]cves.Vulnerability, allParts map[c
 		if len(allParts[cveId]) == 0 {
 			continue
 		}
-		convertedCve := vulns.FromCVE(
-			cveId,
-			cve.CVE.ID,
-			cve.CVE.References,
-			cve.CVE.Descriptions,
-			cve.CVE.Published.Time,
-			cve.CVE.LastModified.Time,
-			cve.CVE.Metrics)
+		convertedCve := vulns.FromNVDCVE(cveId, cve.CVE)
 		if len(cveList) > 0 {
 			// Best-effort attempt to mark a disputed CVE as withdrawn.
 			modified, err := vulns.CVEIsDisputed(convertedCve, cveList)

--- a/vulnfeeds/cmd/nvd-cve-osv/main.go
+++ b/vulnfeeds/cmd/nvd-cve-osv/main.go
@@ -78,14 +78,7 @@ func CVEToOSV(CVE cves.CVE, repos []string, cache git.RepoTagsCache, directory s
 		}
 	}
 
-	v := vulns.FromCVE(
-		CVE.ID,
-		CVE.ID,
-		CVE.References,
-		CVE.Descriptions,
-		CVE.Published.Time,
-		CVE.LastModified.Time,
-		CVE.Metrics)
+	v := vulns.FromNVDCVE(CVE.ID, CVE)
 	versions, notes := cves.ExtractVersionInfo(CVE, nil, http.DefaultClient)
 
 	if len(versions.AffectedVersions) != 0 {

--- a/vulnfeeds/cmd/pypi/main.go
+++ b/vulnfeeds/cmd/pypi/main.go
@@ -161,7 +161,7 @@ func main() {
 				PURL:      purl,
 			}
 
-			v := vulns.FromCVE(id, cve.CVE.ID, cve.CVE.References, cve.CVE.Descriptions, cve.CVE.Published.Time, cve.CVE.LastModified.Time, cve.CVE.Metrics)
+			v := vulns.FromNVDCVE(id, cve.CVE)
 			v.AddPkgInfo(pkgInfo)
 			versions, notes := cves.ExtractVersionInfo(cve.CVE, validVersions, http.DefaultClient)
 

--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -566,21 +566,21 @@ func ClassifyReferences(refs []cves.Reference) []osvschema.Reference {
 	return references
 }
 
-// FromCVE creates a minimal OSV object from a given CVE and id.
+// FromNVDCVE creates a minimal OSV object from a given CVE and id.
 // Leaves affected and version fields empty to be filled in later with AddPkgInfo
 // There are two id fields passed in as one of the users of this field (PyPi) sometimes has a different id than the CVEID
 // and the ExtractReferencedVulns function uses these in a check to add the other ID as an alias.
-func FromCVE(id cves.CVEID, cveID cves.CVEID, references []cves.Reference, descriptions []cves.LangString, publishedDate time.Time, modifiedDate time.Time, metrics any) *Vulnerability {
-	aliases, related := ExtractReferencedVulns(id, cveID, references)
+func FromNVDCVE(id cves.CVEID, cve cves.CVE) *Vulnerability {
+	aliases, related := ExtractReferencedVulns(id, cve.ID, cve.References)
 	v := Vulnerability{}
 	v.ID = string(id)
-	v.Details = cves.EnglishDescription(descriptions)
+	v.Details = cves.EnglishDescription(cve.Descriptions)
 	v.Aliases = aliases
 	v.Related = related
-	v.Published = publishedDate
-	v.Modified = modifiedDate
-	v.References = ClassifyReferences(references)
-	v.AddSeverity(metrics)
+	v.Published = cve.Published.Time
+	v.Modified = cve.LastModified.Time
+	v.References = ClassifyReferences(cve.References)
+	v.AddSeverity(cve.Metrics)
 	return &v
 }
 

--- a/vulnfeeds/vulns/vulns_test.go
+++ b/vulnfeeds/vulns/vulns_test.go
@@ -368,12 +368,7 @@ func TestAddSeverity(t *testing.T) {
 
 	for _, tc := range tests {
 		id := tc.inputCVE.CVE.ID
-		references := tc.inputCVE.CVE.References
-		descriptions := tc.inputCVE.CVE.Descriptions
-		published := tc.inputCVE.CVE.Published.Time
-		modified := tc.inputCVE.CVE.LastModified.Time
-		metrics := tc.inputCVE.CVE.Metrics
-		vuln := FromCVE(id, id, references, descriptions, published, modified, metrics)
+		vuln := FromNVDCVE(id, tc.inputCVE.CVE)
 
 		got := vuln.Severity
 		if diff := gocmp.Diff(got, tc.expectedResult); diff != "" {


### PR DESCRIPTION
Renamed it "FromNVDCVE" to prepare for CVE5 version that will also do a similar thing.