### PR TITLE
docs(api): Warn users about API response size limit

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -30,3 +30,10 @@ There are five different types of requests that can be made of the API.
 ### Is the API rate limited?  
 
 Currently there are no limits on the API.
+
+### Are there any response size limits?
+
+The API has a response size limit of 32MiB when using HTTP/1.1.
+There is no limit when using HTTP/2.
+
+We recommend using HTTP/2 for queries that may result in large responses (e.g. big OSV Linux queries).

--- a/docs/api/post-v1-query.md
+++ b/docs/api/post-v1-query.md
@@ -162,4 +162,7 @@ curl -d \
 ```
 
 {: .note }
+The API has a response size limit of 32MiB when using HTTP/1.1. There is **no limit** when using HTTP/2. We recommend using HTTP/2 for queries that may result in large responses.
+
+{: .note }
 In rare cases, the response might contain **only** the `next_page_token`. In those cases, there might be more data that can be retrieved, but were not found within the time limit, please keep querying with the `next_page_token` until either results are returned, or no more page tokens are returned. 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -174,6 +174,13 @@ When a record is deleted from an upstream source, OSV.dev currently handles them
 
 No. Currently there is not a limit on the API.
 
+### Are there any response size limits?
+
+The API has a response size limit of 32MiB when using HTTP/1.1.
+There is no limit when using HTTP/2.
+
+We recommend using HTTP/2 for queries that may result in large responses (e.g. big OSV Linux queries).
+
 ### What are OSV.dev's service level objectives (SLOs)?
 
 OSV.dev strives to provide reliable vulnerability information to our users. To support that goal, the following service level objectives are targeted:


### PR DESCRIPTION
Updated the API documentation to warn users of API response limit on HTTP/1.1 and recommend using HTTP/2 for large queries.

Fixes #3119 