### PR TITLE
fix(frontend): Prevent navbar search overflow

### DIFF
--- a/gcp/website/frontend3/src/styles.scss
+++ b/gcp/website/frontend3/src/styles.scss
@@ -1648,7 +1648,7 @@ div.highlight {
   align-items: center;
   height: 24px; /* Match the GitHub icon height */
   
-  @media (max-width: $osv-mobile-breakpoint) {
+  @media (max-width: 990px) { // Max width to prevent navbar from overlapping on other navbar elements
     display: none;
   }
 }


### PR DESCRIPTION
Resolves a layout issue where the expandable search bar in the navbar would overflow and cover other items on smaller screens. The search icon now appears on viewports within an appropriate minimum width.

Closes #3726 