### PR TITLE
feat: Export a modified_id.csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build/lib
 */datastore-helper/
 hurl-scripts/
 temp/*
+**/tmp/**

--- a/gcp/workers/exporter/export_runner.py
+++ b/gcp/workers/exporter/export_runner.py
@@ -122,12 +122,12 @@ def aggregate_all_vulnerabilities(work_dir: str, export_bucket: str):
       reader = csv.reader(infile)
       for line in reader:
         # Create <timestamp>,<dir>/<osv_id>
-        full_modified_list.append(f'{line[0]},{dir_from_work_dir}/{line[1]}')
+        full_modified_list.append((line[0],f'{dir_from_work_dir}/{line[1]}'))
 
   full_modified_list.sort(reverse=True)
 
   with open(output_modified_list, 'w') as outfile:
-    outfile.write('\n'.join(full_modified_list))
+    csv.writer(outfile).writerows(full_modified_list)
 
   storage_client = storage.Client()
   bucket = storage_client.get_bucket(export_bucket)

--- a/gcp/workers/exporter/export_runner.py
+++ b/gcp/workers/exporter/export_runner.py
@@ -122,7 +122,7 @@ def aggregate_all_vulnerabilities(work_dir: str, export_bucket: str):
       reader = csv.reader(infile)
       for line in reader:
         # Create <timestamp>,<dir>/<osv_id>
-        full_modified_list.append((line[0],f'{dir_from_work_dir}/{line[1]}'))
+        full_modified_list.append((line[0], f'{dir_from_work_dir}/{line[1]}'))
 
   full_modified_list.sort(reverse=True)
 

--- a/gcp/workers/exporter/export_runner.py
+++ b/gcp/workers/exporter/export_runner.py
@@ -24,7 +24,7 @@ import zipfile as z
 
 from google.cloud import ndb, storage
 
-from exporter import safe_upload_single
+from exporter import safe_upload_single, LAST_MODIFIED_FILE
 import osv
 import osv.logs
 
@@ -44,6 +44,7 @@ def main():
   parser.add_argument(
       '--processes',
       help='Maximum number of parallel exports, default to number of cpu cores',
+      type=int,
       # If 0 or None, use the DEFAULT_EXPORT_PROCESSES value
       default=os.cpu_count() or DEFAULT_EXPORT_PROCESSES)
   args = parser.parse_args()
@@ -74,7 +75,9 @@ def spawn_ecosystem_exporter(work_dir: str, bucket: str, eco: str):
   """
   logging.info('Starting export of ecosystem: %s', eco)
   proc = subprocess.Popen([
-      'exporter.py', '--work_dir', work_dir, '--bucket', bucket, '--ecosystem',
+      # Assume exporter.py is in the same directory as this file
+      # This is true for local dev and Docker
+      f'{__file__}/exporter.py', '--work_dir', work_dir, '--bucket', bucket, '--ecosystem',
       eco
   ])
   return_code = proc.wait()
@@ -103,10 +106,31 @@ def aggregate_all_vulnerabilities(work_dir: str, export_bucket: str):
       file_path = all_vulns[vuln_filename]
       all_zip.write(file_path, os.path.basename(file_path))
 
+  # Also aggregate modified_list.csv files
+  output_modified_list = os.path.join(work_dir, LAST_MODIFIED_FILE)
+  full_modified_list = []
+  for file_path in glob.glob(
+          os.path.join(work_dir, f'**/{LAST_MODIFIED_FILE}'), recursive=True):
+    dir_from_work_dir = os.path.relpath(os.path.dirname(file_path), work_dir)
+    with open(file_path, 'r') as infile:
+      modified_list = infile.read().splitlines()
+      for modified in modified_list:
+        split_modified = modified.split(',')
+        # Create <timestamp>,<dir>/<osv_id>
+        full_modified_list.append(
+          f'{split_modified[0]},{dir_from_work_dir}/{split_modified[1]}')
+
+  full_modified_list.sort(reverse=True)
+
+  with open(output_modified_list, 'w') as outfile:
+    outfile.write('\n'.join(full_modified_list))
+
   storage_client = storage.Client()
   bucket = storage_client.get_bucket(export_bucket)
   safe_upload_single(bucket, output_zip, zip_file_name)
   logging.info('Unified all.zip uploaded successfully.')
+  safe_upload_single(bucket, output_modified_list, LAST_MODIFIED_FILE)
+  logging.info('Unified modified_list.csv uploaded successfully.')
 
 
 if __name__ == '__main__':

--- a/gcp/workers/exporter/exporter.py
+++ b/gcp/workers/exporter/exporter.py
@@ -36,6 +36,7 @@ DEFAULT_EXPORT_BUCKET = 'osv-vulnerabilities'
 DEFAULT_SAFE_DELTA_PCT = 10
 _EXPORT_WORKERS = 32
 ECOSYSTEMS_FILE = 'ecosystems.txt'
+LAST_MODIFIED_FILE = 'modified_id.csv'
 
 
 class Error(Exception):
@@ -141,6 +142,7 @@ class Exporter:
     zip_path = os.path.join(ecosystem_dir, 'all.zip')
     with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zip_file:
       files_to_zip = []
+      id_and_modified = []
 
       @ndb.tasklet
       def _export_to_file_and_zipfile(bug: osv.Bug):
@@ -155,6 +157,10 @@ class Exporter:
           osv.write_vulnerability(vulnerability, file_path)
 
           files_to_zip.append(file_path)
+          # ToJsonString converts it into an ISO string
+          # with timezone Z correctly appended
+          id_and_modified.append('{},{}'.format(
+            vulnerability.modified.ToJsonString(), vulnerability.id))
         except Exception:
           logging.exception('Failed to export bug: "%s"', bug.id())
           raise
@@ -167,6 +173,11 @@ class Exporter:
       files_to_zip.sort()
       for file_path in files_to_zip:
         zip_file.write(file_path, os.path.basename(file_path))
+
+      id_and_modified.sort(reverse=True)
+      with open(os.path.join(ecosystem_dir, LAST_MODIFIED_FILE), 'w') as modified_file:
+        modified_file.write('\n'.join(id_and_modified))
+
 
     with concurrent.futures.ThreadPoolExecutor(
         max_workers=_EXPORT_WORKERS) as executor:

--- a/gcp/workers/exporter/exporter.py
+++ b/gcp/workers/exporter/exporter.py
@@ -15,6 +15,7 @@
 """OSV Exporter."""
 import argparse
 import concurrent.futures
+import csv
 import logging
 import os
 import zipfile
@@ -159,8 +160,8 @@ class Exporter:
           files_to_zip.append(file_path)
           # ToJsonString converts it into an ISO string
           # with timezone Z correctly appended
-          id_and_modified.append('{},{}'.format(
-            vulnerability.modified.ToJsonString(), vulnerability.id))
+          id_and_modified.append(
+              (vulnerability.modified.ToJsonString(), vulnerability.id))
         except Exception:
           logging.exception('Failed to export bug: "%s"', bug.id())
           raise
@@ -175,9 +176,9 @@ class Exporter:
         zip_file.write(file_path, os.path.basename(file_path))
 
       id_and_modified.sort(reverse=True)
-      with open(os.path.join(ecosystem_dir, LAST_MODIFIED_FILE), 'w') as modified_file:
-        modified_file.write('\n'.join(id_and_modified))
-
+      with open(os.path.join(ecosystem_dir, LAST_MODIFIED_FILE),
+                'w') as modified_file:
+        csv.writer(modified_file).writerows(id_and_modified)
 
     with concurrent.futures.ThreadPoolExecutor(
         max_workers=_EXPORT_WORKERS) as executor:


### PR DESCRIPTION
Resolves #3671

This outputs a `modified_id.csv` in this format in each ecosystem directory:
```
<iso modified date>,<id>
```

Then a `modified_id.csv` at the top level containing all vulns:
```
<iso modified date>,<ecosystem_dir>/<id>
```

No deduplication is done between ecosystems.