### PR TITLE
chore(deps): bump go to 1.24.6

### DIFF
--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,6 +1,6 @@
 module osv.dev/bindings/go
 
-go 1.24.4
+go 1.24.6
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,6 +1,6 @@
 module osv.dev/tools
 
-go 1.24.4
+go 1.24.6
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1

--- a/gcp/indexer/go.mod
+++ b/gcp/indexer/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/osv.dev/gcp/indexer
 
-go 1.24.4
+go 1.24.6
 
 require (
 	cloud.google.com/go/datastore v1.20.0

--- a/tools/datastore-remover/go.mod
+++ b/tools/datastore-remover/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/datastore-remover
 
-go 1.24.4
+go 1.24.6
 
 require (
 	cloud.google.com/go/datastore v1.20.0

--- a/tools/indexer-api-caller/go.mod
+++ b/tools/indexer-api-caller/go.mod
@@ -1,3 +1,3 @@
 module github.com/google/indexer-api-caller
 
-go 1.24.4
+go 1.24.6

--- a/vulnfeeds/go.mod
+++ b/vulnfeeds/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/osv/vulnfeeds
 
-go 1.24.4
+go 1.24.6
 
 require (
 	cloud.google.com/go/logging v1.13.0


### PR DESCRIPTION
Should fix the vulnerability osv-scanner is reporting in the docs go.mod file.