### PR TITLE
fix(staging): make GCS 404 less noisy

### DIFF
--- a/gcp/api/server_new.py
+++ b/gcp/api/server_new.py
@@ -203,7 +203,8 @@ def get_vuln_async(vuln_id: str) -> ndb.Future:
     try:
       return f.result()
     except exceptions.NotFound:
-      logging.error('Vulnerability %s not found in GCS', vuln_id)
+      logging.error('Vulnerability %s matched query but not found in GCS',
+                    vuln_id)
       # TODO: send pub/sub message to reimport.
       return None
 


### PR DESCRIPTION
Calling `logging.exception` causes the error reporting dashboard to flag the log, even though 404s are sometimes expected (by e.g. GetByID for an invalid ID)