### PR TITLE
fix(frontend): fix search input style for linter dashboard

### DIFF
--- a/gcp/website/frontend3/src/linter.scss
+++ b/gcp/website/frontend3/src/linter.scss
@@ -207,7 +207,7 @@ tr:hover {
   margin-bottom: 24px;
 }
 
-.search-box input[type="text"] {
+.search-box input {
   flex: 1 0 auto;
   padding: 15px 10px;
   border: none;
@@ -216,7 +216,7 @@ tr:hover {
   font-size: 12pt;
 }
 
-.search-box input[type="text"]:focus {
+.search-box input:focus {
   outline: none;
 }
 

--- a/gcp/website/frontend3/src/templates/linter/index.html
+++ b/gcp/website/frontend3/src/templates/linter/index.html
@@ -64,7 +64,7 @@
                         <div class="search-icon">
                             <i class="material-icons">search</i>
                         </div>
-                        <input type="text" id="search-input" placeholder="Search for a specific record..." />
+                        <input id="search-input" placeholder="Search for a specific record..." />
                     </div>
 
                     <div id="ecosystem-details">


### PR DESCRIPTION
The webpack production build removes type="text" from inputs, since it's the default and seen as redundant. This broke the styling for the linter search input, which was using the selector `.search-box input[type="text"]`. 

This PR fixes the issue by updating the selector to `.search-box input`, which works correctly in all environments without needing complex Webpack configuration changes.