### PR TITLE
chore: enable git submodule updates with renovate

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,4 @@
 [submodule "osv-schema"]
 	path = osv/osv-schema
 	url = https://github.com/ossf/osv-schema.git
+	branch = v1.7.3

--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
     "groupName": "lockfile maintenance"
   },
   "git-submodules": {
-    "enabled": false
+    "enabled": true
   },
   "packageRules": [
     {


### PR DESCRIPTION
Trying to get renovate to only use tagged versions of osv-schema [from their docs](https://docs.renovatebot.com/modules/manager/git-submodules/#updating-to-specific-tag-values). We won't really see how this works until we need to release a new osv-schema version.

One thing to keep in mind:
> **Note:** Using this approach will disrupt the native git submodule update experience when using `git submodule update --remote`. You may encounter an error like `fatal: Unable to find refs/remotes/origin/v0.0.1 revision in submodule path...` because Git can only update submodules when tracking a branch. To manually update the submodule, navigate to the submodule directory and run the following commands: `git fetch && git checkout <new tag>`.

Also, we probably need some way to have the schema version in `models.py` track the tag: https://github.com/google/osv.dev/blob/41bfd396e74faaee38c6f411c33e2b97bbcc9871/osv/models.py#L38
But, currently, changing this version also requires us to update a few tests.
Created #3816 for this.