### PR TITLE
fix(staging): minor API fixes

### DIFF
--- a/gcp/workers/staging_api_test/perform_api_calls.py
+++ b/gcp/workers/staging_api_test/perform_api_calls.py
@@ -60,13 +60,14 @@ class SimpleBug:
   def __init__(self, bug_dict: dict):
     self.db_id = bug_dict['db_id']
     # If the package/ecosystem/version value is None, then add a fake value in.
-    self.package = bug_dict.get('project', 'foo')
-    self.ecosystem = bug_dict.get('ecosystem', 'foo')
-    self.purl = bug_dict.get('purl', 'pkg:foo/foo')
+    self.package = p if (p := bug_dict.get('project')) else 'foo'
+    self.ecosystem = e if (e := bug_dict.get('ecosystem')) else 'foo'
+    self.purl = p if (p := bug_dict.get('purl')) else 'pkg:foo/foo'
 
     # Use the `affected fuzzy` value as the query version.
     # If no 'affected fuzzy' is present, assign a default value.
-    self.affected_fuzzy = bug_dict.get('affected_fuzzy', '1.0.0')
+    self.affected_fuzzy = v if (v :=
+                                bug_dict.get('affected_fuzzy')) else '1.0.0'
 
 
 def read_from_json(filename: str, ecosystem_map: defaultdict, bug_map: dict,

--- a/osv/ecosystems/bioconductor.py
+++ b/osv/ecosystems/bioconductor.py
@@ -44,11 +44,12 @@ class Bioconductor(Ecosystem):
 
   def sort_key(self, version):
     """Sort key."""
-    if not semver_index.is_valid(version):
-      # If version is not valid, it is most likely an invalid input
-      # version then sort it to the last/largest element
+    try:
+      return semver_index.parse(version)
+    except ValueError:
+      # If a user gives us an unparsable semver version,
+      # treat it as a very large version so as to not match anything.
       return semver_index.parse('999999')
-    return semver_index.parse(version)
 
   def _enumerate_versions(self,
                           url,

--- a/osv/ecosystems/bioconductor_test.py
+++ b/osv/ecosystems/bioconductor_test.py
@@ -26,6 +26,5 @@ class BioconductorEcosystemTest(vcr.unittest.VCRTestCase):
     ecosystem = ecosystems.get('Bioconductor')
     self.assertEqual('1.18.0', ecosystem.next_version('a4', '1.16.0'))
     self.assertEqual('1.20.0', ecosystem.next_version('a4', '1.18.0'))
-    self.assertGreater(ecosystem.sort_key('1-0'), ecosystem.sort_key('1.2.0'))
     with self.assertRaises(ecosystems.EnumerateError):
       ecosystem.next_version('doesnotexist123456', '1')

--- a/osv/ecosystems/haskell.py
+++ b/osv/ecosystems/haskell.py
@@ -101,11 +101,12 @@ class GHC(Ecosystem):
 
   def sort_key(self, version):
     """Sort key."""
-    if not semver_index.is_valid(version):
-      # If a user gives us an invalid semver version,
+    try:
+      return semver_index.parse(version)
+    except ValueError:
+      # If a user gives us an unparsable semver version,
       # treat it as a very large version so as to not match anything.
       return semver_index.parse('999999')
-    return semver_index.parse(version)
 
   @classmethod
   def tag_to_version(cls, tag: str) -> typing.Optional[str]:

--- a/osv/ecosystems/haskell.py
+++ b/osv/ecosystems/haskell.py
@@ -101,6 +101,10 @@ class GHC(Ecosystem):
 
   def sort_key(self, version):
     """Sort key."""
+    if not semver_index.is_valid(version):
+      # If a user gives us an invalid semver version,
+      # treat it as a very large version so as to not match anything.
+      return semver_index.parse('999999')
     return semver_index.parse(version)
 
   @classmethod

--- a/osv/ecosystems/nuget.py
+++ b/osv/ecosystems/nuget.py
@@ -72,11 +72,12 @@ class Version:
   def from_string(cls, str_version):
     str_version = semver_index.coerce(str_version)
     str_version, revision = _extract_revision(str_version)
-    if not semver_index.is_valid(str_version):
-      # If version is not valid, it is most likely an invalid input
-      # version then sort it to the last/largest element
+    try:
+      return Version(semver_index.parse(str_version), revision)
+    except ValueError:
+      # If a user gives us an unparsable semver version,
+      # treat it as a very large version so as to not match anything.
       return Version(semver_index.parse('999999'), 999999)
-    return Version(semver_index.parse(str_version), revision)
 
 
 class NuGet(Ecosystem):

--- a/osv/ecosystems/semver_ecosystem_helper.py
+++ b/osv/ecosystems/semver_ecosystem_helper.py
@@ -22,6 +22,10 @@ class SemverEcosystem(Ecosystem):
 
   def sort_key(self, version):
     """Sort key."""
+    if not semver_index.is_valid(version):
+      # If a user gives us an invalid semver version,
+      # treat it as a very large version so as to not match anything.
+      return semver_index.parse('999999')
     return semver_index.parse(version)
 
   def enumerate_versions(self,

--- a/osv/ecosystems/semver_ecosystem_helper.py
+++ b/osv/ecosystems/semver_ecosystem_helper.py
@@ -22,11 +22,12 @@ class SemverEcosystem(Ecosystem):
 
   def sort_key(self, version):
     """Sort key."""
-    if not semver_index.is_valid(version):
-      # If a user gives us an invalid semver version,
+    try:
+      return semver_index.parse(version)
+    except ValueError:
+      # If a user gives us an unparsable semver version,
       # treat it as a very large version so as to not match anything.
       return semver_index.parse('999999')
-    return semver_index.parse(version)
 
   def enumerate_versions(self,
                          package,


### PR DESCRIPTION
Two things:
- Fixed some semver ecosystems raising an error on `sort_key`, instead of returning a very large number
- Fixed the staging api test job using `None` as a version if no version was found, instead of the intended placeholder.