### PR TITLE
fix(vulnfeeds): Improve semver sort comparison so that it is parts length agnostic

### DIFF
--- a/vulnfeeds/cmd/cvelist2osv/version_extraction.go
+++ b/vulnfeeds/cmd/cvelist2osv/version_extraction.go
@@ -424,7 +424,6 @@ func sortBadSemver(a, b string) int {
 	partsA := strings.Split(a, ".")
 	partsB := strings.Split(b, ".")
 
-	if c := cmp.Compare(majorA, majorB); c != 0 {
 	minLen := min(len(partsA), len(partsB))
 	for i := 0; i < minLen; i++ {
 		// Convert parts to integers for numerical comparison.


### PR DESCRIPTION
When running the converter on some Linux vulns, it would break if parts lengths were different. This should make the comparison parts-length agnostic.