### PR TITLE
Add PySentry to the third-party tools list in documentation

### DIFF
--- a/docs/third-party.md
+++ b/docs/third-party.md
@@ -20,3 +20,4 @@ to determine suitability for your use. Some popular third party tools are:
 - [pip-audit](https://github.com/pypa/pip-audit)
 - [Renovate](https://github.com/renovatebot/renovate)
 - [Trivy](https://github.com/aquasecurity/trivy)
+- [PySentry](https://github.com/nyudenkov/pysentry)


### PR DESCRIPTION
Hello!

I recently released PySentry, a Python security vulnerability scanner that leverages OSV.dev as one of its vulnerability data sources alongside PyPA and PyPI databases.

**OSV.dev integration:**
PySentry uses OSV.dev's API to fetch vulnerability data for comprehensive Python package security analysis. Users can specify `--sources osv` or include OSV.dev alongside other sources for broader coverage.

**Links:**
- GitHub: https://github.com/nyudenkov/pysentry  
- Website: https://pysentry.com
- PyPI: https://pypi.org/project/pysentry-rs/

Would you consider adding PySentry to the third-party tools list?

Thanks for maintaining OSV.dev - it's been invaluable for this project!