### PR TITLE
fix(ci): use `ENV key=value` format in Dockerfile

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -25,7 +25,7 @@ COPY install_go.sh /tmp/install_go.sh
 
 RUN "/tmp/install_go.sh"
 # root/go/bin is needed here in order to install Hugo.
-ENV PATH "$PATH:/usr/local/go/bin:/root/go/bin" 
+ENV PATH="$PATH:/usr/local/go/bin:/root/go/bin"
 
 RUN go install -tags extended github.com/gohugoio/hugo@v0.111.3
 


### PR DESCRIPTION
There is a warning of [LegacyKeyValueFormat](https://docs.docker.com/reference/build-checks/legacy-key-value-format/) when building the `ci` image so this PR updates the Dockerfile to use `ENV key=value` format.