### PR TITLE
fix(vulnfeeds): Unwithdraw disputed CVE records

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -163,7 +163,6 @@ func combineIntoOSV(loadedCves map[cves.CVEID]cves.Vulnerability, allParts map[c
 				Logger.Warnf("Unable to determine CVE dispute status of %s: %v", convertedCve.ID, err)
 			}
 			if err == nil && !modified.IsZero() {
-				convertedCve.Withdrawn = modified
 				convertedCve.DatabaseSpecific = make(map[string]interface{})
 				convertedCve.DatabaseSpecific["isDisputed"] = true
 			}


### PR DESCRIPTION
Decision was made to not 'withdraw' disputed vulns, and instead just surface that they were disputed in database_specific