### PR TITLE
docs: mention bindings directory in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ consists of:
 
 | directory       | what |
 |-----------------|------|
+| `bindings/`     | Language bindings for the OSV API (currently Go only) |
 | `deployment/`   | Terraform & Cloud Deploy config files <br /> A few Cloud Build config yamls |
 | `docker/`       | CI docker files (`ci`, `deployment`, `terraform`) <br /> `worker-base` docker image for `gcp/workers/worker` |
 | `docs/`         | Jekyll files for https://google.github.io/osv.dev/ <br /> `build_swagger.py` and `tools.go` |


### PR DESCRIPTION
The `bindings/` directory was not documented in the main `README.md` file.
  
This change adds an entry for it to the directory table, making the repository overview more complete for anyone navigating the project.
