### PR TITLE
fix(ui): Add border to final ecosystem panel

### DIFF
--- a/gcp/website/frontend3/src/styles.scss
+++ b/gcp/website/frontend3/src/styles.scss
@@ -1016,10 +1016,11 @@ dl.vulnerability-details,
     }
 
     $last-ecosystem-border-offset: 12px;
+    $last-ecosystem-border-gap: 8px;
     $last-ecosystem-border-thickness: 3px;
 
     .ecosystem-content-panel--last {
-      padding-bottom: $last-ecosystem-border-offset + 8px;
+      padding-bottom: $last-ecosystem-border-offset + $last-ecosystem-border-gap;
 
       &::before {
         bottom: $last-ecosystem-border-offset + $last-ecosystem-border-thickness;
@@ -1053,7 +1054,11 @@ dl.vulnerability-details,
     }
 
     .package-accordion--last {
-      margin-bottom: $last-ecosystem-border-offset;
+      margin-bottom: 0;
+
+      .package-details-card {
+        margin-bottom: $last-ecosystem-border-gap;
+      }
     }
 
     .package-accordion h3.package-name-title {

--- a/gcp/website/frontend3/src/styles.scss
+++ b/gcp/website/frontend3/src/styles.scss
@@ -999,7 +999,7 @@ dl.vulnerability-details,
       }
     }
 
-.ecosystem-content-panel {
+    .ecosystem-content-panel {
       position: relative;
       padding: 8px 0 16px 16px;
 
@@ -1012,6 +1012,15 @@ dl.vulnerability-details,
         bottom: 0;
         width: 1px;
         background: #555;
+      }
+
+      &:last-child,
+      &:last-of-type {
+        padding-bottom: 0;
+
+        &::before {
+          bottom: 0;
+        }
       }
     }
     

--- a/gcp/website/frontend3/src/styles.scss
+++ b/gcp/website/frontend3/src/styles.scss
@@ -1017,7 +1017,7 @@ dl.vulnerability-details,
 
     $last-ecosystem-border-offset: 12px;
     $last-ecosystem-border-gap: 8px;
-    $last-ecosystem-border-thickness: 3px;
+    $last-ecosystem-border-thickness: 1px;
 
     .ecosystem-content-panel--last {
       padding-bottom: $last-ecosystem-border-offset + $last-ecosystem-border-gap;

--- a/gcp/website/frontend3/src/styles.scss
+++ b/gcp/website/frontend3/src/styles.scss
@@ -1013,14 +1013,26 @@ dl.vulnerability-details,
         width: 1px;
         background: #555;
       }
+    }
 
-      &:last-child,
-      &:last-of-type {
-        padding-bottom: 0;
+    $last-ecosystem-border-offset: 12px;
+    $last-ecosystem-border-thickness: 3px;
 
-        &::before {
-          bottom: 0;
-        }
+    .ecosystem-content-panel--last {
+      padding-bottom: $last-ecosystem-border-offset + 8px;
+
+      &::before {
+        bottom: $last-ecosystem-border-offset + $last-ecosystem-border-thickness;
+      }
+
+      &::after {
+        content: '';
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: $last-ecosystem-border-offset;
+        height: $last-ecosystem-border-thickness;
+        background: $osv-grey-600;
       }
     }
     
@@ -1038,6 +1050,10 @@ dl.vulnerability-details,
         height: 1px;
         background: #555;
       }
+    }
+
+    .package-accordion--last {
+      margin-bottom: $last-ecosystem-border-offset;
     }
 
     .package-accordion h3.package-name-title {

--- a/gcp/website/frontend3/src/templates/vulnerability.html
+++ b/gcp/website/frontend3/src/templates/vulnerability.html
@@ -179,12 +179,13 @@
     {% set ecosystems = vulnerability.affected | group_by_ecosystem %}
   <spicy-sections class="vulnerability-packages force-collapse">
     {% for ecosystem_name, packages in ecosystems.items() -%}
+      {% set is_last_ecosystem = loop.last %}
       <h2 class="package-header">
         <span class="vuln-ecosystem spicy-sections-workaround">{{ ecosystem_name }}</span>
       </h2>
-      <div class="ecosystem-content-panel">
+      <div class="ecosystem-content-panel{% if is_last_ecosystem %} ecosystem-content-panel--last{% endif %}">
         {% for affected in packages -%}
-          <spicy-sections class="package-accordion">
+          <spicy-sections class="package-accordion{% if is_last_ecosystem and loop.last %} package-accordion--last{% endif %}">
             <h3 class="package-name-title">
               {% if 'package' in affected %}{{ affected.package.name }}{% else %}{{ vulnerability.repo | strip_scheme }}{% endif %}
             </h3>


### PR DESCRIPTION
Adds a footer bar so the last ecosystem’s tree ends on a visible horizontal line instead of trailing off.

<img width="1546" height="958" alt="terminator" src="https://github.com/user-attachments/assets/41149d30-9da4-46e0-a53d-c3d296011fe0" />
