### PR TITLE
feat: Normalize git repository URLs for API queries on the new API

### DIFF
--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -26,7 +26,6 @@ import threading
 import time
 import concurrent.futures
 from typing import Callable
-from urllib.parse import urlparse
 
 from collections import defaultdict
 
@@ -108,38 +107,6 @@ ToResponseCallable = Callable[[osv.Bug], ndb.Future]
 _ndb_client = ndb.Client()
 
 # ----
-
-
-def _normalize_git_repo_url(repo_url: str) -> str:
-  """Normalize git repository URL for matching by removing protocol/scheme.
-  
-  This enables matching git repositories regardless of whether they use
-  http, https, git, or other protocols. For example:
-  - http://git.musl-libc.org/git/musl
-  - https://git.musl-libc.org/git/musl
-  - git://git.musl-libc.org/git/musl
-  
-  Will all normalize to: git.musl-libc.org/git/musl
-  
-  Args:
-    repo_url: The git repository URL to normalize
-    
-  Returns:
-    The normalized URL without protocol/scheme
-  """
-  if not repo_url:
-    return repo_url
-
-  try:
-    parsed = urlparse(repo_url)
-    # Remove scheme and reconstruct without it
-    # Keep netloc (hostname) and path
-    normalized = parsed.netloc + parsed.path
-
-    # Remove trailing slash
-    return normalized.rstrip('/')
-  except Exception:
-    return repo_url
 
 
 def ndb_context(func):
@@ -1082,8 +1049,8 @@ def _is_version_affected(affected_packages,
 
         # Normalize both URLs for comparison to handle protocol differences
         # (http vs https vs git://, etc.)
-        normalized_package_name = _normalize_git_repo_url(package_name)
-        normalized_repo_url = _normalize_git_repo_url(repo_url)
+        normalized_package_name = osv.normalize_repo_package(package_name)
+        normalized_repo_url = osv.normalize_repo_package(repo_url)
 
         if normalized_package_name != normalized_repo_url:
           continue

--- a/gcp/api/server_new.py
+++ b/gcp/api/server_new.py
@@ -105,7 +105,8 @@ def affected_affects(name: str, version: str,
   # Make sure the package name correctly matches this entity.
   if affected.ecosystem != 'GIT' and name != affected.name:
     return False
-  if affected.ecosystem == 'GIT' and osv.normalize_repo_package(name) != name:
+  if (affected.ecosystem == 'GIT' and
+      osv.normalize_repo_package(name) != affected.name):
     return False
 
   if len(affected.versions) > 0:

--- a/gcp/api/server_test.py
+++ b/gcp/api/server_test.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from server import should_skip_bucket, _normalize_git_repo_url
+from server import should_skip_bucket
 
 
 class ServerTest(unittest.TestCase):
@@ -40,38 +40,6 @@ class ServerTest(unittest.TestCase):
 
     for path, expected in test_cases:
       self.assertEqual(expected, should_skip_bucket(path))
-
-  def test_normalize_git_repo_url(self):
-    """Test _normalize_git_repo_url function."""
-    test_cases = [
-        # protocol normalization
-        ('http://git.musl-libc.org/git/musl', 'git.musl-libc.org/git/musl'),
-        ('https://git.musl-libc.org/git/musl', 'git.musl-libc.org/git/musl'),
-        ('git://git.musl-libc.org/git/musl', 'git.musl-libc.org/git/musl'),
-
-        # github examples
-        ('http://github.com/user/repo', 'github.com/user/repo'),
-        ('https://github.com/user/repo', 'github.com/user/repo'),
-        ('git://github.com/user/repo', 'github.com/user/repo'),
-
-        # trailing slash
-        ('https://github.com/user/repo/', 'github.com/user/repo'),
-        ('http://git.example.com/path/', 'git.example.com/path'),
-
-        # .git suffix preserved
-        ('https://github.com/user/repo.git', 'github.com/user/repo.git'),
-        ('http://git.example.com/repo.git', 'git.example.com/repo.git'),
-
-        # edge cases
-        ('', ''),
-        ('invalid-url', 'invalid-url'),
-        ('http://', ''),
-        ('https://hostname', 'hostname'),
-    ]
-
-    for repo_url, expected in test_cases:
-      with self.subTest(repo_url=repo_url):
-        self.assertEqual(expected, _normalize_git_repo_url(repo_url))
 
 
 if __name__ == '__main__':

--- a/osv/models_test.py
+++ b/osv/models_test.py
@@ -174,7 +174,7 @@ class ModelsTest(unittest.TestCase):
         models.AffectedVersions(
             vuln_id=vuln_id,
             ecosystem='GIT',
-            name='https://github.com/test/test',
+            name='github.com/test/test',
             versions=['v1', 'v2']),
         models.AffectedVersions(
             vuln_id=vuln_id,
@@ -374,6 +374,38 @@ class ModelsTest(unittest.TestCase):
     bucket = gcs.get_osv_bucket()
     blob = bucket.get_blob(os.path.join(gcs.VULN_PB_PATH, f'{vuln_id}.pb'))
     self.assertIsNone(blob)
+
+  def test_normalize_repo(self):
+    """Test normalize_repo_package function."""
+    test_cases = [
+        # protocol normalization
+        ('http://git.musl-libc.org/git/musl', 'git.musl-libc.org/git/musl'),
+        ('https://git.musl-libc.org/git/musl', 'git.musl-libc.org/git/musl'),
+        ('git://git.musl-libc.org/git/musl', 'git.musl-libc.org/git/musl'),
+
+        # github examples
+        ('http://github.com/user/repo', 'github.com/user/repo'),
+        ('https://github.com/user/repo', 'github.com/user/repo'),
+        ('git://github.com/user/repo', 'github.com/user/repo'),
+
+        # trailing slash
+        ('https://github.com/user/repo/', 'github.com/user/repo'),
+        ('http://git.example.com/path/', 'git.example.com/path'),
+
+        # .git suffix removed
+        ('https://github.com/user/repo.git', 'github.com/user/repo'),
+        ('http://git.example.com/repo.git', 'git.example.com/repo'),
+
+        # edge cases
+        ('', ''),
+        ('invalid-url', 'invalid-url'),
+        ('http://', ''),
+        ('https://hostname', 'hostname'),
+    ]
+
+    for repo_url, expected in test_cases:
+      with self.subTest(repo_url=repo_url):
+        self.assertEqual(expected, models.normalize_repo_package(repo_url))
 
 
 def setUpModule():


### PR DESCRIPTION
For #3830
Change the new `AffectedVersions` entities to store a normalized Git repository URL so that queries with the new API logic so that queries for tags aren't dependent on the exact repository URL:
- remove the protocol/scheme
  -  There are currently only 16 unique repositories in OSV (test instance) that don't use the `https://` scheme, and only 3[^1] of these repos have vulns with both `http://` & `https://`
- remove the `.git` extension
  - Mostly, OSS-Fuzz and CURL uses GitHub repos with the `.git` extension, while our CVE's do not.

I will need to do a re-put of all the GIT records in the test instance to repopulate the names in the `AffectedVersions` entities.

This doesn't yet fix the issue on production - it's too complicated to try fix with the current/old querying logic, it'll just be fixed when the migration is complete.

[^1]: git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git ([http](https://osv.dev/vulnerability/CVE-2019-19352), [https](https://osv.dev/vulnerability/CVE-2023-32255))
git.musl-libc.org/git/musl ([http](https://osv.dev/vulnerability/CVE-2017-15650), [https](https://osv.dev/vulnerability/CVE-2025-26519))
git.savannah.gnu.org/git/wget.git ([http](https://osv.dev/vulnerability/CVE-2016-7098), [https](https://osv.dev/vulnerability/CVE-2018-20483))