### PR TITLE
fix(frontend): affected.package.ecosystem giving 500 errors

### DIFF
--- a/gcp/website/frontend3/src/templates/vulnerability.html
+++ b/gcp/website/frontend3/src/templates/vulnerability.html
@@ -276,7 +276,7 @@
                 <div class="vulnerability-package-subsection mdc-layout-grid__inner">
                     <h3 class="mdc-layout-grid__cell--span-3">Affected versions <a href="https://ossf.github.io/osv-schema/#affectedversions-field" target="_blank" rel="noopener noreferrer"></a></h3>
                     <div class="mdc-layout-grid__cell--span-9 version-value">
-                      {% for group, versions in (affected.versions|group_versions(affected.package.ecosystem)).items() -%}
+                      {% for group, versions in (affected.versions|group_versions(ecosystem_name)).items() -%}
                       <spicy-sections class="versions-section">
                         <h2 class="version-header">{{ group }}</h2>
                         <div class="versions {% if not loop.last %}versions-separator{% endif %}">


### PR DESCRIPTION
Git doesn't strictly have an ecosystem name, so it caused 500 errors when trying to render.