### PR TITLE
fix: binary name in run_debian_convert.sh

### DIFF
--- a/vulnfeeds/cmd/debian/run_debian_convert.sh
+++ b/vulnfeeds/cmd/debian/run_debian_convert.sh
@@ -22,5 +22,5 @@ echo "Begin syncing NVD data from GCS bucket ${INPUT_BUCKET}"
 gcloud --no-user-output-enabled storage -q cp "gs://${INPUT_BUCKET}/nvd/*-????.json" "${CVE_OUTPUT}"
 echo "Successfully synced from GCS bucket"
 
-./debian-osv -output_bucket "$OUTPUT_BUCKET" -output_path "$OSV_OUTPUT_PATH" -num_workers "$WORKERS"
+./debian -output_bucket "$OUTPUT_BUCKET" -output_path "$OSV_OUTPUT_PATH" -num_workers "$WORKERS"
 echo "Successfully converted and uploaded to cloud"


### PR DESCRIPTION
The binary name changed in #3987, but we didn't update the script.