### PR TITLE
fix(api): skip alpine/ubuntu on new api, check vuln ID length

### DIFF
--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -167,6 +167,11 @@ class OSVServicer(osv_service_v1_pb2_grpc.OSVServicer,
   @ndb.synctasklet
   def GetVulnById(self, request, context: grpc.ServicerContext):
     """Return a `Vulnerability` object for a given OSV ID."""
+    # Datastore has a limit of how large indexed properties can be (<=1500B).
+    # Vulnerability IDs aren't going to be that long.
+    if len(request.id) > 100:
+      context.abort(grpc.StatusCode.INVALID_ARGUMENT, 'ID too long')
+      return None
 
     if get_gcp_project() in ('oss-vdb-test', 'test-osv'):
       # Get vuln from GCS

--- a/gcp/api/server_new.py
+++ b/gcp/api/server_new.py
@@ -161,6 +161,14 @@ def _match_versions(version: str, affected: osv.AffectedVersions) -> bool:
 
 def _match_events(version: str, affected: osv.AffectedVersions) -> bool:
   """Check if the given version matches in the AffectedVersions' events list."""
+  # TODO(michaelkedar): We don't support grabbing the release number from PURLs
+  # https://github.com/google/osv.dev/issues/3126
+  # This causes many false positive matches in Ubuntu and Alpine in particular
+  # when doing range-based matching.
+  # We have version enumeration for Alpine, and Ubuntu provides versions for us.
+  # Just skip range-based matching if they don't have release numbers for now.
+  if affected.ecosystem in ('Alpine', 'Ubuntu'):
+    return False
   ecosystem_helper = osv.ecosystems.get(affected.ecosystem)
   if ecosystem_helper is None:
     # Ecosystem does not support comparisons.


### PR DESCRIPTION
- Repeated #3980 for the new API matching logic
- Added a length check to GetVulnById to avoid 500 errors from Datastore