### PR TITLE
refactor(frontend): streamline ecosystem auto-expand logic

### DIFF
--- a/gcp/website/frontend3/src/templates/vulnerability.html
+++ b/gcp/website/frontend3/src/templates/vulnerability.html
@@ -497,23 +497,36 @@
   document.addEventListener('turbo:load', function() {
     const ECOSYSTEM_EXPAND_THRESHOLD = 10;
     const PACKAGE_EXPAND_THRESHOLD = 7;
+    const ECOSYSTEM_PACKAGE_COLLAPSE_THRESHOLD = 9;
 
   /**
    * Sets up the vertical, grouped layout for vulnerability packages.
-   * - All ecosystem headers are expanded if their total count is below `ECOSYSTEM_EXPAND_THRESHOLD`.
+   * - All ecosystem headers are expanded if their total count is below `ECOSYSTEM_EXPAND_THRESHOLD`,
+   *   and if their total packages count is below `ECOSYSTEM_PACKAGE_COLLAPSE_THRESHOLD`.
    * - Within each ecosystem, all package headers are expanded if their count is below `PACKAGE_EXPAND_THRESHOLD`.
    */
     function setupVerticalLayout() {
       const ecosystemHeaders = document.querySelectorAll('.vulnerability-packages.force-collapse .package-header');
       if (!ecosystemHeaders.length) return;
 
-      if (ecosystemHeaders.length < ECOSYSTEM_EXPAND_THRESHOLD) {
-        ecosystemHeaders.forEach(header => {
-          if (header.getAttribute('aria-expanded') === 'false') {
-            header.click();
-          }
-        });
-      }
+      const shouldExpandEcosystems = ecosystemHeaders.length < ECOSYSTEM_EXPAND_THRESHOLD;
+
+      ecosystemHeaders.forEach(header => {
+        const panel = header.nextElementSibling;
+        const packageHeaders = panel ? panel.querySelectorAll('.package-name-title') : [];
+        const hasManyPackages =
+          ecosystemHeaders.length > 1 && packageHeaders.length > ECOSYSTEM_PACKAGE_COLLAPSE_THRESHOLD;
+
+        const shouldExpandHeader =
+          shouldExpandEcosystems &&
+          header.getAttribute('aria-expanded') === 'false' &&
+          panel !== null &&
+          !hasManyPackages;
+
+        if (shouldExpandHeader) {
+          header.click();
+        }
+      });
 
       const ecosystemPanels = document.querySelectorAll('.ecosystem-content-panel');
       ecosystemPanels.forEach(panel => {

--- a/gcp/website/frontend3/src/templates/vulnerability.html
+++ b/gcp/website/frontend3/src/templates/vulnerability.html
@@ -513,13 +513,17 @@
 
       ecosystemHeaders.forEach(header => {
         const panel = header.nextElementSibling;
-        if (
+        const packageHeaders = panel ? panel.querySelectorAll('.package-name-title') : [];
+        const hasManyPackages =
+          ecosystemHeaders.length > 1 && packageHeaders.length > ECOSYSTEM_PACKAGE_COLLAPSE_THRESHOLD;
+
+        const shouldExpandHeader =
           shouldExpandEcosystems &&
           header.getAttribute('aria-expanded') === 'false' &&
-          panel &&
-          !(ecosystemHeaders.length > 1 &&
-            panel.querySelectorAll('.package-name-title').length > ECOSYSTEM_PACKAGE_COLLAPSE_THRESHOLD)
-        ) {
+          panel !== null &&
+          !hasManyPackages;
+
+        if (shouldExpandHeader) {
           header.click();
         }
       });

--- a/gcp/website/frontend3/src/templates/vulnerability.html
+++ b/gcp/website/frontend3/src/templates/vulnerability.html
@@ -513,17 +513,13 @@
 
       ecosystemHeaders.forEach(header => {
         const panel = header.nextElementSibling;
-        const packageHeaders = panel ? panel.querySelectorAll('.package-name-title') : [];
-        const hasManyPackages =
-          ecosystemHeaders.length > 1 && packageHeaders.length > ECOSYSTEM_PACKAGE_COLLAPSE_THRESHOLD;
-
-        const shouldExpandHeader =
+        if (
           shouldExpandEcosystems &&
           header.getAttribute('aria-expanded') === 'false' &&
-          panel !== null &&
-          !hasManyPackages;
-
-        if (shouldExpandHeader) {
+          panel &&
+          !(ecosystemHeaders.length > 1 &&
+            panel.querySelectorAll('.package-name-title').length > ECOSYSTEM_PACKAGE_COLLAPSE_THRESHOLD)
+        ) {
           header.click();
         }
       });


### PR DESCRIPTION
Refactors the Ecosystem Header expand/collapse logic for cases where multi-ecosystem vulnerabilities with large package counts stay collapsed by default. Single-ecosystem vulns behave as before.

This helps avoid endless vertical scrolling for cases like: [RHSA-2025:16669](https://osv.dev/vulnerability/RHSA-2025:16669)