### PR TITLE
fix: ensure '0' version is always sorted first

### DIFF
--- a/osv/ecosystems/alpine.py
+++ b/osv/ecosystems/alpine.py
@@ -31,11 +31,11 @@ from ..cache import cached
 class APK(OrderedEcosystem):
   """Alpine Package Keeper ecosystem helper."""
 
-  def sort_key(self, version):
+  def _sort_key(self, version):
     if not AlpineLinuxVersion.is_valid(version):
       # If version is not valid, it is most likely an invalid input
       # version then sort it to the last/largest element
-      return AlpineLinuxVersion('999999')
+      return AlpineLinuxVersion('9999999999')
     return AlpineLinuxVersion(version)
 
 

--- a/osv/ecosystems/alpine_test.py
+++ b/osv/ecosystems/alpine_test.py
@@ -45,6 +45,10 @@ class APKEcosystemTest(unittest.TestCase):
     self.assertGreater(
         ecosystem.sort_key('1.13.2-r0'), ecosystem.sort_key('1.13.2_alpha'))
 
+    # Check the 0 sentinel value.
+    self.assertLess(
+        ecosystem.sort_key('0'), ecosystem.sort_key('0.0.0_alpha-r0'))
+
     # Check invalid version handle
     self.assertGreater(
         ecosystem.sort_key('1-0-0'), ecosystem.sort_key('1.13.2-r0'))

--- a/osv/ecosystems/bioconductor_test.py
+++ b/osv/ecosystems/bioconductor_test.py
@@ -38,8 +38,7 @@ class BioconductorEcosystemTest(vcr.unittest.VCRTestCase):
     ecosystem = ecosystems.get('Bioconductor')
     self.assertGreater(
         ecosystem.sort_key('1.20.0'), ecosystem.sort_key('1.18.0'))
-    self.assertLess(
-        ecosystem.sort_key('1.18.0'), ecosystem.sort_key('1.18.1'))
+    self.assertLess(ecosystem.sort_key('1.18.0'), ecosystem.sort_key('1.18.1'))
 
     # Check the 0 sentinel value.
     self.assertLess(ecosystem.sort_key('0'), ecosystem.sort_key('0.0.0'))

--- a/osv/ecosystems/bioconductor_test.py
+++ b/osv/ecosystems/bioconductor_test.py
@@ -32,3 +32,20 @@ class BioconductorEcosystemTest(vcr.unittest.VCRTestCase):
       self.assertEqual('1.20.0', ecosystem.next_version('a4', '1.18.0'))
       with self.assertRaises(ecosystems.EnumerateError):
         ecosystem.next_version('doesnotexist123456', '1')
+
+  def test_sort_key(self):
+    """Test sort_key."""
+    ecosystem = ecosystems.get('Bioconductor')
+    self.assertGreater(
+        ecosystem.sort_key('1.20.0'), ecosystem.sort_key('1.18.0'))
+    self.assertLess(
+        ecosystem.sort_key('1.18.0'), ecosystem.sort_key('1.18.1'))
+
+    # Check the 0 sentinel value.
+    self.assertLess(ecosystem.sort_key('0'), ecosystem.sort_key('0.0.0'))
+
+    # Check >= / <= methods
+    self.assertGreaterEqual(
+        ecosystem.sort_key('1.20.0'), ecosystem.sort_key('1.18.0'))
+    self.assertLessEqual(
+        ecosystem.sort_key('1.18.0'), ecosystem.sort_key('1.20.0'))

--- a/osv/ecosystems/cran.py
+++ b/osv/ecosystems/cran.py
@@ -29,7 +29,7 @@ class CRAN(EnumerableEcosystem):
   _API_PACKAGE_URL_POSIT_CRAN = 'https://packagemanager.posit.co/__api__/' + \
     'repos/2/packages/{package}'
 
-  def sort_key(self, version):
+  def _sort_key(self, version):
     """Sort key."""
     # Some documentation on CRAN versioning and the R numeric_version method:
     # https://cran.r-project.org/doc/manuals/R-exts.html#The-DESCRIPTION-file

--- a/osv/ecosystems/cran_test.py
+++ b/osv/ecosystems/cran_test.py
@@ -43,3 +43,18 @@ class CRANEcosystemTest(vcr.unittest.VCRTestCase):
 
       # Test atypical versioned package
       self.assertEqual('0.99-8.47', ecosystem.next_version('aqp', '0.99-8.1'))
+
+  def test_sort_key(self):
+    """Test sort_key."""
+    ecosystem = ecosystems.get('CRAN')
+    self.assertGreater(ecosystem.sort_key('1.0-0'), ecosystem.sort_key('0.1-0'))
+    self.assertLess(ecosystem.sort_key('0.1-0'), ecosystem.sort_key('0.1-1'))
+
+    # Check the 0 sentinel value.
+    self.assertLess(ecosystem.sort_key('0'), ecosystem.sort_key('0.0-0'))
+
+    # Check >= / <= methods
+    self.assertGreaterEqual(
+        ecosystem.sort_key('1.10-0'), ecosystem.sort_key('1.2-0'))
+    self.assertLessEqual(
+        ecosystem.sort_key('1.2-0'), ecosystem.sort_key('1.10-0'))

--- a/osv/ecosystems/debian.py
+++ b/osv/ecosystems/debian.py
@@ -29,11 +29,11 @@ from ..request_helper import RequestError, RequestHelper
 class DPKG(OrderedEcosystem):
   """Debian package (dpkg) ecosystem"""
 
-  def sort_key(self, version):
+  def _sort_key(self, version):
     if not DebianVersion.is_valid(version):
       # If debian version is not valid, it is most likely an invalid fixed
       # version then sort it to the last/largest element
-      return DebianVersion(999999, '999999')
+      return DebianVersion(9999999999, '9999999999')
     return DebianVersion.from_string(version)
 
 

--- a/osv/ecosystems/debian_test.py
+++ b/osv/ecosystems/debian_test.py
@@ -35,6 +35,9 @@ class DPKGEcosystemTest(unittest.TestCase):
     self.assertGreater(
         ecosystem.sort_key('1.13.6-2'), ecosystem.sort_key('1.13.6-1'))
 
+    # Check the 0 sentinel value.
+    self.assertLess(ecosystem.sort_key('0'), ecosystem.sort_key('0:0~0-0'))
+
     # Test that <end-of-life> specifically is greater than normal versions
     self.assertGreater(
         ecosystem.sort_key('<end-of-life>'), ecosystem.sort_key('1.13.6-1'))

--- a/osv/ecosystems/ecosystems_base.py
+++ b/osv/ecosystems/ecosystems_base.py
@@ -52,7 +52,7 @@ class VersionKey:
 
     if self._is_zero:
       return other._is_zero
-    
+
     if other._is_zero:
       return False
 

--- a/osv/ecosystems/ecosystems_base.py
+++ b/osv/ecosystems/ecosystems_base.py
@@ -16,10 +16,56 @@ from abc import ABC, abstractmethod
 from typing import Any
 from warnings import deprecated
 import bisect
+import functools
 import requests
 from urllib.parse import quote
 
 from . import config
+
+
+@functools.total_ordering
+class VersionKey:
+  """A wrapper class for version keys."""
+
+  _key: Any
+  _is_zero: bool
+
+  def __init__(self, key: Any = None, is_zero: bool = False):
+    self._key = key
+    self._is_zero = is_zero
+
+  def __lt__(self, other):
+    if not isinstance(other, VersionKey):
+      return NotImplemented
+
+    if self._is_zero:
+      return not other._is_zero
+
+    if other._is_zero:
+      return False
+
+    return self._key < other._key
+
+  def __eq__(self, other):
+    if not isinstance(other, VersionKey):
+      return NotImplemented
+
+    if self._is_zero:
+      return other._is_zero
+    
+    if other._is_zero:
+      return False
+
+    return self._key == other._key
+
+  def __repr__(self):
+    if self._is_zero:
+      return 'VersionKey(is_zero=True)'
+
+    return f'VersionKey(key={self._key!r})'
+
+
+_VERSION_ZERO = VersionKey(is_zero=True)
 
 
 class OrderedEcosystem(ABC):
@@ -34,11 +80,18 @@ class OrderedEcosystem(ABC):
     self.suffix = suffix
 
   @abstractmethod
-  def sort_key(self, version: str) -> Any:
+  def _sort_key(self, version: str) -> Any:
     """Comparable key for a version.
     
     If the version string is invalid, return a very large version.
     """
+
+  def sort_key(self, version: str) -> VersionKey:
+    """Sort key."""
+    if version == '0':
+      return _VERSION_ZERO
+
+    return VersionKey(self._sort_key(version))
 
   def sort_versions(self, versions: list[str]):
     """Sort versions."""

--- a/osv/ecosystems/haskell.py
+++ b/osv/ecosystems/haskell.py
@@ -32,7 +32,7 @@ class Hackage(EnumerableEcosystem):
 
   _API_PACKAGE_URL = 'https://hackage.haskell.org/package/{package}.json'
 
-  def sort_key(self, version):
+  def _sort_key(self, version):
     """Sort key.
 
     The Haskell package version data type is defined at

--- a/osv/ecosystems/haskell_test.py
+++ b/osv/ecosystems/haskell_test.py
@@ -42,6 +42,9 @@ class HackageEcosystemTest(vcr.unittest.VCRTestCase):
     self.assertGreater(
         ecosystem.sort_key('1-20-0'), ecosystem.sort_key('1.20.0'))
 
+    # Check the 0 sentinel value.
+    self.assertLess(ecosystem.sort_key('0'), ecosystem.sort_key('0.0.0.1'))
+
     # Check >= / <= methods
     self.assertGreaterEqual(
         ecosystem.sort_key('1-20-0'), ecosystem.sort_key('1.20.0'))

--- a/osv/ecosystems/maven.py
+++ b/osv/ecosystems/maven.py
@@ -240,7 +240,7 @@ class Maven(DepsDevMixin, EnumerableEcosystem):
   def deps_dev_system(self) -> str:
     return 'maven'
 
-  def sort_key(self, version):
+  def _sort_key(self, version):
     """Sort key."""
     return Version.from_string(version)
 

--- a/osv/ecosystems/maven_test.py
+++ b/osv/ecosystems/maven_test.py
@@ -93,7 +93,10 @@ class MavenVersionTest(unittest.TestCase):
         '1-alpha-1', '2', 'valid', '0.0'
     ]
 
-    sorted_versions = [str(vk._key) for vk in sorted(self.ecosystem.sort_key(v) for v in unsorted)]
+    sorted_versions = [
+        str(vk._key) for vk in sorted(  # pylint: disable=protected-access
+            self.ecosystem.sort_key(v) for v in unsorted)
+    ]
 
     self.assertListEqual([
         'valid', '0', '1-alpha-1', '1-alpha-1', '1-snapshot', '1', '1', '1',

--- a/osv/ecosystems/maven_test.py
+++ b/osv/ecosystems/maven_test.py
@@ -29,10 +29,11 @@ class MavenVersionTest(unittest.TestCase):
 
   def setUp(self):
     self.maxDiff = None  # pylint: disable=invalid-name
+    self.ecosystem = maven.Maven()
 
   def check_versions_order(self, *versions):
     """Check that our precedence logic matches the expected order."""
-    parsed_versions = [maven.Version.from_string(v) for v in versions]
+    parsed_versions = [self.ecosystem.sort_key(v) for v in versions]
 
     # pylint: disable=consider-using-enumerate
     for i in range(len(parsed_versions)):
@@ -52,7 +53,7 @@ class MavenVersionTest(unittest.TestCase):
 
   def check_versions_equal(self, *versions):
     """Check that the provided versions are equivalent."""
-    parsed_versions = [maven.Version.from_string(v) for v in versions]
+    parsed_versions = [self.ecosystem.sort_key(v) for v in versions]
 
     # pylint: disable=consider-using-enumerate
     for i in range(len(parsed_versions)):
@@ -89,15 +90,13 @@ class MavenVersionTest(unittest.TestCase):
         '1', '1.1', '1-snapshot', '1', '1-sp', '1-foo2', '1-foo10', '1.foo',
         '1-foo', '1-1', '1.1', '1.ga', '1-ga', '1-0', '1.0', '1', '1-sp',
         '1-ga', '1-sp.1', '1-ga.1', '1-sp-1', '1-ga-1', '1-1', '1-a1',
-        '1-alpha-1', '2', 'invalid', '0'
+        '1-alpha-1', '2', 'valid', '0.0'
     ]
 
-    sorted_versions = [
-        str(v) for v in sorted(maven.Version.from_string(v) for v in unsorted)
-    ]
+    sorted_versions = [str(vk._key) for vk in sorted(self.ecosystem.sort_key(v) for v in unsorted)]
 
     self.assertListEqual([
-        'invalid', '0', '1-alpha-1', '1-alpha-1', '1-snapshot', '1', '1', '1',
+        'valid', '0', '1-alpha-1', '1-alpha-1', '1-snapshot', '1', '1', '1',
         '1', '1', '1', '1', '1', '1.foo', '1-.1', '1-sp', '1-sp', '1-sp-1',
         '1-sp.1', '1-foo', '1-foo-2', '1-foo-10', '1-1', '1-1', '1-1', '1.1',
         '1.1', '2'
@@ -152,6 +151,8 @@ class MavenVersionTest(unittest.TestCase):
 
     self.check_versions_order('2.0.1', '2.0.1-123')
     self.check_versions_order('2.0.1-xyz', '2.0.1-123')
+    self.check_versions_order('0-alpha-alpha', '0-alpha')
+    self.check_versions_order('alpha', '0.0')
 
   def test_versions_order_mng_5568(self):
     """Regression test for MNG 5568."""
@@ -234,9 +235,16 @@ class MavenVersionTest(unittest.TestCase):
 
   def test_version_zero(self):
     """Test comparison and equality with versions 0.0.0"""
-    self.check_versions_equal('0.0.0', '0.0', '0')
-    self.check_versions_equal('0.0.0-0.0.0', '0-final-ga', '0')
-    self.check_versions_order('0', '1')
+    self.check_versions_equal('0.0.0', '0.0', '0-0')
+    self.check_versions_equal('0.0.0-0.0.0', '0-final-ga', '0-0')
+    self.check_versions_order('0.0', '1')
+
+    # Check the 0 sentinel value.
+    # This is technically incorrect per Maven's ordering rules, but osv-schema
+    # says "introduced allows a version of the value "0" to represent a version
+    # that sorts before any other version."
+    # The minimal Maven version is alpha-alpha-alpha-... infinitely
+    self.check_versions_order('0', 'alpha-alpha-alpha-alpha')
 
     # actual case from com.graphql-java:graphql-java
     self.check_versions_order('0.0.0-2021-05-17T01-01-51-5ec03a8b', '20.0.0')
@@ -244,9 +252,9 @@ class MavenVersionTest(unittest.TestCase):
   def test_version_ge_le(self):
     """Test >= and <=."""
     self.assertGreaterEqual(
-        maven.Version.from_string('1.10.0'), maven.Version.from_string('1.2.0'))
+        self.ecosystem.sort_key('1.10.0'), self.ecosystem.sort_key('1.2.0'))
     self.assertLessEqual(
-        maven.Version.from_string('1.2.0'), maven.Version.from_string('1.10.0'))
+        self.ecosystem.sort_key('1.2.0'), self.ecosystem.sort_key('1.10.0'))
 
 
 class MavenEcosystemTest(vcr.unittest.VCRTestCase):

--- a/osv/ecosystems/nuget.py
+++ b/osv/ecosystems/nuget.py
@@ -86,7 +86,7 @@ class NuGet(EnumerableEcosystem):
   _API_PACKAGE_URL = ('https://api.nuget.org/v3/registration5-semver1/'
                       '{package}/index.json')
 
-  def sort_key(self, version):
+  def _sort_key(self, version):
     """Sort key."""
     return Version.from_string(version)
 

--- a/osv/ecosystems/nuget_test.py
+++ b/osv/ecosystems/nuget_test.py
@@ -34,8 +34,7 @@ class NuGetVersionTest(unittest.TestCase):
 
   def check_order(self, comparison, first, second):
     """Check order."""
-    comparison(
-        self.ecosystem.sort_key(first), self.ecosystem.sort_key(second))
+    comparison(self.ecosystem.sort_key(first), self.ecosystem.sort_key(second))
 
   def test_equals(self):
     """Test version equals."""

--- a/osv/ecosystems/nuget_test.py
+++ b/osv/ecosystems/nuget_test.py
@@ -30,11 +30,12 @@ class NuGetVersionTest(unittest.TestCase):
 
   def setUp(self):
     self.maxDiff = None  # pylint: disable=invalid-name
+    self.ecosystem = nuget.NuGet()
 
   def check_order(self, comparison, first, second):
     """Check order."""
     comparison(
-        nuget.Version.from_string(first), nuget.Version.from_string(second))
+        self.ecosystem.sort_key(first), self.ecosystem.sort_key(second))
 
   def test_equals(self):
     """Test version equals."""
@@ -83,6 +84,9 @@ class NuGetVersionTest(unittest.TestCase):
     self.check_order(self.assertLess, '1.0.0-pre', '1.0.0.1-alpha')
     self.check_order(self.assertLess, '1.0.0', '1.0.0.1-alpha')
     self.check_order(self.assertLess, '0.9.9.1', '1.0.0')
+
+    # Check the 0 sentinel value.
+    self.check_order(self.assertLess, '0', '0.0.0-0')
 
   def test_ge_le(self):
     """Test version >=/<=."""

--- a/osv/ecosystems/packagist.py
+++ b/osv/ecosystems/packagist.py
@@ -69,7 +69,7 @@ class PackagistVersion:
   def __eq__(self, other):
     if not isinstance(other, self.__class__):
       return NotImplemented
-    return self.canonicalized_version == other.canonicalized_version
+    return self.__cmp__(other) == 0
 
   def __lt__(self, other):
     return self.__cmp__(other) < 0
@@ -199,7 +199,7 @@ class Packagist(EnumerableEcosystem):
 
   _API_PACKAGE_URL = 'https://repo.packagist.org/p2/{package}.json'
 
-  def sort_key(self, version):
+  def _sort_key(self, version):
     return PackagistVersion(version)
 
   def enumerate_versions(self,

--- a/osv/ecosystems/packagist_test.py
+++ b/osv/ecosystems/packagist_test.py
@@ -27,8 +27,7 @@ class PackagistEcosystemTest(vcr.unittest.VCRTestCase):
   def test_packagist(self):
     """Test Packagist."""
     ecosystem = ecosystems.get('Packagist')
-    # Any invalid versions will be handled.
-    self.assertLess(ecosystem.sort_key('invalid'), ecosystem.sort_key('0'))
+    self.assertLess(ecosystem.sort_key('string'), ecosystem.sort_key('0.0'))
     self.assertLess(
         ecosystem.sort_key('4.3-2RC1'), ecosystem.sort_key('4.3-2RC2'))
     self.assertGreater(
@@ -38,6 +37,9 @@ class PackagistEcosystemTest(vcr.unittest.VCRTestCase):
     self.assertGreater(ecosystem.sort_key('1.0.0'), ecosystem.sort_key('1.0'))
     self.assertEqual(
         ecosystem.sort_key('1.0.0rc2'), ecosystem.sort_key('1.0.0.rc2'))
+
+    # Check the 0 sentinel value.
+    self.assertLess(ecosystem.sort_key('0'), ecosystem.sort_key('0-a'))
 
     # Check >= / <= methods
     self.assertGreaterEqual(
@@ -58,8 +60,9 @@ class PackagistEcosystemTest(vcr.unittest.VCRTestCase):
         if line.startswith('//') or line.isspace():
           continue
         pieces = line.strip('\n').split(' ')
-        sort_value = ecosystem.sort_key(pieces[0]).__cmp__(
-            ecosystem.sort_key(pieces[2]))
+        v1 = ecosystem.sort_key(pieces[0])
+        v2 = ecosystem.sort_key(pieces[2])
+        sort_value = (v1 > v2) - (v1 < v2)
 
         if pieces[1] == '<':
           expected_value = -1

--- a/osv/ecosystems/pub.py
+++ b/osv/ecosystems/pub.py
@@ -71,7 +71,7 @@ class Pub(EnumerableEcosystem):
 
   _API_PACKAGE_URL = 'https://pub.dev/api/packages/{package}'
 
-  def sort_key(self, version):
+  def _sort_key(self, version):
     """Sort key."""
     return Version.from_string(version)
 

--- a/osv/ecosystems/pub_test.py
+++ b/osv/ecosystems/pub_test.py
@@ -52,8 +52,7 @@ class PubVersionTest(unittest.TestCase):
     """Test version equality."""
 
     def check_version_equals(v1, v2):
-      self.assertEqual(
-          self.ecosystem.sort_key(v1), self.ecosystem.sort_key(v2))
+      self.assertEqual(self.ecosystem.sort_key(v1), self.ecosystem.sort_key(v2))
 
     check_version_equals('01.2.3', '1.2.3')
     check_version_equals('1.02.3', '1.2.3')

--- a/osv/ecosystems/pub_test.py
+++ b/osv/ecosystems/pub_test.py
@@ -29,6 +29,7 @@ class PubVersionTest(unittest.TestCase):
 
   def setUp(self):
     self.maxDiff = None  # pylint: disable=invalid-name
+    self.ecosystem = pub.Pub()
 
   def test_comparison(self):
     """Test version comparisons."""
@@ -42,8 +43,8 @@ class PubVersionTest(unittest.TestCase):
 
     for i, a_str in enumerate(versions):
       for j, b_str in enumerate(versions):
-        a = pub.Version.from_string(a_str)
-        b = pub.Version.from_string(b_str)
+        a = self.ecosystem.sort_key(a_str)
+        b = self.ecosystem.sort_key(b_str)
         self.assertEqual(a < b, i < j)
         self.assertEqual(a == b, i == j)
 
@@ -51,7 +52,8 @@ class PubVersionTest(unittest.TestCase):
     """Test version equality."""
 
     def check_version_equals(v1, v2):
-      self.assertEqual(pub.Version.from_string(v1), pub.Version.from_string(v2))
+      self.assertEqual(
+          self.ecosystem.sort_key(v1), self.ecosystem.sort_key(v2))
 
     check_version_equals('01.2.3', '1.2.3')
     check_version_equals('1.02.3', '1.2.3')
@@ -62,21 +64,26 @@ class PubVersionTest(unittest.TestCase):
   def test_ge_le(self):
     """Test version >=/<=."""
     self.assertGreaterEqual(
-        pub.Version.from_string('1.10.0'), pub.Version.from_string('1.2.0'))
+        self.ecosystem.sort_key('1.10.0'), self.ecosystem.sort_key('1.2.0'))
     self.assertLessEqual(
-        pub.Version.from_string('1.2.0'), pub.Version.from_string('1.10.0'))
+        self.ecosystem.sort_key('1.2.0'), self.ecosystem.sort_key('1.10.0'))
+
+  def test_zero_sentinel(self):
+    """Test the 0 sentinel value."""
+    self.assertLess(
+        self.ecosystem.sort_key('0'), self.ecosystem.sort_key('0.0.0-0'))
 
   def test_parse(self):
     """Test versions can be parsed."""
-    pub.Version.from_string('0.0.0')
-    pub.Version.from_string('12.34.56')
-    pub.Version.from_string('1.2.3-alpha.1')
-    pub.Version.from_string('1.2.3-x.7.z-92')
-    pub.Version.from_string('1.2.3+build.1')
-    pub.Version.from_string('1.2.3+x.7.z-92')
-    pub.Version.from_string('1.0.0-rc-1+build-1')
+    self.ecosystem.sort_key('0.0.0')
+    self.ecosystem.sort_key('12.34.56')
+    self.ecosystem.sort_key('1.2.3-alpha.1')
+    self.ecosystem.sort_key('1.2.3-x.7.z-92')
+    self.ecosystem.sort_key('1.2.3+build.1')
+    self.ecosystem.sort_key('1.2.3+x.7.z-92')
+    self.ecosystem.sort_key('1.0.0-rc-1+build-1')
     # Tests invalid versions
-    pub.Version.from_string('3.4.0rc3-invalid')
+    self.ecosystem.sort_key('3.4.0rc3-invalid')
 
   def test_empty_identifier(self):
     """Test parsing versions with empty identifiers.
@@ -86,20 +93,20 @@ class PubVersionTest(unittest.TestCase):
 
     This test is probably unnecessary."""
 
-    pub.Version.from_string('1.0.0-a..b')
-    pub.Version.from_string('1.0.0-.a.b')
-    pub.Version.from_string('1.0.0-a.b.')
-    pub.Version.from_string('1.0.0+a..b')
-    pub.Version.from_string('1.0.0+.a.b')
-    pub.Version.from_string('1.0.0+a.b.')
-    pub.Version.from_string('1.0.0-+')
-    pub.Version.from_string('1.0.0-.+.')
-    pub.Version.from_string('1.0.0-....+....')
+    self.ecosystem.sort_key('1.0.0-a..b')
+    self.ecosystem.sort_key('1.0.0-.a.b')
+    self.ecosystem.sort_key('1.0.0-a.b.')
+    self.ecosystem.sort_key('1.0.0+a..b')
+    self.ecosystem.sort_key('1.0.0+.a.b')
+    self.ecosystem.sort_key('1.0.0+a.b.')
+    self.ecosystem.sort_key('1.0.0-+')
+    self.ecosystem.sort_key('1.0.0-.+.')
+    self.ecosystem.sort_key('1.0.0-....+....')
 
     # Basic test for ordering.
-    v_empty = pub.Version.from_string('1.0.0-a..b')
-    v_number = pub.Version.from_string('1.0.0-a.0.b')
-    v_str = pub.Version.from_string('1.0.0-a.a.b')
+    v_empty = self.ecosystem.sort_key('1.0.0-a..b')
+    v_number = self.ecosystem.sort_key('1.0.0-a.0.b')
+    v_str = self.ecosystem.sort_key('1.0.0-a.a.b')
     self.assertLess(v_number, v_empty)
     self.assertLess(v_empty, v_str)
 

--- a/osv/ecosystems/pypi.py
+++ b/osv/ecosystems/pypi.py
@@ -25,7 +25,7 @@ class PyPI(EnumerableEcosystem):
 
   _API_PACKAGE_URL = 'https://pypi.org/pypi/{package}/json'
 
-  def sort_key(self, version):
+  def _sort_key(self, version):
     """Sort key."""
     # version.parse() handles invalid versions by returning LegacyVersion()
     return packaging_legacy.version.parse(version)

--- a/osv/ecosystems/pypi_test.py
+++ b/osv/ecosystems/pypi_test.py
@@ -38,7 +38,11 @@ class PyPIEcosystemTest(vcr.unittest.VCRTestCase):
     """Test sort_key"""
     ecosystem = ecosystems.get('PyPI')
     self.assertGreater(ecosystem.sort_key('2.0.0'), ecosystem.sort_key('1.0.0'))
-    self.assertLess(ecosystem.sort_key('invalid'), ecosystem.sort_key('0'))
+    self.assertLess(ecosystem.sort_key('0'), ecosystem.sort_key('legacy'))
+
+    # Check the 0 sentinel value.
+    self.assertLess(ecosystem.sort_key('0'), ecosystem.sort_key('0.dev0'))
+
     # Check >= / <= methods
     self.assertGreaterEqual(
         ecosystem.sort_key('1.10.0'), ecosystem.sort_key('1.2.0'))

--- a/osv/ecosystems/redhat.py
+++ b/osv/ecosystems/redhat.py
@@ -20,5 +20,5 @@ from .ecosystems_base import OrderedEcosystem
 class RPM(OrderedEcosystem):
   """Red Hat Package Manager ecosystem helper."""
 
-  def sort_key(self, version):
+  def _sort_key(self, version):
     return RpmVersion.from_string(version)

--- a/osv/ecosystems/redhat_test.py
+++ b/osv/ecosystems/redhat_test.py
@@ -36,7 +36,10 @@ class RPMEcosystemTest(unittest.TestCase):
     self.assertGreater(
         ecosystem.sort_key('2:1.14.3-2.module+el8.10.0+1815+5fe7415e'),
         ecosystem.sort_key('2:1.10.3-1.module+el8.10.0+1815+5fe7415e'))
-    self.assertLess(ecosystem.sort_key('invalid'), ecosystem.sort_key('0'))
+    self.assertLess(ecosystem.sort_key('0.string'), ecosystem.sort_key('0.0'))
+
+    # Check the 0 sentinel value.
+    self.assertLess(ecosystem.sort_key('0'), ecosystem.sort_key('0:0~0-0'))
 
     # AlmaLinux
     self.assertGreater(
@@ -60,7 +63,6 @@ class RPMEcosystemTest(unittest.TestCase):
         ecosystem.sort_key('3.2.7-1.mga9'))
     self.assertGreater(
         ecosystem.sort_key('3.2.7-1.2.mga9'), ecosystem.sort_key('0'))
-    self.assertLess(ecosystem.sort_key('invalid'), ecosystem.sort_key('0'))
     self.assertGreater(
         ecosystem.sort_key('1:1.8.11-1.mga9'),
         ecosystem.sort_key('0:1.9.1-2.mga9'))

--- a/osv/ecosystems/rubygems.py
+++ b/osv/ecosystems/rubygems.py
@@ -26,14 +26,14 @@ class RubyGems(EnumerableEcosystem):
 
   _API_PACKAGE_URL = 'https://rubygems.org/api/v1/versions/{package}.json'
 
-  def sort_key(self, version):
+  def _sort_key(self, version):
     """Sort key."""
     # If version is not valid, it is most likely an invalid input
     # version then sort it to the last/largest element
     try:
       return GemVersion(version)
     except InvalidVersionError:
-      return GemVersion('999999')
+      return GemVersion('9999999999')
 
   def enumerate_versions(self,
                          package,

--- a/osv/ecosystems/rubygems_test.py
+++ b/osv/ecosystems/rubygems_test.py
@@ -50,3 +50,5 @@ class RubyGemsEcosystemTest(vcr.unittest.VCRTestCase):
         ecosystem.sort_key('1.10.0.rc1'), ecosystem.sort_key('1.2.0.rc1'))
     self.assertLessEqual(
         ecosystem.sort_key('1.2.0.rc1'), ecosystem.sort_key('1.10.0.rc1'))
+    # Check the 0 sentinel value
+    self.assertLess(ecosystem.sort_key('0'), ecosystem.sort_key('0.0.0.rc0'))

--- a/osv/ecosystems/semver_ecosystem_helper.py
+++ b/osv/ecosystems/semver_ecosystem_helper.py
@@ -22,14 +22,14 @@ class SemverLike(OrderedEcosystem):
   """Ecosystem helper for ecosystems that use SEMVER-compatible versioning,
   but use the ECOSYSTEM version type."""
 
-  def sort_key(self, version):
+  def _sort_key(self, version):
     """Sort key."""
     try:
       return semver_index.parse(version)
     except ValueError:
       # If a user gives us an unparsable semver version,
       # treat it as a very large version so as to not match anything.
-      return semver_index.parse('999999')
+      return semver_index.parse('9999999999')
 
 
 class SemverEcosystem(SemverLike):

--- a/osv/ecosystems/semver_ecosystem_helper_test.py
+++ b/osv/ecosystems/semver_ecosystem_helper_test.py
@@ -32,7 +32,7 @@ class SemVerEcosystemTest(unittest.TestCase):
       self.assertEqual('1.0.1-0', ecosystem.next_version('blah', '1.0.0'))
       self.assertEqual('1.0.0-pre.0',
                        ecosystem.next_version('blah', '1.0.0-pre'))
-      
+
   def test_sort_key(self):
     """Test sort_key"""
     ecosystem = semver_ecosystem_helper.SemverLike('')

--- a/osv/ecosystems/semver_ecosystem_helper_test.py
+++ b/osv/ecosystems/semver_ecosystem_helper_test.py
@@ -16,6 +16,7 @@
 import unittest
 import warnings
 
+from . import semver_ecosystem_helper
 from .. import ecosystems
 
 
@@ -31,3 +32,9 @@ class SemVerEcosystemTest(unittest.TestCase):
       self.assertEqual('1.0.1-0', ecosystem.next_version('blah', '1.0.0'))
       self.assertEqual('1.0.0-pre.0',
                        ecosystem.next_version('blah', '1.0.0-pre'))
+      
+  def test_sort_key(self):
+    """Test sort_key"""
+    ecosystem = semver_ecosystem_helper.SemverLike('')
+    # Check the 0 sentinel value
+    self.assertLess(ecosystem.sort_key('0'), ecosystem.sort_key('0.0.0-0.0'))

--- a/osv/ecosystems/ubuntu.py
+++ b/osv/ecosystems/ubuntu.py
@@ -21,7 +21,7 @@ from .ecosystems_base import OrderedEcosystem
 class Ubuntu(OrderedEcosystem):
   """Ubuntu ecosystem"""
 
-  def sort_key(self, version):
+  def _sort_key(self, version):
     if not UbuntuVersion.is_valid(version):
-      return UbuntuVersion(999999, '999999')
+      return UbuntuVersion(9999999999, '9999999999')
     return UbuntuVersion.from_string(version)

--- a/osv/ecosystems/ubuntu_test.py
+++ b/osv/ecosystems/ubuntu_test.py
@@ -30,6 +30,10 @@ class UbuntuEcosystemTest(unittest.TestCase):
         ecosystem.sort_key('2.42.8+dfsg-1ubuntu0.3'),
         ecosystem.sort_key('2.42.8+dfsg-1ubuntu0.2'))
     self.assertGreater(ecosystem.sort_key('5.4.13-1'), ecosystem.sort_key('0'))
+
+    # Check the 0 sentinel value.
+    self.assertLess(ecosystem.sort_key('0'), ecosystem.sort_key('0:0~0-0'))
+
     self.assertGreater(
         ecosystem.sort_key('5.4.13-1'), ecosystem.sort_key('3.2.30-1'))
     self.assertGreater(


### PR DESCRIPTION
Per the osv-schema:
> `introduced` allows a version of the value `"0"` to represent a version that sorts before any other version.

Previously, we were just coercing "0" to be the general 0 value for the ecosystem (e.g. in semver `0.0.0`).
This caused problems when trying to match e.g. `0.0.0-pre`, which sorts before.

Wrapped all the sort_keys in a `VersionKey` type and added a new sentinel `0` value type that always sorts before other versions.

This is technically incorrect for ecosystems where "0" is a valid version and that supports pre-releases (e.g. in Maven `alpha` < `0-alpha` < `0`) but these edge cases are not worth handling.

On an semi unrelated note, also bumped the max version that some invalid versions get mapped to from `999999` to `9999999999` so that they're larger than CalVer versions e.g. `20250607`

I'm going to have to do a re-computation/reput of the AffectedVersions entities to make sure they're all still sorted.