### PR TITLE
feat(api): make prod api use new datastore entities

### DIFF
--- a/deployment/clouddeploy/osv-api/run-prod.yaml
+++ b/deployment/clouddeploy/osv-api/run-prod.yaml
@@ -10,6 +10,9 @@ spec:
     spec:
       containers:
       - image: osv-server
+        env:
+        - name: OSV_VULNERABILITIES_BUCKET
+          value: osv-vulnerabilities
         resources:
           limits:
             cpu: 2


### PR DESCRIPTION
Switch production over to use new `AffectedVersions` for matching.
There's now a bunch of unused code in server.py that I will remove in a follow-up PR.