### PR TITLE
fix(linter): handle page routing with trailing slash

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -67,5 +67,5 @@ nav_external_links:
     url: https://google.github.io/osv-scanner/
     hide_icon: false # set to true to hide the external link icon - defaults to false
   - title: OSV-Linter
-    url: https://test.osv.dev/linter
+    url: https://osv.dev/linter/
     hide_icon: false # set to true to hide the external link icon - defaults to false

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -67,5 +67,5 @@ nav_external_links:
     url: https://google.github.io/osv-scanner/
     hide_icon: false # set to true to hide the external link icon - defaults to false
   - title: OSV-Linter
-    url: https://osv.dev/linter/
+    url: https://test.osv.dev/linter/
     hide_icon: false # set to true to hide the external link icon - defaults to false

--- a/gcp/website/frontend_handlers.py
+++ b/gcp/website/frontend_handlers.py
@@ -217,7 +217,7 @@ def docs():
   return redirect('https://google.github.io/osv.dev')
 
 
-@blueprint.route('/linter')
+@blueprint.route('/linter', strict_slashes=False)
 def linter():
   return render_template('linter.html')
 


### PR DESCRIPTION
Fixes the trailing slash problem, so now [`/linter`](https://test.osv.dev/linter) and [`/linter/`](https://test.osv.dev/linter/) both resolve correctly.