### PR TITLE
refactor: Move buildVersionRange to be more reusable

### DIFF
--- a/vulnfeeds/cmd/cvelist2osv/version_extraction.go
+++ b/vulnfeeds/cmd/cvelist2osv/version_extraction.go
@@ -187,9 +187,9 @@ func findCPEVersionRanges(cve cves.CVE5) (versionRanges []osvschema.Range, cpes 
 				}
 
 				if match.VersionEndExcluding != "" {
-					versionRanges = append(versionRanges, buildVersionRange(match.VersionStartIncluding, "", match.VersionEndExcluding))
+					versionRanges = append(versionRanges, cves.BuildVersionRange(match.VersionStartIncluding, "", match.VersionEndExcluding))
 				} else if match.VersionEndIncluding != "" {
-					versionRanges = append(versionRanges, buildVersionRange(match.VersionStartIncluding, match.VersionEndIncluding, ""))
+					versionRanges = append(versionRanges, cves.BuildVersionRange(match.VersionStartIncluding, match.VersionEndIncluding, ""))
 				}
 			}
 		}
@@ -276,7 +276,7 @@ func findInverseAffectedRanges(cveAff cves.Affected, cnaAssigner string, metrics
 	// Create ranges by pairing sorted introduced and fixed versions.
 	for index, f := range fixed {
 		if index < len(introduced) {
-			ranges = append(ranges, buildVersionRange(introduced[index], "", f))
+			ranges = append(ranges, cves.BuildVersionRange(introduced[index], "", f))
 			metrics.AddNote("Introduced from version value - %s", introduced[index])
 			metrics.AddNote("Fixed from version value - %s", f)
 		}
@@ -333,9 +333,9 @@ func findNormalAffectedRanges(affected cves.Affected, metrics *ConversionMetrics
 			}
 
 			if introduced != "" && fixed != "" {
-				versionRanges = append(versionRanges, buildVersionRange(introduced, "", fixed))
+				versionRanges = append(versionRanges, cves.BuildVersionRange(introduced, "", fixed))
 			} else if introduced != "" && lastaffected != "" {
-				versionRanges = append(versionRanges, buildVersionRange(introduced, lastaffected, ""))
+				versionRanges = append(versionRanges, cves.BuildVersionRange(introduced, lastaffected, ""))
 			}
 
 			continue
@@ -353,16 +353,16 @@ func findNormalAffectedRanges(affected cves.Affected, metrics *ConversionMetrics
 				continue
 			}
 			if av.Fixed != "" {
-				versionRanges = append(versionRanges, buildVersionRange(av.Introduced, "", av.Fixed))
+				versionRanges = append(versionRanges, cves.BuildVersionRange(av.Introduced, "", av.Fixed))
 				continue
 			} else if av.LastAffected != "" {
-				versionRanges = append(versionRanges, buildVersionRange(av.Introduced, av.LastAffected, ""))
+				versionRanges = append(versionRanges, cves.BuildVersionRange(av.Introduced, av.LastAffected, ""))
 				continue
 			}
 		}
 
 		if currentVersionType == VersionRangeTypeGit {
-			versionRanges = append(versionRanges, buildVersionRange(vers.Version, "", ""))
+			versionRanges = append(versionRanges, cves.BuildVersionRange(vers.Version, "", ""))
 			continue
 		}
 
@@ -380,7 +380,7 @@ func findNormalAffectedRanges(affected cves.Affected, metrics *ConversionMetrics
 
 		// As a fallback, assume a single version means it's the last affected version.
 		if vQuality.AtLeast(acceptableQuality) {
-			versionRanges = append(versionRanges, buildVersionRange("0", vers.Version, ""))
+			versionRanges = append(versionRanges, cves.BuildVersionRange("0", vers.Version, ""))
 			metrics.Notes = append(metrics.Notes, fmt.Sprintf("%s - Single version found %v - Assuming introduced = 0 and last affected = %v", vQuality, vers.Version, vers.Version))
 		}
 	}
@@ -396,31 +396,6 @@ func findNormalAffectedRanges(affected cves.Affected, metrics *ConversionMetrics
 	}
 
 	return versionRanges, mostFrequentVersionType
-}
-
-// buildVersionRange is a helper function that adds 'introduced', 'fixed', or 'last_affected'
-// events to an OSV version range. If 'intro' is empty, it defaults to "0".
-func buildVersionRange(intro string, lastAff string, fixed string) osvschema.Range {
-	var versionRange osvschema.Range
-	var i string
-	if intro == "" {
-		i = "0"
-	} else {
-		i = intro
-	}
-	versionRange.Events = append(versionRange.Events, osvschema.Event{
-		Introduced: i})
-
-	if fixed != "" {
-		versionRange.Events = append(versionRange.Events, osvschema.Event{
-			Fixed: fixed})
-	} else if lastAff != "" {
-		versionRange.Events = append(versionRange.Events, osvschema.Event{
-			LastAffected: lastAff,
-		})
-	}
-
-	return versionRange
 }
 
 // compareSemverLike provides a custom comparison function for version strings that may not

--- a/vulnfeeds/cmd/cvelist2osv/version_extraction_test.go
+++ b/vulnfeeds/cmd/cvelist2osv/version_extraction_test.go
@@ -32,65 +32,6 @@ func TestToVersionRangeType(t *testing.T) {
 	}
 }
 
-func TestBuildVersionRange(t *testing.T) {
-	tests := []struct {
-		name    string
-		intro   string
-		lastAff string
-		fixed   string
-		want    osvschema.Range
-	}{
-		{
-			name:  "intro and fixed",
-			intro: "1.0.0",
-			fixed: "1.0.1",
-			want: osvschema.Range{
-				Events: []osvschema.Event{
-					{Introduced: "1.0.0"},
-					{Fixed: "1.0.1"},
-				},
-			},
-		},
-		{
-			name:    "intro and last_affected",
-			intro:   "1.0.0",
-			lastAff: "1.0.0",
-			want: osvschema.Range{
-				Events: []osvschema.Event{
-					{Introduced: "1.0.0"},
-					{LastAffected: "1.0.0"},
-				},
-			},
-		},
-		{
-			name:  "only intro",
-			intro: "1.0.0",
-			want: osvschema.Range{
-				Events: []osvschema.Event{
-					{Introduced: "1.0.0"},
-				},
-			},
-		},
-		{
-			name: "empty intro",
-			want: osvschema.Range{
-				Events: []osvschema.Event{
-					{Introduced: "0"},
-				},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := buildVersionRange(tt.intro, tt.lastAff, tt.fixed)
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("buildVersionRange() mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
 func TestFindNormalAffectedRanges(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -112,7 +53,7 @@ func TestFindNormalAffectedRanges(t *testing.T) {
 				},
 			},
 			wantRanges: []osvschema.Range{
-				buildVersionRange("1.0", "", "1.5"),
+				cves.BuildVersionRange("1.0", "", "1.5"),
 			},
 			wantRangeType: VersionRangeTypeSemver,
 		},
@@ -128,7 +69,7 @@ func TestFindNormalAffectedRanges(t *testing.T) {
 				},
 			},
 			wantRanges: []osvschema.Range{
-				buildVersionRange("0", "2.0", ""),
+				cves.BuildVersionRange("0", "2.0", ""),
 			},
 			wantRangeType: VersionRangeTypeSemver,
 		},
@@ -143,7 +84,7 @@ func TestFindNormalAffectedRanges(t *testing.T) {
 				},
 			},
 			wantRanges: []osvschema.Range{
-				buildVersionRange("2.0", "", "2.5"),
+				cves.BuildVersionRange("2.0", "", "2.5"),
 			},
 			wantRangeType: VersionRangeTypeEcosystem,
 		},
@@ -159,7 +100,7 @@ func TestFindNormalAffectedRanges(t *testing.T) {
 				},
 			},
 			wantRanges: []osvschema.Range{
-				buildVersionRange("deadbeef", "", ""),
+				cves.BuildVersionRange("deadbeef", "", ""),
 			},
 			wantRangeType: VersionRangeTypeGit,
 		},
@@ -228,7 +169,7 @@ func TestFindInverseAffectedRanges(t *testing.T) {
 			versionType: VersionRangeTypeSemver,
 			cnaAssigner: "Linux",
 			want: []osvschema.Range{
-				buildVersionRange("5.0.0", "", "5.10.1"),
+				cves.BuildVersionRange("5.0.0", "", "5.10.1"),
 			},
 		},
 		{
@@ -267,7 +208,7 @@ func TestFindInverseAffectedRanges(t *testing.T) {
 			versionType: VersionRangeTypeSemver,
 			cnaAssigner: "Linux",
 			want: []osvschema.Range{
-				buildVersionRange("4.0.0", "", "4.5.2"),
+				cves.BuildVersionRange("4.0.0", "", "4.5.2"),
 			},
 		},
 	}

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/knqyf263/go-cpe/naming"
+	"github.com/ossf/osv-schema/bindings/go/osvschema"
 	"github.com/sethvargo/go-retry"
 
 	"github.com/google/osv/vulnfeeds/git"
@@ -1074,4 +1075,29 @@ func ReposFromReferencesCVEList(cve string, refs []Reference, tagDenyList []stri
 	}
 
 	return repos, notes
+}
+
+// BuildVersionRange is a helper function that adds 'introduced', 'fixed', or 'last_affected'
+// events to an OSV version range. If 'intro' is empty, it defaults to "0".
+func BuildVersionRange(intro string, lastAff string, fixed string) osvschema.Range {
+	var versionRange osvschema.Range
+	var i string
+	if intro == "" {
+		i = "0"
+	} else {
+		i = intro
+	}
+	versionRange.Events = append(versionRange.Events, osvschema.Event{
+		Introduced: i})
+
+	if fixed != "" {
+		versionRange.Events = append(versionRange.Events, osvschema.Event{
+			Fixed: fixed})
+	} else if lastAff != "" {
+		versionRange.Events = append(versionRange.Events, osvschema.Event{
+			LastAffected: lastAff,
+		})
+	}
+
+	return versionRange
 }


### PR DESCRIPTION
This function will be used by the new combine-to-osv function, so moving it somewhere for better reusability