### PR TITLE
fix(api): page_tokens

### DIFF
--- a/gcp/api/cursor.py
+++ b/gcp/api/cursor.py
@@ -125,7 +125,7 @@ class QueryCursor:
     try:
       self._ndb_cursor = typing.cast(ndb.Cursor, it.cursor_after())
       self._cursor_state = _QueryCursorState.IN_PROGRESS
-    except ndb_exceptions.BadArgumentError:
+    except ndb_exceptions.BadArgumentError as e:
       # This exception can happen when iterator has not begun iterating
       # and it.next() is the very first element.
       #
@@ -133,8 +133,11 @@ class QueryCursor:
       # throwing this exception.
 
       # We represent this by setting the state to STARTED.
-      self._ndb_cursor = None
-      self._cursor_state = _QueryCursorState.STARTED
+      if 'There is no cursor currently' in str(e):
+        self._ndb_cursor = None
+        self._cursor_state = _QueryCursorState.STARTED
+      else:
+        raise
 
   @property
   def ndb_cursor(self) -> ndb.Cursor | None:

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -957,12 +957,14 @@ def query_package(context,
   if not package_name:
     return []
 
-  query = osv.AffectedVersions.query(
-      osv.AffectedVersions.name.IN([
-          package_name,
-          # Also query the normalized name in case this is a GIT repo.
-          osv.normalize_repo_package(package_name)
-      ]))
+  # Ideally, we'd check both unnormalized and normalized named at once, if there
+  # is no provided ecosystem (even though that is not explicitly supported), but
+  # Datastore cannot give cursors for 'OR' queries, so just only normalize if
+  # this is explicitly GIT.
+  if ecosystem == 'GIT':
+    package_name = osv.normalize_repo_package(package_name)
+
+  query = osv.AffectedVersions.query(osv.AffectedVersions.name == package_name)
   if ecosystem:
     query = query.filter(osv.AffectedVersions.ecosystem == ecosystem)
   query = query.order(osv.AffectedVersions.vuln_id)
@@ -984,7 +986,7 @@ def query_package(context,
     affected: osv.AffectedVersions = it.next()
     if affected.vuln_id == last_matched_id:
       continue
-    if not version or affected_affects(package_name, version, affected):
+    if not version or affected_affects(version, affected):
       if include_details:
         bugs.append(get_vuln_async(affected.vuln_id))
       else:
@@ -995,16 +997,9 @@ def query_package(context,
   return bugs
 
 
-def affected_affects(name: str, version: str,
+def affected_affects(version: str,
                      affected: osv.AffectedVersions) -> bool:
   """Check if a given version is affected by the AffectedVersions entry."""
-  # Make sure the package name correctly matches this entity.
-  if affected.ecosystem != 'GIT' and name != affected.name:
-    return False
-  if (affected.ecosystem == 'GIT' and
-      osv.normalize_repo_package(name) != affected.name):
-    return False
-
   if len(affected.versions) > 0:
     return _match_versions(version, affected)
   if len(affected.events) > 0:

--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -997,8 +997,7 @@ def query_package(context,
   return bugs
 
 
-def affected_affects(version: str,
-                     affected: osv.AffectedVersions) -> bool:
+def affected_affects(version: str, affected: osv.AffectedVersions) -> bool:
   """Check if a given version is affected by the AffectedVersions entry."""
   if len(affected.versions) > 0:
     return _match_versions(version, affected)


### PR DESCRIPTION
When package querying was paginated, it was always returning the 'not started' page token, because you cannot have page tokens in 'OR' queries. The exception was being caught and assumed to be the 'There is no cursor currently' error that happens when you ask for a cursor before iterating.

Removed the 'IN' query (so ecosystem-less queries will not match GIT repos), and made the exception handler explicitly check for 'There is no cursor currently' to help catch this in the future.