### PR TITLE
feat: enable cve5 conversion cron job for prod

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/cve5-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/cve5-to-osv.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cve5-to-osv
+  labels:
+    cronLastSuccessfulTimeMins: "2160"
+spec:
+  timeZone: Australia/Sydney
+  schedule: "0 6,13 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 86400
+      template:
+        spec:
+          containers:
+          - name: cve5-to-osv
+            image: cve5-to-osv
+            imagePullPolicy: Always
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: "8"
+                memory: "64G"
+              limits:
+                cpu: "12"
+                memory: "96G"
+          restartPolicy: Never
+          tolerations:
+          - key: workloadType
+            operator: Equal
+            value: highend
+          volumes:
+            - name: "ssd"
+              hostPath:
+                path: "/mnt/disks/ssd0"

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/cve5-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/cve5-to-osv.yaml
@@ -13,6 +13,6 @@ spec:
               - name: LOCAL_OUT_DIR
                 value: cvelist2osv
               - name: GOOGLE_CLOUD_PROJECT
-                value: oss-vdb-test 
+                value: oss-vdb
               - name: NUM_WORKERS
                 value: "30"


### PR DESCRIPTION
This cron job will only enable the conversion of records into the bucket, not the ingestion into OSV :)