### PR TITLE
fix(frontend): prevent pURL overflow in vulnerability details

### DIFF
--- a/gcp/website/frontend3/src/styles.scss
+++ b/gcp/website/frontend3/src/styles.scss
@@ -806,6 +806,8 @@ dl.vulnerability-details,
 
   .purl {
     font-family: $osv-heading-font-family;
+    overflow-wrap: anywhere;
+    word-break: break-all;
   }
 
   .links {


### PR DESCRIPTION
Fixes a UI issue on the vulnerability details page, where extremely long pURLs would overflow outside their containers. This was spotted on [SUSE-SU-2025](https://osv.dev/vulnerability/SUSE-SU-2025:03333-1#:~:text=pkg%3Arpm/suse/avahi%26distro%3DSUSE%2520Linux%2520Enterprise%2520Module%2520for%2520Desktop%2520Applications%252015%2520SP6). The overflow also caused the layout to break completely on mobile displays, which should now be resolved.