### PR TITLE
fix: CVEList specify a different output

### DIFF
--- a/vulnfeeds/cmd/cve-bulk-converter/run-cvelist-converter.sh
+++ b/vulnfeeds/cmd/cve-bulk-converter/run-cvelist-converter.sh
@@ -54,12 +54,12 @@ fi
 echo "Commence CVEList bulk conversion run"
 ./cve-bulk-converter \
  --years="2022,2023,2024,2025" \
- --out_dir="${LOCAL_OUT_DIR}" \
+ --out_dir="${LOCAL_OUT_DIR}/${OSV_OUTPUT_PATH}" \
  --workers="${NUM_WORKERS}"
 
 # Copy results to staging area.
 echo "Copying CVEList records successfully converted to OSV to aggregated staging"
-find "${LOCAL_OUT_DIR}" -type f -name \*.json \
+find "${LOCAL_OUT_DIR}/${OSV_OUTPUT_PATH}" -type f -name \*.json \
   -exec cp '{}' "${LOCAL_OUT_DIR}/gcs_stage/" \;
 
 # Copy (and remove any missing) results to GCS bucket, with some sanity

--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -1015,7 +1015,7 @@ func ReposFromReferences(cve string, cache VendorProductToRepoMap, vp *VendorPro
 		if !RefAcceptable(ref, tagDenyList) {
 			// Also remove it if previously added under an acceptable tag.
 			MaybeRemoveFromVPRepoCache(cache, vp, ref.URL)
-			logger.Info("Disregarding due to a denied tag", slog.String("cve", cve), slog.String("url", ref.URL), slog.Any("product", vp), slog.Any("tags", ref.Tags))
+			logger.Info(fmt.Sprintf("[%s] Disregarding due to a denied tag", cve), slog.String("cve", cve), slog.String("url", ref.URL), slog.Any("product", vp), slog.Any("tags", ref.Tags))
 
 			continue
 		}
@@ -1036,10 +1036,10 @@ func ReposFromReferences(cve string, cache VendorProductToRepoMap, vp *VendorPro
 		repos = append(repos, repo)
 		MaybeUpdateVPRepoCache(cache, vp, repo)
 	}
-	if vp != nil {
-		logger.Info("Derived repos using references", slog.String("cve", cve), slog.Any("repos", repos), slog.String("vendor", vp.Vendor), slog.String("product", vp.Product))
+	if vp != nil && repos != nil {
+		logger.Info(fmt.Sprintf("[%s] Derived repos using references", cve), slog.String("cve", cve), slog.Any("repos", repos), slog.String("vendor", vp.Vendor), slog.String("product", vp.Product))
 	} else {
-		logger.Info("Derived repos (no CPEs) using references", slog.String("cve", cve), slog.Any("repos", repos))
+		logger.Info(fmt.Sprintf("[%s] Derived repos (no CPEs) using references", cve), slog.String("cve", cve), slog.Any("repos", repos))
 	}
 
 	return repos


### PR DESCRIPTION
I think there's a minor bug that it's capturing everything inside the local dir so it's trying to cp everything twice. this should hopefully fix that