### PR TITLE
ci: disable updating `uses-with` versions in GHA workflows

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -140,6 +140,10 @@
         "python"
       ],
       "enabled": false
+    },
+    {
+      "matchDepTypes": ["uses-with"],
+      "enabled": false
     }
   ],
   "ignorePaths": ["docker/poetry/requirements.txt"]


### PR DESCRIPTION
Renovate has recently gotten support for updating the `uses-with` for GHA actions i.e. `python-version` with `actions/setup-python`, `node-version` with `actions/setup-node` - unfortunately though for some reason it includes this as part of the general "update workflows" task, so we end up with e.g. #4116 which casually bumps the Python version being used up a minor version.

I assume folks would prefer that wasn't the case, so this disables that - I'm pretty sure we could alternatively have Renovate open a dedicated PR for these updates but I'm not sure we could have seperate PRs per action/type (i.e. Node and Python would probably be included together) and overall I just don't think it's that important to have these on the latest versions 🤷 