### PR TITLE
ci: ensure filenames don't have undesired characters

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,9 +32,9 @@ jobs:
         with:
           persist-credentials: false
       - run: |
-          find . -mindepth 1 ! -regex '.*/[()#@,A-Za-z0-9._+-]*' \
-            | xargs -I '{}' bash -c \
-              "echo '{}' && echo '::error file={}::This filename contains undesired characters' && false"
+          find . -mindepth 1 ! -regex '.*/[()#@,A-Za-z0-9._+-]*' -print0 \
+            | xargs -0 -I{} bash -c \
+              'printf "::error file=%q::This filename contains undesired characters\n" "$1" && false' _ {}
   lint:
     name: Lint and format
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should ensure that files are valid across OSs - I've gone with an inclusive pattern which purposely does not have some characters that are technically legal but that I don't think there's a good reason to use them in a filename.

That technically applies to a few of the included characters too since there are existing files that use them, but I am happy to rename those if folks are ok with banning the characters