### PR TITLE
fix: download ALL of the applicable vulns to operate on

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	defaultOSVOutputPath = "osv_output"
+	defaultOSVOutputPath = "osv-output"
 	defaultCVE5Path      = "cve5"
 	defaultNVDOSVPath    = "nvd"
 )

--- a/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
+++ b/vulnfeeds/cmd/combine-to-osv/run_combine_to_osv_convert.sh
@@ -19,7 +19,7 @@ set -eu
 INPUT_BUCKET="${INPUT_GCS_BUCKET:=cve-osv-conversion}"
 OUTPUT_BUCKET="${OUTPUT_GCS_BUCKET:=cve-osv-conversion}"
 
-OSV_OUTPUT="osv_output/"
+OSV_OUTPUT="osv-output"
 NVD_OSV_OUTPUT="nvd"
 CVE5_OSV_OUTPUT="cve5" 
 
@@ -29,11 +29,11 @@ rm -rf $OSV_OUTPUT && mkdir -p $OSV_OUTPUT
 rm -rf $CVE5_OSV_OUTPUT && mkdir -p $CVE5_OSV_OUTPUT
 
 echo "Begin syncing NVD data from GCS bucket ${INPUT_BUCKET}"
-gcloud --no-user-output-enabled storage -q cp "gs://${INPUT_BUCKET}/nvd-osv/*-????.json" "${NVD_OSV_OUTPUT}"
+gcloud --no-user-output-enabled storage -q cp "gs://${INPUT_BUCKET}/nvd-osv/CVE-????-*.json" "${NVD_OSV_OUTPUT}"
 echo "Successfully synced from GCS bucket"
 
 echo "Begin syncing CVE5 data from GCS bucket ${INPUT_BUCKET}"
-gcloud --no-user-output-enabled storage -q cp "gs://${INPUT_BUCKET}/cve5/*-????.json" "${CVE5_OSV_OUTPUT}"
+gcloud --no-user-output-enabled storage -q cp "gs://${INPUT_BUCKET}/cve5/CVE-????-*.json" "${CVE5_OSV_OUTPUT}"
 echo "Successfully synced from GCS bucket"
 
 echo "Run combine-to-osv"


### PR DESCRIPTION
Bad logic was only downloading the OSV records from CVE5 ending in 4 characters, despite CVEs usually having 4-5 characters. this downloads anything with the CVE structure, unfortunately including the .metrics.json files.

I would like to change this to get downloaded with go but for now, this will fix the cron job.