### PR TITLE
docs(blog): fix broken external link

### DIFF
--- a/gcp/website/blog/content/posts/introducing-broad-c-c++-support/index.md
+++ b/gcp/website/blog/content/posts/introducing-broad-c-c++-support/index.md
@@ -35,13 +35,13 @@ Matching C/C++ dependencies to known vulnerabilities has been one of the final p
 
 Submoduled dependencies retain their Git histories. [OSV-Scanner](https://google.github.io/osv-scanner/) [v1.4.3](https://github.com/google/osv-scanner/releases/tag/v1.4.3) is able to determine the most recent Git commits for the submoduled dependencies and return any associated vulnerabilities. 
 
-For example, let’s consider the [yuzu](https://github.com/yuzu-emu/yuzu) project and see if we can find any vulnerabilities in the project dependencies. We’ll be working from commit `43be2bfe332d5537041262eb08037993239eaf5f` for this example. 
+For example, let’s consider the archived [yuzu](https://github.com/yuzu-emu-mirror/yuzu) project repository and see if we can find any vulnerabilities in the project dependencies. We’ll be working from commit `43be2bfe332d5537041262eb08037993239eaf5f` for this example. 
 
 Follow these steps:
 
-1. Clone the yuzu project to your local machine using `git clone https://github.com/yuzu-emu/yuzu`. It is not necessary to use `git clone –recursive`. OSV-Scanner will be able to determine the appropriate Git commits without the recursive flag. 
+1. Clone the yuzu project to your local machine using `git clone --recursive https://github.com/yuzu-emu-mirror/yuzu`.
 2. Checkout the relevant commit using `git -C yuzu checkout 43be2bfe332d5537041262eb08037993239eaf5f`
-3. Run `osv-scanner yuzu/`
+3. Run `osv-scanner -r yuzu`
 
 OSV-Scanner returns the following vulnerabilities from the submoduled dependencies:
 
@@ -67,4 +67,4 @@ Let’s consider the [OpenCV](https://github.com/opencv/opencv) project, which u
 
 ## Try it yourself!
 
-Do you have a project that uses C/C++ dependencies? We encourage you to try our new vulnerable commit range features by using the [latest OSV-Scanner release](https://github.com/google/osv-scanner/releases/tag/v1.4.3) and [let us know](https://github.com/google/osv.dev/issues/new/) about your experience. If you encounter a data issue, please fill out a [data quality report](https://github.com/google/osv.dev/issues/new?assignees=&labels=data+quality&projects=&template=converted-nvd-cve-data-quality-report.md&title=Data+quality+issue+with+CVE-yyyy-nnnn). Your contributions, questions, and feedback will help us improve not only the quality of our data, but will ultimately help users identify and fix vulnerabilities in their projects. 
+Do you have a project that uses C/C++ dependencies? We encourage you to try our new vulnerable commit range features by using the [latest OSV-Scanner release](https://github.com/google/osv-scanner/releases/latest) and [let us know](https://github.com/google/osv.dev/issues/new/) about your experience. If you encounter a data issue, please fill out a [data quality report](https://github.com/google/osv.dev/issues/new?assignees=&labels=data+quality&projects=&template=converted-nvd-cve-data-quality-report.md&title=Data+quality+issue+with+CVE-yyyy-nnnn). Your contributions, questions, and feedback will help us improve not only the quality of our data, but will ultimately help users identify and fix vulnerabilities in their projects. 


### PR DESCRIPTION
This replaces the yuzu link in [Introducing broad C/C++ vulnerability management support](https://osv.dev/blog/posts/introducing-broad-c-c++-support/) with an archived version, since the original repository is no longer available. The example steps have also been updated to reflect the current flow verified locally.

This should fix a `404` reported by the markdown-link-check action.  
There's still `429`/`403` issues but those can be fixed in a separate PR.