### PR TITLE
ci: add mlc_config.json to handle link check failures

### DIFF
--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,11 @@
+{
+  "timeout": "60s",
+  "retryOn429": true,
+  "retryCount": 8,
+  "fallbackRetryDelay": "60s",
+  "aliveStatusCodes": [
+    200, 201, 202, 203, 204, 206,
+    301, 302, 303, 307, 308,
+    401, 403, 405
+  ]
+}


### PR DESCRIPTION
Adds a configuration file for the markdown-link-check action. The config enables retries to handle 429 responses and treats 403 (along with other status codes) as alive.

This should reduce false failures caused by 429/403 responses during link checking. Together with #4133, this should fully fix the failing markdown-link-check action.