### PR TITLE
fix: preserve crates.io build metadata

### DIFF
--- a/osv/ecosystems/_ecosystems.py
+++ b/osv/ecosystems/_ecosystems.py
@@ -19,6 +19,7 @@ from .ecosystems_base import EnumerableEcosystem, OrderedEcosystem
 from .alpine import Alpine, APK
 from .bioconductor import Bioconductor
 from .cran import CRAN
+from .crates import CratesIO
 from .debian import Debian, DPKG
 from .haskell import Hackage, GHC
 from .maven import Maven
@@ -40,7 +41,7 @@ _ecosystems = {
     'Bitnami': SemverEcosystem,
     'Chainguard': APK,
     'CRAN': CRAN,
-    'crates.io': SemverEcosystem,
+    'crates.io': CratesIO,
     'Debian': Debian,
     'Echo': DPKG,
     'GHC': GHC,

--- a/osv/ecosystems/crates.py
+++ b/osv/ecosystems/crates.py
@@ -1,0 +1,81 @@
+"""crates.io ecosystem helper."""
+
+import json
+from typing import Final
+
+from . import config
+from .ecosystems_base import EnumerableEcosystem, EnumerateError
+from .semver_ecosystem_helper import SemverEcosystem
+from ..request_helper import RequestError, RequestHelper
+
+
+class CratesIO(SemverEcosystem, EnumerableEcosystem):
+  """Ecosystem helper for crates.io packages."""
+
+  _API_PACKAGE_URL: Final[str] = 'https://crates.io/api/v1/crates/{package}'
+
+  def __init__(self, suffix: str | None = None):
+    super().__init__(suffix)
+    self._versions_cache: dict[str, list[str]] = {}
+
+  def _fetch_versions(self, package: str) -> list[str]:
+    """Fetch the published versions for the given package."""
+
+    normalized = package.lower()
+    if normalized in self._versions_cache:
+      return self._versions_cache[normalized]
+
+    url = self._API_PACKAGE_URL.format(package=normalized)
+    request_helper = RequestHelper(config.shared_cache)
+
+    try:
+      text_response = request_helper.get(url)
+    except RequestError as ex:
+      if ex.response.status_code == 404:
+        raise EnumerateError(f'Package {package} not found') from ex
+      raise RuntimeError(
+          f'Failed to get crates.io versions for {package} with: '
+          f'{ex.response.text}') from ex
+
+    payload = json.loads(text_response)
+    versions = [
+        entry['num'] for entry in payload.get('versions', [])
+        if not entry.get('yanked', False)
+    ]
+
+    cached_versions = list(versions)
+    self.sort_versions(cached_versions)
+    self._versions_cache[normalized] = cached_versions
+    return cached_versions
+
+  def enumerate_versions(self,
+                         package: str,
+                         introduced: str | None,
+                         fixed: str | None = None,
+                         last_affected: str | None = None,
+                         limits: list[str] | None = None) -> list[str]:
+    versions = self._fetch_versions(package)
+    return self._get_affected_versions(versions, introduced, fixed,
+                                       last_affected, limits)
+
+  def resolve_version(self, package: str, version: str) -> str:
+    """Enrich a version string with build metadata when available."""
+
+    if not version or '+' in version or version in {'0', '0.0.0-0'}:
+      return version
+
+    try:
+      versions = self._fetch_versions(package)
+    except EnumerateError:
+      return version
+
+    if version in versions:
+      return version
+
+    prefix = version + '+'
+    matches = [candidate for candidate in versions if candidate.startswith(prefix)]
+
+    if len(matches) == 1:
+      return matches[0]
+
+    return version

--- a/osv/ecosystems/crates_test.py
+++ b/osv/ecosystems/crates_test.py
@@ -1,0 +1,69 @@
+"""Tests for the crates.io ecosystem helper."""
+
+import json
+import unittest
+from unittest import mock
+
+from .crates import CratesIO
+
+
+def _mock_versions_payload() -> str:
+  """Create a mocked crates.io API payload."""
+
+  payload = {
+      'versions': [
+          {
+              'num': '0.16.2+1.7.2',
+              'yanked': False,
+          },
+          {
+              'num': '0.16.1+1.6.4',
+              'yanked': False,
+          },
+          {
+              'num': '0.16.1+1.6.4-alpha',
+              'yanked': True,
+          },
+          {
+              'num': '0.15.0',
+              'yanked': False,
+          },
+      ],
+  }
+  return json.dumps(payload)
+
+
+class CratesIOTest(unittest.TestCase):
+  """Unit tests for CratesIO."""
+
+  def setUp(self):
+    self.helper = CratesIO()
+
+  @mock.patch('osv.ecosystems.crates.RequestHelper.get')
+  def test_enumerate_versions(self, mock_get):
+    mock_get.return_value = _mock_versions_payload()
+
+    versions = self.helper.enumerate_versions(
+        'libgit2-sys', introduced='0.0.0-0', fixed='0.16.2')
+
+    self.assertIn('0.16.1+1.6.4', versions)
+    self.assertIn('0.15.0', versions)
+    self.assertNotIn('0.16.2+1.7.2', versions)
+
+  @mock.patch('osv.ecosystems.crates.RequestHelper.get')
+  def test_resolve_version_adds_metadata(self, mock_get):
+    mock_get.return_value = _mock_versions_payload()
+
+    resolved = self.helper.resolve_version('libgit2-sys', '0.16.2')
+    self.assertEqual('0.16.2+1.7.2', resolved)
+
+  @mock.patch('osv.ecosystems.crates.RequestHelper.get')
+  def test_resolve_version_no_change_when_unknown(self, mock_get):
+    mock_get.return_value = _mock_versions_payload()
+
+    resolved = self.helper.resolve_version('libgit2-sys', '1.0.0')
+    self.assertEqual('1.0.0', resolved)
+
+
+if __name__ == '__main__':  # pragma: no cover
+  unittest.main()


### PR DESCRIPTION
## Summary
- add a crates.io ecosystem helper that resolves versions with build metadata
- enrich semver ranges for crates.io packages using the helper during impact analysis
- cover the new helper and analysis flow with unit tests

Fixes #4143