### PR TITLE
fix: worker not updating converted record if override doesn't exist

### DIFF
--- a/vulnfeeds/upload/cveworker.go
+++ b/vulnfeeds/upload/cveworker.go
@@ -153,7 +153,9 @@ func Worker(ctx context.Context, vulnChan <-chan *osvschema.Vulnerability, outBk
 				logger.Error("Failed to use override", slog.Any("error", err))
 				continue
 			}
-		} else {
+		}
+
+		if preModifiedBuf == nil {
 			// Marshal before setting modified time to generate hash.
 			preModifiedBuf, err = json.MarshalIndent(vulnToProcess, "", "  ")
 			if err != nil {


### PR DESCRIPTION
When checking for vulnerability overrides, if an override doesn't exist for a specific vulnerability, the code proceeds without marshalling the original vulnerability data. This means an empty buffer is passed to the hashing function and all of our records attached to the upload worker had the same empty input hash.

This is not ideal, as it means nothing gets updated... 