### PR TITLE
feat(frontend): collapse `database_specific` fields

### DIFF
--- a/gcp/website/frontend3/src/styles.scss
+++ b/gcp/website/frontend3/src/styles.scss
@@ -948,6 +948,46 @@ dl.vulnerability-details,
     overflow: auto;
   }
 
+  .database-specific-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .database-specific-section {
+    --const-mq-affordances: [screen] collapse;
+
+    h2.database-specific-header {
+      background: none;
+      font-family: $osv-heading-font-family;
+      color: #fff;
+      padding-left: 0;
+      font-size: 16px;
+      display: flex;
+      align-items: center;
+
+      &::before {
+        content: '';
+        width: 12px;
+        height: 12px;
+        margin-right: 8px;
+        background: url(/static/img/filled-triangle.svg);
+        background-position: center;
+        background-repeat: no-repeat;
+        transform: rotate(0deg);
+        filter: invert(100%);
+      }
+
+      &[expanded]::before {
+        transform: rotate(90deg);
+      }
+    }
+  }
+
+  .database-specific-content {
+    padding: 8px 0 0 24px;
+  }
+
   .spicy-sections-workaround {
     // https://github.com/tabvengers/spicy-sections/issues/64.
     pointer-events: none;

--- a/gcp/website/frontend3/src/templates/vulnerability.html
+++ b/gcp/website/frontend3/src/templates/vulnerability.html
@@ -299,7 +299,23 @@
                 {% if affected.database_specific -%}
                 <div class="vulnerability-package-subsection mdc-layout-grid__inner">
                     <h3 class="mdc-layout-grid__cell--span-3">Database specific <a href="https://ossf.github.io/osv-schema/#affecteddatabase_specific-field" target="_blank" rel="noopener noreferrer"></a></h3>
-                    <div class="mdc-layout-grid__cell--span-9"><pre class="specific">{{ affected.database_specific | display_json }}</pre></div>
+                    <div class="mdc-layout-grid__cell--span-9">
+                      {% set db_specific = affected.database_specific %}
+                      {% if db_specific is mapping %}
+                      <div class="database-specific-list">
+                        {% for key, value in db_specific.items() %}
+                        <spicy-sections class="database-specific-section">
+                          <h2 class="database-specific-header">{{ key }}</h2>
+                          <div class="database-specific-content">
+                            <pre class="specific">{{ value | display_json }}</pre>
+                          </div>
+                        </spicy-sections>
+                        {% endfor %}
+                      </div>
+                      {% else %}
+                      <pre class="specific">{{ db_specific | display_json }}</pre>
+                      {% endif %}
+                    </div>
                 </div>
                 {% endif -%}
               </div>
@@ -477,7 +493,21 @@
               rel="noopener noreferrer"></a>
           </h3>
           <div class="mdc-layout-grid__cell--span-9">
-            <pre class="specific">{{ affected.database_specific | display_json }}</pre>
+            {% set db_specific = affected.database_specific %}
+            {% if db_specific is mapping %}
+            <div class="database-specific-list">
+              {% for key, value in db_specific.items() %}
+              <spicy-sections class="database-specific-section">
+                <h2 class="database-specific-header">{{ key }}</h2>
+                <div class="database-specific-content">
+                  <pre class="specific">{{ value | display_json }}</pre>
+                </div>
+              </spicy-sections>
+              {% endfor %}
+            </div>
+            {% else %}
+            <pre class="specific">{{ db_specific | display_json }}</pre>
+            {% endif %}
           </div>
         </div>
         {% endif -%}


### PR DESCRIPTION
Updates the `database_specific` section to collapse its top-level keys by default. Users can expand individual entries as needed, similar to how the "Affected versions" section works.

Fixes #4163 