### PR TITLE
fix(frontend): render correct repo names in package headers

### DIFF
--- a/gcp/website/frontend3/src/templates/vulnerability.html
+++ b/gcp/website/frontend3/src/templates/vulnerability.html
@@ -193,8 +193,6 @@
                 {% set affected_repo = affected.ranges | default([], true) | selectattr('repo') | map(attribute='repo') | first %}
                 {% if affected_repo %}
                   {{ affected_repo | strip_scheme }}
-                {% elif vulnerability.repo %}
-                  {{ vulnerability.repo | strip_scheme }}
                 {% endif %}
               {% endif %}
             </h3>
@@ -347,8 +345,6 @@
       {% set affected_repo = affected.ranges | default([], true) | selectattr('repo') | map(attribute='repo') | first %}
       {% if affected_repo %}
       {% set package = affected_repo | strip_scheme %}
-      {% elif vulnerability.repo %}
-      {% set package = vulnerability.repo | strip_scheme %}
       {% endif %}
       {% endif %}
       <h2 class="package-header">


### PR DESCRIPTION
Updates Git package headers to use the repo associated with each affected range.

Fixes #4196 