### PR TITLE
fix(models): Handle missing database_specific field in AffectedRange2

### DIFF
--- a/osv/models.py
+++ b/osv/models.py
@@ -628,7 +628,7 @@ class Bug(ndb.Model):
         cr.type = vulnerability_pb2.Credit.Type.Name(credit.type)
       self.credits.append(cr)
 
-    if vulnerability.HasField('database_specific'):
+    if vulnerability.database_specific:
       self.database_specific = json_format.MessageToDict(
           vulnerability.database_specific, preserving_proto_field_name=True)
 


### PR DESCRIPTION
The `AffectedRange2` object was raising an `AttributeError` when `database_specific` was not present in the incoming vulnerability proto message. This change modifies the `update_from_vulnerability` function to safely check for the existence of the `database_specific` field using `HasField()` before attempting to access it.
