### PR TITLE
fix(go/exporter): Make sure all channels readers/writers are context-cancellable

### DIFF
--- a/go/cmd/exporter/exporter.go
+++ b/go/cmd/exporter/exporter.go
@@ -196,6 +196,6 @@ RouterLoop:
 	if ctx.Err() == nil {
 		logger.Info("ecosystem router finished, all vulnerabilities dispatched", slog.Int("total_vulnerabilities", vulnCounter))
 	} else {
-		logger.Info("ecosystem router cancelled")
+		logger.Info("ecosystem router cancelled", slog.Any("err", ctx.Err()))
 	}
 }


### PR DESCRIPTION
When the context was being cancelled, the `ecosystemRouter` seems to have been getting stuck, causing go to ungracefully terminate the program due to deadlock.