### PR TITLE
fix(exporter): resolve some discrepancies between python and go outputs

### DIFF
--- a/go/cmd/exporter/worker.go
+++ b/go/cmd/exporter/worker.go
@@ -251,7 +251,6 @@ func writeZIP(ctx context.Context, path string, allVulns []vulnData, outCh chan<
 	var buf bytes.Buffer
 	wr := zip.NewWriter(&buf)
 	for _, vuln := range allVulns {
-		// w, err := wr.Create(vuln.id + ".json")
 		w, err := wr.CreateHeader(&zip.FileHeader{
 			Name:     vuln.id + ".json",
 			Modified: vuln.modified,


### PR DESCRIPTION
I've identified some differences between the python and go output, and trying to fix some of them (and ignoring some other non-important ones)

So far:
| Difference | Python | Go | 'Fixed' in this PR |
| - | - | - | - |
| JSON formatting | Formatted with indent=2 | Compact | :heavy_check_mark: #4227 |
| JSON keys | Alphabetically sorted keys |Keys in protobuf schema order | :x: |
| Empty `versions` | Explicitly adds `"versions": []` to affected objects for non-`SEMVER` ranges. | Omits `versions` key if empty | :x: |
| JSON numbers | Integers in database_specific can be converted to floats (e.g., "length": 241.0) | Integers are preserved as integers (e.g., "length": 241) | :x: |
| ZIP file timestamps | modified time of file is set to vuln's `modified` time | Left unset (1980-00-00) | :heavy_check_mark: |
| `modified_id.csv` line endings | `\r\n` | `\n` | :x: |
| `modified_id.csv` timestamp tie-breaking | Order not guaranteed | Sorted by ID/path (ascending) after timestamp | :x: |
| `modified_id.csv` timetamp format | Microsecond (if non-zero) with padding 0s (`53.678910Z`)| Nanoseconds, no padding (`53.67891Z`) | :x: |

Most of these are non-issues (or incorrect in the Python version), but I've fixed the ones that seemed important.
