### PR TITLE
fix: run-tests on cloud build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,34 +17,34 @@ steps:
   id: 'init'
   args: ['submodule', 'update', '--init']
 
-- name: 'gcr.io/cloud-builders/gcloud'
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
   id: 'lib-tests'
-  args: ['builds', 'submit', '--region=${LOCATION}', '--config=osv/cloudbuild.yaml', '.']
+  args: ['gcloud', 'builds', 'submit', '--region=${LOCATION}', '--config=osv/cloudbuild.yaml', '.']
   waitFor: ['init']
 
-- name: 'gcr.io/cloud-builders/gcloud'
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
   id: 'worker-tests'
-  args: ['builds', 'submit', '--region=${LOCATION}', '--config=gcp/workers/cloudbuild.yaml', '.']
+  args: ['gcloud', 'builds', 'submit', '--region=${LOCATION}', '--config=gcp/workers/cloudbuild.yaml', '.']
   waitFor: ['init']
 
-- name: 'gcr.io/cloud-builders/gcloud'
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
   id: 'website-tests'
-  args: ['builds', 'submit', '--region=${LOCATION}', '--config=gcp/website/cloudbuild.yaml', '.']
+  args: ['gcloud', 'builds', 'submit', '--region=${LOCATION}', '--config=gcp/website/cloudbuild.yaml', '.']
   waitFor: ['init']
 
-- name: 'gcr.io/cloud-builders/gcloud'
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
   id: 'api-tests'
-  args: ['builds', 'submit', '--region=${LOCATION}', '--config=gcp/api/cloudbuild.yaml', '.']
+  args: ['gcloud', 'builds', 'submit', '--region=${LOCATION}', '--config=gcp/api/cloudbuild.yaml', '.']
   waitFor: ['init']
 
-- name: 'gcr.io/cloud-builders/gcloud'
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
   id: 'vulnfeeds-tests'
-  args: ['builds', 'submit', '--region=${LOCATION}', '--config=vulnfeeds/cloudbuild.yaml', '.']
+  args: ['gcloud', 'builds', 'submit', '--region=${LOCATION}', '--config=vulnfeeds/cloudbuild.yaml', '.']
   waitFor: ['init']
 
-- name: 'gcr.io/cloud-builders/gcloud'
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
   id: 'bindings-tests'
-  args: ['builds', 'submit', '--region=${LOCATION}', '--config=bindings/cloudbuild.yaml', '.']
+  args: ['gcloud', 'builds', 'submit', '--region=${LOCATION}', '--config=bindings/cloudbuild.yaml', '.']
   waitFor: ['init']
 
 timeout: 7200s


### PR DESCRIPTION
For some reason we started getting this error on the `run-tests` Cloud Build job:
```
ERROR: (gcloud.builds.submit) The required property [project] is not currently set.
```

There's also this notice for the images we were using:
```
                   ***** NOTICE *****

Official `cloud-sdk` images, including multiple tagged versions across multiple
platforms, can be found at
https://github.com/GoogleCloudPlatform/cloud-sdk-docker.

Suggested alternative images include:

    gcr.io/google.com/cloudsdktool/cloud-sdk
    gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
    gcr.io/google.com/cloudsdktool/cloud-sdk:debian_component_based
    gcr.io/google.com/cloudsdktool/cloud-sdk:slim

Please note that the `gcloud` entrypoint must be specified when using these
images.

                ***** END OF NOTICE *****
```

I've tried replacing the images with one of these official ones. Creating it locally seems to have worked, but if run-tests is still broken after this I guess we'll have to add the `--project` flag to each of the steps.