### PR TITLE
fix(frontend): affected packages not collapsing when long

### DIFF
--- a/gcp/website/frontend_handlers.py
+++ b/gcp/website/frontend_handlers.py
@@ -773,9 +773,9 @@ def should_collapse(affected):
   total_text_length_ecosystem = sum(
       len(entry.get('package', {}).get('ecosystem', '')) for entry in affected)
   total_text_length_package = sum(
-      (len(entry.get('package', {}).get('name', '')) \
-       + len(entry.get('ranges', {})[0].get('repo','')) \
-       for entry in affected))
+      len(entry.get('package', {}).get('name', '')) +
+      (len(ranges[0].get('repo', '')) if (ranges := entry.get('ranges')) else 0)
+      for entry in affected)
 
   max_total_length = max(total_text_length_ecosystem, total_text_length_package)
 


### PR DESCRIPTION
Git being a fake ecosystem is causing a few edge-case rendering issues. This should help fix this issue where parts are getting cut off:

<img width="1285" height="236" alt="image" src="https://github.com/user-attachments/assets/70529aa5-9d62-4174-91eb-9d6b42665445" />
