### PR TITLE
fix(exporter): Do not indent JSON files

### DIFF
--- a/go/cmd/exporter/worker.go
+++ b/go/cmd/exporter/worker.go
@@ -278,7 +278,7 @@ func writeVanir(ctx context.Context, vanirVulns []vulnData, outCh chan<- writeMs
 	for i, v := range vanirVulns {
 		vulns[i] = v.data
 	}
-	finalJSON, err := json.MarshalIndent(vulns, "", "  ")
+	finalJSON, err := json.Marshal(vulns)
 	if err != nil {
 		logger.Error("failed to marshal vanir JSON file", slog.Any("err", err))
 		return


### PR DESCRIPTION
Indenting the JSON files made the zip files upwards of 6x bigger, which got the exporter OOM killed.

It's better for the data dumps to be smaller & easier to download anyway.