### PR TITLE
fix(api): don't query non-public commits

### DIFF
--- a/gcp/api/server.py
+++ b/gcp/api/server.py
@@ -894,7 +894,10 @@ def query_by_commit(context: QueryContext,
   Returns:
     A list of Vulnerability protos.
   """
-  query = osv.AffectedCommits.query(osv.AffectedCommits.commits == commit)
+  query = osv.AffectedCommits.query(
+      osv.AffectedCommits.commits == commit,
+      # pylint: disable=singleton-comparison
+      osv.AffectedCommits.public == True)
 
   context.query_counter += 1
   if context.should_skip_query():


### PR DESCRIPTION
I didn't add a check for `public` `AffectedCommits` to the new API logic, which was causing error logs because non-public OSS-Fuzz vulns doing have `Vulnerability` entities or protos in the bucket.