### PR TITLE
chore(exporter): update osvschema version for protojson change

### DIFF
--- a/go/cmd/exporter/worker.go
+++ b/go/cmd/exporter/worker.go
@@ -194,13 +194,9 @@ func (w *allEcosystemWorker) Finish() {
 	close(w.inCh)
 }
 
-var protoMarshaller = protojson.MarshalOptions{
-	UseProtoNames: true, // TODO(michaelkedar): https://github.com/ossf/osv-schema/pull/442
-}
-
 // marshalToJSON marshals the vulnerability proto to formatted JSON bytes.
 func marshalToJSON(vuln *osvschema.Vulnerability) ([]byte, error) {
-	b, err := protoMarshaller.Marshal(vuln)
+	b, err := protojson.Marshal(vuln)
 	if err != nil {
 		return nil, err
 	}

--- a/go/go.mod
+++ b/go/go.mod
@@ -7,7 +7,7 @@ require (
 	cloud.google.com/go/pubsub/v2 v2.2.1
 	cloud.google.com/go/storage v1.57.0
 	github.com/charmbracelet/lipgloss v1.1.0
-	github.com/ossf/osv-schema/bindings/go v0.0.0-20251021042217-ed6345fb08ca
+	github.com/ossf/osv-schema/bindings/go v0.0.0-20251023235818-d5eaee79a3a5
 	google.golang.org/api v0.252.0
 	google.golang.org/protobuf v1.36.10
 )

--- a/go/go.sum
+++ b/go/go.sum
@@ -121,8 +121,8 @@ github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6T
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
-github.com/ossf/osv-schema/bindings/go v0.0.0-20251021042217-ed6345fb08ca h1:SRgWTKiWfQFjtJi95PolKubEo9qOAgE+V0APAnI3ThM=
-github.com/ossf/osv-schema/bindings/go v0.0.0-20251021042217-ed6345fb08ca/go.mod h1:Eo7R19vlnflsCRdHW1ynyNUyoRwxdaTmTWD9MtKnJTc=
+github.com/ossf/osv-schema/bindings/go v0.0.0-20251023235818-d5eaee79a3a5 h1:FLTrCJwXqCpxVwaZXmYDKaNJSypW2Ffzu0B5SntW/sg=
+github.com/ossf/osv-schema/bindings/go v0.0.0-20251023235818-d5eaee79a3a5/go.mod h1:Eo7R19vlnflsCRdHW1ynyNUyoRwxdaTmTWD9MtKnJTc=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
The vulnerability.proto in osv-schema now has `json_name`s  to make the multi-word fields snake_case, so we don't need to `UseProtoNames` anymore.