### PR TITLE
fix: eef yaml config

### DIFF
--- a/source_test.yaml
+++ b/source_test.yaml
@@ -224,8 +224,8 @@
   type: 2
   rest_api_url: 'https://cna.erlef.org/osv/all.json'
   db_prefix: ['EEF-']
-  human_link: 'https://cna.erlef.org/cves/{{ CVE_ID }}.html'
-  link:  'https://cna.erlef.org/cves/'
+  human_link: 'https://cna.erlef.org/cves/{{ BUG_ID }}.html'
+  link:  'https://cna.erlef.org/osv/'
   directory_path: 'osv'
   extension: '.json'
   ignore_patterns: ['^(?!EEF-).*$']


### PR DESCRIPTION
We didn't catch this when merging:
- `link` was 404-ing, since it's expecting the prefix of the path to the OSV record
- `human_link` was using `CVE_ID` instead of `BUG_ID`