### PR TITLE
fix: Correct EEF Test Source Link

### DIFF
--- a/source_test.yaml
+++ b/source_test.yaml
@@ -224,7 +224,7 @@
   type: 2
   rest_api_url: 'https://cna.erlef.org/osv/all.json'
   db_prefix: ['EEF-']
-  human_link: 'https://cna.erlef.org/cves/{{ BUG_ID }}.html'
+  human_link: 'https://cna.erlef.org/osv/{{ BUG_ID }}.html'
   link:  'https://cna.erlef.org/osv/'
   directory_path: 'osv'
   extension: '.json'


### PR DESCRIPTION
Follow up to #4192 & #4267

The link only existed with the CVE ID in it and not the OSV ID. I created a redirect at the given path.

I've verified a few test cases manually, but still can't see any info on `https://api.test.osv.dev/v1experimental/importfindings/eef`.