### PR TITLE
fix: Set Hex ecosystem purl type

### DIFF
--- a/osv/purl_helpers.py
+++ b/osv/purl_helpers.py
@@ -56,7 +56,7 @@ ECOSYSTEM_PURL_DATA = {
     'Hackage':
         EcosystemPURL('hackage', None),
     'Hex':
-        EcosystemPURL('hex', None),
+        EcosystemPURL('hex', 'hex'),
     'Julia':
         EcosystemPURL('julia', None),
     # Linux


### PR DESCRIPTION
See https://github.com/package-url/purl-spec/blob/3e98d4aaa7f4ad3c67eff0b753d12b378ea47a0a/types-doc/hex-definition.md#L4