### PR TITLE
chore: have renovate update osv-schema version in the linter

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -158,6 +158,20 @@
       ],
       "depNameTemplate": "gcr.io/endpoints-release/endpoints-runtime-serverless",
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "gcp/workers/linter/Dockerfile"
+      ],
+      "matchStrings": [
+        "git clone https://github\\.com/ossf/osv-schema\\.git.*checkout (?<currentDigest>[a-f0-9]{40})"
+      ],
+      "currentValueTemplate": "main",
+      "depNameTemplate": "osv-schema",
+      "packageNameTemplate": "https://github.com/ossf/osv-schema",
+      "datasourceTemplate": "git-refs",
+      "versioningTemplate": "git"
     }
   ],
   "ignorePaths": ["docker/poetry/requirements.txt"]


### PR DESCRIPTION
`customManagers` are fun.
The regex matching is quite brittle, but it should be working.