### PR TITLE
ci: Enable bumping golang-version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -144,6 +144,10 @@
     {
       "matchDepTypes": ["uses-with"],
       "enabled": false
+    },
+    {
+      "matchDatasources": ["golang-version"],
+      "rangeStrategy": "bump"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Enable renovatebot to bump the golang-version e.g. `go 1.23.4` at the top of go.mod files