### PR TITLE
feat: Add Julia ecosystem to source_test

### DIFF
--- a/source_test.yaml
+++ b/source_test.yaml
@@ -279,6 +279,21 @@
   repo_username: 'git'
   strict_validation: True
 
+- name: 'julia'
+  versions_from_repo: False
+  type: 0
+  ignore_patterns: ['^(?!JLSEC-).*$']
+  repo_branch: 'generated/osv'
+  repo_url: 'https://github.com/JuliaLang/SecurityAdvisories.jl.git'
+  detect_cherrypicks: False
+  extension: '.json'
+  db_prefix: ['JLSEC-']
+  ignore_git: False
+  link: 'https://github.com/JuliaLang/SecurityAdvisories.jl/tree/generated/osv/'
+  editable: False
+  repo_username: 'git'
+  strict_validation: True
+
 - name: 'mageia'
   versions_from_repo: False
   rest_api_url: 'https://advisories.mageia.org/vulns.json'


### PR DESCRIPTION
Our structure is quite similar to Haskell's here.  We don't (yet) have a human-rendered HTML page, but we could link directly to the markdowns on GitHub if you'd prefer to have _something_ for the human_link.  E.g., https://github.com/JuliaLang/SecurityAdvisories.jl/blob/main/advisories/published/2025/JLSEC-2025-1.md is fairly human-friendly.