### PR TITLE
chore: Update the go version to fix vulnerability

### DIFF
--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,6 +1,6 @@
 module osv.dev/bindings/go
 
-go 1.24.8
+go 1.25.3
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,6 +1,6 @@
 module osv.dev/tools
 
-go 1.24.8
+go 1.25.3
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3

--- a/gcp/indexer/go.mod
+++ b/gcp/indexer/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/osv.dev/gcp/indexer
 
-go 1.24.8
+go 1.25.3
 
 require (
 	cloud.google.com/go/datastore v1.21.0

--- a/gcp/workers/linter/Dockerfile
+++ b/gcp/workers/linter/Dockerfile
@@ -14,7 +14,7 @@
 
 
 # Stage 1: Build the Go linter binary
-FROM golang:1.25.3-alpine AS go_builder
+FROM golang:1.25.3-alpine@sha256:aee43c3ccbf24fdffb7295693b6e33b21e01baec1b2a55acc351fde345e9ec34 AS go_builder
 
 RUN apk add --no-cache git
 WORKDIR /src

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/osv.dev/go
 
-go 1.24.8
+go 1.25.3
 
 require (
 	cloud.google.com/go/datastore v1.21.0

--- a/tools/apitester/go.mod
+++ b/tools/apitester/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/apitester
 
-go 1.24.8
+go 1.25.3
 
 require (
 	github.com/gkampitakis/go-snaps v0.5.15

--- a/tools/datastore-remover/go.mod
+++ b/tools/datastore-remover/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/datastore-remover
 
-go 1.24.8
+go 1.25.3
 
 require (
 	cloud.google.com/go/datastore v1.21.0

--- a/tools/indexer-api-caller/go.mod
+++ b/tools/indexer-api-caller/go.mod
@@ -1,3 +1,3 @@
 module github.com/google/indexer-api-caller
 
-go 1.24.8
+go 1.25.3

--- a/vulnfeeds/cmd/alpine/Dockerfile
+++ b/vulnfeeds/cmd/alpine/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25.1-alpine@sha256:b6ed3fd0452c0e9bcdef5597f29cc1418f61672e9d3a2f55bf02e7222c014abd AS GO_BUILD
+FROM golang:1.25.3-alpine@sha256:aee43c3ccbf24fdffb7295693b6e33b21e01baec1b2a55acc351fde345e9ec34 AS GO_BUILD
 
 RUN mkdir /src
 WORKDIR /src

--- a/vulnfeeds/cmd/combine-to-osv/Dockerfile
+++ b/vulnfeeds/cmd/combine-to-osv/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25.1-alpine@sha256:b6ed3fd0452c0e9bcdef5597f29cc1418f61672e9d3a2f55bf02e7222c014abd AS GO_BUILD
+FROM golang:1.25.3-alpine@sha256:aee43c3ccbf24fdffb7295693b6e33b21e01baec1b2a55acc351fde345e9ec34 AS GO_BUILD
 
 RUN mkdir /src
 WORKDIR /src

--- a/vulnfeeds/cmd/cpe-repo-gen/Dockerfile
+++ b/vulnfeeds/cmd/cpe-repo-gen/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25.1-alpine@sha256:b6ed3fd0452c0e9bcdef5597f29cc1418f61672e9d3a2f55bf02e7222c014abd AS GO_BUILD
+FROM golang:1.25.3-alpine@sha256:aee43c3ccbf24fdffb7295693b6e33b21e01baec1b2a55acc351fde345e9ec34 AS GO_BUILD
 
 RUN mkdir /src
 WORKDIR /src

--- a/vulnfeeds/cmd/cve-bulk-converter/Dockerfile
+++ b/vulnfeeds/cmd/cve-bulk-converter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25.1-alpine@sha256:b6ed3fd0452c0e9bcdef5597f29cc1418f61672e9d3a2f55bf02e7222c014abd AS go_build
+FROM golang:1.25.3-alpine@sha256:aee43c3ccbf24fdffb7295693b6e33b21e01baec1b2a55acc351fde345e9ec34 AS go_build
 
 RUN mkdir /src
 WORKDIR /src

--- a/vulnfeeds/cmd/debian/Dockerfile
+++ b/vulnfeeds/cmd/debian/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25.1-alpine@sha256:b6ed3fd0452c0e9bcdef5597f29cc1418f61672e9d3a2f55bf02e7222c014abd AS GO_BUILD
+FROM golang:1.25.3-alpine@sha256:aee43c3ccbf24fdffb7295693b6e33b21e01baec1b2a55acc351fde345e9ec34 AS GO_BUILD
 
 RUN mkdir /src
 WORKDIR /src

--- a/vulnfeeds/cmd/download-cves/Dockerfile
+++ b/vulnfeeds/cmd/download-cves/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25.1-alpine@sha256:b6ed3fd0452c0e9bcdef5597f29cc1418f61672e9d3a2f55bf02e7222c014abd AS GO_BUILD
+FROM golang:1.25.3-alpine@sha256:aee43c3ccbf24fdffb7295693b6e33b21e01baec1b2a55acc351fde345e9ec34 AS GO_BUILD
 
 RUN mkdir /src
 WORKDIR /src

--- a/vulnfeeds/cmd/nvd-cve-osv/Dockerfile
+++ b/vulnfeeds/cmd/nvd-cve-osv/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.25.1-alpine@sha256:b6ed3fd0452c0e9bcdef5597f29cc1418f61672e9d3a2f55bf02e7222c014abd AS GO_BUILD
+FROM golang:1.25.3-alpine@sha256:aee43c3ccbf24fdffb7295693b6e33b21e01baec1b2a55acc351fde345e9ec34 AS GO_BUILD
 
 WORKDIR /go/src
 

--- a/vulnfeeds/go.mod
+++ b/vulnfeeds/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/osv/vulnfeeds
 
-go 1.24.8
+go 1.25.3
 
 require (
 	cloud.google.com/go/secretmanager v1.15.0


### PR DESCRIPTION
OSV-Scanner is reporting new vulns for go 1.24.6, so bumping everything up to 1.25.3. Hopefully in the future renovatebot can do this for us.