### PR TITLE
chore(apitester): replace modified properties to reduce noise

### DIFF
--- a/tools/apitester/__snapshots__/cassette_TestCommand.snap
+++ b/tools/apitester/__snapshots__/cassette_TestCommand.snap
@@ -61,123 +61,123 @@
       "vulns": [
         {
           "id": "GO-2024-2598",
-          "modified": "2024-10-22T05:29:10.013727Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2599",
-          "modified": "2024-10-22T05:29:04.026559Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2600",
-          "modified": "2024-10-22T05:29:00.945548Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2609",
-          "modified": "2024-10-22T05:29:09.769129Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2610",
-          "modified": "2024-10-22T05:29:02.767625Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2687",
-          "modified": "2025-03-31T16:24:22.897568Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2024-2887",
-          "modified": "2024-10-22T05:28:58.836290Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2888",
-          "modified": "2024-10-22T05:28:58.470910Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2963",
-          "modified": "2024-07-15T22:26:59.152Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-3105",
-          "modified": "2024-09-10T08:12:19.721080Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-3106",
-          "modified": "2024-09-10T08:12:21.917879Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-3107",
-          "modified": "2024-09-10T08:12:21.518996Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2025-3373",
-          "modified": "2025-01-30T20:12:14.327943Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3420",
-          "modified": "2025-01-30T20:12:08.973745Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3447",
-          "modified": "2025-02-08T08:11:54.994992Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3563",
-          "modified": "2025-10-24T21:27:27.901002Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3750",
-          "modified": "2025-06-14T06:28:19.438040Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3751",
-          "modified": "2025-06-14T06:28:26.229496Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3849",
-          "modified": "2025-08-11T06:27:06.746398Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3956",
-          "modified": "2025-09-20T09:27:14.409080Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4006",
-          "modified": "2025-10-29T22:12:48.634968Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4007",
-          "modified": "2025-10-29T22:12:48.435061Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4008",
-          "modified": "2025-10-29T22:12:48.502316Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4009",
-          "modified": "2025-10-29T22:27:48.435693Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4010",
-          "modified": "2025-10-29T22:27:48.167777Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4011",
-          "modified": "2025-10-29T22:27:48.303690Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4012",
-          "modified": "2025-10-29T22:12:48.369018Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4013",
-          "modified": "2025-10-29T22:27:48.370442Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4014",
-          "modified": "2025-10-29T22:27:48.236933Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4015",
-          "modified": "2025-10-29T22:12:48.567065Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     }
@@ -193,123 +193,123 @@
       "vulns": [
         {
           "id": "GO-2024-2598",
-          "modified": "2024-10-22T05:29:10.013727Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2599",
-          "modified": "2024-10-22T05:29:04.026559Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2600",
-          "modified": "2024-10-22T05:29:00.945548Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2609",
-          "modified": "2024-10-22T05:29:09.769129Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2610",
-          "modified": "2024-10-22T05:29:02.767625Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2687",
-          "modified": "2025-03-31T16:24:22.897568Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2024-2887",
-          "modified": "2024-10-22T05:28:58.836290Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2888",
-          "modified": "2024-10-22T05:28:58.470910Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2963",
-          "modified": "2024-07-15T22:26:59.152Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-3105",
-          "modified": "2024-09-10T08:12:19.721080Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-3106",
-          "modified": "2024-09-10T08:12:21.917879Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-3107",
-          "modified": "2024-09-10T08:12:21.518996Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2025-3373",
-          "modified": "2025-01-30T20:12:14.327943Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3420",
-          "modified": "2025-01-30T20:12:08.973745Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3447",
-          "modified": "2025-02-08T08:11:54.994992Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3563",
-          "modified": "2025-10-24T21:27:27.901002Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3750",
-          "modified": "2025-06-14T06:28:19.438040Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3751",
-          "modified": "2025-06-14T06:28:26.229496Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3849",
-          "modified": "2025-08-11T06:27:06.746398Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3956",
-          "modified": "2025-09-20T09:27:14.409080Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4006",
-          "modified": "2025-10-29T22:12:48.634968Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4007",
-          "modified": "2025-10-29T22:12:48.435061Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4008",
-          "modified": "2025-10-29T22:12:48.502316Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4009",
-          "modified": "2025-10-29T22:27:48.435693Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4010",
-          "modified": "2025-10-29T22:27:48.167777Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4011",
-          "modified": "2025-10-29T22:27:48.303690Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4012",
-          "modified": "2025-10-29T22:12:48.369018Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4013",
-          "modified": "2025-10-29T22:27:48.370442Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4014",
-          "modified": "2025-10-29T22:27:48.236933Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4015",
-          "modified": "2025-10-29T22:12:48.567065Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -317,123 +317,123 @@
       "vulns": [
         {
           "id": "GO-2024-2598",
-          "modified": "2024-10-22T05:29:10.013727Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2599",
-          "modified": "2024-10-22T05:29:04.026559Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2600",
-          "modified": "2024-10-22T05:29:00.945548Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2609",
-          "modified": "2024-10-22T05:29:09.769129Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2610",
-          "modified": "2024-10-22T05:29:02.767625Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2687",
-          "modified": "2025-03-31T16:24:22.897568Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2024-2887",
-          "modified": "2024-10-22T05:28:58.836290Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2888",
-          "modified": "2024-10-22T05:28:58.470910Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2963",
-          "modified": "2024-07-15T22:26:59.152Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-3105",
-          "modified": "2024-09-10T08:12:19.721080Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-3106",
-          "modified": "2024-09-10T08:12:21.917879Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-3107",
-          "modified": "2024-09-10T08:12:21.518996Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2025-3373",
-          "modified": "2025-01-30T20:12:14.327943Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3420",
-          "modified": "2025-01-30T20:12:08.973745Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3447",
-          "modified": "2025-02-08T08:11:54.994992Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3563",
-          "modified": "2025-10-24T21:27:27.901002Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3750",
-          "modified": "2025-06-14T06:28:19.438040Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3751",
-          "modified": "2025-06-14T06:28:26.229496Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3849",
-          "modified": "2025-08-11T06:27:06.746398Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3956",
-          "modified": "2025-09-20T09:27:14.409080Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4006",
-          "modified": "2025-10-29T22:12:48.634968Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4007",
-          "modified": "2025-10-29T22:12:48.435061Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4008",
-          "modified": "2025-10-29T22:12:48.502316Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4009",
-          "modified": "2025-10-29T22:27:48.435693Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4010",
-          "modified": "2025-10-29T22:27:48.167777Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4011",
-          "modified": "2025-10-29T22:27:48.303690Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4012",
-          "modified": "2025-10-29T22:12:48.369018Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4013",
-          "modified": "2025-10-29T22:27:48.370442Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4014",
-          "modified": "2025-10-29T22:27:48.236933Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4015",
-          "modified": "2025-10-29T22:12:48.567065Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     }
@@ -449,123 +449,123 @@
       "vulns": [
         {
           "id": "GO-2024-2598",
-          "modified": "2024-10-22T05:29:10.013727Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2599",
-          "modified": "2024-10-22T05:29:04.026559Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2600",
-          "modified": "2024-10-22T05:29:00.945548Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2609",
-          "modified": "2024-10-22T05:29:09.769129Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2610",
-          "modified": "2024-10-22T05:29:02.767625Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2687",
-          "modified": "2025-03-31T16:24:22.897568Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2024-2887",
-          "modified": "2024-10-22T05:28:58.836290Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2888",
-          "modified": "2024-10-22T05:28:58.470910Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2963",
-          "modified": "2024-07-15T22:26:59.152Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-3105",
-          "modified": "2024-09-10T08:12:19.721080Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-3106",
-          "modified": "2024-09-10T08:12:21.917879Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-3107",
-          "modified": "2024-09-10T08:12:21.518996Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2025-3373",
-          "modified": "2025-01-30T20:12:14.327943Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3420",
-          "modified": "2025-01-30T20:12:08.973745Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3447",
-          "modified": "2025-02-08T08:11:54.994992Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3563",
-          "modified": "2025-10-24T21:27:27.901002Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3750",
-          "modified": "2025-06-14T06:28:19.438040Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3751",
-          "modified": "2025-06-14T06:28:26.229496Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3849",
-          "modified": "2025-08-11T06:27:06.746398Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3956",
-          "modified": "2025-09-20T09:27:14.409080Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4006",
-          "modified": "2025-10-29T22:12:48.634968Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4007",
-          "modified": "2025-10-29T22:12:48.435061Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4008",
-          "modified": "2025-10-29T22:12:48.502316Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4009",
-          "modified": "2025-10-29T22:27:48.435693Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4010",
-          "modified": "2025-10-29T22:27:48.167777Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4011",
-          "modified": "2025-10-29T22:27:48.303690Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4012",
-          "modified": "2025-10-29T22:12:48.369018Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4013",
-          "modified": "2025-10-29T22:27:48.370442Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4014",
-          "modified": "2025-10-29T22:27:48.236933Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4015",
-          "modified": "2025-10-29T22:12:48.567065Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     }
@@ -590,7 +590,7 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2025-26519",
-          "modified": "2025-10-14T04:20:58.312543Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -601,11 +601,11 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2018-25032",
-          "modified": "2025-09-30T05:12:01.222445Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "ALPINE-CVE-2022-37434",
-          "modified": "2025-09-30T05:24:11.325920Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     }
@@ -621,7 +621,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     }
@@ -640,7 +640,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -656,7 +656,7 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2025-26519",
-          "modified": "2025-10-14T04:20:58.312543Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -700,11 +700,11 @@
       "vulns": [
         {
           "id": "CVE-2023-39137",
-          "modified": "2025-10-21T13:22:57.391415Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "CVE-2023-39139",
-          "modified": "2025-10-21T13:22:57.568653Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -720,7 +720,7 @@
       "vulns": [
         {
           "id": "GHSA-9f46-5r25-5wfm",
-          "modified": "2024-02-16T08:21:35.601880Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },
@@ -731,7 +731,7 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2025-26519",
-          "modified": "2025-10-14T04:20:58.312543Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -766,7 +766,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -782,7 +782,7 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2025-26519",
-          "modified": "2025-10-14T04:20:58.312543Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -816,7 +816,7 @@
       "vulns": [
         {
           "id": "GHSA-9f46-5r25-5wfm",
-          "modified": "2024-02-16T08:21:35.601880Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },
@@ -836,7 +836,7 @@
       "vulns": [
         {
           "id": "GHSA-9f46-5r25-5wfm",
-          "modified": "2024-02-16T08:21:35.601880Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },
@@ -855,7 +855,7 @@
       "vulns": [
         {
           "id": "UBUNTU-CVE-2017-11164",
-          "modified": "2025-10-24T04:46:24Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     }
@@ -871,7 +871,7 @@
       "vulns": [
         {
           "id": "UBUNTU-CVE-2017-11164",
-          "modified": "2025-10-24T04:46:24Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     }
@@ -899,31 +899,31 @@
       "vulns": [
         {
           "id": "DEBIAN-CVE-2011-3374",
-          "modified": "2025-09-30T05:06:04.952537Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2018-0501",
-          "modified": "2025-09-30T03:54:36Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2019-3462",
-          "modified": "2025-09-30T03:54:28Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2020-27350",
-          "modified": "2025-09-30T03:54:24Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2020-3810",
-          "modified": "2025-09-30T03:54:28Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-4685-1",
-          "modified": "2025-05-26T07:21:59.359875Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-4808-1",
-          "modified": "2025-05-26T07:21:52.187597Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -933,11 +933,11 @@
       "vulns": [
         {
           "id": "DEBIAN-CVE-2019-18276",
-          "modified": "2025-09-30T03:54:24Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-3715",
-          "modified": "2025-09-30T05:15:42.832192Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -951,19 +951,19 @@
       "vulns": [
         {
           "id": "DEBIAN-CVE-2016-2781",
-          "modified": "2025-09-30T05:09:50.011310Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2017-18018",
-          "modified": "2025-09-30T05:11:30.332345Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2024-0684",
-          "modified": "2025-09-30T03:54:30Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2025-5278",
-          "modified": "2025-10-14T04:26:57.619904Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -973,7 +973,7 @@
       "vulns": [
         {
           "id": "DLA-3482-1",
-          "modified": "2025-05-26T07:01:25.263124Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -984,19 +984,19 @@
       "vulns": [
         {
           "id": "DEBIAN-CVE-2022-1664",
-          "modified": "2025-09-30T05:16:51.415730Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2025-6297",
-          "modified": "2025-10-14T04:26:59.720246Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3022-1",
-          "modified": "2025-05-26T07:22:47.007443Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-5147-1",
-          "modified": "2025-05-26T07:22:47.069263Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -1005,23 +1005,23 @@
       "vulns": [
         {
           "id": "DEBIAN-CVE-2019-5094",
-          "modified": "2025-09-30T03:54:32Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2019-5188",
-          "modified": "2025-09-30T03:54:23Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-1304",
-          "modified": "2025-09-30T05:15:32.082724Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3910-1",
-          "modified": "2025-05-26T07:22:45.827447Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-4535-1",
-          "modified": "2025-05-26T07:21:16.735871Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -1031,59 +1031,59 @@
       "vulns": [
         {
           "id": "GHSA-f3fp-gc8g-vw66",
-          "modified": "2024-08-21T15:26:57.192290Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-g2j6-57v7-gm8c",
-          "modified": "2024-12-06T15:31:17Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-jfvp-7x6p-h2pv",
-          "modified": "2025-02-21T21:03:04Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-m8cg-xc2p-r3fc",
-          "modified": "2024-08-20T20:58:42.328556Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-v95c-p5hm-xq8f",
-          "modified": "2024-05-31T17:47:57Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-vpvm-3wq2-2wvm",
-          "modified": "2024-12-06T15:31:17Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-xr7r-f8xq-vfvv",
-          "modified": "2024-07-05T21:38:20Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2022-0274",
-          "modified": "2024-05-20T16:03:47Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2022-0452",
-          "modified": "2025-08-05T19:57:40Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2023-1627",
-          "modified": "2025-08-05T19:57:40Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2023-1682",
-          "modified": "2025-08-05T19:57:40Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2023-1683",
-          "modified": "2025-08-05T19:57:40Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2024-2491",
-          "modified": "2024-07-01T21:50:42Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-3110",
-          "modified": "2025-08-05T19:57:40Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -1094,11 +1094,11 @@
       "vulns": [
         {
           "id": "GHSA-p782-xgp4-8hr8",
-          "modified": "2024-05-20T21:27:32Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2022-0493",
-          "modified": "2024-05-20T16:03:47Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },
@@ -1108,11 +1108,11 @@
       "vulns": [
         {
           "id": "DEBIAN-CVE-2022-1271",
-          "modified": "2025-09-30T05:15:31.933011Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-5122-1",
-          "modified": "2025-05-26T07:22:45.579215Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -1148,35 +1148,35 @@
       "vulns": [
         {
           "id": "DEBIAN-CVE-2017-0379",
-          "modified": "2025-09-30T03:54:28Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2017-7526",
-          "modified": "2025-09-30T03:54:18Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2018-0495",
-          "modified": "2025-09-30T03:54:32Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2018-6829",
-          "modified": "2025-09-30T05:12:32.270287Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2019-13627",
-          "modified": "2025-09-30T03:54:34Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2021-33560",
-          "modified": "2025-09-30T05:15:05.256213Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2021-40528",
-          "modified": "2025-09-30T03:54:28Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2024-2236",
-          "modified": "2025-10-14T04:26:27.441228Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -1233,35 +1233,35 @@
       "vulns": [
         {
           "id": "DEBIAN-CVE-2017-10790",
-          "modified": "2025-09-30T03:54:40Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2018-1000654",
-          "modified": "2025-09-30T03:54:35Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2018-6003",
-          "modified": "2025-09-30T03:54:32Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2021-46848",
-          "modified": "2025-09-30T05:16:34.989211Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2024-12133",
-          "modified": "2025-10-14T04:26:25.110494Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3263-1",
-          "modified": "2025-05-26T07:22:42.617563Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-4061-1",
-          "modified": "2025-05-26T07:23:58.435350Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-5863-1",
-          "modified": "2025-05-26T07:23:58.495667Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -1273,255 +1273,255 @@
       "vulns": [
         {
           "id": "DEBIAN-CVE-2016-3709",
-          "modified": "2025-09-30T05:07:48.968808Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2016-9318",
-          "modified": "2025-09-30T03:54:26Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2017-0663",
-          "modified": "2025-09-30T03:54:27Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2017-15412",
-          "modified": "2025-09-30T03:54:39Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2017-16931",
-          "modified": "2025-09-30T03:54:37Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2017-16932",
-          "modified": "2025-09-30T03:54:33Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2017-18258",
-          "modified": "2025-09-30T03:54:20Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2017-5130",
-          "modified": "2025-09-30T03:54:28Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2017-5969",
-          "modified": "2025-09-30T03:54:32Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2017-7375",
-          "modified": "2025-09-30T03:54:40Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2017-7376",
-          "modified": "2025-09-30T03:54:22Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2017-8872",
-          "modified": "2025-09-30T03:54:34Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2017-9047",
-          "modified": "2025-09-30T03:54:38Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2017-9048",
-          "modified": "2025-09-30T03:54:23Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2017-9049",
-          "modified": "2025-09-30T03:54:40Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2017-9050",
-          "modified": "2025-09-30T03:54:32Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2018-14404",
-          "modified": "2025-09-30T03:54:37Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2018-14567",
-          "modified": "2025-09-30T03:54:30Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2019-19956",
-          "modified": "2025-09-30T03:54:35Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2019-20388",
-          "modified": "2025-09-30T03:54:40Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2020-24977",
-          "modified": "2025-09-30T03:54:31Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2020-7595",
-          "modified": "2025-09-30T03:54:20Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2021-3516",
-          "modified": "2025-09-30T03:54:29Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2021-3517",
-          "modified": "2025-09-30T03:54:22Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2021-3518",
-          "modified": "2025-09-30T03:54:31Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2021-3537",
-          "modified": "2025-09-30T03:54:20Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2021-3541",
-          "modified": "2025-09-30T03:54:40Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-2309",
-          "modified": "2025-09-30T05:15:35.000126Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-23308",
-          "modified": "2025-09-30T05:15:35.395077Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-29824",
-          "modified": "2025-09-30T05:17:04.517276Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-40303",
-          "modified": "2025-09-30T05:17:14.800715Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-40304",
-          "modified": "2025-09-30T05:17:14.902889Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-49043",
-          "modified": "2025-10-08T09:06:37.369470Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-28484",
-          "modified": "2025-09-30T05:18:46.109507Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-29469",
-          "modified": "2025-09-30T05:16:06.919340Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-39615",
-          "modified": "2025-09-30T05:17:48.305959Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-45322",
-          "modified": "2025-09-30T05:18:54.814406Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2024-25062",
-          "modified": "2025-09-30T05:18:09.745225Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2024-34459",
-          "modified": "2025-10-14T04:25:52.660904Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2024-56171",
-          "modified": "2025-10-17T09:09:21.962050Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2025-24928",
-          "modified": "2025-10-17T09:09:25.586275Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2025-27113",
-          "modified": "2025-09-30T05:20:23.506173Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2025-32414",
-          "modified": "2025-09-30T05:20:26.810088Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2025-32415",
-          "modified": "2025-09-30T05:20:27.204513Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2025-49794",
-          "modified": "2025-10-14T04:26:56.710856Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2025-49796",
-          "modified": "2025-10-14T04:26:56.742815Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2025-6021",
-          "modified": "2025-10-14T04:26:07.997183Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2025-6170",
-          "modified": "2025-09-30T05:01:22.918795Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2025-8732",
-          "modified": "2025-09-30T05:20:50.301333Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2025-9714",
-          "modified": "2025-09-30T23:06:11.726389Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3012-1",
-          "modified": "2025-05-26T07:23:01.266561Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3172-1",
-          "modified": "2025-05-26T07:23:10.448009Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3405-1",
-          "modified": "2025-05-26T07:23:30.714665Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3878-1",
-          "modified": "2025-05-26T07:18:39.626843Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-4064-1",
-          "modified": "2025-05-26T07:23:19.568188Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-4146-1",
-          "modified": "2025-05-26T06:58:47.071983Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-4251-1",
-          "modified": "2025-07-26T19:45:29.054316Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-4319-1",
-          "modified": "2025-09-30T22:17:08.381361Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-5142-1",
-          "modified": "2025-05-26T07:23:01.328825Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-5271-1",
-          "modified": "2025-05-26T07:23:10.510965Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-5391-1",
-          "modified": "2025-05-26T07:23:30.774960Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-5949-1",
-          "modified": "2025-06-25T19:16:29.342484Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-5990-1",
-          "modified": "2025-08-29T13:01:48.117026Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -1537,7 +1537,7 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2025-26519",
-          "modified": "2025-10-14T04:20:58.312543Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -1545,7 +1545,7 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2025-26519",
-          "modified": "2025-10-14T04:20:58.312543Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -1559,339 +1559,339 @@
       "vulns": [
         {
           "id": "DEBIAN-CVE-2018-0732",
-          "modified": "2025-09-30T03:54:18Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2018-0734",
-          "modified": "2025-09-30T03:54:35Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2018-0735",
-          "modified": "2025-09-30T03:54:29Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2018-5407",
-          "modified": "2025-09-30T03:54:32Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2019-1543",
-          "modified": "2025-09-30T03:54:24Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2019-1547",
-          "modified": "2025-09-30T03:54:39Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2019-1549",
-          "modified": "2025-09-30T03:54:22Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2019-1551",
-          "modified": "2025-09-30T03:54:20Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2019-1563",
-          "modified": "2025-09-30T03:54:20Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2020-1967",
-          "modified": "2025-09-30T03:54:20Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2020-1971",
-          "modified": "2025-09-30T03:54:22Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2021-23840",
-          "modified": "2025-09-30T03:54:33Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2021-23841",
-          "modified": "2025-09-30T03:54:24Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2021-3449",
-          "modified": "2025-09-30T03:54:23Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2021-3450",
-          "modified": "2025-09-30T03:54:27Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2021-3711",
-          "modified": "2025-09-30T05:15:12.520051Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2021-3712",
-          "modified": "2025-09-30T05:15:12.437866Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2021-4160",
-          "modified": "2025-09-30T05:16:26.190657Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-0778",
-          "modified": "2025-09-30T05:16:47.731955Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-1292",
-          "modified": "2025-09-30T05:15:31.921255Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-2068",
-          "modified": "2025-09-30T05:16:53.575776Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-2097",
-          "modified": "2025-09-30T05:16:53.824930Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-2274",
-          "modified": "2025-09-30T03:54:28Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-3358",
-          "modified": "2025-09-30T03:54:18Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-3602",
-          "modified": "2025-09-30T03:54:38Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-3786",
-          "modified": "2025-09-30T03:54:21Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-3996",
-          "modified": "2025-09-30T03:54:33Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-4203",
-          "modified": "2025-09-30T03:54:32Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-4304",
-          "modified": "2025-09-30T05:17:19.861190Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-4450",
-          "modified": "2025-09-30T05:17:21.093928Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-0215",
-          "modified": "2025-09-30T05:18:42.010374Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-0216",
-          "modified": "2025-09-30T03:54:38Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-0217",
-          "modified": "2025-09-30T03:54:22Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-0286",
-          "modified": "2025-09-30T05:16:01.248088Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-0401",
-          "modified": "2025-09-30T03:54:30Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-0464",
-          "modified": "2025-09-30T05:16:01.641013Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-0465",
-          "modified": "2025-09-30T05:16:02.045372Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-0466",
-          "modified": "2025-09-30T05:16:01.708280Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-1255",
-          "modified": "2025-09-30T03:54:40Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-2650",
-          "modified": "2025-09-30T05:17:42.542187Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-2975",
-          "modified": "2025-09-30T05:18:46.490428Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-3446",
-          "modified": "2025-09-30T05:18:51.056405Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-3817",
-          "modified": "2025-09-30T05:17:47.598783Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-5363",
-          "modified": "2025-09-30T05:18:00.667766Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-5678",
-          "modified": "2025-09-30T05:18:01.372501Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-6129",
-          "modified": "2025-09-30T05:19:01.445816Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-6237",
-          "modified": "2025-10-14T04:26:22.812056Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2024-0727",
-          "modified": "2025-09-30T05:19:01.928308Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2024-12797",
-          "modified": "2025-10-14T04:01:12Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2024-13176",
-          "modified": "2025-10-14T04:26:25.245361Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2024-2511",
-          "modified": "2025-10-14T04:26:28.832129Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2024-4603",
-          "modified": "2025-10-14T04:26:36.782060Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2024-4741",
-          "modified": "2025-10-14T04:26:37.515272Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2024-5535",
-          "modified": "2025-10-14T04:26:02.039869Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2024-6119",
-          "modified": "2025-09-30T05:20:04.217199Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2024-9143",
-          "modified": "2025-10-14T04:26:41.185225Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2025-27587",
-          "modified": "2025-10-14T04:26:05.068273Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2025-4575",
-          "modified": "2025-10-14T04:01:10Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2025-9230",
-          "modified": "2025-10-14T04:27:01.173650Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2025-9231",
-          "modified": "2025-10-14T04:27:01.062719Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2025-9232",
-          "modified": "2025-10-14T04:27:01.157291Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3008-1",
-          "modified": "2025-05-26T07:22:45.706031Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3325-1",
-          "modified": "2025-05-26T07:22:47.806974Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3449-1",
-          "modified": "2025-05-26T07:23:20.191820Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3530-1",
-          "modified": "2025-05-26T07:23:36.219658Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3942-1",
-          "modified": "2025-05-26T07:23:52.994725Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3942-2",
-          "modified": "2025-05-26T07:23:53.056205Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-4176-1",
-          "modified": "2025-05-26T07:02:17.127596Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-4321-1",
-          "modified": "2025-10-03T16:33:24.717173Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-4539-1",
-          "modified": "2025-05-26T07:20:57.698150Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-4539-3",
-          "modified": "2025-05-26T07:05:14.261652Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-4661-1",
-          "modified": "2025-05-26T07:21:44.983880Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-4807-1",
-          "modified": "2025-05-26T07:21:45.227381Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-4855-1",
-          "modified": "2025-05-26T07:20:57.944135Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-4875-1",
-          "modified": "2025-05-26T07:22:25.295971Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-4963-1",
-          "modified": "2025-05-26T07:22:29.610492Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-5103-1",
-          "modified": "2025-05-26T07:22:36.298650Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-5139-1",
-          "modified": "2025-05-26T07:22:45.765450Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-5169-1",
-          "modified": "2025-05-26T07:22:47.687377Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-5343-1",
-          "modified": "2025-05-26T07:22:47.870882Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-5417-1",
-          "modified": "2025-05-26T07:23:20.254324Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-5532-1",
-          "modified": "2025-05-26T07:23:52.176093Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-5764-1",
-          "modified": "2025-05-26T07:24:15.576601Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-6015-1",
-          "modified": "2025-10-01T13:32:01.848986Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -1900,7 +1900,7 @@
       "vulns": [
         {
           "id": "UBUNTU-CVE-2017-11164",
-          "modified": "2025-10-24T04:46:24Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -1908,99 +1908,99 @@
       "vulns": [
         {
           "id": "DEBIAN-CVE-2011-4116",
-          "modified": "2025-09-30T05:06:10.466254Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2017-12837",
-          "modified": "2025-09-30T03:54:37Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2017-12883",
-          "modified": "2025-09-30T03:54:21Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2018-12015",
-          "modified": "2025-09-30T03:54:34Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2018-18311",
-          "modified": "2025-09-30T03:54:41Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2018-18312",
-          "modified": "2025-09-30T03:54:23Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2018-18313",
-          "modified": "2025-09-30T03:54:34Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2018-18314",
-          "modified": "2025-09-30T03:54:34Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2018-6797",
-          "modified": "2025-09-30T03:54:28Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2018-6798",
-          "modified": "2025-09-30T03:54:19Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2018-6913",
-          "modified": "2025-09-30T03:54:30Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2020-10543",
-          "modified": "2025-09-30T03:54:36Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2020-10878",
-          "modified": "2025-09-30T03:54:26Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2020-12723",
-          "modified": "2025-09-30T03:54:30Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2020-16156",
-          "modified": "2025-09-30T05:13:56.278767Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2021-36770",
-          "modified": "2025-09-30T05:15:12.023320Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-48522",
-          "modified": "2025-09-30T03:54:21Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-31484",
-          "modified": "2025-09-30T05:18:47.836063Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-31486",
-          "modified": "2025-09-30T05:18:47.858714Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-47038",
-          "modified": "2025-09-30T05:16:13.182241Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2024-56406",
-          "modified": "2025-10-17T09:09:21.918357Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2025-40909",
-          "modified": "2025-10-14T04:26:51.876407Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3926-1",
-          "modified": "2025-05-26T07:21:42.385892Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-5902-1",
-          "modified": "2025-05-26T07:24:14.898997Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -2013,35 +2013,35 @@
       "vulns": [
         {
           "id": "DLA-3072-1",
-          "modified": "2025-05-26T07:22:56.848703Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3189-1",
-          "modified": "2025-05-26T07:01:07.887113Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3316-1",
-          "modified": "2025-05-26T07:01:13.127412Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3422-1",
-          "modified": "2025-05-26T07:23:26.375715Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3600-1",
-          "modified": "2025-05-26T07:23:40.030714Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3651-1",
-          "modified": "2025-05-26T07:23:53.368012Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3764-1",
-          "modified": "2025-05-26T07:23:55.849014Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-5135-1",
-          "modified": "2025-05-26T07:22:46.760638Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -2057,7 +2057,7 @@
       "vulns": [
         {
           "id": "DEBIAN-CVE-2017-17512",
-          "modified": "2025-09-30T03:54:30Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -2069,47 +2069,47 @@
       "vulns": [
         {
           "id": "CVE-2018-20482",
-          "modified": "2025-07-04T10:02:32.704601Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "CVE-2019-9923",
-          "modified": "2025-08-09T19:01:28Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "CVE-2021-20193",
-          "modified": "2025-07-04T09:58:48.263398Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "CVE-2023-39804",
-          "modified": "2025-08-08T04:59:26.787002Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2005-2541",
-          "modified": "2025-09-30T05:01:48.824260Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2018-20482",
-          "modified": "2025-09-30T03:54:34Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2019-9923",
-          "modified": "2025-09-30T03:54:20Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2021-20193",
-          "modified": "2025-09-30T03:54:33Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-48303",
-          "modified": "2025-09-30T05:15:48.799797Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2023-39804",
-          "modified": "2025-10-14T04:26:18.796446Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3755-1",
-          "modified": "2025-05-26T07:23:40.399798Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -2117,43 +2117,43 @@
       "vulns": [
         {
           "id": "DLA-3051-1",
-          "modified": "2025-05-26T07:01:56.257796Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3134-1",
-          "modified": "2025-05-26T07:01:01.500124Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3161-1",
-          "modified": "2025-05-26T07:01:03.882213Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3366-1",
-          "modified": "2025-05-26T07:01:17.027142Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3412-1",
-          "modified": "2025-05-26T07:01:20.109212Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3684-1",
-          "modified": "2025-05-26T07:01:38.953691Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3788-1",
-          "modified": "2025-05-26T07:01:46.700929Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3972-1",
-          "modified": "2025-05-26T07:02:05.284676Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-4085-1",
-          "modified": "2025-05-26T07:02:10.958749Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-4105-1",
-          "modified": "2025-05-26T07:02:13.921097Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -2161,7 +2161,7 @@
       "vulns": [
         {
           "id": "DLA-4016-1",
-          "modified": "2025-05-26T07:02:06.504254Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -2169,43 +2169,43 @@
       "vulns": [
         {
           "id": "DEBIAN-CVE-2016-2779",
-          "modified": "2025-09-30T03:54:26Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2018-7738",
-          "modified": "2025-09-30T05:13:25.839468Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2021-37600",
-          "modified": "2025-09-30T03:54:26Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2021-3995",
-          "modified": "2025-09-30T05:15:19.954085Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2021-3996",
-          "modified": "2025-09-30T05:15:19.991738Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2022-0563",
-          "modified": "2025-09-30T05:16:46.891866Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2024-28085",
-          "modified": "2025-10-14T04:25:36.206480Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DLA-3782-1",
-          "modified": "2025-05-26T07:22:30.567107Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-5055-1",
-          "modified": "2025-05-26T07:22:33.646795Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-5650-1",
-          "modified": "2025-05-26T07:24:03.887524Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -2213,23 +2213,23 @@
       "vulns": [
         {
           "id": "DEBIAN-CVE-2022-1271",
-          "modified": "2025-09-30T05:15:31.933011Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2024-3094",
-          "modified": "2025-09-30T03:54:34Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DEBIAN-CVE-2025-31115",
-          "modified": "2025-10-22T16:28:39.853418Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-5123-1",
-          "modified": "2025-05-26T07:22:45.643786Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "DSA-5895-1",
-          "modified": "2025-05-26T07:24:22.556406Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -2237,11 +2237,11 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2018-25032",
-          "modified": "2025-09-30T05:12:01.222445Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "ALPINE-CVE-2022-37434",
-          "modified": "2025-09-30T05:24:11.325920Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -2249,11 +2249,11 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2018-25032",
-          "modified": "2025-09-30T05:12:01.222445Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "ALPINE-CVE-2022-37434",
-          "modified": "2025-09-30T05:24:11.325920Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -2261,11 +2261,11 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2018-25032",
-          "modified": "2025-09-30T05:12:01.222445Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "ALPINE-CVE-2022-37434",
-          "modified": "2025-09-30T05:24:11.325920Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -2273,7 +2273,7 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2022-37434",
-          "modified": "2025-09-30T05:24:11.325920Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -2291,7 +2291,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     }
@@ -2307,51 +2307,51 @@
       "vulns": [
         {
           "id": "GO-2025-3849",
-          "modified": "2025-08-11T06:27:06.746398Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-3956",
-          "modified": "2025-09-20T09:27:14.409080Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4006",
-          "modified": "2025-10-29T22:12:48.634968Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4007",
-          "modified": "2025-10-29T22:12:48.435061Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4008",
-          "modified": "2025-10-29T22:12:48.502316Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4009",
-          "modified": "2025-10-29T22:27:48.435693Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4010",
-          "modified": "2025-10-29T22:27:48.167777Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4011",
-          "modified": "2025-10-29T22:27:48.303690Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4012",
-          "modified": "2025-10-29T22:12:48.369018Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4013",
-          "modified": "2025-10-29T22:27:48.370442Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4014",
-          "modified": "2025-10-29T22:27:48.236933Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GO-2025-4015",
-          "modified": "2025-10-29T22:12:48.567065Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -2359,7 +2359,7 @@
       "vulns": [
         {
           "id": "GO-2025-3828",
-          "modified": "2025-07-31T07:14:38.402440Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     }
@@ -2375,7 +2375,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     }
@@ -2453,7 +2453,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     }
@@ -2487,7 +2487,7 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2025-26519",
-          "modified": "2025-10-14T04:20:58.312543Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -2498,11 +2498,11 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2018-25032",
-          "modified": "2025-09-30T05:12:01.222445Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "ALPINE-CVE-2022-37434",
-          "modified": "2025-09-30T05:24:11.325920Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     }
@@ -2527,7 +2527,7 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2025-26519",
-          "modified": "2025-10-14T04:20:58.312543Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -2538,11 +2538,11 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2018-25032",
-          "modified": "2025-09-30T05:12:01.222445Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "ALPINE-CVE-2022-37434",
-          "modified": "2025-09-30T05:24:11.325920Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     }
@@ -2599,7 +2599,7 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2025-26519",
-          "modified": "2025-10-14T04:20:58.312543Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -2610,11 +2610,11 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2018-25032",
-          "modified": "2025-09-30T05:12:01.222445Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "ALPINE-CVE-2022-37434",
-          "modified": "2025-09-30T05:24:11.325920Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     }
@@ -2639,7 +2639,7 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2025-26519",
-          "modified": "2025-10-14T04:20:58.312543Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -2650,11 +2650,11 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2018-25032",
-          "modified": "2025-09-30T05:12:01.222445Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "ALPINE-CVE-2022-37434",
-          "modified": "2025-09-30T05:24:11.325920Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     }
@@ -2679,7 +2679,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     }
@@ -2704,27 +2704,27 @@
       "vulns": [
         {
           "id": "GHSA-68w8-qjq3-2gfm",
-          "modified": "2024-09-20T15:46:52.557962Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-6w2r-r2m5-xq5w",
-          "modified": "2025-09-25T09:27:02.888520Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-7xr5-9hcq-chf9",
-          "modified": "2025-09-25T09:27:02.969281Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-8x94-hmjh-97hq",
-          "modified": "2025-01-14T11:27:04.205746Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-rrqc-c2jx-6jgv",
-          "modified": "2024-10-30T19:23:59.139649Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "PYSEC-2021-98",
-          "modified": "2023-12-06T01:01:16.755410Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -2732,27 +2732,27 @@
       "vulns": [
         {
           "id": "GHSA-68w8-qjq3-2gfm",
-          "modified": "2024-09-20T15:46:52.557962Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-6w2r-r2m5-xq5w",
-          "modified": "2025-09-25T09:27:02.888520Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-7xr5-9hcq-chf9",
-          "modified": "2025-09-25T09:27:02.969281Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-8x94-hmjh-97hq",
-          "modified": "2025-01-14T11:27:04.205746Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-rrqc-c2jx-6jgv",
-          "modified": "2024-10-30T19:23:59.139649Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "PYSEC-2021-98",
-          "modified": "2023-12-06T01:01:16.755410Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -2760,83 +2760,83 @@
       "vulns": [
         {
           "id": "GHSA-2gwj-7jmv-h26r",
-          "modified": "2025-02-21T05:41:10.759178Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-53qw-q765-4fww",
-          "modified": "2024-09-20T16:09:39.890846Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-6cw3-g6wv-c2xv",
-          "modified": "2024-09-20T15:47:27.155401Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-6w2r-r2m5-xq5w",
-          "modified": "2025-09-25T09:27:02.888520Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-7xr5-9hcq-chf9",
-          "modified": "2025-09-25T09:27:02.969281Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-8c5j-9r9f-c6w8",
-          "modified": "2025-02-21T05:29:59.213830Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-8x94-hmjh-97hq",
-          "modified": "2025-01-14T11:27:04.205746Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-95rw-fx8r-36v6",
-          "modified": "2024-09-20T15:47:46.984048Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-jrh2-hc4r-7jwx",
-          "modified": "2024-09-20T12:22:54.101910Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-rrqc-c2jx-6jgv",
-          "modified": "2024-10-30T19:23:59.139649Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-v6rh-hp5x-86rv",
-          "modified": "2024-11-19T05:35:04.095106Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-w24h-v9qh-8gxj",
-          "modified": "2025-02-21T05:41:01.294618Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2021-439",
-          "modified": "2023-12-06T01:01:41.266810Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2022-1",
-          "modified": "2023-12-06T01:01:43.028018Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2022-19",
-          "modified": "2023-12-06T01:01:58.226668Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2022-190",
-          "modified": "2023-12-06T01:02:11.594317Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2022-191",
-          "modified": "2023-12-06T01:02:11.666037Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2022-2",
-          "modified": "2023-12-06T01:01:43.088680Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2022-20",
-          "modified": "2023-12-06T01:02:02.697371Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2022-3",
-          "modified": "2023-12-06T01:01:43.819827Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -2844,11 +2844,11 @@
       "vulns": [
         {
           "id": "GHSA-m2qf-hxjv-5gpq",
-          "modified": "2025-02-21T05:42:17.337040Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2023-62",
-          "modified": "2023-11-08T04:12:28.231927Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -2856,11 +2856,11 @@
       "vulns": [
         {
           "id": "GHSA-m2qf-hxjv-5gpq",
-          "modified": "2025-02-21T05:42:17.337040Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2023-62",
-          "modified": "2023-11-08T04:12:28.231927Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -2868,11 +2868,11 @@
       "vulns": [
         {
           "id": "GHSA-m2qf-hxjv-5gpq",
-          "modified": "2025-02-21T05:42:17.337040Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2023-62",
-          "modified": "2023-11-08T04:12:28.231927Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -2880,11 +2880,11 @@
       "vulns": [
         {
           "id": "GHSA-m2qf-hxjv-5gpq",
-          "modified": "2025-02-21T05:42:17.337040Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2023-62",
-          "modified": "2023-11-08T04:12:28.231927Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -2892,35 +2892,35 @@
       "vulns": [
         {
           "id": "GHSA-43qf-4rqw-9q2g",
-          "modified": "2025-05-17T19:15:25.774254Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-7rxf-gvfg-47g4",
-          "modified": "2025-05-17T19:20:41.784125Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-84pr-m4jr-85g5",
-          "modified": "2024-05-07T13:31:00.917496Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-8vgw-p6qm-5gr7",
-          "modified": "2025-10-16T08:06:42.178747Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-hxwh-jpp2-84pm",
-          "modified": "2025-04-07T20:13:56.570363Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-xc3p-ff3m-f46v",
-          "modified": "2024-09-20T20:01:25.449661Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "PYSEC-2020-43",
-          "modified": "2025-10-09T07:22:50.566622Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2024-71",
-          "modified": "2025-10-09T08:27:44.186589Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -2928,11 +2928,11 @@
       "vulns": [
         {
           "id": "GHSA-jjg7-2v4v-x38h",
-          "modified": "2025-10-16T08:05:31.743063Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2024-60",
-          "modified": "2024-07-11T17:42:33.704488Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },
@@ -2940,11 +2940,11 @@
       "vulns": [
         {
           "id": "GHSA-jjg7-2v4v-x38h",
-          "modified": "2025-10-16T08:05:31.743063Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2024-60",
-          "modified": "2024-07-11T17:42:33.704488Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },
@@ -2965,7 +2965,7 @@
       "vulns": [
         {
           "id": "PYSEC-2020-73",
-          "modified": "2023-11-08T04:02:12.263851Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -2978,19 +2978,19 @@
       "vulns": [
         {
           "id": "GHSA-9hjg-9r4m-mvj7",
-          "modified": "2025-06-09T19:27:13.389930Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-9wx4-h78v-vm56",
-          "modified": "2024-07-15T22:12:27.987373Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-j8r2-6x86-q33q",
-          "modified": "2025-02-13T19:20:45.182158Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2023-74",
-          "modified": "2023-11-08T04:12:35.436175Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -2998,19 +2998,19 @@
       "vulns": [
         {
           "id": "GHSA-9hjg-9r4m-mvj7",
-          "modified": "2025-06-09T19:27:13.389930Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-9wx4-h78v-vm56",
-          "modified": "2024-07-15T22:12:27.987373Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-j8r2-6x86-q33q",
-          "modified": "2025-02-13T19:20:45.182158Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2023-74",
-          "modified": "2023-11-08T04:12:35.436175Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -3021,39 +3021,39 @@
       "vulns": [
         {
           "id": "GHSA-34jh-p97f-mpxf",
-          "modified": "2024-12-18T22:24:07.021304Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-g4mx-q9vg-27p4",
-          "modified": "2025-02-13T19:37:22.196603Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-pq67-6m6q-mj2v",
-          "modified": "2025-06-19T16:15:11.736637Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-v845-jxx5-vc9f",
-          "modified": "2024-12-13T16:37:46.297254Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-wqvq-5m8c-6g24",
-          "modified": "2024-11-18T22:47:07.792720Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "PYSEC-2020-148",
-          "modified": "2023-11-08T04:03:14.251187Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2021-108",
-          "modified": "2023-11-08T04:06:04.829992Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2023-192",
-          "modified": "2023-11-08T04:13:33.452167Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2023-212",
-          "modified": "2023-11-08T04:13:39.165450Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -3061,39 +3061,39 @@
       "vulns": [
         {
           "id": "GHSA-34jh-p97f-mpxf",
-          "modified": "2024-12-18T22:24:07.021304Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-g4mx-q9vg-27p4",
-          "modified": "2025-02-13T19:37:22.196603Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-pq67-6m6q-mj2v",
-          "modified": "2025-06-19T16:15:11.736637Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-v845-jxx5-vc9f",
-          "modified": "2024-12-13T16:37:46.297254Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-wqvq-5m8c-6g24",
-          "modified": "2024-11-18T22:47:07.792720Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "PYSEC-2020-148",
-          "modified": "2023-11-08T04:03:14.251187Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2021-108",
-          "modified": "2023-11-08T04:06:04.829992Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2023-192",
-          "modified": "2023-11-08T04:13:33.452167Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2023-212",
-          "modified": "2023-11-08T04:13:39.165450Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -3121,27 +3121,27 @@
       "vulns": [
         {
           "id": "GHSA-68w8-qjq3-2gfm",
-          "modified": "2024-09-20T15:46:52.557962Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-6w2r-r2m5-xq5w",
-          "modified": "2025-09-25T09:27:02.888520Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-7xr5-9hcq-chf9",
-          "modified": "2025-09-25T09:27:02.969281Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-8x94-hmjh-97hq",
-          "modified": "2025-01-14T11:27:04.205746Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-rrqc-c2jx-6jgv",
-          "modified": "2024-10-30T19:23:59.139649Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "PYSEC-2021-98",
-          "modified": "2023-12-06T01:01:16.755410Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -3149,27 +3149,27 @@
       "vulns": [
         {
           "id": "GHSA-68w8-qjq3-2gfm",
-          "modified": "2024-09-20T15:46:52.557962Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-6w2r-r2m5-xq5w",
-          "modified": "2025-09-25T09:27:02.888520Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-7xr5-9hcq-chf9",
-          "modified": "2025-09-25T09:27:02.969281Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-8x94-hmjh-97hq",
-          "modified": "2025-01-14T11:27:04.205746Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-rrqc-c2jx-6jgv",
-          "modified": "2024-10-30T19:23:59.139649Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "PYSEC-2021-98",
-          "modified": "2023-12-06T01:01:16.755410Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -3177,83 +3177,83 @@
       "vulns": [
         {
           "id": "GHSA-2gwj-7jmv-h26r",
-          "modified": "2025-02-21T05:41:10.759178Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-53qw-q765-4fww",
-          "modified": "2024-09-20T16:09:39.890846Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-6cw3-g6wv-c2xv",
-          "modified": "2024-09-20T15:47:27.155401Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-6w2r-r2m5-xq5w",
-          "modified": "2025-09-25T09:27:02.888520Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-7xr5-9hcq-chf9",
-          "modified": "2025-09-25T09:27:02.969281Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-8c5j-9r9f-c6w8",
-          "modified": "2025-02-21T05:29:59.213830Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-8x94-hmjh-97hq",
-          "modified": "2025-01-14T11:27:04.205746Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-95rw-fx8r-36v6",
-          "modified": "2024-09-20T15:47:46.984048Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-jrh2-hc4r-7jwx",
-          "modified": "2024-09-20T12:22:54.101910Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-rrqc-c2jx-6jgv",
-          "modified": "2024-10-30T19:23:59.139649Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-v6rh-hp5x-86rv",
-          "modified": "2024-11-19T05:35:04.095106Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-w24h-v9qh-8gxj",
-          "modified": "2025-02-21T05:41:01.294618Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2021-439",
-          "modified": "2023-12-06T01:01:41.266810Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2022-1",
-          "modified": "2023-12-06T01:01:43.028018Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2022-19",
-          "modified": "2023-12-06T01:01:58.226668Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2022-190",
-          "modified": "2023-12-06T01:02:11.594317Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2022-191",
-          "modified": "2023-12-06T01:02:11.666037Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2022-2",
-          "modified": "2023-12-06T01:01:43.088680Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2022-20",
-          "modified": "2023-12-06T01:02:02.697371Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2022-3",
-          "modified": "2023-12-06T01:01:43.819827Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -3261,11 +3261,11 @@
       "vulns": [
         {
           "id": "GHSA-m2qf-hxjv-5gpq",
-          "modified": "2025-02-21T05:42:17.337040Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2023-62",
-          "modified": "2023-11-08T04:12:28.231927Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -3273,11 +3273,11 @@
       "vulns": [
         {
           "id": "GHSA-m2qf-hxjv-5gpq",
-          "modified": "2025-02-21T05:42:17.337040Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2023-62",
-          "modified": "2023-11-08T04:12:28.231927Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -3285,11 +3285,11 @@
       "vulns": [
         {
           "id": "GHSA-m2qf-hxjv-5gpq",
-          "modified": "2025-02-21T05:42:17.337040Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2023-62",
-          "modified": "2023-11-08T04:12:28.231927Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -3297,11 +3297,11 @@
       "vulns": [
         {
           "id": "GHSA-m2qf-hxjv-5gpq",
-          "modified": "2025-02-21T05:42:17.337040Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2023-62",
-          "modified": "2023-11-08T04:12:28.231927Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -3309,35 +3309,35 @@
       "vulns": [
         {
           "id": "GHSA-43qf-4rqw-9q2g",
-          "modified": "2025-05-17T19:15:25.774254Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-7rxf-gvfg-47g4",
-          "modified": "2025-05-17T19:20:41.784125Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-84pr-m4jr-85g5",
-          "modified": "2024-05-07T13:31:00.917496Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-8vgw-p6qm-5gr7",
-          "modified": "2025-10-16T08:06:42.178747Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-hxwh-jpp2-84pm",
-          "modified": "2025-04-07T20:13:56.570363Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-xc3p-ff3m-f46v",
-          "modified": "2024-09-20T20:01:25.449661Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "PYSEC-2020-43",
-          "modified": "2025-10-09T07:22:50.566622Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2024-71",
-          "modified": "2025-10-09T08:27:44.186589Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -3345,11 +3345,11 @@
       "vulns": [
         {
           "id": "GHSA-jjg7-2v4v-x38h",
-          "modified": "2025-10-16T08:05:31.743063Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2024-60",
-          "modified": "2024-07-11T17:42:33.704488Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },
@@ -3357,11 +3357,11 @@
       "vulns": [
         {
           "id": "GHSA-jjg7-2v4v-x38h",
-          "modified": "2025-10-16T08:05:31.743063Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2024-60",
-          "modified": "2024-07-11T17:42:33.704488Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },
@@ -3382,7 +3382,7 @@
       "vulns": [
         {
           "id": "PYSEC-2020-73",
-          "modified": "2023-11-08T04:02:12.263851Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -3395,19 +3395,19 @@
       "vulns": [
         {
           "id": "GHSA-9hjg-9r4m-mvj7",
-          "modified": "2025-06-09T19:27:13.389930Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-9wx4-h78v-vm56",
-          "modified": "2024-07-15T22:12:27.987373Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-j8r2-6x86-q33q",
-          "modified": "2025-02-13T19:20:45.182158Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2023-74",
-          "modified": "2023-11-08T04:12:35.436175Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -3415,19 +3415,19 @@
       "vulns": [
         {
           "id": "GHSA-9hjg-9r4m-mvj7",
-          "modified": "2025-06-09T19:27:13.389930Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-9wx4-h78v-vm56",
-          "modified": "2024-07-15T22:12:27.987373Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-j8r2-6x86-q33q",
-          "modified": "2025-02-13T19:20:45.182158Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2023-74",
-          "modified": "2023-11-08T04:12:35.436175Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -3438,39 +3438,39 @@
       "vulns": [
         {
           "id": "GHSA-34jh-p97f-mpxf",
-          "modified": "2024-12-18T22:24:07.021304Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-g4mx-q9vg-27p4",
-          "modified": "2025-02-13T19:37:22.196603Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-pq67-6m6q-mj2v",
-          "modified": "2025-06-19T16:15:11.736637Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-v845-jxx5-vc9f",
-          "modified": "2024-12-13T16:37:46.297254Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-wqvq-5m8c-6g24",
-          "modified": "2024-11-18T22:47:07.792720Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "PYSEC-2020-148",
-          "modified": "2023-11-08T04:03:14.251187Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2021-108",
-          "modified": "2023-11-08T04:06:04.829992Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2023-192",
-          "modified": "2023-11-08T04:13:33.452167Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2023-212",
-          "modified": "2023-11-08T04:13:39.165450Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -3478,39 +3478,39 @@
       "vulns": [
         {
           "id": "GHSA-34jh-p97f-mpxf",
-          "modified": "2024-12-18T22:24:07.021304Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-g4mx-q9vg-27p4",
-          "modified": "2025-02-13T19:37:22.196603Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-pq67-6m6q-mj2v",
-          "modified": "2025-06-19T16:15:11.736637Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-v845-jxx5-vc9f",
-          "modified": "2024-12-13T16:37:46.297254Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-wqvq-5m8c-6g24",
-          "modified": "2024-11-18T22:47:07.792720Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "PYSEC-2020-148",
-          "modified": "2023-11-08T04:03:14.251187Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2021-108",
-          "modified": "2023-11-08T04:06:04.829992Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2023-192",
-          "modified": "2023-11-08T04:13:33.452167Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2023-212",
-          "modified": "2023-11-08T04:13:39.165450Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -3530,7 +3530,7 @@
       "vulns": [
         {
           "id": "GHSA-9f46-5r25-5wfm",
-          "modified": "2024-02-16T08:21:35.601880Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },

--- a/tools/apitester/__snapshots__/cassette_TestCommand_CallAnalysis.snap
+++ b/tools/apitester/__snapshots__/cassette_TestCommand_CallAnalysis.snap
@@ -6,11 +6,11 @@
       "vulns": [
         {
           "id": "GHSA-c3h9-896r-86jm",
-          "modified": "2023-12-06T01:01:11.322262Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "GO-2021-0053",
-          "modified": "2024-05-20T16:03:47Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },
@@ -18,11 +18,11 @@
       "vulns": [
         {
           "id": "GHSA-2h6c-j3gf-xp9r",
-          "modified": "2023-11-08T04:11:41.796349Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "GO-2023-1558",
-          "modified": "2024-05-20T16:03:47Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },
@@ -30,35 +30,35 @@
       "vulns": [
         {
           "id": "GHSA-9phm-fm57-rhg8",
-          "modified": "2024-08-02T15:50:53Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-j3p8-6mrq-6g7h",
-          "modified": "2024-05-20T21:54:17Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-qgc7-mgm3-q253",
-          "modified": "2024-05-20T21:46:58Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-x92r-3vfx-4cv3",
-          "modified": "2024-05-20T21:54:21Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2023-1572",
-          "modified": "2024-05-20T16:03:47Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2023-1989",
-          "modified": "2024-05-20T16:03:47Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2023-1990",
-          "modified": "2024-05-20T16:03:47Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GO-2024-2937",
-          "modified": "2024-07-15T22:12:27.099111Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     }
@@ -74,11 +74,11 @@
       "vulns": [
         {
           "id": "GHSA-c3h9-896r-86jm",
-          "modified": "2023-12-06T01:01:11.322262Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "GO-2021-0053",
-          "modified": "2024-05-20T16:03:47Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     }
@@ -94,11 +94,11 @@
       "vulns": [
         {
           "id": "GHSA-c3h9-896r-86jm",
-          "modified": "2023-12-06T01:01:11.322262Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "GO-2021-0053",
-          "modified": "2024-05-20T16:03:47Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     }

--- a/tools/apitester/__snapshots__/cassette_TestCommand_ExplicitExtractors.snap
+++ b/tools/apitester/__snapshots__/cassette_TestCommand_ExplicitExtractors.snap
@@ -6,7 +6,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -23,7 +23,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -40,7 +40,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     }
@@ -67,7 +67,7 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2025-26519",
-          "modified": "2025-10-14T04:20:58.312543Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -88,7 +88,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     }
@@ -104,7 +104,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     }

--- a/tools/apitester/__snapshots__/cassette_TestCommand_ExplicitExtractors_WithDefaults.snap
+++ b/tools/apitester/__snapshots__/cassette_TestCommand_ExplicitExtractors_WithDefaults.snap
@@ -21,7 +21,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -37,7 +37,7 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2025-26519",
-          "modified": "2025-10-14T04:20:58.312543Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -61,7 +61,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -77,7 +77,7 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2025-26519",
-          "modified": "2025-10-14T04:20:58.312543Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -113,7 +113,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -129,7 +129,7 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2025-26519",
-          "modified": "2025-10-14T04:20:58.312543Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -184,7 +184,7 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2025-26519",
-          "modified": "2025-10-14T04:20:58.312543Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -208,7 +208,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -224,7 +224,7 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2025-26519",
-          "modified": "2025-10-14T04:20:58.312543Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -266,7 +266,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     }

--- a/tools/apitester/__snapshots__/cassette_TestCommand_ExplicitExtractors_WithoutDefaults.snap
+++ b/tools/apitester/__snapshots__/cassette_TestCommand_ExplicitExtractors_WithoutDefaults.snap
@@ -6,7 +6,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -33,7 +33,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -60,7 +60,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     }
@@ -96,7 +96,7 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2025-26519",
-          "modified": "2025-10-14T04:20:58.312543Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -128,7 +128,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     }
@@ -153,7 +153,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     }

--- a/tools/apitester/__snapshots__/cassette_TestCommand_GithubActions.snap
+++ b/tools/apitester/__snapshots__/cassette_TestCommand_GithubActions.snap
@@ -7,11 +7,11 @@
       "vulns": [
         {
           "id": "CVE-2023-39137",
-          "modified": "2025-10-21T13:22:57.391415Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "CVE-2023-39139",
-          "modified": "2025-10-21T13:22:57.568653Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -29,11 +29,11 @@
       "vulns": [
         {
           "id": "CVE-2023-39137",
-          "modified": "2025-10-21T13:22:57.391415Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "CVE-2023-39139",
-          "modified": "2025-10-21T13:22:57.568653Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },

--- a/tools/apitester/__snapshots__/cassette_TestCommand_JavareachArchive.snap
+++ b/tools/apitester/__snapshots__/cassette_TestCommand_JavareachArchive.snap
@@ -8,7 +8,7 @@
       "vulns": [
         {
           "id": "GHSA-c28r-hw5m-5gv3",
-          "modified": "2023-11-08T04:09:28.159861Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -19,7 +19,7 @@
       "vulns": [
         {
           "id": "GHSA-h46c-h94j-95f3",
-          "modified": "2025-06-27T16:03:13.670847Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -27,195 +27,195 @@
       "vulns": [
         {
           "id": "GHSA-288c-cq4h-88gq",
-          "modified": "2024-10-22T05:28:57.400652Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-4gq5-ch57-c2mg",
-          "modified": "2024-03-15T05:20:21.411726Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-4w82-r329-3q67",
-          "modified": "2024-03-16T05:18:54.922179Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-57j2-w4cx-62h2",
-          "modified": "2024-10-22T05:29:08.356656Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-5949-rw7g-wx7w",
-          "modified": "2025-09-15T07:42:14.888352Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-5r5r-6hpj-8gg9",
-          "modified": "2024-02-18T05:42:28.539166Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-5ww9-j83m-q7qx",
-          "modified": "2024-03-15T01:17:50.016820Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-645p-88qh-w398",
-          "modified": "2024-03-16T05:19:17.936174Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-6fpp-rgj9-8rwc",
-          "modified": "2024-03-15T05:18:54.134884Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-85cw-hj65-qqv9",
-          "modified": "2024-03-15T05:20:15.574552Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-89qr-369f-5m5x",
-          "modified": "2024-02-18T05:37:27.581808Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-8c4j-34r4-xr8g",
-          "modified": "2024-02-18T05:31:52.762759Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-8w26-6f25-cm9x",
-          "modified": "2024-02-18T05:30:48.085017Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-9gph-22xh-8x98",
-          "modified": "2024-02-18T05:33:27.617261Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-9m6f-7xcq-8vf8",
-          "modified": "2024-02-18T05:32:25.400029Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-c8hm-7hpq-7jhg",
-          "modified": "2024-03-15T01:17:19.251183Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-cf6r-3wgc-h863",
-          "modified": "2024-02-18T05:32:56.325249Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-cggj-fvv3-cqwv",
-          "modified": "2024-03-15T01:18:46.938616Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-cjjf-94ff-43w7",
-          "modified": "2024-03-11T05:19:23.395848Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-cmfg-87vq-g5g4",
-          "modified": "2024-03-15T01:18:17.903231Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-cvm9-fjm9-3572",
-          "modified": "2024-02-18T05:25:36.165759Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-f3j5-rmmp-3fc5",
-          "modified": "2024-03-15T05:20:35.120151Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-f9xh-2qgp-cq57",
-          "modified": "2024-02-18T05:32:05.421673Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-fmmc-742q-jg75",
-          "modified": "2024-03-16T05:19:55.172981Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-fqwf-pjwf-7vqv",
-          "modified": "2024-07-03T21:22:37.578162Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-gjmw-vf9h-g25v",
-          "modified": "2024-03-16T05:19:37.211801Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-gwp4-hfv6-p7hw",
-          "modified": "2024-03-13T05:27:58.436849Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-gww7-p5w4-wrfv",
-          "modified": "2024-03-15T01:05:18.790961Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-h3cw-g4mq-c5x2",
-          "modified": "2024-02-18T05:30:45.329621Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-h592-38cm-4ggp",
-          "modified": "2024-03-15T01:16:50.905794Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-h822-r4r5-v8jg",
-          "modified": "2024-07-15T22:00:19.609618Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-jjjh-jjxp-wpff",
-          "modified": "2024-10-22T05:28:54.705123Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-m6x4-97wx-4q27",
-          "modified": "2024-02-18T05:21:54.725837Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-mph4-vhrx-mv67",
-          "modified": "2024-03-15T01:16:21.467932Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-mx7p-6679-8g3q",
-          "modified": "2024-03-15T01:01:46.432481Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-p43x-xfjf-5jhr",
-          "modified": "2024-03-15T00:33:14.700288Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-q93h-jc49-78gg",
-          "modified": "2024-03-16T05:19:47.711015Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-qjw2-hr98-qgfh",
-          "modified": "2024-02-18T05:20:56.894470Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-qr7j-h6gg-jmgc",
-          "modified": "2024-03-11T05:21:14.313980Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-r3gr-cxrf-hg25",
-          "modified": "2024-06-25T14:20:21.323050Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-r695-7vr9-jgc2",
-          "modified": "2024-02-18T05:30:45.856594Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-rfx6-vp9g-rh7v",
-          "modified": "2024-03-11T05:17:47.425595Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-rgv9-q543-rqg4",
-          "modified": "2024-12-02T16:25:52.858445Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-rpr3-cw39-3pxh",
-          "modified": "2025-04-14T22:28:33.735201Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-v585-23hc-c647",
-          "modified": "2024-02-18T05:22:38.024460Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-vfqx-33qm-g869",
-          "modified": "2024-02-18T05:24:26.785781Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-w3f4-3q6j-rh82",
-          "modified": "2024-03-11T05:18:22.727055Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-wh8g-3j2c-rqj5",
-          "modified": "2024-03-15T00:31:15.123603Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },
@@ -227,7 +227,7 @@
       "vulns": [
         {
           "id": "GHSA-j288-q9x7-2f5v",
-          "modified": "2025-07-12T01:27:15.943417Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -235,7 +235,7 @@
       "vulns": [
         {
           "id": "GHSA-7r82-7xv7-xcpj",
-          "modified": "2024-03-15T05:19:17.323914Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },
@@ -245,15 +245,15 @@
       "vulns": [
         {
           "id": "GHSA-cj7v-27pg-wf7q",
-          "modified": "2024-02-16T08:00:47.277184Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-hmr7-m48g-48f6",
-          "modified": "2024-02-16T07:59:58.440241Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-qh8g-58pp-2wxh",
-          "modified": "2025-03-07T14:20:03.913209Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -262,15 +262,15 @@
       "vulns": [
         {
           "id": "GHSA-3gh6-v5v9-6v9j",
-          "modified": "2025-02-13T19:35:45.539740Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-gwcr-j4wh-j3cq",
-          "modified": "2024-03-15T05:36:20.374672Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-j26w-f9rq-mr2q",
-          "modified": "2025-03-07T14:21:02.659392Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -279,7 +279,7 @@
       "vulns": [
         {
           "id": "GHSA-264p-99wq-f4j6",
-          "modified": "2024-04-12T17:16:19.921675Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     }
@@ -297,7 +297,7 @@
       "vulns": [
         {
           "id": "GHSA-c28r-hw5m-5gv3",
-          "modified": "2023-11-08T04:09:28.159861Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -308,7 +308,7 @@
       "vulns": [
         {
           "id": "GHSA-h46c-h94j-95f3",
-          "modified": "2025-06-27T16:03:13.670847Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -316,195 +316,195 @@
       "vulns": [
         {
           "id": "GHSA-288c-cq4h-88gq",
-          "modified": "2024-10-22T05:28:57.400652Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-4gq5-ch57-c2mg",
-          "modified": "2024-03-15T05:20:21.411726Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-4w82-r329-3q67",
-          "modified": "2024-03-16T05:18:54.922179Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-57j2-w4cx-62h2",
-          "modified": "2024-10-22T05:29:08.356656Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-5949-rw7g-wx7w",
-          "modified": "2025-09-15T07:42:14.888352Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-5r5r-6hpj-8gg9",
-          "modified": "2024-02-18T05:42:28.539166Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-5ww9-j83m-q7qx",
-          "modified": "2024-03-15T01:17:50.016820Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-645p-88qh-w398",
-          "modified": "2024-03-16T05:19:17.936174Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-6fpp-rgj9-8rwc",
-          "modified": "2024-03-15T05:18:54.134884Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-85cw-hj65-qqv9",
-          "modified": "2024-03-15T05:20:15.574552Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-89qr-369f-5m5x",
-          "modified": "2024-02-18T05:37:27.581808Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-8c4j-34r4-xr8g",
-          "modified": "2024-02-18T05:31:52.762759Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-8w26-6f25-cm9x",
-          "modified": "2024-02-18T05:30:48.085017Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-9gph-22xh-8x98",
-          "modified": "2024-02-18T05:33:27.617261Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-9m6f-7xcq-8vf8",
-          "modified": "2024-02-18T05:32:25.400029Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-c8hm-7hpq-7jhg",
-          "modified": "2024-03-15T01:17:19.251183Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-cf6r-3wgc-h863",
-          "modified": "2024-02-18T05:32:56.325249Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-cggj-fvv3-cqwv",
-          "modified": "2024-03-15T01:18:46.938616Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-cjjf-94ff-43w7",
-          "modified": "2024-03-11T05:19:23.395848Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-cmfg-87vq-g5g4",
-          "modified": "2024-03-15T01:18:17.903231Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-cvm9-fjm9-3572",
-          "modified": "2024-02-18T05:25:36.165759Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-f3j5-rmmp-3fc5",
-          "modified": "2024-03-15T05:20:35.120151Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-f9xh-2qgp-cq57",
-          "modified": "2024-02-18T05:32:05.421673Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-fmmc-742q-jg75",
-          "modified": "2024-03-16T05:19:55.172981Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-fqwf-pjwf-7vqv",
-          "modified": "2024-07-03T21:22:37.578162Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-gjmw-vf9h-g25v",
-          "modified": "2024-03-16T05:19:37.211801Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-gwp4-hfv6-p7hw",
-          "modified": "2024-03-13T05:27:58.436849Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-gww7-p5w4-wrfv",
-          "modified": "2024-03-15T01:05:18.790961Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-h3cw-g4mq-c5x2",
-          "modified": "2024-02-18T05:30:45.329621Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-h592-38cm-4ggp",
-          "modified": "2024-03-15T01:16:50.905794Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-h822-r4r5-v8jg",
-          "modified": "2024-07-15T22:00:19.609618Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-jjjh-jjxp-wpff",
-          "modified": "2024-10-22T05:28:54.705123Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-m6x4-97wx-4q27",
-          "modified": "2024-02-18T05:21:54.725837Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-mph4-vhrx-mv67",
-          "modified": "2024-03-15T01:16:21.467932Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-mx7p-6679-8g3q",
-          "modified": "2024-03-15T01:01:46.432481Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-p43x-xfjf-5jhr",
-          "modified": "2024-03-15T00:33:14.700288Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-q93h-jc49-78gg",
-          "modified": "2024-03-16T05:19:47.711015Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-qjw2-hr98-qgfh",
-          "modified": "2024-02-18T05:20:56.894470Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-qr7j-h6gg-jmgc",
-          "modified": "2024-03-11T05:21:14.313980Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-r3gr-cxrf-hg25",
-          "modified": "2024-06-25T14:20:21.323050Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-r695-7vr9-jgc2",
-          "modified": "2024-02-18T05:30:45.856594Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-rfx6-vp9g-rh7v",
-          "modified": "2024-03-11T05:17:47.425595Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-rgv9-q543-rqg4",
-          "modified": "2024-12-02T16:25:52.858445Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-rpr3-cw39-3pxh",
-          "modified": "2025-04-14T22:28:33.735201Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-v585-23hc-c647",
-          "modified": "2024-02-18T05:22:38.024460Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-vfqx-33qm-g869",
-          "modified": "2024-02-18T05:24:26.785781Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-w3f4-3q6j-rh82",
-          "modified": "2024-03-11T05:18:22.727055Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-wh8g-3j2c-rqj5",
-          "modified": "2024-03-15T00:31:15.123603Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },
@@ -516,7 +516,7 @@
       "vulns": [
         {
           "id": "GHSA-j288-q9x7-2f5v",
-          "modified": "2025-07-12T01:27:15.943417Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -524,7 +524,7 @@
       "vulns": [
         {
           "id": "GHSA-7r82-7xv7-xcpj",
-          "modified": "2024-03-15T05:19:17.323914Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },
@@ -534,15 +534,15 @@
       "vulns": [
         {
           "id": "GHSA-cj7v-27pg-wf7q",
-          "modified": "2024-02-16T08:00:47.277184Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-hmr7-m48g-48f6",
-          "modified": "2024-02-16T07:59:58.440241Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-qh8g-58pp-2wxh",
-          "modified": "2025-03-07T14:20:03.913209Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -551,15 +551,15 @@
       "vulns": [
         {
           "id": "GHSA-3gh6-v5v9-6v9j",
-          "modified": "2025-02-13T19:35:45.539740Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-gwcr-j4wh-j3cq",
-          "modified": "2024-03-15T05:36:20.374672Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-j26w-f9rq-mr2q",
-          "modified": "2025-03-07T14:21:02.659392Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -568,7 +568,7 @@
       "vulns": [
         {
           "id": "GHSA-264p-99wq-f4j6",
-          "modified": "2024-04-12T17:16:19.921675Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     }

--- a/tools/apitester/__snapshots__/cassette_TestCommand_Licenses.snap
+++ b/tools/apitester/__snapshots__/cassette_TestCommand_Licenses.snap
@@ -78,7 +78,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -94,7 +94,7 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2025-26519",
-          "modified": "2025-10-14T04:20:58.312543Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -118,7 +118,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -134,7 +134,7 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2025-26519",
-          "modified": "2025-10-14T04:20:58.312543Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -186,7 +186,7 @@
       "vulns": [
         {
           "id": "GHSA-9f46-5r25-5wfm",
-          "modified": "2024-02-16T08:21:35.601880Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },
@@ -197,7 +197,7 @@
       "vulns": [
         {
           "id": "ALPINE-CVE-2025-26519",
-          "modified": "2025-10-14T04:20:58.312543Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -221,7 +221,7 @@
       "vulns": [
         {
           "id": "GHSA-9f46-5r25-5wfm",
-          "modified": "2024-02-16T08:21:35.601880Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },
@@ -264,7 +264,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     }
@@ -280,7 +280,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     }
@@ -296,7 +296,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     }

--- a/tools/apitester/__snapshots__/cassette_TestCommand_LockfileWithExplicitParseAs.snap
+++ b/tools/apitester/__snapshots__/cassette_TestCommand_LockfileWithExplicitParseAs.snap
@@ -33,7 +33,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -41,7 +41,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -50,7 +50,7 @@
       "vulns": [
         {
           "id": "GHSA-9f46-5r25-5wfm",
-          "modified": "2024-02-16T08:21:35.601880Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },
@@ -69,7 +69,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -77,7 +77,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -86,7 +86,7 @@
       "vulns": [
         {
           "id": "GHSA-9f46-5r25-5wfm",
-          "modified": "2024-02-16T08:21:35.601880Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },
@@ -110,7 +110,7 @@
       "vulns": [
         {
           "id": "GHSA-whgm-jr23-g3j9",
-          "modified": "2023-11-08T04:05:08.868477Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -119,7 +119,7 @@
       "vulns": [
         {
           "id": "GHSA-9f46-5r25-5wfm",
-          "modified": "2024-02-16T08:21:35.601880Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },

--- a/tools/apitester/__snapshots__/cassette_TestCommand_MoreLockfiles.snap
+++ b/tools/apitester/__snapshots__/cassette_TestCommand_MoreLockfiles.snap
@@ -11,7 +11,7 @@
       "vulns": [
         {
           "id": "HSEC-2024-0009",
-          "modified": "2025-10-15T13:12:21.549202Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     }
@@ -29,7 +29,7 @@
       "vulns": [
         {
           "id": "GHSA-4cv2-4hjh-77rx",
-          "modified": "2025-01-27T19:00:52.634361Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -58,7 +58,7 @@
       "vulns": [
         {
           "id": "GHSA-9m3q-rhmv-5q44",
-          "modified": "2025-03-13T21:49:32.847007Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -67,19 +67,19 @@
       "vulns": [
         {
           "id": "GHSA-353f-x4gh-cqq8",
-          "modified": "2025-07-21T19:42:17.531986Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-5w6v-399v-w3cc",
-          "modified": "2025-04-21T22:04:45.823585Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-mrxw-mxhj-p664",
-          "modified": "2025-03-21T15:52:20.761884Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-vvfq-8hwr-qm4m",
-          "modified": "2025-03-10T22:51:07.538402Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -137,7 +137,7 @@
       "vulns": [
         {
           "id": "GHSA-8qvm-5x2c-j2w7",
-          "modified": "2025-06-16T16:27:17.848804Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     }

--- a/tools/apitester/__snapshots__/cassette_TestCommand_Transitive.snap
+++ b/tools/apitester/__snapshots__/cassette_TestCommand_Transitive.snap
@@ -15,27 +15,27 @@
       "vulns": [
         {
           "id": "GHSA-68w8-qjq3-2gfm",
-          "modified": "2024-09-20T15:46:52.557962Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-6w2r-r2m5-xq5w",
-          "modified": "2025-09-25T09:27:02.888520Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-7xr5-9hcq-chf9",
-          "modified": "2025-09-25T09:27:02.969281Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-8x94-hmjh-97hq",
-          "modified": "2025-01-14T11:27:04.205746Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-rrqc-c2jx-6jgv",
-          "modified": "2024-10-30T19:23:59.139649Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "PYSEC-2021-98",
-          "modified": "2023-12-06T01:01:16.755410Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -43,11 +43,11 @@
       "vulns": [
         {
           "id": "GHSA-m2qf-hxjv-5gpq",
-          "modified": "2025-02-21T05:42:17.337040Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2023-62",
-          "modified": "2023-11-08T04:12:28.231927Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -55,19 +55,19 @@
       "vulns": [
         {
           "id": "GHSA-9hjg-9r4m-mvj7",
-          "modified": "2025-06-09T19:27:13.389930Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-9wx4-h78v-vm56",
-          "modified": "2024-07-15T22:12:27.987373Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-j8r2-6x86-q33q",
-          "modified": "2025-02-13T19:20:45.182158Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2023-74",
-          "modified": "2023-11-08T04:12:35.436175Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     }
@@ -83,11 +83,11 @@
       "vulns": [
         {
           "id": "GHSA-m2qf-hxjv-5gpq",
-          "modified": "2025-02-21T05:42:17.337040Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2023-62",
-          "modified": "2023-11-08T04:12:28.231927Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -95,35 +95,35 @@
       "vulns": [
         {
           "id": "GHSA-43qf-4rqw-9q2g",
-          "modified": "2025-05-17T19:15:25.774254Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-7rxf-gvfg-47g4",
-          "modified": "2025-05-17T19:20:41.784125Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-84pr-m4jr-85g5",
-          "modified": "2024-05-07T13:31:00.917496Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-8vgw-p6qm-5gr7",
-          "modified": "2025-10-16T08:06:42.178747Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-hxwh-jpp2-84pm",
-          "modified": "2025-04-07T20:13:56.570363Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-xc3p-ff3m-f46v",
-          "modified": "2024-09-20T20:01:25.449661Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "PYSEC-2020-43",
-          "modified": "2025-10-09T07:22:50.566622Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2024-71",
-          "modified": "2025-10-09T08:27:44.186589Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -131,7 +131,7 @@
       "vulns": [
         {
           "id": "PYSEC-2020-73",
-          "modified": "2023-11-08T04:02:12.263851Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     }
@@ -164,7 +164,7 @@
       "vulns": [
         {
           "id": "GHSA-cm6r-892j-jv2g",
-          "modified": "2023-11-08T04:08:28.014834Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -211,19 +211,19 @@
       "vulns": [
         {
           "id": "GHSA-7rjr-3q55-vv33",
-          "modified": "2025-10-22T19:37:53.742023Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-8489-44mv-ggj8",
-          "modified": "2025-05-09T13:12:38.923602Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-jfh8-c2jp-5v3q",
-          "modified": "2025-10-22T19:37:02.616807Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-p6xc-xr62-6r2g",
-          "modified": "2025-05-09T13:12:54.089856Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -240,27 +240,27 @@
       "vulns": [
         {
           "id": "GHSA-68w8-qjq3-2gfm",
-          "modified": "2024-09-20T15:46:52.557962Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-6w2r-r2m5-xq5w",
-          "modified": "2025-09-25T09:27:02.888520Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-7xr5-9hcq-chf9",
-          "modified": "2025-09-25T09:27:02.969281Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-8x94-hmjh-97hq",
-          "modified": "2025-01-14T11:27:04.205746Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-rrqc-c2jx-6jgv",
-          "modified": "2024-10-30T19:23:59.139649Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "PYSEC-2021-98",
-          "modified": "2023-12-06T01:01:16.755410Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -268,11 +268,11 @@
       "vulns": [
         {
           "id": "GHSA-m2qf-hxjv-5gpq",
-          "modified": "2025-02-21T05:42:17.337040Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2023-62",
-          "modified": "2023-11-08T04:12:28.231927Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -281,19 +281,19 @@
       "vulns": [
         {
           "id": "GHSA-9hjg-9r4m-mvj7",
-          "modified": "2025-06-09T19:27:13.389930Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-9wx4-h78v-vm56",
-          "modified": "2024-07-15T22:12:27.987373Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-j8r2-6x86-q33q",
-          "modified": "2025-02-13T19:20:45.182158Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2023-74",
-          "modified": "2023-11-08T04:12:35.436175Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     }
@@ -326,7 +326,7 @@
       "vulns": [
         {
           "id": "GHSA-cm6r-892j-jv2g",
-          "modified": "2023-11-08T04:08:28.014834Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -373,19 +373,19 @@
       "vulns": [
         {
           "id": "GHSA-7rjr-3q55-vv33",
-          "modified": "2025-10-22T19:37:53.742023Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-8489-44mv-ggj8",
-          "modified": "2025-05-09T13:12:38.923602Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-jfh8-c2jp-5v3q",
-          "modified": "2025-10-22T19:37:02.616807Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-p6xc-xr62-6r2g",
-          "modified": "2025-05-09T13:12:54.089856Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -402,7 +402,7 @@
       "vulns": [
         {
           "id": "GHSA-269g-pwp5-87pp",
-          "modified": "2024-03-15T05:20:38.405881Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },
@@ -420,19 +420,19 @@
       "vulns": [
         {
           "id": "GHSA-7rjr-3q55-vv33",
-          "modified": "2025-10-22T19:37:53.742023Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-8489-44mv-ggj8",
-          "modified": "2025-05-09T13:12:38.923602Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-jfh8-c2jp-5v3q",
-          "modified": "2025-10-22T19:37:02.616807Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-p6xc-xr62-6r2g",
-          "modified": "2025-05-09T13:12:54.089856Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -450,19 +450,19 @@
       "vulns": [
         {
           "id": "GHSA-7rjr-3q55-vv33",
-          "modified": "2025-10-22T19:37:53.742023Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-8489-44mv-ggj8",
-          "modified": "2025-05-09T13:12:38.923602Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-jfh8-c2jp-5v3q",
-          "modified": "2025-10-22T19:37:02.616807Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-p6xc-xr62-6r2g",
-          "modified": "2025-05-09T13:12:54.089856Z"
+          "modified": "<RFC3339 date with the year 2025>"
         }
       ]
     },
@@ -482,27 +482,27 @@
       "vulns": [
         {
           "id": "GHSA-68w8-qjq3-2gfm",
-          "modified": "2024-09-20T15:46:52.557962Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-6w2r-r2m5-xq5w",
-          "modified": "2025-09-25T09:27:02.888520Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-7xr5-9hcq-chf9",
-          "modified": "2025-09-25T09:27:02.969281Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-8x94-hmjh-97hq",
-          "modified": "2025-01-14T11:27:04.205746Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-rrqc-c2jx-6jgv",
-          "modified": "2024-10-30T19:23:59.139649Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "PYSEC-2021-98",
-          "modified": "2023-12-06T01:01:16.755410Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -510,11 +510,11 @@
       "vulns": [
         {
           "id": "GHSA-m2qf-hxjv-5gpq",
-          "modified": "2025-02-21T05:42:17.337040Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2023-62",
-          "modified": "2023-11-08T04:12:28.231927Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -522,11 +522,11 @@
       "vulns": [
         {
           "id": "GHSA-jjg7-2v4v-x38h",
-          "modified": "2025-10-16T08:05:31.743063Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2024-60",
-          "modified": "2024-07-11T17:42:33.704488Z"
+          "modified": "<RFC3339 date with the year 2024>"
         }
       ]
     },
@@ -538,19 +538,19 @@
       "vulns": [
         {
           "id": "GHSA-9hjg-9r4m-mvj7",
-          "modified": "2025-06-09T19:27:13.389930Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-9wx4-h78v-vm56",
-          "modified": "2024-07-15T22:12:27.987373Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "GHSA-j8r2-6x86-q33q",
-          "modified": "2025-02-13T19:20:45.182158Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "PYSEC-2023-74",
-          "modified": "2023-11-08T04:12:35.436175Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },
@@ -558,39 +558,39 @@
       "vulns": [
         {
           "id": "GHSA-34jh-p97f-mpxf",
-          "modified": "2024-12-18T22:24:07.021304Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-g4mx-q9vg-27p4",
-          "modified": "2025-02-13T19:37:22.196603Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-pq67-6m6q-mj2v",
-          "modified": "2025-06-19T16:15:11.736637Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-v845-jxx5-vc9f",
-          "modified": "2024-12-13T16:37:46.297254Z"
+          "modified": "<RFC3339 date with the year 2025>"
         },
         {
           "id": "GHSA-wqvq-5m8c-6g24",
-          "modified": "2024-11-18T22:47:07.792720Z"
+          "modified": "<RFC3339 date with the year 2024>"
         },
         {
           "id": "PYSEC-2020-148",
-          "modified": "2023-11-08T04:03:14.251187Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2021-108",
-          "modified": "2023-11-08T04:06:04.829992Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2023-192",
-          "modified": "2023-11-08T04:13:33.452167Z"
+          "modified": "<RFC3339 date with the year 2023>"
         },
         {
           "id": "PYSEC-2023-212",
-          "modified": "2023-11-08T04:13:39.165450Z"
+          "modified": "<RFC3339 date with the year 2023>"
         }
       ]
     },

--- a/tools/apitester/__snapshots__/cassette_single_query.snap
+++ b/tools/apitester/__snapshots__/cassette_single_query.snap
@@ -5,7 +5,7 @@
     {
       "id": "CVE-2021-45931",
       "details": "HarfBuzz 2.9.0 has an out-of-bounds write in hb_bit_set_invertible_t::set (called from hb_sparseset_t\u003chb_bit_set_invertible_t\u003e::set and hb_set_copy).",
-      "modified": "2025-10-30T16:06:18.247283Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2022-01-01T01:15:08Z",
       "references": [
         {
@@ -82,7 +82,7 @@
     {
       "id": "CVE-2022-33068",
       "details": "An integer overflow in the component hb-ot-shape-fallback.cc of Harfbuzz v4.3.0 allows attackers to cause a Denial of Service (DoS) via unspecified vectors.",
-      "modified": "2025-10-23T04:57:03.996269Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2022-06-23T17:15:14Z",
       "related": [
         "ALSA-2022:8384",
@@ -123,20 +123,6 @@
           "ranges": [
             {
               "type": "GIT",
-              "repo": "https://github.com/behdad/harfbuzz",
-              "events": [
-                {
-                  "introduced": "0"
-                }
-              ]
-            }
-          ],
-          "database_specific": "<Any value>"
-        },
-        {
-          "ranges": [
-            {
-              "type": "GIT",
               "repo": "https://github.com/harfbuzz/harfbuzz",
               "events": [
                 {
@@ -149,6 +135,20 @@
             }
           ],
           "versions": 154,
+          "database_specific": "<Any value>"
+        },
+        {
+          "ranges": [
+            {
+              "type": "GIT",
+              "repo": "https://github.com/behdad/harfbuzz",
+              "events": [
+                {
+                  "introduced": "0"
+                }
+              ]
+            }
+          ],
           "database_specific": "<Any value>"
         }
       ],
@@ -163,7 +163,7 @@
     {
       "id": "CVE-2023-25193",
       "details": "hb-ot-layout-gsubgpos.hh in HarfBuzz through 6.0.0 allows attackers to trigger O(n^2) growth via consecutive marks during the process of looking back for base glyphs when attaching marks.",
-      "modified": "2025-10-29T13:50:56.312379Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2023-02-04T20:15:08Z",
       "related": [
         "ALSA-2023:4158",
@@ -268,7 +268,7 @@
       "id": "OSV-2020-484",
       "summary": "Heap-buffer-overflow in AAT::KerxSubTableFormat4\u003cAAT::KerxSubTableHeader\u003e::driver_context_t::transition",
       "details": "OSS-Fuzz report: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=12532\n\n```\nCrash type: Heap-buffer-overflow READ 4\nCrash state:\nAAT::KerxSubTableFormat4\u003cAAT::KerxSubTableHeader\u003e::driver_context_t::transition\nvoid AAT::StateTableDriver\u003cAAT::ExtendedTypes, AAT::KerxSubTableFormat4\u003cAAT::Ker\nAAT::KerxSubTableFormat4\u003cAAT::KerxSubTableHeader\u003e::apply\n```\n",
-      "modified": "2022-04-13T03:04:32.842142Z",
+      "modified": "<RFC3339 date with the year 2022>",
       "published": "2020-07-01T00:00:12.297418Z",
       "references": [
         {
@@ -319,7 +319,7 @@
       "summary": "OCSP verification bypass with TLS session reuse",
       "details": "curl inadvertently kept the SSL session ID for connections in its cache even\nwhen the verify status (*OCSP stapling*) test failed. A subsequent transfer to\nthe same hostname could then succeed if the session ID cache was still fresh,\nwhich then skipped the verify status check.",
       "aliases": ["CVE-2024-0853"],
-      "modified": "2024-01-31T08:07:21Z",
+      "modified": "<RFC3339 date with the year 2024>",
       "published": "2024-01-31T08:00:00Z",
       "database_specific": "<Any value>",
       "affected": [
@@ -370,7 +370,7 @@
       "summary": "netrc and redirect credential leak",
       "details": "When asked to both use a `.netrc` file for credentials and to follow HTTP\nredirects, curl could leak the password used for the first host to the\nfollowed-to host under certain circumstances.\n\nThis flaw only manifests itself if the netrc file has an entry that matches\nthe redirect target hostname but the entry either omits just the password or\nomits both login and password.",
       "aliases": ["CVE-2024-11053"],
-      "modified": "2025-09-15T12:12:51Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2024-12-11T08:00:00Z",
       "database_specific": "<Any value>",
       "affected": [
@@ -421,7 +421,7 @@
       "summary": "Usage of disabled protocol",
       "details": "When a protocol selection parameter option disables all protocols without\nadding any then the default set of protocols would remain in the allowed set\ndue to an error in the logic for removing protocols. The below command would\nperform a request to curl.se with a plaintext protocol which has been\nexplicitly disabled.\n\n    curl --proto -all,-http http://curl.se\n\nThe flaw is only present if the set of selected protocols disables the entire\nset of available protocols, in itself a command with no practical use and\ntherefore unlikely to be encountered in real situations. The curl security team\nhas thus assessed this to be low severity bug.",
       "aliases": ["CVE-2024-2004"],
-      "modified": "2024-03-27T07:12:10.551612Z",
+      "modified": "<RFC3339 date with the year 2024>",
       "published": "2024-03-27T08:00:00Z",
       "database_specific": "<Any value>",
       "affected": [
@@ -472,7 +472,7 @@
       "summary": "HTTP/2 push headers memory-leak",
       "details": "When an application tells libcurl it wants to allow HTTP/2 server push, and\nthe amount of received headers for the push surpasses the maximum allowed\nlimit (1000), libcurl aborts the server push. When aborting, libcurl\ninadvertently does not free all the previously allocated headers and instead\nleaks the memory.\n\nFurther, this error condition fails silently and is therefore not easily\ndetected by an application.",
       "aliases": ["CVE-2024-2398"],
-      "modified": "2024-03-27T07:12:10.712629Z",
+      "modified": "<RFC3339 date with the year 2024>",
       "published": "2024-03-27T08:00:00Z",
       "database_specific": "<Any value>",
       "affected": [
@@ -523,7 +523,7 @@
       "summary": "TLS certificate check bypass with mbedTLS",
       "details": "libcurl did not check the server certificate of TLS connections done to a host\nspecified as an IP address, when built to use mbedTLS.\n\nlibcurl would wrongly avoid using the set hostname function when the specified\nhostname was given as an IP address, therefore completely skipping the\ncertificate check. This affects all uses of TLS protocols (HTTPS, FTPS, IMAPS,\nPOPS3, SMTPS, etc).",
       "aliases": ["CVE-2024-2466"],
-      "modified": "2024-06-07T13:53:51Z",
+      "modified": "<RFC3339 date with the year 2024>",
       "published": "2024-03-27T08:00:00Z",
       "database_specific": "<Any value>",
       "affected": [
@@ -574,7 +574,7 @@
       "summary": "ASN.1 date parser overread",
       "details": "libcurl's ASN1 parser code has the `GTime2str()` function, used for parsing an\nASN.1 Generalized Time field. If given an syntactically incorrect field, the\nparser might end up using -1 for the length of the *time fraction*, leading to\na `strlen()` getting performed on a pointer to a heap buffer area that is not\n(purposely) null terminated.\n\nThis flaw most likely leads to a crash, but can also lead to heap contents\ngetting returned to the application when\n[CURLINFO_CERTINFO](https://curl.se/libcurl/c/CURLINFO_CERTINFO.html) is used.",
       "aliases": ["CVE-2024-7264"],
-      "modified": "2024-07-31T09:57:12Z",
+      "modified": "<RFC3339 date with the year 2024>",
       "published": "2024-07-31T08:00:00Z",
       "database_specific": "<Any value>",
       "affected": [
@@ -625,7 +625,7 @@
       "summary": "OCSP stapling bypass with GnuTLS",
       "details": "When curl is told to use the Certificate Status Request TLS extension, often\nreferred to as OCSP stapling, to verify that the server certificate is valid,\nit might fail to detect some OCSP problems and instead wrongly consider the\nresponse as fine.\n\nIf the returned status reports another error than \"revoked\" (like for example\n\"unauthorized\") it is not treated as a bad certificate.",
       "aliases": ["CVE-2024-8096"],
-      "modified": "2024-10-24T18:05:41Z",
+      "modified": "<RFC3339 date with the year 2024>",
       "published": "2024-09-11T08:00:00Z",
       "database_specific": "<Any value>",
       "affected": [
@@ -676,7 +676,7 @@
       "summary": "HSTS subdomain overwrites parent cache entry",
       "details": "When curl is asked to use HSTS, the expiry time for a subdomain might\noverwrite a parent domain's cache entry, making it end sooner or later than\notherwise intended.\n\nThis affects curl using applications that enable HSTS and use URLs with the\ninsecure `HTTP://` scheme and perform transfers with hosts like\n`x.example.com` as well as `example.com` where the first host is a subdomain\nof the second host.\n\n(The HSTS cache either needs to have been populated manually or there needs to\nhave been previous HTTPS accesses done as the cache needs to have entries for\nthe domains involved to trigger this problem.)\n\nWhen `x.example.com` responds with `Strict-Transport-Security:` headers, this\nbug can make the subdomain's expiry timeout *bleed over* and get set for the\nparent domain `example.com` in curl's HSTS cache.\n\nThe result of a triggered bug is that HTTP accesses to `example.com` get\nconverted to HTTPS for a different period of time than what was asked for by\nthe origin server. If `example.com` for example stops supporting HTTPS at its\nexpiry time, curl might then fail to access `http://example.com` until the\n(wrongly set) timeout expires. This bug can also expire the parent's entry\n*earlier*, thus making curl inadvertently switch back to insecure HTTP earlier\nthan otherwise intended.",
       "aliases": ["CVE-2024-9681"],
-      "modified": "2024-11-07T23:43:58Z",
+      "modified": "<RFC3339 date with the year 2024>",
       "published": "2024-11-05T08:00:00Z",
       "database_specific": "<Any value>",
       "affected": [
@@ -727,7 +727,7 @@
       "summary": "netrc and default credential leak",
       "details": "When asked to use a `.netrc` file for credentials **and** to follow HTTP\nredirects, curl could leak the password used for the first host to the\nfollowed-to host under certain circumstances.\n\nThis flaw only manifests itself if the netrc file has a `default` entry that\nomits both login and password. A rare circumstance.",
       "aliases": ["CVE-2025-0167"],
-      "modified": "2025-09-15T12:17:28Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2025-02-05T08:00:00Z",
       "database_specific": "<Any value>",
       "affected": [
@@ -778,7 +778,7 @@
       "summary": "gzip integer overflow",
       "details": "When libcurl is asked to perform automatic gzip decompression of\ncontent-encoded HTTP responses with the `CURLOPT_ACCEPT_ENCODING` option,\n**using zlib 1.2.0.3 or older**, an attacker-controlled integer overflow would\nmake libcurl perform a buffer overflow.",
       "aliases": ["CVE-2025-0725"],
-      "modified": "2025-05-15T17:48:29Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2025-02-05T08:00:00Z",
       "database_specific": "<Any value>",
       "affected": [
@@ -829,7 +829,7 @@
       "summary": "No QUIC certificate pinning with wolfSSL",
       "details": "libcurl supports *pinning* of the server certificate public key for HTTPS\ntransfers. Due to an omission, this check is not performed when connecting\nwith QUIC for HTTP/3, when the TLS backend is wolfSSL.\n\nDocumentation says the option works with wolfSSL, failing to specify that it\ndoes not for QUIC and HTTP/3.\n\nSince pinning makes the transfer succeed if the pin is fine, users could\nunwittingly connect to an impostor server without noticing.",
       "aliases": ["CVE-2025-5025"],
-      "modified": "2025-05-28T08:10:29Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2025-05-28T08:00:00Z",
       "database_specific": "<Any value>",
       "affected": [
@@ -880,7 +880,7 @@
       "summary": "Out of bounds read for cookie path",
       "details": "1. A cookie is set using the `secure` keyword for `https://target`\n2. curl is redirected to or otherwise made to speak with `http://target` (same\n   hostname, but using clear text HTTP) using the same cookie set\n3. The same cookie name is set - but with just a slash as path (`path=\"/\"`).\n   Since this site is not secure, the cookie *should* just be ignored.\n4. A bug in the path comparison logic makes curl read outside a heap buffer\n   boundary\n\nThe bug either causes a crash or it potentially makes the comparison come to\nthe wrong conclusion and lets the clear-text site override the contents of the\nsecure cookie, contrary to expectations and depending on the memory contents\nimmediately following the single-byte allocation that holds the path.\n\nThe presumed and correct behavior would be to plainly ignore the second set of\nthe cookie since it was already set as secure on a secure host so overriding\nit on an insecure host should not be okay.",
       "aliases": ["CVE-2025-9086"],
-      "modified": "2025-09-10T07:45:33Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2025-09-10T08:00:00Z",
       "database_specific": "<Any value>",
       "affected": [
@@ -930,7 +930,7 @@
       "id": "CVE-2024-0853",
       "details": "curl inadvertently kept the SSL session ID for connections in its cache even when the verify status (*OCSP stapling*) test failed. A subsequent transfer to\nthe same hostname could then succeed if the session ID cache was still fresh, which then skipped the verify status check.",
       "aliases": ["CURL-CVE-2024-0853"],
-      "modified": "2025-10-21T17:20:50.512526Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2024-02-03T14:15:50Z",
       "related": ["CGA-w4px-x37v-694c", "openSUSE-SU-2024:13637-1"],
       "references": [
@@ -991,7 +991,7 @@
       "id": "CVE-2024-11053",
       "details": "When asked to both use a `.netrc` file for credentials and to follow HTTP\nredirects, curl could leak the password used for the first host to the\nfollowed-to host under certain circumstances.\n\nThis flaw only manifests itself if the netrc file has an entry that matches\nthe redirect target hostname but the entry either omits just the password or\nomits both login and password.",
       "aliases": ["CURL-CVE-2024-11053"],
-      "modified": "2025-10-21T17:24:13.347448Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2024-12-11T08:15:05Z",
       "related": [
         "ALSA-2025:1671",
@@ -1063,7 +1063,7 @@
       "id": "CVE-2024-2004",
       "details": "When a protocol selection parameter option disables all protocols without adding any then the default set of protocols would remain in the allowed set due to an error in the logic for removing protocols. The below command would perform a request to curl.se with a plaintext protocol which has been explicitly disabled.      curl --proto -all,-http http://curl.se  The flaw is only present if the set of selected protocols disables the entire set of available protocols, in itself a command with no practical use and therefore unlikely to be encountered in real situations. The curl security team has thus assessed this to be low severity bug.",
       "aliases": ["CURL-CVE-2024-2004"],
-      "modified": "2025-10-21T17:28:16.902449Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2024-03-27T08:15:41Z",
       "related": [
         "CGA-jqm4-7q66-4rv5",
@@ -1161,7 +1161,7 @@
       "id": "CVE-2024-2398",
       "details": "When an application tells libcurl it wants to allow HTTP/2 server push, and the amount of received headers for the push surpasses the maximum allowed limit (1000), libcurl aborts the server push. When aborting, libcurl inadvertently does not free all the previously allocated headers and instead leaks the memory.  Further, this error condition fails silently and is therefore not easily detected by an application.",
       "aliases": ["CURL-CVE-2024-2398"],
-      "modified": "2025-10-21T17:36:44.979235Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2024-03-27T08:15:41Z",
       "related": [
         "ALSA-2024:5529",
@@ -1261,7 +1261,7 @@
       "id": "CVE-2024-2466",
       "details": "libcurl did not check the server certificate of TLS connections done to a host specified as an IP address, when built to use mbedTLS.  libcurl would wrongly avoid using the set hostname function when the specified hostname was given as an IP address, therefore completely skipping the certificate check. This affects all uses of TLS protocols (HTTPS, FTPS, IMAPS, POPS3, SMTPS, etc).",
       "aliases": ["CURL-CVE-2024-2466"],
-      "modified": "2025-10-21T17:35:47.949485Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2024-03-27T08:15:41Z",
       "related": [
         "CGA-hx4m-3q2w-96wj",
@@ -1350,7 +1350,7 @@
       "id": "CVE-2024-6874",
       "details": "libcurl's URL API function\n[curl_url_get()](https://curl.se/libcurl/c/curl_url_get.html) offers punycode\nconversions, to and from IDN. Asking to convert a name that is exactly 256\nbytes, libcurl ends up reading outside of a stack based buffer when built to\nuse the *macidn* IDN backend. The conversion function then fills up the\nprovided buffer exactly - but does not null terminate the string.\n\nThis flaw can lead to stack contents accidently getting returned as part of\nthe converted string.",
       "aliases": ["CURL-CVE-2024-6874"],
-      "modified": "2025-10-22T07:40:24.525626Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2024-07-24T08:15:03Z",
       "related": ["openSUSE-SU-2024:14225-1"],
       "references": [
@@ -1407,7 +1407,7 @@
       "id": "CVE-2024-7264",
       "details": "libcurl's ASN1 parser code has the `GTime2str()` function, used for parsing an\nASN.1 Generalized Time field. If given an syntactically incorrect field, the\nparser might end up using -1 for the length of the *time fraction*, leading to\na `strlen()` getting performed on a pointer to a heap buffer area that is not\n(purposely) null terminated.\n\nThis flaw most likely leads to a crash, but can also lead to heap contents\ngetting returned to the application when\n[CURLINFO_CERTINFO](https://curl.se/libcurl/c/CURLINFO_CERTINFO.html) is used.",
       "aliases": ["CURL-CVE-2024-7264"],
-      "modified": "2025-10-22T07:43:47.421649Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2024-07-31T08:15:02Z",
       "related": [
         "ALSA-2025:1671",
@@ -1480,7 +1480,7 @@
       "id": "CVE-2024-8096",
       "details": "When curl is told to use the Certificate Status Request TLS extension, often referred to as OCSP stapling, to verify that the server certificate is valid, it might fail to detect some OCSP problems and instead wrongly consider the response as fine.  If the returned status reports another error than 'revoked' (like for example 'unauthorized') it is not treated as a bad certficate.",
       "aliases": ["CURL-CVE-2024-8096"],
-      "modified": "2025-10-22T07:48:57.631245Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2024-09-11T10:15:02Z",
       "related": [
         "CGA-g55g-qx76-5fjj",
@@ -1548,7 +1548,7 @@
       "id": "CVE-2024-9681",
       "details": "When curl is asked to use HSTS, the expiry time for a subdomain might\noverwrite a parent domain's cache entry, making it end sooner or later than\notherwise intended.\n\nThis affects curl using applications that enable HSTS and use URLs with the\ninsecure `HTTP://` scheme and perform transfers with hosts like\n`x.example.com` as well as `example.com` where the first host is a subdomain\nof the second host.\n\n(The HSTS cache either needs to have been populated manually or there needs to\nhave been previous HTTPS accesses done as the cache needs to have entries for\nthe domains involved to trigger this problem.)\n\nWhen `x.example.com` responds with `Strict-Transport-Security:` headers, this\nbug can make the subdomain's expiry timeout *bleed over* and get set for the\nparent domain `example.com` in curl's HSTS cache.\n\nThe result of a triggered bug is that HTTP accesses to `example.com` get\nconverted to HTTPS for a different period of time than what was asked for by\nthe origin server. If `example.com` for example stops supporting HTTPS at its\nexpiry time, curl might then fail to access `http://example.com` until the\n(wrongly set) timeout expires. This bug can also expire the parent's entry\n*earlier*, thus making curl inadvertently switch back to insecure HTTP earlier\nthan otherwise intended.",
       "aliases": ["CURL-CVE-2024-9681"],
-      "modified": "2025-10-22T07:53:54.931263Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2024-11-06T08:15:03Z",
       "related": [
         "MGASA-2024-0360",
@@ -1612,7 +1612,7 @@
       "id": "CVE-2025-0167",
       "details": "When asked to use a `.netrc` file for credentials **and** to follow HTTP\nredirects, curl could leak the password used for the first host to the\nfollowed-to host under certain circumstances.\n\nThis flaw only manifests itself if the netrc file has a `default` entry that\nomits both login and password. A rare circumstance.",
       "aliases": ["CURL-CVE-2025-0167"],
-      "modified": "2025-10-22T07:55:07.627071Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2025-02-05T10:15:22Z",
       "related": [
         "MGASA-2025-0123",
@@ -1671,7 +1671,7 @@
       "id": "CVE-2025-0665",
       "details": "libcurl would wrongly close the same eventfd file descriptor twice when taking\ndown a connection channel after having completed a threaded name resolve.",
       "aliases": ["CURL-CVE-2025-0665"],
-      "modified": "2025-10-22T07:56:22.501113Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2025-02-05T10:15:22Z",
       "related": ["MGASA-2025-0123", "openSUSE-SU-2025:14809-1"],
       "references": [
@@ -1732,7 +1732,7 @@
       "id": "CVE-2025-0725",
       "details": "When libcurl is asked to perform automatic gzip decompression of\ncontent-encoded HTTP responses with the `CURLOPT_ACCEPT_ENCODING` option,\n**using zlib 1.2.0.3 or older**, an attacker-controlled integer overflow would\nmake libcurl perform a buffer overflow.",
       "aliases": ["CURL-CVE-2025-0725"],
-      "modified": "2025-10-22T07:57:05.447914Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2025-02-05T10:15:22Z",
       "related": [
         "MGASA-2025-0123",
@@ -1807,7 +1807,7 @@
       "id": "CVE-2025-5025",
       "details": "libcurl supports *pinning* of the server certificate public key for HTTPS transfers. Due to an omission, this check is not performed when connecting with QUIC for HTTP/3, when the TLS backend is wolfSSL. Documentation says the option works with wolfSSL, failing to specify that it does not for QUIC and HTTP/3. Since pinning makes the transfer succeed if the pin is fine, users could unwittingly connect to an impostor server without noticing.",
       "aliases": ["CURL-CVE-2025-5025"],
-      "modified": "2025-10-22T16:20:21.101851Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2025-05-28T07:15:24Z",
       "references": [
         {
@@ -1875,7 +1875,7 @@
       "id": "GHSA-353f-x4gh-cqq8",
       "summary": "Nokogiri patches vendored libxml2 to resolve multiple CVEs",
       "details": "## Summary\n\nNokogiri v1.18.9 patches the vendored libxml2 to address CVE-2025-6021, CVE-2025-6170, CVE-2025-49794, CVE-2025-49795, and CVE-2025-49796.\n\n## Impact and severity\n\n### CVE-2025-6021\n\nA flaw was found in libxml2's xmlBuildQName function, where integer overflows in buffer size calculations can lead to a stack-based buffer overflow. This issue can result in memory corruption or a denial of service when processing crafted input.\n\nNVD claims a severity of 7.5 High (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H)\n\nFixed by applying https://gitlab.gnome.org/GNOME/libxml2/-/commit/17d950ae\n\n### CVE-2025-6170\n\nA flaw was found in the interactive shell of the xmllint command-line tool, used for parsing XML files. When a user inputs an overly long command, the program does not check the input size properly, which can cause it to crash. This issue might allow attackers to run harmful code in rare configurations without modern protections.\n\nNVD claims a severity of 2.5 Low (CVSS:3.1/AV:L/AC:H/PR:N/UI:R/S:U/C:N/I:N/A:L)\n\nFixed by applying https://gitlab.gnome.org/GNOME/libxml2/-/commit/5e9ec5c1\n\n### CVE-2025-49794\n\nA use-after-free vulnerability was found in libxml2. This issue occurs when parsing XPath elements under certain circumstances when the XML schematron has the \u003csch:name path=\"...\"/\u003e schema elements. This flaw allows a malicious actor to craft a malicious XML document used as input for libxml, resulting in the program's crash using libxml or other possible undefined behaviors.\n\nNVD claims a severity of 9.1 Critical (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H)\n\nFixed by applying https://gitlab.gnome.org/GNOME/libxml2/-/commit/81cef8c5\n\n### CVE-2025-49795\n\nA NULL pointer dereference vulnerability was found in libxml2 when processing XPath XML expressions. This flaw allows an attacker to craft a malicious XML input to libxml2, leading to a denial of service.\n\nNVD claims a severity of 7.5 High (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H)\n\nFixed by applying https://gitlab.gnome.org/GNOME/libxml2/-/commit/62048278\n\n### CVE-2025-49796\n\nA vulnerability was found in libxml2. Processing certain sch:name elements from the input XML file can trigger a memory corruption issue. This flaw allows an attacker to craft a malicious XML input file that can lead libxml to crash, resulting in a denial of service or other possible undefined behavior due to sensitive data being corrupted in memory.\n\nNVD claims a severity of 9.1 Critical (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H)\n\nFixed by applying https://gitlab.gnome.org/GNOME/libxml2/-/commit/81cef8c5\n\n## Affected Versions\n\n- Nokogiri \u003c 1.18.9 when using CRuby (MRI) with vendored libxml2\n\n## Patched Versions\n\n- Nokogiri \u003e= 1.18.9\n\n## Mitigation\n\nUpgrade to Nokogiri v1.18.9 or later.\n\nUsers who are unable to upgrade Nokogiri may also choose a more complicated mitigation: compile and link Nokogiri against patched external libxml2 libraries which will also address these same issues.\n\n## References\n\n- https://github.com/sparklemotion/nokogiri/pull/3526\n- https://nvd.nist.gov/vuln/detail/CVE-2025-6021\n- https://nvd.nist.gov/vuln/detail/CVE-2025-6170\n- https://nvd.nist.gov/vuln/detail/CVE-2025-49794\n- https://nvd.nist.gov/vuln/detail/CVE-2025-49795\n- https://nvd.nist.gov/vuln/detail/CVE-2025-49796",
-      "modified": "2025-07-21T19:42:17.531986Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2025-07-21T19:35:18Z",
       "related": [
         "CGA-73h8-h425-x4mp",
@@ -1950,7 +1950,7 @@
       "id": "GHSA-5w6v-399v-w3cc",
       "summary": "Nokogiri updates packaged libxml2 to v2.13.8 to resolve CVE-2025-32414 and CVE-2025-32415",
       "details": "## Summary\n\nNokogiri v1.18.8 upgrades its dependency libxml2 to [v2.13.8](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.8).\n\nlibxml2 v2.13.8 addresses:\n\n- CVE-2025-32414\n  - described at https://gitlab.gnome.org/GNOME/libxml2/-/issues/889\n- CVE-2025-32415\n  - described at https://gitlab.gnome.org/GNOME/libxml2/-/issues/890\n\n## Impact\n\n### CVE-2025-32414: No impact\n\nIn libxml2 before 2.13.8 and 2.14.x before 2.14.2, out-of-bounds memory access can occur in the Python API (Python bindings) because of an incorrect return value. This occurs in xmlPythonFileRead and xmlPythonFileReadRaw because of a difference between bytes and characters.\n\n**There is no impact** from this CVE for Nokogiri users.\n\n\n### CVE-2025-32415: Low impact\n\nIn libxml2 before 2.13.8 and 2.14.x before 2.14.2, xmlSchemaIDCFillNodeTables in xmlschemas.c has a heap-based buffer under-read. To exploit this, a crafted XML document must be validated against an XML schema with certain identity constraints, or a crafted XML schema must be used.\n\nIn the upstream issue, further context is provided by the maintainer:\n\n\u003e The bug affects validation against untrusted XML Schemas (.xsd) and validation of untrusted\n\u003e documents against trusted Schemas if they make use of xsd:keyref in combination with recursively\n\u003e defined types that have additional identity constraints.\n\nMITRE has published a severity score of 2.9 LOW (CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L) for this CVE.",
-      "modified": "2025-04-21T22:04:45.823585Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2025-04-21T21:55:56Z",
       "related": [
         "CGA-36hq-gx42-7ph7",
@@ -2012,7 +2012,7 @@
       "id": "GHSA-mrxw-mxhj-p664",
       "summary": "Nokogiri updates packaged libxslt to v1.1.43 to resolve multiple CVEs",
       "details": "## Summary\n\nNokogiri v1.18.4 upgrades its dependency libxslt to [v1.1.43](https://gitlab.gnome.org/GNOME/libxslt/-/releases/v1.1.43).\n\nlibxslt v1.1.43 resolves:\n\n- CVE-2025-24855: Fix use-after-free of XPath context node\n- CVE-2024-55549: Fix UAF related to excluded namespaces\n\n## Impact\n\n### CVE-2025-24855\n\n- \"Use-after-free due to xsltEvalXPathStringNs leaking xpathCtxt-\u003enode\"\n- MITRE has rated this 7.8 High CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:C/C:N/I:H/A:H\n- Upstream report: https://gitlab.gnome.org/GNOME/libxslt/-/issues/128\n- NVD entry: https://nvd.nist.gov/vuln/detail/CVE-2025-24855\n\n### CVE-2024-55549\n\n- \"Use-after-free related to excluded result prefixes\"\n- MITRE has rated this 7.8 High CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:C/C:N/I:H/A:H\n- Upstream report: https://gitlab.gnome.org/GNOME/libxslt/-/issues/127\n- NVD entry: https://nvd.nist.gov/vuln/detail/CVE-2024-55549",
-      "modified": "2025-03-21T15:52:20.761884Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2025-03-14T18:51:37Z",
       "related": [
         "CGA-2534-mwf5-4939",
@@ -2089,7 +2089,7 @@
       "id": "GHSA-vvfq-8hwr-qm4m",
       "summary": "Nokogiri updates packaged libxml2 to 2.13.6 to resolve CVE-2025-24928 and CVE-2024-56171",
       "details": "## Summary\n\nNokogiri v1.18.3 upgrades its dependency libxml2 to [v2.13.6](https://gitlab.gnome.org/GNOME/libxml2/-/releases/v2.13.6).\n\nlibxml2 v2.13.6 addresses:\n\n- CVE-2025-24928\n  - described at https://gitlab.gnome.org/GNOME/libxml2/-/issues/847\n- CVE-2024-56171\n   - described at https://gitlab.gnome.org/GNOME/libxml2/-/issues/828\n\n## Impact\n\n### CVE-2025-24928\n\nStack-buffer overflow is possible when reporting DTD validation errors if the input contains a long (~3kb) QName prefix.\n\n### CVE-2024-56171\n\nUse-after-free is possible during validation against untrusted XML Schemas (.xsd) and, potentially, validation of untrusted documents against trusted Schemas if they make use of `xsd:keyref` in combination with recursively defined types that have additional identity constraints.",
-      "modified": "2025-03-10T22:51:07.538402Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2025-02-18T22:36:03Z",
       "related": [
         "CGA-9832-f6q3-5726",
@@ -2153,7 +2153,7 @@
       "summary": "Jinja2 vulnerable to sandbox breakout through attr filter selecting format method",
       "details": "An oversight in how the Jinja sandboxed environment interacts with the `|attr` filter allows an attacker that controls the content of a template to execute arbitrary Python code.\n\nTo exploit the vulnerability, an attacker needs to control the content of a template. Whether that is the case depends on the type of application using Jinja. This vulnerability impacts users of applications which execute untrusted templates.\n\nJinja's sandbox does catch calls to `str.format` and ensures they don't escape the sandbox. However, it's possible to use the `|attr` filter to get a reference to a string's plain format method, bypassing the sandbox. After the fix, the `|attr` filter no longer bypasses the environment's attribute lookup.",
       "aliases": ["CVE-2025-27516"],
-      "modified": "2025-05-01T04:08:20.224875Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2025-03-05T20:40:14Z",
       "related": [
         "CGA-2h34-36gr-7wjw",
@@ -2166,6 +2166,7 @@
         "CGA-ch38-hm3p-vqfx",
         "CGA-hw4r-mxqv-7jj9",
         "CGA-m6wh-c9m7-3g8v",
+        "CGA-mcp3-399f-p32w",
         "CGA-p346-mccf-rp28",
         "CGA-pxmx-r998-7p4j",
         "CGA-q74h-cfpr-qvcv",
@@ -2189,6 +2190,10 @@
         {
           "type": "PACKAGE",
           "url": "https://github.com/pallets/jinja"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.debian.org/debian-lts-announce/2025/04/msg00022.html"
         },
         {
           "type": "WEB",
@@ -2232,7 +2237,7 @@
       "summary": "Jinja has a sandbox breakout through malicious filenames",
       "details": "A bug in the Jinja compiler allows an attacker that controls both the content and filename of a template to execute arbitrary Python code, regardless of if Jinja's sandbox is used.\n\nTo exploit the vulnerability, an attacker needs to control both the filename and the contents of a template. Whether that is the case depends on the type of application using Jinja. This vulnerability impacts users of applications which execute untrusted templates where the template author can also choose the template filename.",
       "aliases": ["CVE-2024-56201"],
-      "modified": "2025-01-08T16:26:10.957556Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2024-12-23T17:54:12Z",
       "related": [
         "CGA-2589-9xpr-fmp7",
@@ -2321,7 +2326,7 @@
       "summary": "Jinja has a sandbox breakout through indirect reference to format method",
       "details": "An oversight in how the Jinja sandboxed environment detects calls to `str.format` allows an attacker that controls the content of a template to execute arbitrary Python code.\n\nTo exploit the vulnerability, an attacker needs to control the content of a template. Whether that is the case depends on the type of application using Jinja. This vulnerability impacts users of applications which execute untrusted templates.\n\nJinja's sandbox does catch calls to `str.format` and ensures they don't escape the sandbox. However, it's possible to store a reference to a malicious string's `format` method, then pass that to a filter that calls it. No such filters are built-in to Jinja, but could be present through custom filters in an application. After the fix, such indirect calls are also handled by the sandbox.",
       "aliases": ["CVE-2024-56326"],
-      "modified": "2024-12-27T19:24:19.224818Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2024-12-23T17:56:08Z",
       "related": [
         "CGA-3cj4-2jg2-4qm3",
@@ -2364,6 +2369,10 @@
         {
           "type": "WEB",
           "url": "https://github.com/pallets/jinja/releases/tag/3.1.5"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.debian.org/debian-lts-announce/2025/04/msg00022.html"
         }
       ],
       "affected": [
@@ -2415,7 +2424,7 @@
       "summary": "Jinja2 vulnerable to sandbox breakout through attr filter selecting format method",
       "details": "An oversight in how the Jinja sandboxed environment interacts with the `|attr` filter allows an attacker that controls the content of a template to execute arbitrary Python code.\n\nTo exploit the vulnerability, an attacker needs to control the content of a template. Whether that is the case depends on the type of application using Jinja. This vulnerability impacts users of applications which execute untrusted templates.\n\nJinja's sandbox does catch calls to `str.format` and ensures they don't escape the sandbox. However, it's possible to use the `|attr` filter to get a reference to a string's plain format method, bypassing the sandbox. After the fix, the `|attr` filter no longer bypasses the environment's attribute lookup.",
       "aliases": ["CVE-2025-27516"],
-      "modified": "2025-05-01T04:08:20.224875Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2025-03-05T20:40:14Z",
       "related": [
         "CGA-2h34-36gr-7wjw",
@@ -2428,6 +2437,7 @@
         "CGA-ch38-hm3p-vqfx",
         "CGA-hw4r-mxqv-7jj9",
         "CGA-m6wh-c9m7-3g8v",
+        "CGA-mcp3-399f-p32w",
         "CGA-p346-mccf-rp28",
         "CGA-pxmx-r998-7p4j",
         "CGA-q74h-cfpr-qvcv",
@@ -2451,6 +2461,10 @@
         {
           "type": "PACKAGE",
           "url": "https://github.com/pallets/jinja"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.debian.org/debian-lts-announce/2025/04/msg00022.html"
         },
         {
           "type": "WEB",
@@ -2494,7 +2508,7 @@
       "summary": "Jinja has a sandbox breakout through malicious filenames",
       "details": "A bug in the Jinja compiler allows an attacker that controls both the content and filename of a template to execute arbitrary Python code, regardless of if Jinja's sandbox is used.\n\nTo exploit the vulnerability, an attacker needs to control both the filename and the contents of a template. Whether that is the case depends on the type of application using Jinja. This vulnerability impacts users of applications which execute untrusted templates where the template author can also choose the template filename.",
       "aliases": ["CVE-2024-56201"],
-      "modified": "2025-01-08T16:26:10.957556Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2024-12-23T17:54:12Z",
       "related": [
         "CGA-2589-9xpr-fmp7",
@@ -2583,7 +2597,7 @@
       "summary": "Jinja has a sandbox breakout through indirect reference to format method",
       "details": "An oversight in how the Jinja sandboxed environment detects calls to `str.format` allows an attacker that controls the content of a template to execute arbitrary Python code.\n\nTo exploit the vulnerability, an attacker needs to control the content of a template. Whether that is the case depends on the type of application using Jinja. This vulnerability impacts users of applications which execute untrusted templates.\n\nJinja's sandbox does catch calls to `str.format` and ensures they don't escape the sandbox. However, it's possible to store a reference to a malicious string's `format` method, then pass that to a filter that calls it. No such filters are built-in to Jinja, but could be present through custom filters in an application. After the fix, such indirect calls are also handled by the sandbox.",
       "aliases": ["CVE-2024-56326"],
-      "modified": "2024-12-27T19:24:19.224818Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2024-12-23T17:56:08Z",
       "related": [
         "CGA-3cj4-2jg2-4qm3",
@@ -2626,6 +2640,10 @@
         {
           "type": "WEB",
           "url": "https://github.com/pallets/jinja/releases/tag/3.1.5"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.debian.org/debian-lts-announce/2025/04/msg00022.html"
         }
       ],
       "affected": [
@@ -2677,7 +2695,7 @@
       "summary": "Jinja2 vulnerable to sandbox breakout through attr filter selecting format method",
       "details": "An oversight in how the Jinja sandboxed environment interacts with the `|attr` filter allows an attacker that controls the content of a template to execute arbitrary Python code.\n\nTo exploit the vulnerability, an attacker needs to control the content of a template. Whether that is the case depends on the type of application using Jinja. This vulnerability impacts users of applications which execute untrusted templates.\n\nJinja's sandbox does catch calls to `str.format` and ensures they don't escape the sandbox. However, it's possible to use the `|attr` filter to get a reference to a string's plain format method, bypassing the sandbox. After the fix, the `|attr` filter no longer bypasses the environment's attribute lookup.",
       "aliases": ["CVE-2025-27516"],
-      "modified": "2025-05-01T04:08:20.224875Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2025-03-05T20:40:14Z",
       "related": [
         "CGA-2h34-36gr-7wjw",
@@ -2690,6 +2708,7 @@
         "CGA-ch38-hm3p-vqfx",
         "CGA-hw4r-mxqv-7jj9",
         "CGA-m6wh-c9m7-3g8v",
+        "CGA-mcp3-399f-p32w",
         "CGA-p346-mccf-rp28",
         "CGA-pxmx-r998-7p4j",
         "CGA-q74h-cfpr-qvcv",
@@ -2713,6 +2732,10 @@
         {
           "type": "PACKAGE",
           "url": "https://github.com/pallets/jinja"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.debian.org/debian-lts-announce/2025/04/msg00022.html"
         },
         {
           "type": "WEB",
@@ -2756,7 +2779,7 @@
       "summary": "Jinja has a sandbox breakout through malicious filenames",
       "details": "A bug in the Jinja compiler allows an attacker that controls both the content and filename of a template to execute arbitrary Python code, regardless of if Jinja's sandbox is used.\n\nTo exploit the vulnerability, an attacker needs to control both the filename and the contents of a template. Whether that is the case depends on the type of application using Jinja. This vulnerability impacts users of applications which execute untrusted templates where the template author can also choose the template filename.",
       "aliases": ["CVE-2024-56201"],
-      "modified": "2025-01-08T16:26:10.957556Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2024-12-23T17:54:12Z",
       "related": [
         "CGA-2589-9xpr-fmp7",
@@ -2845,7 +2868,7 @@
       "summary": "Jinja has a sandbox breakout through indirect reference to format method",
       "details": "An oversight in how the Jinja sandboxed environment detects calls to `str.format` allows an attacker that controls the content of a template to execute arbitrary Python code.\n\nTo exploit the vulnerability, an attacker needs to control the content of a template. Whether that is the case depends on the type of application using Jinja. This vulnerability impacts users of applications which execute untrusted templates.\n\nJinja's sandbox does catch calls to `str.format` and ensures they don't escape the sandbox. However, it's possible to store a reference to a malicious string's `format` method, then pass that to a filter that calls it. No such filters are built-in to Jinja, but could be present through custom filters in an application. After the fix, such indirect calls are also handled by the sandbox.",
       "aliases": ["CVE-2024-56326"],
-      "modified": "2024-12-27T19:24:19.224818Z",
+      "modified": "<RFC3339 date with the year 2025>",
       "published": "2024-12-23T17:56:08Z",
       "related": [
         "CGA-3cj4-2jg2-4qm3",
@@ -2888,6 +2911,10 @@
         {
           "type": "WEB",
           "url": "https://github.com/pallets/jinja/releases/tag/3.1.5"
+        },
+        {
+          "type": "WEB",
+          "url": "https://lists.debian.org/debian-lts-announce/2025/04/msg00022.html"
         }
       ],
       "affected": [


### PR DESCRIPTION
As the modified date can change frequently, this replaces it based on if its formatted correctly and its year