### PR TITLE
fix(bindings): use correct query parameter for DetermineVersion endpoint

### DIFF
--- a/bindings/go/osvdev/osvdev.go
+++ b/bindings/go/osvdev/osvdev.go
@@ -175,7 +175,7 @@ func (c *OSVClient) Query(ctx context.Context, query *api.Query) (*api.Vulnerabi
 
 func (c *OSVClient) ExperimentalDetermineVersion(ctx context.Context, query *api.DetermineVersionParameters) (*api.VersionMatchList, error) {
 	var result api.VersionMatchList
-	err := c.makeRequest(ctx, DetermineVersionEndpoint, query.Query, &result)
+	err := c.makeRequest(ctx, DetermineVersionEndpoint, query.GetQuery(), &result)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR fixes a bug in the `ExperimentalDetermineVersion` function.

Previously, the entire `api.DetermineVersionParameters` struct was passed as the request body, however the API endpoint expects the nested `Query` object instead. This change fixes it by passing `query.Query` to the request, aligning it with the intended API usage.

The bug was not caught in the test because we don't have actual testing for it... https://github.com/google/osv.dev/blob/master/bindings/go/osvdev/osvdev_test.go#L422