### PR TITLE
fix: Remove extra log of successful generation of OSV record

### DIFF
--- a/vulnfeeds/cvelist2osv/converter.go
+++ b/vulnfeeds/cvelist2osv/converter.go
@@ -258,7 +258,6 @@ func ConvertAndExportCVEToOSV(cve cves.CVE5, vulnSink io.Writer, metricsSink io.
 		logger.Info("Failed to write", slog.Any("err", err))
 		return err
 	}
-	logger.Info("Generated OSV record for "+string(cveID), slog.String("cve", string(cveID)), slog.String("cna", cnaAssigner))
 
 	marshalledMetrics, err := json.MarshalIndent(&metrics, "", "  ")
 	if err != nil {


### PR DESCRIPTION
The log "Generated OSV Record for CVE-xxx" is logged both in the `converter.go` logic and the cmd tools that run them, so it shows up twice. I'm leaving it to the cmd tools to log it appropriately.