### PR TITLE
fix(vulnfeeds): too many spaces in git versions regex causing issues.

### DIFF
--- a/vulnfeeds/git/versions.go
+++ b/vulnfeeds/git/versions.go
@@ -119,7 +119,7 @@ func NormalizeVersion(version string) (normalizedVersion string, e error) {
 // Parse a version range string into an models.AffectedVersion struct,
 // which aligns with the structure used by GitHub CNA feeds.
 func ParseVersionRange(versionRange string) (models.AffectedVersion, error) {
-	matches := versionRangeRegex.FindStringSubmatch(strings.TrimSpace(versionRange))
+	matches := versionRangeRegex.FindStringSubmatch(strings.ReplaceAll(versionRange, " ", ""))
 
 	if len(matches) == 0 {
 		return models.AffectedVersion{}, fmt.Errorf("invalid version range format: %s", versionRange)

--- a/vulnfeeds/git/versions_test.go
+++ b/vulnfeeds/git/versions_test.go
@@ -297,6 +297,15 @@ func TestParseVersionRange(t *testing.T) {
 			input:       "< 1.0, < 2.0",
 			expectErr:   true,
 		},
+		{
+			description: "too many spaces",
+			input:       ">= 7.65.0 , < 7.71.0",
+			expectedResult: models.AffectedVersion{
+				Introduced: "7.65.0",
+				Fixed:      "7.71.0",
+			},
+			expectErr: false,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
CVE-2025-61667 flagged as going through an unexpected codepath during ingestion, and it turns out there was an extra space causing it not to be regexed/extracted properly. This should fix that.

Also added a testcase.