### PR TITLE
fix(ui): consistent padding for collapsed/expanded package accordions

### DIFF
--- a/gcp/website/frontend3/src/styles.scss
+++ b/gcp/website/frontend3/src/styles.scss
@@ -1071,7 +1071,7 @@ dl.vulnerability-details,
     }
 
     $last-ecosystem-border-offset: 12px;
-    $last-ecosystem-border-gap: 8px;
+    $last-ecosystem-border-gap: 16px;
     $last-ecosystem-border-thickness: 1px;
 
     .ecosystem-content-panel--last {
@@ -1110,10 +1110,7 @@ dl.vulnerability-details,
 
     .package-accordion--last {
       margin-bottom: 0;
-
-      .package-details-card {
-        margin-bottom: $last-ecosystem-border-gap;
-      }
+      padding-bottom: $last-ecosystem-border-gap;
     }
 
     .package-accordion h3.package-name-title {


### PR DESCRIPTION
When viewing affected packages on vulnerability pages, the last package in an ecosystem had different bottom padding depending on whether it was collapsed or expanded:

<img width="1777" height="849" alt="befafter" src="https://github.com/user-attachments/assets/12b4af46-6cd4-4a13-b8bb-bad533c19742" />

This was caused by the CSS rule `margin-bottom` being applied to `.package-details-card` inside `.package-accordion--last`. When the accordion was collapsed, this element was hidden, so the margin didn't apply.

The padding rule is now applied on the last accordion element instead of the hidden child element.