### PR TITLE
perf(worker): disable vanir generation on kernel vulns

### DIFF
--- a/gcp/workers/worker/worker.py
+++ b/gcp/workers/worker/worker.py
@@ -508,7 +508,7 @@ class TaskRunner:
           'Skipping Vanir signature generation for %s as it has no '
           'GIT affected ranges.', vulnerability.id)
       return vulnerability
-    if any(affected.package.name == "Kernel" and 
+    if any(affected.package.name == "Kernel" and
            affected.package.ecosystem == "Linux"
            for affected in vulnerability.affected):
       logging.info(


### PR DESCRIPTION
It's not using the mirror so it's being blocked and taking 20 mins to do so