### PR TITLE
fix: bump importer memory

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/importer.yaml
+++ b/deployment/clouddeploy/gke-workers/base/importer.yaml
@@ -27,10 +27,10 @@ spec:
             resources:
               requests:
                 cpu: "1"
-                memory: "4G"
+                memory: "8G"
               limits:
                 cpu: "1"
-                memory: "8G"
+                memory: "16G"
           nodeSelector:
             cloud.google.com/gke-nodepool: importer-pool
           restartPolicy: Never

--- a/deployment/terraform/modules/osv/workers_gke.tf
+++ b/deployment/terraform/modules/osv/workers_gke.tf
@@ -137,7 +137,7 @@ resource "google_container_node_pool" "importer_pool" {
   }
 
   node_config {
-    machine_type    = "n2-standard-2"
+    machine_type    = "n2-highmem-2"
     disk_type       = "pd-ssd"
     disk_size_gb    = 64
     local_ssd_count = 1


### PR DESCRIPTION
Seems to be silently being memory-killed. Have to give it a bigger machine.
