### PR TITLE
fix(website): add GOOGLE_CLOUD_PROJECT to run_tests.sh

### DIFF
--- a/gcp/website/run_tests.sh
+++ b/gcp/website/run_tests.sh
@@ -1,4 +1,6 @@
 #!/bin/bash -ex
 
+export GOOGLE_CLOUD_PROJECT=fake-project123
+
 poetry install
 poetry run python frontend_handlers_test.py


### PR DESCRIPTION
Without this, frontend_handlers_test fails on import because ndb.Client() requires a project to be set.
This matches how [`/worker/run_tests.sh`](https://github.com/google/osv.dev/blob/ff13718c6bcd1e67cba5c29768c4945d643078ba/gcp/workers/worker/run_tests.sh#L16) handles it.