### PR TITLE
fix: remove `index-url` from poetry requirements.txt

### DIFF
--- a/docker/poetry/requirements.txt
+++ b/docker/poetry/requirements.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile --generate-hashes requirements.in
 #
---index-url https://us-python.pkg.dev/artifact-foundry-prod/ah-3p-staging-python/simple/
 
 anyio==4.12.0 \
     --hash=sha256:73c693b567b0c55130c104d0b43a9baf3aa6a31fc6110116509f27bf75e21ec0 \


### PR DESCRIPTION
We don't want this to talk to artifact registry
(I'm not 100% sure if this will work as-is)