### PR TITLE
fix: update schema_version to 1.7.4

### DIFF
--- a/gcp/website/frontend3/src/templates/home.html
+++ b/gcp/website/frontend3/src/templates/home.html
@@ -86,7 +86,7 @@
       <div class="mdc-layout-grid__inner">
         <div class="mdc-layout-grid__cell--span-12">
           <pre class="big-code-block"><code>{
-  "schema_version": "1.3.0",
+  "schema_version": "1.7.4",
   "id": "GHSA-c3g4-w6cv-6v7h",
   "modified": "2022-04-01T13:56:42Z",
   "published": "2022-04-01T13:56:42Z",


### PR DESCRIPTION
### Summary
Updates the documented `schema_version` to `1.7.4` to reflect the current OSV schema.

### Details
- Bumps `schema_version` from the previous value to `1.7.4`
- No other content or formatting changes

### Reference
Fixes #4479 
