### PR TITLE
feat: redirect human Go vanity URL requests to pkg.go.dev

### DIFF
--- a/gcp/website/frontend_handlers.py
+++ b/gcp/website/frontend_handlers.py
@@ -139,8 +139,7 @@ def go_bindings_vanity():
   if request.args.get('go-get', 0) == '1':
     return _GO_VANITY_METADATA
 
-  abort(404)
-  return None
+  return redirect('https://pkg.go.dev/osv.dev/bindings/go')
 
 
 @blueprint.route('/')


### PR DESCRIPTION
This is just a simple QoL change to redirect to the Go module documentation for humans visiting osv.dev/bindings/go.

Other libraries with vanity URLs do this too, like http://go.uber.org/zap