### PR TITLE
fix: Revert "chore: remove old python exporter and alias code"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ worker-tests:
 importer-tests:
 	cd gcp/workers/importer && ./run_tests.sh
 
+alias-tests:
+	cd gcp/workers/alias && ./run_tests.sh
+
 recoverer-tests:
 	cd gcp/workers/recoverer && ./run_tests.sh
 
@@ -106,4 +109,4 @@ run-api-server-test:
 	cd gcp/api && $(install-cmd) && GOOGLE_CLOUD_PROJECT=oss-vdb-test OSV_VULNERABILITIES_BUCKET=osv-test-vulnerabilities $(run-cmd) python test_server.py $(HOME)/.config/gcloud/application_default_credentials.json $(ARGS)
 
 # TODO: API integration tests.
-all-tests: lib-tests worker-tests importer-tests recoverer-tests website-tests vulnfeed-tests bindings-tests go-tests
+all-tests: lib-tests worker-tests importer-tests alias-tests recoverer-tests website-tests vulnfeed-tests bindings-tests go-tests

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ consists of:
 | `gcp/functions` | The Cloud Function for publishing PyPI vulnerabilities (maintained, but not developed) |
 | `gcp/indexer`   | The determine version `indexer` |
 | `gcp/website`   | The backend of the osv.dev web interface, with the frontend in `frontend3` <br /> Blog posts (in `blog`) |
-| `gcp/workers/`  | Workers for bisection and impact analysis (`worker`, `importer`) <br /> `cron/` jobs for database backups and processing oss-fuzz records |
-| `go/`           | Go module for shared libraries and commands (`cmd/exporter`, `cmd/recordchecker`, `cmd/relations`) |
+| `gcp/workers/`  | Workers for bisection and impact analysis (`worker`, `importer`, `alias`) <br /> `cron/` jobs for database backups and processing oss-fuzz records |
+| `go/`           | Go module for shared libraries and commands (`cmd/exporter`, `cmd/recordchecker`) |
 | `osv/`          | The core OSV Python library, used in basically all Python services <br /> OSV ecosystem package versioning helpers in `ecosystems/` <br /> Datastore model definitions in `models.py` |
 | `tools/`        | Misc scripts/tools, mostly intended for development (datastore stuff, linting) <br /> The `indexer-api-caller` for indexer calling |
 | `vulnfeeds/`    | Go module for (mostly) the NVD CVE conversion <br /> The Alpine feed converter (`cmd/alpine`) <br /> The Debian feed converter (`tools/debian`, which is written in Python) |

--- a/gcp/workers/alias/Dockerfile
+++ b/gcp/workers/alias/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-vdb/worker
+
+COPY alias_computation.py upstream_computation.py run_cron.sh /usr/local/bin/
+RUN chmod 755 /usr/local/bin/alias_computation.py /usr/local/bin/upstream_computation.py /usr/local/bin/run_cron.sh
+
+ENTRYPOINT ["run_cron.sh"]

--- a/gcp/workers/alias/alias_computation.py
+++ b/gcp/workers/alias/alias_computation.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OSV alias computation."""
+import datetime
+import logging
+
+from google.cloud import exceptions
+from google.cloud import ndb
+
+import osv
+from osv import gcs, pubsub
+import osv.logs
+
+ALIAS_GROUP_VULN_LIMIT = 32
+VULN_ALIASES_LIMIT = 5
+
+
+def _update_group(bug_ids: list[str], alias_group: osv.AliasGroup,
+                  changed_vulns: dict[str, osv.AliasGroup | None]):
+  """Updates the alias group in the datastore."""
+  if len(bug_ids) <= 1:
+    logging.info('Deleting alias group due to too few bugs: %s', bug_ids)
+    for vuln_id in bug_ids:
+      changed_vulns[vuln_id] = None
+    alias_group.key.delete()
+    return
+  if len(bug_ids) > ALIAS_GROUP_VULN_LIMIT:
+    logging.info('Deleting alias group due to too many bugs: %s', bug_ids)
+    for vuln_id in bug_ids:
+      changed_vulns[vuln_id] = None
+    alias_group.key.delete()
+    return
+
+  if bug_ids == alias_group.bug_ids:
+    return
+
+  alias_group.bug_ids = bug_ids
+  alias_group.last_modified = datetime.datetime.now(datetime.UTC)
+  alias_group.put()
+  for vuln_id in bug_ids:
+    changed_vulns[vuln_id] = alias_group
+
+
+def _create_alias_group(bug_ids: list[str],
+                        changed_vulns: dict[str, osv.AliasGroup | None]):
+  """Creates a new alias group in the datastore."""
+  if len(bug_ids) <= 1:
+    logging.info('Skipping alias group creation due to too few bugs: %s',
+                 bug_ids)
+    return
+  if len(bug_ids) > ALIAS_GROUP_VULN_LIMIT:
+    logging.info('Skipping alias group creation due to too many bugs: %s',
+                 bug_ids)
+    return
+
+  new_group = osv.AliasGroup(bug_ids=bug_ids)
+  new_group.last_modified = datetime.datetime.now(datetime.UTC)
+  new_group.put()
+  for vuln_id in bug_ids:
+    changed_vulns[vuln_id] = new_group
+
+
+def _compute_aliases(bug_id: str, visited: set[str],
+                     bug_aliases: dict[str, set[str]]) -> list[str]:
+  """Computes all aliases for the given bug ID.
+  The returned list contains the bug ID itself, all the IDs from the bug's
+  raw aliases, all the IDs of bugs that have the current bug as an alias,
+  and repeat for every bug encountered here."""
+  to_visit = {bug_id}
+  bug_ids = []
+  while to_visit:
+    bug_id = to_visit.pop()
+    if bug_id in visited:
+      continue
+    visited.add(bug_id)
+    bug_ids.append(bug_id)
+
+    aliases = bug_aliases.get(bug_id, set())
+    to_visit.update(aliases - visited)
+
+  # Returns a sorted list of bug IDs, which ensures deterministic behaviour
+  # and avoids unnecessary updates to the groups.
+  return sorted(bug_ids)
+
+
+def _update_vuln_with_group(vuln_id: str, alias_group: osv.AliasGroup | None):
+  """Updates the Vulnerability in Datastore & GCS with the new alias group.
+  If `alias_group` is None, assumes a preexisting AliasGroup was just deleted.
+  """
+  # Get the existing vulnerability first, so we can recalculate search_indices
+  result = gcs.get_by_id_with_generation(vuln_id)
+  if result is None:
+    if osv.Vulnerability.get_by_id(vuln_id) is not None:
+      logging.error('vulnerability not in GCS - %s', vuln_id)
+      pubsub.publish_failure(b'', type='gcs_missing', id=vuln_id)
+    return
+  vuln_proto, generation = result
+
+  def transaction():
+    vuln: osv.Vulnerability = osv.Vulnerability.get_by_id(vuln_id)
+    if vuln is None:
+      logging.error('vulnerability not in Datastore - %s', vuln_id)
+      # TODO(michaelkedar): What to do in this case?
+      return
+    if alias_group is None:
+      modified = datetime.datetime.now(datetime.UTC)
+      aliases = []
+    else:
+      modified = alias_group.last_modified
+      aliases = sorted(set(alias_group.bug_ids) - {vuln_id})
+    vuln_proto.aliases[:] = aliases
+    vuln_proto.modified.FromDatetime(modified)
+    osv.ListedVulnerability.from_vulnerability(vuln_proto).put()
+    vuln.modified = modified
+    vuln.put()
+
+  ndb.transaction(transaction)
+  try:
+    gcs.upload_vulnerability(vuln_proto, generation)
+  except exceptions.PreconditionFailed:
+    logging.error('Generation mismatch when writing aliases for %s', vuln_id)
+    osv.pubsub.publish_failure(
+        b'', type='gcs_gen_mismatch', id=vuln_id, field='aliases')
+  except Exception:
+    logging.error('Writing to bucket failed for %s', vuln_id)
+    osv.pubsub.publish_failure(
+        vuln_proto.SerializeToString(deterministic=True), type='gcs_retry')
+
+
+def main():
+  """Updates all alias groups in the datastore by re-computing existing
+  AliasGroups and creating new AliasGroups for un-computed bugs."""
+
+  # Query for all bugs that have aliases.
+  # Use (> '' OR < '') instead of (!= '') / (> '') to de-duplicate results
+  # and avoid datastore emulator problems, see issue #2093
+  bugs = osv.Bug.query(ndb.OR(osv.Bug.aliases > '', osv.Bug.aliases < ''))
+  all_alias_group = osv.AliasGroup.query()
+  allow_list = {
+      allow_entry.bug_id for allow_entry in osv.AliasAllowListEntry.query()
+  }
+  deny_list = {
+      deny_entry.bug_id for deny_entry in osv.AliasDenyListEntry.query()
+  }
+
+  # Mapping of ID to a set of all aliases for that bug,
+  # including its raw aliases and bugs that it is referenced in as an alias.
+  bug_aliases = {}
+
+  # For each bug, add its aliases to the maps and ignore invalid bugs.
+  for bug in bugs:
+    if bug.db_id in deny_list:
+      continue
+    if len(bug.aliases) > VULN_ALIASES_LIMIT and bug.db_id not in allow_list:
+      logging.info('%s has too many listed aliases, skipping computation.',
+                   bug.db_id)
+      continue
+    if bug.status != osv.BugStatus.PROCESSED:
+      continue
+    for alias in bug.aliases:
+      bug_aliases.setdefault(bug.db_id, set()).add(alias)
+      bug_aliases.setdefault(alias, set()).add(bug.db_id)
+
+  visited = set()
+
+  # Keep track of vulnerabilities that have been modified, to update GCS later.
+  # `None` means the AliasGroup has been removed.
+  changed_vulns: dict[str, osv.AliasGroup | None] = {}
+
+  # For each alias group, re-compute the bug IDs in the group and update the
+  # group with the computed bug IDs.
+  for alias_group in all_alias_group:
+    bug_id = alias_group.bug_ids[0]  # AliasGroups contain more than one bug.
+    # If the bug has already been counted in a different alias group,
+    # we delete the original one to merge two alias groups.
+    if bug_id in visited:
+      for vuln_id in alias_group.bug_ids:
+        if vuln_id not in changed_vulns:
+          changed_vulns[vuln_id] = None
+      alias_group.key.delete()
+      continue
+    bug_ids = _compute_aliases(bug_id, visited, bug_aliases)
+    _update_group(bug_ids, alias_group, changed_vulns)
+
+  # For each bug ID that has not been visited, create new alias groups.
+  for bug_id in bug_aliases:
+    if bug_id not in visited:
+      bug_ids = _compute_aliases(bug_id, visited, bug_aliases)
+      _create_alias_group(bug_ids, changed_vulns)
+
+  # For each updated vulnerability, update them in Datastore & GCS
+  for vuln_id, alias_group in changed_vulns.items():
+    _update_vuln_with_group(vuln_id, alias_group)
+
+
+if __name__ == '__main__':
+  _ndb_client = ndb.Client()
+  osv.logs.setup_gcp_logging('alias')
+  with _ndb_client.context():
+    main()

--- a/gcp/workers/alias/alias_computation_test.py
+++ b/gcp/workers/alias/alias_computation_test.py
@@ -1,0 +1,471 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Alias computation tests."""
+import datetime
+import os
+import unittest
+
+from google.cloud import ndb
+from google.protobuf import timestamp_pb2
+
+import osv
+import alias_computation
+from osv import tests
+
+TEST_DATA_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), 'testdata')
+
+
+class AliasTest(unittest.TestCase, tests.ExpectationTest(TEST_DATA_DIR)):
+  """Alias tests."""
+
+  def _get_aliases_from_bucket(self, vuln_id):
+    """Get the aliases from the vulnerabilities written to the GCS bucket."""
+    bucket = osv.gcs.get_osv_bucket()
+    pb_blob = bucket.blob(os.path.join(osv.gcs.VULN_PB_PATH, vuln_id + '.pb'))
+    pb = osv.vulnerability_pb2.Vulnerability.FromString(
+        pb_blob.download_as_bytes())
+    pb_aliases = list(pb.aliases)
+
+    return pb_aliases
+
+  def test_basic(self):
+    """Tests basic case."""
+    osv.AliasGroup(
+        bug_ids=['aaa-123', 'aaa-124'],
+        last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='aaa-123',
+        db_id='aaa-123',
+        aliases=['aaa-124'],
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='aaa-124',
+        db_id='aaa-124',
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    alias_computation.main()
+    bug_ids = osv.AliasGroup.query(
+        osv.AliasGroup.bug_ids == 'aaa-123').get().bug_ids
+    self.assertEqual(['aaa-123', 'aaa-124'], bug_ids)
+
+    pb_aliases = self._get_aliases_from_bucket('aaa-123')
+    self.assertEqual(['aaa-124'], pb_aliases)
+
+  def test_bug_reaches_limit(self):
+    """Tests bug reaches limit."""
+    osv.Bug(
+        id='aaa-111',
+        db_id='aaa-111',
+        aliases=[
+            'aaa-222', 'aaa-333', 'aaa-444', 'aaa-555', 'aaa-666', 'aaa-777'
+        ],
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    alias_computation.main()
+    alias_group = osv.AliasGroup.query(
+        osv.AliasGroup.bug_ids == 'aaa-111').get()
+    self.assertIsNone(alias_group)
+
+    pb_aliases = self._get_aliases_from_bucket('aaa-111')
+    self.assertEqual([], pb_aliases)
+
+  def test_update_alias_group(self):
+    """Tests updating an existing alias group."""
+    osv.AliasGroup(
+        bug_ids=['bbb-123', 'bbb-234'],
+        last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='bbb-123',
+        db_id='bbb-123',
+        aliases=['bbb-345', 'bbb-456'],
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='bbb-234',
+        db_id='bbb-234',
+        aliases=['bbb-123'],
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='bbb-789',
+        db_id='bbb-789',
+        aliases=['bbb-456'],
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    alias_computation.main()
+    alias_group = osv.AliasGroup.query(
+        osv.AliasGroup.bug_ids == 'bbb-123').get()
+    expected_aliases = ['bbb-234', 'bbb-345', 'bbb-456', 'bbb-789']
+    self.assertEqual(['bbb-123'] + expected_aliases, alias_group.bug_ids)
+    self.assertNotEqual(
+        datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+        alias_group.last_modified)
+
+    pb_aliases = self._get_aliases_from_bucket('bbb-123')
+    self.assertEqual(expected_aliases, pb_aliases)
+
+  def test_create_alias_group(self):
+    """Tests adding a new alias group."""
+    osv.Bug(
+        id='test-123',
+        db_id='test-123',
+        aliases=['test-124'],
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='test-222',
+        db_id='test-222',
+        aliases=['test-124'],
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    alias_computation.main()
+    alias_group = osv.AliasGroup.query(
+        osv.AliasGroup.bug_ids == 'test-123').get()
+    self.assertIsNotNone(alias_group)
+    self.assertEqual(['test-123', 'test-124', 'test-222'], alias_group.bug_ids)
+
+    pb_aliases = self._get_aliases_from_bucket('test-123')
+    self.assertEqual(['test-124', 'test-222'], pb_aliases)
+
+  def test_delete_alias_group(self):
+    """Tests deleting alias groups that only has one vulnerability."""
+    osv.AliasGroup(
+        bug_ids=['ccc-123'],
+        last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='ccc-123',
+        db_id='ccc-123',
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    alias_computation.main()
+    alias_group = osv.AliasGroup.query(
+        osv.AliasGroup.bug_ids == 'ccc-123').get()
+    self.assertIsNone(alias_group)
+
+    pb_aliases = self._get_aliases_from_bucket('ccc-123')
+    self.assertEqual([], pb_aliases)
+
+  def test_split_alias_group(self):
+    """Tests split an existing alias group into two.
+    AliasGroup A -> B -> C -> D, remove the B -> C alias
+    to get AliasGroups A -> B and C -> D."""
+    osv.AliasGroup(
+        bug_ids=['ddd-123', 'ddd-124', 'ddd-125', 'ddd-126'],
+        last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='ddd-123',
+        db_id='ddd-123',
+        aliases=['ddd-124'],
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='ddd-124',
+        db_id='ddd-124',
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='ddd-125',
+        db_id='ddd-125',
+        aliases=['ddd-126'],
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='ddd-126',
+        db_id='ddd-126',
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    alias_computation.main()
+    alias_group = osv.AliasGroup.query(
+        osv.AliasGroup.bug_ids == 'ddd-123').get()
+    self.assertIsNotNone(alias_group)
+    self.assertEqual(['ddd-123', 'ddd-124'], alias_group.bug_ids)
+    alias_group = osv.AliasGroup.query(
+        osv.AliasGroup.bug_ids == 'ddd-125').get()
+    self.assertIsNotNone(alias_group)
+    self.assertEqual(['ddd-125', 'ddd-126'], alias_group.bug_ids)
+
+    pb_aliases = self._get_aliases_from_bucket('ddd-123')
+    self.assertEqual(['ddd-124'], pb_aliases)
+    pb_aliases = self._get_aliases_from_bucket('ddd-125')
+    self.assertEqual(['ddd-126'], pb_aliases)
+
+  def test_allow_list(self):
+    """Test allow list."""
+    osv.AliasAllowListEntry(bug_id='eee-111',).put()
+    raw_aliases = [
+        'eee-222', 'eee-333', 'eee-444', 'eee-555', 'eee-666', 'eee-777'
+    ]
+    osv.Bug(
+        id='eee-111',
+        db_id='eee-111',
+        aliases=raw_aliases,
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    alias_computation.main()
+    alias_group = osv.AliasGroup.query(
+        osv.AliasGroup.bug_ids == 'eee-111').get()
+    self.assertEqual(7, len(alias_group.bug_ids))
+
+    pb_aliases = self._get_aliases_from_bucket('eee-111')
+    self.assertEqual(raw_aliases, pb_aliases)
+
+  def test_deny_list(self):
+    """Tests deny list."""
+    osv.AliasGroup(
+        bug_ids=['fff-124', 'fff-125'],
+        last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.AliasDenyListEntry(bug_id='fff-123',).put()
+    osv.Bug(
+        id='fff-123',
+        db_id='fff-123',
+        aliases=['fff-124'],
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='fff-124',
+        db_id='fff-124',
+        aliases=['fff-125'],
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    alias_computation.main()
+    bug_ids = osv.AliasGroup.query(
+        osv.AliasGroup.bug_ids == 'fff-124').get().bug_ids
+    self.assertEqual(['fff-124', 'fff-125'], bug_ids)
+
+    pb_aliases = self._get_aliases_from_bucket('fff-124')
+    self.assertEqual(['fff-125'], pb_aliases)
+
+  def test_merge_alias_group(self):
+    """Tests all bugs of one alias group have been
+    merged to other alias group."""
+    osv.AliasGroup(
+        bug_ids=['ggg-123', 'ggg-124'],
+        last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.AliasGroup(
+        bug_ids=['ggg-125', 'ggg-126'],
+        last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='ggg-123',
+        db_id='ggg-123',
+        aliases=['ggg-124', 'ggg-125', 'ggg-126'],
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='ggg-125',
+        db_id='ggg-125',
+        aliases=[],
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    alias_computation.main()
+    alias_group = osv.AliasGroup.query(
+        osv.AliasGroup.bug_ids == 'ggg-125').fetch()
+    self.assertEqual(1, len(alias_group))
+    self.assertEqual(['ggg-123', 'ggg-124', 'ggg-125', 'ggg-126'],
+                     alias_group[0].bug_ids)
+
+    pb_aliases = self._get_aliases_from_bucket('ggg-125')
+    self.assertEqual(['ggg-123', 'ggg-124', 'ggg-126'], pb_aliases)
+
+  def test_partial_merge_alias_group(self):
+    """Tests merging some bugs of one alias group to another alias group."""
+    osv.AliasGroup(
+        bug_ids=['hhh-123', 'hhh-124'],
+        last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.AliasGroup(
+        bug_ids=['hhh-125', 'hhh-126', 'hhh-127'],
+        last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='hhh-123',
+        db_id='hhh-123',
+        aliases=['hhh-124', 'hhh-125'],
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='hhh-126',
+        db_id='hhh-126',
+        aliases=['hhh-127'],
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='hhh-125',
+        db_id='hhh-125',
+        aliases=[],
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='hhh-127',
+        db_id='hhh-127',
+        aliases=[],
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    alias_computation.main()
+    alias_group = osv.AliasGroup.query(
+        osv.AliasGroup.bug_ids == 'hhh-125').fetch()
+    self.assertEqual(1, len(alias_group))
+    self.assertEqual(['hhh-123', 'hhh-124', 'hhh-125'], alias_group[0].bug_ids)
+    alias_group = osv.AliasGroup.query(
+        osv.AliasGroup.bug_ids == 'hhh-127').fetch()
+    self.assertEqual(1, len(alias_group))
+    self.assertEqual(['hhh-126', 'hhh-127'], alias_group[0].bug_ids)
+
+    pb_aliases = self._get_aliases_from_bucket('hhh-125')
+    self.assertEqual(['hhh-123', 'hhh-124'], pb_aliases)
+    pb_aliases = self._get_aliases_from_bucket('hhh-127')
+    self.assertEqual(['hhh-126'], pb_aliases)
+
+  def test_alias_group_reaches_limit(self):
+    """Tests a alias group reaches limit."""
+    aliases = []
+    for i in range(33):
+      aliases.append(f'iii-{i}')
+
+    osv.Bug(
+        id='iii-1',
+        db_id='iii-1',
+        aliases=aliases,
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.AliasAllowListEntry(bug_id='iii-1',).put()
+    alias_computation.main()
+    alias_group = osv.AliasGroup.query(osv.AliasGroup.bug_ids == 'iii-1').get()
+    self.assertIsNone(alias_group)
+
+    pb_aliases = self._get_aliases_from_bucket('iii-1')
+    self.assertEqual([], pb_aliases)
+
+  def test_to_vulnerability(self):
+    """Tests OSV bug to vulnerability function."""
+    bug = osv.Bug(
+        id='jjj-123',
+        db_id='jjj-123',
+        related=['jjj-111'],
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+        last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+        timestamp=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC))
+    bug.put()
+    alias_group_last_modified = datetime.datetime(
+        2023, 10, 1, tzinfo=datetime.UTC)
+    osv.AliasGroup(
+        bug_ids=['jjj-123', 'jjj-234', 'jjj-456'],
+        last_modified=alias_group_last_modified,
+    ).put()
+    osv.Bug(
+        id='jjj-222',
+        db_id='jjj-222',
+        related=['jjj-123'],
+        status=1,
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    vuln = bug.to_vulnerability()
+    self.assertEqual(vuln.related, ['jjj-111', 'jjj-222'])
+    self.assertEqual(vuln.aliases, ['jjj-234', 'jjj-456'])
+    modified = timestamp_pb2.Timestamp()
+    modified.FromDatetime(alias_group_last_modified)
+    self.assertEqual(modified, vuln.modified)
+
+
+def setUpModule():
+  """Set up the test module."""
+  # Start the emulator BEFORE creating the ndb client
+  unittest.enterModuleContext(tests.datastore_emulator())
+  unittest.enterModuleContext(ndb.Client().context(cache_policy=False))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/gcp/workers/alias/build.sh
+++ b/gcp/workers/alias/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -x
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+docker build -t gcr.io/oss-vdb/alias-computation:$1 . && \
+docker build -t gcr.io/oss-vdb/alias-computation:latest . && \
+docker push gcr.io/oss-vdb/alias-computation:$1 && \
+docker push gcr.io/oss-vdb/alias-computation:latest

--- a/gcp/workers/alias/run_cron.sh
+++ b/gcp/workers/alias/run_cron.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -x
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+echo "Starting alias computation"
+python3 /usr/local/bin/alias_computation.py
+echo "Completed alias computation"
+
+echo "Starting upstream computation"
+python3 /usr/local/bin/upstream_computation.py
+echo "Completed upstream computation"

--- a/gcp/workers/alias/run_tests.sh
+++ b/gcp/workers/alias/run_tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -ex
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd ../worker
+
+poetry install
+poetry run python ../alias/alias_computation_test.py
+poetry run python ../alias/upstream_computation_test.py

--- a/gcp/workers/alias/upstream_computation.py
+++ b/gcp/workers/alias/upstream_computation.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OSV Upstream relation computation."""
+
+from collections import defaultdict
+import datetime
+import json
+import logging
+
+from google.cloud import exceptions
+from google.cloud import ndb
+
+import osv
+import osv.logs
+from osv import gcs, pubsub
+
+
+def compute_upstream(target_bug, bugs: dict[str, set[str]]) -> list[str]:
+  """Computes all upstream vulnerabilities for the given bug ID.
+  The returned list contains all of the bug IDs that are upstream of the
+  target bug ID, including transitive upstreams."""
+  visited = set()
+
+  target_bug_upstream = target_bug
+  if not target_bug_upstream:
+    return []
+  to_visit = set(target_bug_upstream)
+  while to_visit:
+    bug_id = to_visit.pop()
+    if bug_id in visited:
+      continue
+    visited.add(bug_id)
+    upstreams = set()
+    if bug_id in bugs.keys():
+      bug = bugs.get(bug_id)
+      upstreams = set(bug)
+
+    to_visit.update(upstreams - visited)
+
+  # Returns a sorted list of bug IDs, which ensures deterministic behaviour
+  # and avoids unnecessary updates.
+  return sorted(visited)
+
+
+def _create_group(bug_id: str, upstream_ids: list[str]) -> osv.UpstreamGroup:
+  """Creates a new upstream group in the datastore."""
+
+  new_group = osv.UpstreamGroup(
+      id=bug_id,
+      db_id=bug_id,
+      upstream_ids=upstream_ids,
+      last_modified=datetime.datetime.now(datetime.UTC))
+  new_group.put()
+  _update_vuln_with_group(bug_id, new_group)
+
+  return new_group
+
+
+def _update_group(upstream_group: osv.UpstreamGroup,
+                  upstream_ids: list[str]) -> osv.UpstreamGroup | None:
+  """Updates the upstream group in the datastore."""
+  if len(upstream_ids) == 0:
+    logging.info('Deleting upstream group due to too few bugs: %s',
+                 upstream_ids)
+    upstream_group.key.delete()
+    _update_vuln_with_group(upstream_group.db_id, None)
+    return None
+
+  if upstream_ids == upstream_group.upstream_ids:
+    return None
+
+  upstream_group.upstream_ids = upstream_ids
+  upstream_group.last_modified = datetime.datetime.now(datetime.UTC)
+  upstream_group.put()
+  _update_vuln_with_group(upstream_group.db_id, upstream_group)
+  return upstream_group
+
+
+def _update_vuln_with_group(vuln_id: str, upstream: osv.UpstreamGroup | None):
+  """Updates the Vulnerability in Datastore & GCS with the new upstream group.
+  If `upstream` is None, assumes a preexisting UpstreamGroup was just deleted.
+  """
+  # Get the existing vulnerability first, so we can recalculate search_indices
+  result = gcs.get_by_id_with_generation(vuln_id)
+  if result is None:
+    logging.error('vulnerability not in GCS - %s', vuln_id)
+    pubsub.publish_failure(b'', type='gcs_missing', id=vuln_id)
+    return
+  vuln_proto, generation = result
+
+  def transaction():
+    vuln: osv.Vulnerability = osv.Vulnerability.get_by_id(vuln_id)
+    if vuln is None:
+      logging.error('vulnerability not in Datastore - %s', vuln_id)
+      # TODO(michaelkedar): What to do in this case?
+      return
+    if upstream is None:
+      modified = datetime.datetime.now(datetime.UTC)
+      upstream_group = []
+    else:
+      modified = upstream.last_modified
+      upstream_group = upstream.upstream_ids
+    vuln_proto.upstream[:] = upstream_group
+    vuln_proto.modified.FromDatetime(modified)
+    osv.ListedVulnerability.from_vulnerability(vuln_proto).put()
+    vuln.modified = modified
+    vuln.put()
+
+  ndb.transaction(transaction)
+  try:
+    gcs.upload_vulnerability(vuln_proto, generation)
+  except exceptions.PreconditionFailed:
+    logging.error('Generation mismatch when writing upstream for %s', vuln_id)
+    osv.pubsub.publish_failure(
+        b'', type='gcs_gen_mismatch', id=vuln_id, field='upstream')
+  except Exception:
+    logging.error('Writing to bucket failed for %s', vuln_id)
+    osv.pubsub.publish_failure(
+        vuln_proto.SerializeToString(deterministic=True), type='gcs_retry')
+
+
+def compute_upstream_hierarchy(
+    target_upstream_group: osv.UpstreamGroup,
+    all_upstream_groups: dict[str, osv.UpstreamGroup]) -> None:
+  """Computes all upstream vulnerabilities for the given bug ID.
+  The returned list contains all of the bug IDs that are upstream of the
+  target bug ID, including transitive upstreams in a map hierarchy.
+  upstream_group:
+        { db_id: bug id
+          upstream_ids: list of upstream bug ids
+          last_modified_date: date
+          upstream_hierarchy: JSON string of upstream hierarchy
+        }
+  """
+
+  # To convert to json, sets need to be converted to lists
+  # and sorting is done for a more consistent outcome.
+  def set_default(obj):
+    if isinstance(obj, set):
+      return list(sorted(obj))
+    raise TypeError
+
+  visited = set()
+  upstream_map = {}
+  to_visit = set([target_upstream_group.db_id])
+  # BFS navigation through the upstream hierarchy of a given upstream group
+  while to_visit:
+    bug_id = to_visit.pop()
+    if bug_id in visited:
+      continue
+    visited.add(bug_id)
+    upstream_group = all_upstream_groups.get(bug_id)
+    if upstream_group is None:
+      continue
+
+    upstreams = set(upstream_group.upstream_ids)
+    if not upstreams:
+      continue
+    for upstream in upstreams:
+      if upstream not in visited and upstream not in to_visit:
+        to_visit.add(upstream)
+      else:
+        if bug_id not in upstream_map:
+          upstream_map[bug_id] = set([upstream])
+        else:
+          upstream_map[bug_id].add(upstream)
+    # Add the immediate upstreams of the bug to the dict
+    upstream_map[bug_id] = upstreams
+    to_visit.update(upstreams - visited)
+
+  # Ensure there are no duplicate entries where transitive vulns appear
+  for k, v in upstream_map.items():
+    if k is target_upstream_group.db_id:
+      continue
+    upstream_map[target_upstream_group
+                 .db_id] = upstream_map[target_upstream_group.db_id] - v
+
+  # Update the datastore entry if hierarchy has changed
+  if upstream_map:
+    upstream_json = json.dumps(upstream_map, default=set_default)
+    if upstream_json == target_upstream_group.upstream_hierarchy:
+      return
+    target_upstream_group.upstream_hierarchy = upstream_json
+    target_upstream_group.put()
+
+
+def main():
+  """Updates all upstream groups in the datastore by re-computing existing
+  UpstreamGroups and creating new UpstreamGroups for un-computed bugs."""
+
+  # Query for all bugs that have upstreams.
+  updated_bugs = []
+  logging.info('Retrieving bugs...')
+  bugs_query = osv.Bug.query(osv.Bug.upstream_raw > '')
+
+  bugs = defaultdict(set)
+  for bug in bugs_query.iter(projection=[osv.Bug.db_id, osv.Bug.upstream_raw]):
+    bugs[bug.db_id].add(bug.upstream_raw[0])
+  logging.info('%s Bugs successfully retrieved', len(bugs))
+
+  logging.info('Retrieving upstream groups...')
+  upstream_groups = {
+      group.db_id: group for group in osv.UpstreamGroup.query().iter()
+  }
+  logging.info('Upstream Groups successfully retrieved')
+
+  for bug_id, bug in bugs.items():
+    # Get the specific upstream_group ID
+    upstream_group = upstream_groups.get(bug_id)
+    # Recompute the transitive upstreams and compare with the existing group
+    upstream_ids = compute_upstream(bug, bugs)
+    if upstream_group:
+      if upstream_ids == upstream_group.upstream_ids:
+        continue
+      # Update the existing UpstreamGroup
+      new_upstream_group = _update_group(upstream_group, upstream_ids)
+      if new_upstream_group is None:
+        continue
+      updated_bugs.append(new_upstream_group)
+      upstream_groups[bug_id] = new_upstream_group
+      logging.info('Upstream group updated for bug: %s', bug_id)
+    else:
+      # Create a new UpstreamGroup
+      new_upstream_group = _create_group(bug_id, upstream_ids)
+      logging.info('New upstream group created for bug: %s', bug_id)
+      updated_bugs.append(new_upstream_group)
+      upstream_groups[bug_id] = new_upstream_group
+
+  for group in updated_bugs:
+    # Recompute the upstream hierarchies
+    compute_upstream_hierarchy(group, upstream_groups)
+    logging.info('Upstream hierarchy updated for bug: %s', group.db_id)
+
+
+if __name__ == '__main__':
+  _ndb_client = ndb.Client()
+  osv.logs.setup_gcp_logging('upstream')
+  with _ndb_client.context():
+    main()

--- a/gcp/workers/alias/upstream_computation_test.py
+++ b/gcp/workers/alias/upstream_computation_test.py
@@ -1,0 +1,473 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Upstream computation tests."""
+import datetime
+import json
+import logging
+import os
+import unittest
+
+from google.cloud import ndb
+
+import osv
+import upstream_computation
+from osv import tests
+
+TEST_DATA_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), 'testdata')
+
+emulator = None
+
+
+class UpstreamTest(unittest.TestCase, tests.ExpectationTest(TEST_DATA_DIR)):
+  """Upstream tests."""
+
+  def setUp(self):
+    self.maxDiff = None  # pylint: disable=invalid-name
+    emulator.reset()
+    osv.Bug(
+        id='CVE-1',
+        db_id='CVE-1',
+        status=1,
+        upstream_raw=[],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='CVE-2',
+        db_id='CVE-2',
+        status=1,
+        upstream_raw=['CVE-1'],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='CVE-3',
+        db_id='CVE-3',
+        status=1,
+        upstream_raw=['CVE-1', 'CVE-2'],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+
+    osv.Bug(
+        id='CVE-2023-21400',
+        db_id='CVE-2023-21400',
+        status=1,
+        upstream_raw=[],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(
+            2025, 1, 14, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='UBUNTU-CVE-2023-21400',
+        db_id='UBUNTU-CVE-2023-21400',
+        status=1,
+        upstream_raw=['CVE-2023-21400'],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(
+            2025, 1, 14, tzinfo=datetime.UTC),
+    ).put()
+
+    osv.Bug(
+        id='UBUNTU-CVE-2023-4004',
+        db_id='UBUNTU-CVE-2023-4004',
+        status=1,
+        upstream_raw=['CVE-2023-4004'],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(
+            2025, 2, 10, tzinfo=datetime.UTC),
+    ).put()
+
+    osv.Bug(
+        id='UBUNTU-CVE-2023-4015',
+        db_id='UBUNTU-CVE-2023-4015',
+        status=1,
+        upstream_raw=['CVE-2023-4015'],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(
+            2025, 2, 10, tzinfo=datetime.UTC),
+    ).put()
+
+    osv.Bug(
+        id='USN-6315-1',
+        db_id='USN-6315-1',
+        status=1,
+        upstream_raw=[
+            "CVE-2022-40982", "CVE-2023-20593", "CVE-2023-21400",
+            "CVE-2023-3609", "CVE-2023-3610", "CVE-2023-3611", "CVE-2023-3776",
+            "CVE-2023-3777", "CVE-2023-4004", "CVE-2023-4015",
+            "UBUNTU-CVE-2022-40982", "UBUNTU-CVE-2023-20593",
+            "UBUNTU-CVE-2023-21400", "UBUNTU-CVE-2023-3609",
+            "UBUNTU-CVE-2023-3610", "UBUNTU-CVE-2023-3611",
+            "UBUNTU-CVE-2023-3776", "UBUNTU-CVE-2023-3777",
+            "UBUNTU-CVE-2023-4004", "UBUNTU-CVE-2023-4015"
+        ],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(
+            2023, 8, 29, tzinfo=datetime.UTC),
+    ).put()
+
+    osv.Bug(
+        id='USN-6325-1',
+        db_id='USN-6325-1',
+        status=1,
+        upstream_raw=[
+            "CVE-2022-40982", "CVE-2023-20593", "CVE-2023-21400",
+            "CVE-2023-3609", "CVE-2023-3610", "CVE-2023-3611", "CVE-2023-3776",
+            "CVE-2023-3777", "CVE-2023-4004", "CVE-2023-4015",
+            "UBUNTU-CVE-2022-40982", "UBUNTU-CVE-2023-20593",
+            "UBUNTU-CVE-2023-21400", "UBUNTU-CVE-2023-3609",
+            "UBUNTU-CVE-2023-3610", "UBUNTU-CVE-2023-3611",
+            "UBUNTU-CVE-2023-3776", "UBUNTU-CVE-2023-3777",
+            "UBUNTU-CVE-2023-4004", "UBUNTU-CVE-2023-4015"
+        ],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(
+            2023, 8, 31, tzinfo=datetime.UTC),
+    ).put()
+
+    osv.Bug(
+        id='USN-6330-1',
+        db_id='USN-6330-1',
+        status=1,
+        upstream_raw=[
+            "CVE-2022-40982", "CVE-2023-20593", "CVE-2023-21400",
+            "CVE-2023-3609", "CVE-2023-3610", "CVE-2023-3611", "CVE-2023-3776",
+            "CVE-2023-3777", "CVE-2023-4004", "CVE-2023-4015",
+            "UBUNTU-CVE-2022-40982", "UBUNTU-CVE-2023-20593",
+            "UBUNTU-CVE-2023-21400", "UBUNTU-CVE-2023-3609",
+            "UBUNTU-CVE-2023-3610", "UBUNTU-CVE-2023-3611",
+            "UBUNTU-CVE-2023-3776", "UBUNTU-CVE-2023-3777",
+            "UBUNTU-CVE-2023-4004", "UBUNTU-CVE-2023-4015"
+        ],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(
+            2023, 8, 31, tzinfo=datetime.UTC),
+    ).put()
+
+    osv.Bug(
+        id='USN-6332-1',
+        db_id='USN-6332-1',
+        status=1,
+        upstream_raw=[
+            "CVE-2022-40982", "CVE-2022-4269", "CVE-2022-48502",
+            "CVE-2023-0597", "CVE-2023-1611", "CVE-2023-1855", "CVE-2023-1990",
+            "CVE-2023-2002", "CVE-2023-20593", "CVE-2023-2124",
+            "CVE-2023-21400", "CVE-2023-2163", "CVE-2023-2194", "CVE-2023-2235",
+            "CVE-2023-2269", "CVE-2023-23004", "CVE-2023-28466",
+            "CVE-2023-30772", "CVE-2023-3141", "CVE-2023-32248",
+            "CVE-2023-3268", "CVE-2023-33203", "CVE-2023-33288",
+            "CVE-2023-35823", "CVE-2023-35824", "CVE-2023-35828",
+            "CVE-2023-35829", "CVE-2023-3609", "CVE-2023-3610", "CVE-2023-3611",
+            "CVE-2023-3776", "CVE-2023-3777", "CVE-2023-4004", "CVE-2023-4015",
+            "UBUNTU-CVE-2022-40982", "UBUNTU-CVE-2022-4269",
+            "UBUNTU-CVE-2022-48502", "UBUNTU-CVE-2023-0597",
+            "UBUNTU-CVE-2023-1611", "UBUNTU-CVE-2023-1855",
+            "UBUNTU-CVE-2023-1990", "UBUNTU-CVE-2023-2002",
+            "UBUNTU-CVE-2023-20593", "UBUNTU-CVE-2023-2124",
+            "UBUNTU-CVE-2023-21400", "UBUNTU-CVE-2023-2163",
+            "UBUNTU-CVE-2023-2194", "UBUNTU-CVE-2023-2235",
+            "UBUNTU-CVE-2023-2269", "UBUNTU-CVE-2023-23004",
+            "UBUNTU-CVE-2023-28466", "UBUNTU-CVE-2023-30772",
+            "UBUNTU-CVE-2023-3141", "UBUNTU-CVE-2023-32248",
+            "UBUNTU-CVE-2023-3268", "UBUNTU-CVE-2023-33203",
+            "UBUNTU-CVE-2023-33288", "UBUNTU-CVE-2023-35823",
+            "UBUNTU-CVE-2023-35824", "UBUNTU-CVE-2023-35828",
+            "UBUNTU-CVE-2023-35829", "UBUNTU-CVE-2023-3609",
+            "UBUNTU-CVE-2023-3610", "UBUNTU-CVE-2023-3611",
+            "UBUNTU-CVE-2023-3776", "UBUNTU-CVE-2023-3777",
+            "UBUNTU-CVE-2023-4004", "UBUNTU-CVE-2023-4015"
+        ],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(
+            2023, 8, 31, tzinfo=datetime.UTC),
+    ).put()
+
+    osv.Bug(
+        id='USN-6348-1',
+        db_id='USN-6348-1',
+        status=1,
+        upstream_raw=[
+            "CVE-2022-40982", "CVE-2023-20593", "CVE-2023-21400",
+            "CVE-2023-3609", "CVE-2023-3610", "CVE-2023-3611", "CVE-2023-3776",
+            "CVE-2023-3777", "CVE-2023-4004", "CVE-2023-4015",
+            "UBUNTU-CVE-2022-40982", "UBUNTU-CVE-2023-20593",
+            "UBUNTU-CVE-2023-21400", "UBUNTU-CVE-2023-3609",
+            "UBUNTU-CVE-2023-3610", "UBUNTU-CVE-2023-3611",
+            "UBUNTU-CVE-2023-3776", "UBUNTU-CVE-2023-3777",
+            "UBUNTU-CVE-2023-4004", "UBUNTU-CVE-2023-4015"
+        ],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2023, 9, 6, tzinfo=datetime.UTC),
+    ).put()
+
+    osv.Bug(
+        id='USN-7234-1',
+        db_id='USN-7234-1',
+        status=1,
+        upstream_raw=[
+            "CVE-2023-21400", "CVE-2024-40967", "CVE-2024-53103",
+            "CVE-2024-53141", "CVE-2024-53164", "UBUNTU-CVE-2023-21400",
+            "UBUNTU-CVE-2024-40967", "UBUNTU-CVE-2024-53103",
+            "UBUNTU-CVE-2024-53141", "UBUNTU-CVE-2024-53164"
+        ],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(
+            2023, 8, 31, tzinfo=datetime.UTC),
+    ).put()
+
+    osv.Bug(
+        id='USN-7234-3',
+        db_id='USN-7234-3',
+        status=1,
+        upstream_raw=[
+            "CVE-2023-21400", "CVE-2024-40967", "CVE-2024-53103",
+            "CVE-2024-53141", "CVE-2024-53164", "UBUNTU-CVE-2023-21400",
+            "UBUNTU-CVE-2024-40967", "UBUNTU-CVE-2024-53103",
+            "UBUNTU-CVE-2024-53141", "UBUNTU-CVE-2024-53164"
+        ],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2025, 2, 4, tzinfo=datetime.UTC),
+    ).put()
+
+    osv.Bug(
+        id='USN-7234-2',
+        db_id='USN-7234-2',
+        status=1,
+        upstream_raw=[
+            "CVE-2023-21400", "CVE-2024-40967", "CVE-2024-53103",
+            "CVE-2024-53141", "CVE-2024-53164", "UBUNTU-CVE-2023-21400",
+            "UBUNTU-CVE-2024-40967", "UBUNTU-CVE-2024-53103",
+            "UBUNTU-CVE-2024-53141", "UBUNTU-CVE-2024-53164"
+        ],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(
+            2023, 8, 31, tzinfo=datetime.UTC),
+    ).put()
+
+    osv.Bug(
+        id='DLA-3623-1',
+        db_id='DLA-3623-1',
+        status=1,
+        upstream_raw=[
+            "CVE-2022-39189", "CVE-2022-4269", "CVE-2023-1206", "CVE-2023-1380",
+            "CVE-2023-2002", "CVE-2023-2007", "CVE-2023-20588", "CVE-2023-2124",
+            "CVE-2023-21255", "CVE-2023-21400", "CVE-2023-2269",
+            "CVE-2023-2898", "CVE-2023-3090", "CVE-2023-31084", "CVE-2023-3111",
+            "CVE-2023-3141", "CVE-2023-3212", "CVE-2023-3268", "CVE-2023-3338",
+            "CVE-2023-3389", "CVE-2023-34256", "CVE-2023-34319",
+            "CVE-2023-35788", "CVE-2023-35823", "CVE-2023-35824",
+            "CVE-2023-3609", "CVE-2023-3611", "CVE-2023-3772", "CVE-2023-3773",
+            "CVE-2023-3776", "CVE-2023-3863", "CVE-2023-4004", "CVE-2023-40283",
+            "CVE-2023-4132", "CVE-2023-4147", "CVE-2023-4194", "CVE-2023-4244",
+            "CVE-2023-4273", "CVE-2023-42753", "CVE-2023-42755",
+            "CVE-2023-42756", "CVE-2023-4622", "CVE-2023-4623", "CVE-2023-4921"
+        ],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(2024, 1, 9, tzinfo=datetime.UTC),
+    ).put()
+
+    osv.Bug(
+        id='SUSE-SU-2023:3313-1',
+        db_id='SUSE-SU-2023:3313-1',
+        status=1,
+        upstream_raw=[
+            "CVE-2022-40982", "CVE-2023-0459", "CVE-2023-20569",
+            "CVE-2023-21400", "CVE-2023-2156", "CVE-2023-2166",
+            "CVE-2023-31083", "CVE-2023-3268", "CVE-2023-3567", "CVE-2023-3609",
+            "CVE-2023-3611", "CVE-2023-3776", "CVE-2023-4004"
+        ],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(
+            2023, 8, 14, tzinfo=datetime.UTC),
+    ).put()
+
+  def test_compute_upstream_basic(self):
+    """Tests basic case.
+    CVE-1-> CVE-2 -> CVE-3
+    Upstream of CVE-3 is CVE-2 & CVE-1
+    """
+
+    bugs_query = osv.Bug.query(
+        ndb.OR(osv.Bug.upstream_raw > '', osv.Bug.upstream_raw < ''))
+
+    bugs = {bug.db_id: bug.upstream_raw for bug in bugs_query.iter()}
+    bug_ids = upstream_computation.compute_upstream(bugs.get('CVE-3'), bugs)
+    self.assertEqual(['CVE-1', 'CVE-2'], bug_ids)
+
+  def test_compute_upstream_example(self):
+    """Test real world case with multiple levels"""
+
+    bugs_query = osv.Bug.query(
+        ndb.OR(osv.Bug.upstream_raw > '', osv.Bug.upstream_raw < ''))
+
+    bugs = {bug.db_id: bug.upstream_raw for bug in bugs_query.iter()}
+    bug_ids = upstream_computation.compute_upstream(
+        bugs.get('USN-7234-3'), bugs)
+    self.assertEqual([
+        "CVE-2023-21400", "CVE-2024-40967", "CVE-2024-53103", "CVE-2024-53141",
+        "CVE-2024-53164", "UBUNTU-CVE-2023-21400", "UBUNTU-CVE-2024-40967",
+        "UBUNTU-CVE-2024-53103", "UBUNTU-CVE-2024-53141",
+        "UBUNTU-CVE-2024-53164"
+    ], bug_ids)
+
+  def test_incomplete_compute_upstream(self):
+    """ Test when incomplete upstream information is given 
+         VULN-1 -> VULN-2, VULN-3 -> VULN-4
+    """
+    osv.Bug(
+        id='VULN-1',
+        db_id='VULN-1',
+        status=1,
+        upstream_raw=[],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(
+            2023, 8, 14, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='VULN-2',
+        db_id='VULN-2',
+        status=1,
+        upstream_raw=['VULN-1'],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(
+            2023, 8, 14, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='VULN-3',
+        db_id='VULN-3',
+        status=1,
+        upstream_raw=['VULN-1'],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(
+            2023, 8, 14, tzinfo=datetime.UTC),
+    ).put()
+    osv.Bug(
+        id='VULN-4',
+        db_id='VULN-4',
+        status=1,
+        upstream_raw=['VULN-3'],
+        source='test',
+        public=True,
+        import_last_modified=datetime.datetime(
+            2023, 8, 14, tzinfo=datetime.UTC),
+    ).put()
+    bugs_query = osv.Bug.query(
+        ndb.OR(osv.Bug.upstream_raw > '', osv.Bug.upstream_raw < ''))
+    bugs = {bug.db_id: bug.upstream_raw for bug in bugs_query.iter()}
+    bug_ids = upstream_computation.compute_upstream(bugs.get('VULN-4'), bugs)
+    self.assertEqual(['VULN-1', 'VULN-3'], bug_ids)
+
+  def _get_upstreams_from_bucket(self, vuln_id):
+    """Get the upstreams from the vulnerabilities written to the GCS bucket."""
+    bucket = osv.gcs.get_osv_bucket()
+    pb_blob = bucket.blob(os.path.join(osv.gcs.VULN_PB_PATH, vuln_id + '.pb'))
+    pb = osv.vulnerability_pb2.Vulnerability.FromString(
+        pb_blob.download_as_bytes())
+    pb_upstream = list(pb.upstream)
+
+    return pb_upstream
+
+  def test_upstream_group_basic(self):
+    """Test the upstream group get by db_id"""
+    upstream_computation.main()
+    osv.UpstreamGroup(
+        db_id='CVE-3',
+        upstream_ids=['CVE-1', 'CVE-2'],
+        last_modified=datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC),
+    ).put()
+    bug_ids = osv.UpstreamGroup.query(
+        osv.UpstreamGroup.db_id == 'CVE-3').get().upstream_ids
+    self.assertEqual(['CVE-1', 'CVE-2'], bug_ids)
+
+    pb_upstream = self._get_upstreams_from_bucket('CVE-3')
+    self.assertEqual(['CVE-1', 'CVE-2'], pb_upstream)
+
+  def test_upstream_group_complex(self):
+    """Testing more complex, realworld case"""
+    upstream_ids = [
+        "CVE-2023-21400", "CVE-2024-40967", "CVE-2024-53103", "CVE-2024-53141",
+        "CVE-2024-53164", "UBUNTU-CVE-2023-21400", "UBUNTU-CVE-2024-40967",
+        "UBUNTU-CVE-2024-53103", "UBUNTU-CVE-2024-53141",
+        "UBUNTU-CVE-2024-53164"
+    ]
+
+    upstream_computation.main()
+    bug_ids = osv.UpstreamGroup.query(
+        osv.UpstreamGroup.db_id == 'USN-7234-3').get().upstream_ids
+
+    self.assertEqual(upstream_ids, bug_ids)
+
+    pb_upstream = self._get_upstreams_from_bucket('USN-7234-3')
+    self.assertEqual(upstream_ids, pb_upstream)
+
+  def test_upstream_hierarchy_computation(self):
+    upstream_computation.main()
+    bug_ids = osv.UpstreamGroup.query(
+        osv.UpstreamGroup.db_id == 'CVE-3').get().upstream_hierarchy
+    self.assertEqual('{"CVE-3": ["CVE-2"], "CVE-2": ["CVE-1"]}', bug_ids)
+
+  def test_upstream_hierarchy_computation_complex(self):
+    """Testing hierarchy computation for more complex, realworld case"""
+
+    upstream_computation.main()
+
+    bug_ids = osv.UpstreamGroup.query(
+        osv.UpstreamGroup.db_id == 'USN-7234-3').get().upstream_hierarchy
+    bug_ids = json.loads(bug_ids)
+    expected = {
+        'USN-7234-3': [
+            'CVE-2024-40967', 'CVE-2024-53103', 'CVE-2024-53141',
+            'CVE-2024-53164', 'UBUNTU-CVE-2023-21400', 'UBUNTU-CVE-2024-40967',
+            'UBUNTU-CVE-2024-53103', 'UBUNTU-CVE-2024-53141',
+            'UBUNTU-CVE-2024-53164'
+        ],
+        'UBUNTU-CVE-2023-21400': ['CVE-2023-21400']
+    }
+    self.assertEqual(expected, bug_ids)
+
+
+def setUpModule():
+  """Set up the test module."""
+  # Start the emulator BEFORE creating the ndb client
+  global emulator
+  emulator = unittest.enterModuleContext(tests.datastore_emulator())
+  unittest.enterModuleContext(ndb.Client().context(cache_policy=False))
+  logging.getLogger("UpstreamTest.test_compute_upstream").setLevel(
+      logging.DEBUG)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/gcp/workers/cloudbuild.yaml
+++ b/gcp/workers/cloudbuild.yaml
@@ -52,6 +52,14 @@ steps:
   waitFor: ['init', 'sync']
 
 - name: 'gcr.io/oss-vdb/ci'
+  id: 'alias-tests'
+  dir: gcp/workers/alias
+  args: ['bash', '-ex', 'run_tests.sh']
+  env:
+    - DATASTORE_EMULATOR_PORT=8002
+  waitFor: ['init', 'sync']
+
+- name: 'gcr.io/oss-vdb/ci'
   id: 'recoverer-tests'
   dir: gcp/workers/recoverer
   args: ['bash', '-ex', 'run_tests.sh']

--- a/gcp/workers/exporter/Dockerfile
+++ b/gcp/workers/exporter/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-vdb/worker
+
+COPY exporter.py /usr/local/bin
+COPY export_runner.py /usr/local/bin
+RUN chmod 755 /usr/local/bin/exporter.py
+RUN chmod 755 /usr/local/bin/export_runner.py
+ENTRYPOINT ["export_runner.py"]

--- a/gcp/workers/exporter/build.sh
+++ b/gcp/workers/exporter/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -x
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+docker build -t gcr.io/oss-vdb/exporter:$1 . && \
+docker build -t gcr.io/oss-vdb/exporter:latest . && \
+docker push gcr.io/oss-vdb/exporter:$1 && \
+docker push gcr.io/oss-vdb/exporter:latest

--- a/gcp/workers/exporter/export_runner.py
+++ b/gcp/workers/exporter/export_runner.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OSV Exporter."""
+import argparse
+import concurrent.futures
+import csv
+import glob
+import logging
+import os
+import subprocess
+import tempfile
+import zipfile as z
+
+from google.cloud import ndb, storage
+
+from exporter import safe_upload_single, LAST_MODIFIED_FILE
+import osv
+import osv.logs
+
+DEFAULT_WORK_DIR = '/work'
+DEFAULT_EXPORT_BUCKET = 'osv-vulnerabilities'
+DEFAULT_EXPORT_PROCESSES = 7
+
+
+def main():
+  parser = argparse.ArgumentParser(description='Exporter')
+  parser.add_argument(
+      '--work_dir', help='Working directory', default=DEFAULT_WORK_DIR)
+  parser.add_argument(
+      '--bucket',
+      help='Bucket name to export to',
+      default=DEFAULT_EXPORT_BUCKET)
+  parser.add_argument(
+      '--processes',
+      help='Maximum number of parallel exports, default to number of cpu cores',
+      type=int,
+      # If 0 or None, use the DEFAULT_EXPORT_PROCESSES value
+      default=os.cpu_count() or DEFAULT_EXPORT_PROCESSES)
+  args = parser.parse_args()
+
+  query = osv.Bug.query(projection=[osv.Bug.ecosystem], distinct=True)
+  ecosystems = [bug.ecosystem[0] for bug in query if bug.ecosystem] + ['list']
+
+  # Set TMPDIR to change the tempfile default directory
+  tmp_dir = os.path.join(args.work_dir, 'tmp')
+  os.makedirs(tmp_dir, exist_ok=True)
+  os.environ['TMPDIR'] = tmp_dir
+
+  with tempfile.TemporaryDirectory() as export_dir:
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=args.processes) as executor:
+      for eco in ecosystems:
+        # Skip exporting data for child ecosystems (e.g., 'Debian:11').
+        if ':' in eco:
+          continue
+        executor.submit(spawn_ecosystem_exporter, export_dir, args.bucket, eco)
+    # Upload a ZIP file containing records from all ecosystems.
+    aggregate_all_vulnerabilities(export_dir, args.bucket)
+
+
+def spawn_ecosystem_exporter(work_dir: str, bucket: str, eco: str):
+  """
+  Spawns the ecosystem specific exporter.
+  """
+  logging.info('Starting export of ecosystem: %s', eco)
+  proc = subprocess.Popen([
+      # Assume exporter.py is in the same directory as this file
+      # This is true for local dev and Docker
+      f'{os.path.dirname(__file__)}/exporter.py',
+      '--work_dir',
+      work_dir,
+      '--bucket',
+      bucket,
+      '--ecosystem',
+      eco
+  ])
+  return_code = proc.wait()
+  if return_code != 0:
+    logging.error(
+        'Export of %s failed with Exit Code: %d. See logs for related errors.',
+        eco, return_code)
+
+
+def aggregate_all_vulnerabilities(work_dir: str, export_bucket: str):
+  """
+  Aggregates vulnerability records from each ecosystem into a single zip
+  file and uploads it to the export bucket.
+  """
+  logging.info('Generating unified all.zip archive.')
+  zip_file_name = 'all.zip'
+  output_zip = os.path.join(work_dir, zip_file_name)
+  all_vulns = {}
+
+  for file_path in glob.glob(
+      os.path.join(work_dir, '**/*.json'), recursive=True):
+    all_vulns[os.path.basename(file_path)] = file_path
+
+  with z.ZipFile(output_zip, 'a', z.ZIP_DEFLATED) as all_zip:
+    for vuln_filename in sorted(all_vulns):
+      file_path = all_vulns[vuln_filename]
+      all_zip.write(file_path, os.path.basename(file_path))
+
+  # Also aggregate modified_list.csv files
+  output_modified_list = os.path.join(work_dir, LAST_MODIFIED_FILE)
+  full_modified_list = []
+  for file_path in glob.glob(
+      os.path.join(work_dir, f'**/{LAST_MODIFIED_FILE}'), recursive=True):
+    dir_from_work_dir = os.path.relpath(os.path.dirname(file_path), work_dir)
+    with open(file_path, 'r') as infile:
+      reader = csv.reader(infile)
+      for line in reader:
+        # Create <timestamp>,<dir>/<osv_id>
+        full_modified_list.append((line[0], f'{dir_from_work_dir}/{line[1]}'))
+
+  full_modified_list.sort(reverse=True)
+
+  with open(output_modified_list, 'w') as outfile:
+    csv.writer(outfile).writerows(full_modified_list)
+
+  storage_client = storage.Client()
+  bucket = storage_client.get_bucket(export_bucket)
+  safe_upload_single(bucket, output_zip, zip_file_name)
+  logging.info('Unified all.zip uploaded successfully.')
+  safe_upload_single(bucket, output_modified_list, LAST_MODIFIED_FILE)
+  logging.info('Unified %s uploaded successfully.', LAST_MODIFIED_FILE)
+
+
+if __name__ == '__main__':
+  _ndb_client = ndb.Client()
+  osv.logs.setup_gcp_logging('exporter-runner')
+  with _ndb_client.context():
+    main()

--- a/gcp/workers/exporter/exporter.py
+++ b/gcp/workers/exporter/exporter.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OSV Exporter."""
+import argparse
+import concurrent.futures
+import csv
+import json
+import logging
+import os
+import zipfile
+from typing import List
+
+from google.cloud import ndb
+from google.cloud import storage
+from google.cloud.storage import retry
+from google.cloud.storage.bucket import Bucket
+from google.protobuf import json_format
+
+import requests
+
+import osv
+import osv.logs
+
+DEFAULT_WORK_DIR = '/work'
+
+DEFAULT_EXPORT_BUCKET = 'osv-vulnerabilities'
+DEFAULT_SAFE_DELTA_PCT = 10
+_EXPORT_WORKERS = 32
+ECOSYSTEMS_FILE = 'ecosystems.txt'
+LAST_MODIFIED_FILE = 'modified_id.csv'
+VANIR_SIGNATURES_KEY = 'vanir_signatures'
+OSV_GIT_JSON_FILE_NAME = 'osv_git.json'
+
+
+class Error(Exception):
+  """Base exception class."""
+
+
+def modify_storage_client_adapters(storage_client: storage.Client,
+                                   pool_connections: int = 128,
+                                   max_retries: int = 3,
+                                   pool_block: bool = True) -> storage.Client:
+  """Returns a modified google.cloud.storage.Client object.
+
+  Due to many concurrent GCS connections, the default connection pool can become
+  overwhelmed, introducing delays.
+
+  Solution described in https://github.com/googleapis/python-storage/issues/253
+
+  These affect the urllib3.HTTPConnectionPool underpinning the storage.Client's
+  HTTP requests.
+
+  Args:
+    storage_client: an existing google.cloud.storage.Client object
+    pool_connections: number of pool_connections desired
+    max_retries: maximum retries
+    pool_block: blocking behaviour when pool is exhausted
+
+  Returns:
+    the google.cloud.storage.Client appropriately modified.
+
+  """
+  adapter = requests.adapters.HTTPAdapter(
+      pool_connections=pool_connections,
+      max_retries=max_retries,
+      pool_block=pool_block)
+  # pylint: disable=protected-access
+  storage_client._http.mount('https://', adapter)
+  storage_client._http._auth_request.session.mount('https://', adapter)
+  return storage_client
+
+
+class Exporter:
+  """Exporter."""
+
+  def __init__(self, work_dir, export_bucket, ecosystem):
+    self._work_dir = work_dir
+    self._export_bucket = export_bucket
+    self._ecosystem = ecosystem
+
+  def run(self):
+    """Run exporter."""
+    if self._ecosystem == "list":
+      query = osv.Bug.query(projection=[osv.Bug.ecosystem], distinct=True)
+      # Filter out ecosystems that contain a colon,
+      # as these represent Linux distro releases.
+      ecosystems = [
+          bug.ecosystem[0]
+          for bug in query
+          if bug.ecosystem and ':' not in bug.ecosystem[0]
+      ]
+      self._export_ecosystem_list_to_bucket(ecosystems, self._work_dir)
+    else:
+      self._export_ecosystem_to_bucket(self._ecosystem, self._work_dir)
+
+  def _export_ecosystem_list_to_bucket(self, ecosystems: List[str],
+                                       tmp_dir: str):
+    """Export an ecosystems.txt file with all of the ecosystem names.
+
+    See https://github.com/google/osv.dev/issues/619
+
+    Args:
+      ecosystems: the list of ecosystem names
+      tmp_dir: temporary directory for scratch
+    """
+
+    logging.info('Exporting ecosystem list to %s', ECOSYSTEMS_FILE)
+    storage_client = storage.Client()
+    bucket = storage_client.get_bucket(self._export_bucket)
+    ecosystems_file_path = os.path.join(tmp_dir, ECOSYSTEMS_FILE)
+    with open(ecosystems_file_path, "w") as ecosystems_file:
+      ecosystems_file.writelines([e + "\n" for e in ecosystems])
+
+    upload_single(bucket, ecosystems_file_path, ECOSYSTEMS_FILE)
+
+  def _export_ecosystem_to_bucket(self, ecosystem: str, work_dir: str):
+    """Export the vulnerabilities in an ecosystem to GCS.
+
+    Args:
+      ecosystem: the ecosystem name
+      work_dir: working directory for scratch
+
+    This simultaneously exports every Bug for the given ecosystem to individual
+    files in the scratch filesystem, and a zip file in the scratch filesystem.
+
+    At the conclusion of this export, all of the files in the scratch filesystem
+    (including the zip file) are uploaded to the GCS bucket.
+    """
+    logging.info('Exporting vulnerabilities for ecosystem %s', ecosystem)
+    storage_client = modify_storage_client_adapters(storage.Client())
+    bucket = storage_client.get_bucket(self._export_bucket)
+
+    ecosystem_dir = os.path.join(work_dir, ecosystem)
+    os.makedirs(ecosystem_dir, exist_ok=True)
+    zip_path = os.path.join(ecosystem_dir, 'all.zip')
+    git_vulns_with_vanir_signatures = []
+    with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zip_file:
+      files_to_zip = []
+      id_and_modified = []
+
+      @ndb.tasklet
+      def _export_to_file_and_zipfile(bug: osv.Bug):
+        """Write out a bug record to both a single file and the zip file."""
+        if not bug.public or bug.status == osv.BugStatus.UNPROCESSED:
+          return
+
+        try:
+          file_path = os.path.join(ecosystem_dir, bug.id() + '.json')
+          vulnerability = yield bug.to_vulnerability_async(
+              include_source=True, include_alias=True, include_upstream=True)
+          osv.write_vulnerability(vulnerability, file_path)
+
+          if ecosystem == 'GIT':
+            # The GIT ecosystem has vulnerabilities that have Vanir sigantures
+            # generated. These are exported to a file.
+            if any(VANIR_SIGNATURES_KEY in affected.database_specific
+                   for affected in vulnerability.affected):
+              git_vulns_with_vanir_signatures.append(
+                  json_format.MessageToDict(
+                      vulnerability, preserving_proto_field_name=True))
+
+          files_to_zip.append(file_path)
+          # ToJsonString converts it into an ISO string
+          # with timezone Z correctly appended
+          id_and_modified.append(
+              (vulnerability.modified.ToJsonString(), vulnerability.id))
+        except Exception:
+          logging.exception('Failed to export bug: "%s"', bug.id())
+          raise
+
+      # This *should* pause here until
+      # all the exports have been written to disk.
+      osv.Bug.query(
+          osv.Bug.ecosystem == ecosystem).map(_export_to_file_and_zipfile)
+
+      # Write out the GIT vulnerabilities that have Vanir signatures to
+      # a JSON file.
+      if ecosystem == 'GIT' and git_vulns_with_vanir_signatures:
+        output_path = os.path.join(ecosystem_dir, OSV_GIT_JSON_FILE_NAME)
+        with open(output_path, 'w') as f:
+          json.dump(git_vulns_with_vanir_signatures, f, indent=2)
+
+      files_to_zip.sort()
+      for file_path in files_to_zip:
+        zip_file.write(file_path, os.path.basename(file_path))
+
+      id_and_modified.sort(reverse=True)
+      with open(os.path.join(ecosystem_dir, LAST_MODIFIED_FILE),
+                'w') as modified_file:
+        csv.writer(modified_file).writerows(id_and_modified)
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=_EXPORT_WORKERS) as executor:
+      # Note: the individual ecosystem all.zip is included here
+      # TODO: use safe_upload_single() on the zip files.
+      for filename in os.listdir(ecosystem_dir):
+        executor.submit(upload_single, bucket,
+                        os.path.join(ecosystem_dir, filename),
+                        f'{ecosystem}/{filename}')
+
+
+def upload_single(bucket: Bucket, source_path: str, target_path: str):
+  """Upload a single file to a GCS bucket."""
+  logging.info('Uploading %s', target_path)
+  try:
+    blob = bucket.blob(target_path)
+    blob.upload_from_filename(source_path, retry=retry.DEFAULT_RETRY)
+  except Exception as e:
+    logging.exception('Failed to export: %s', e)
+
+
+def safe_upload_single(bucket: Bucket,
+                       source_path: str,
+                       target_path: str,
+                       safe_delta_pct: int = DEFAULT_SAFE_DELTA_PCT):
+  """Upload a single file to a GCS bucket, with a size check.
+
+  This refuses to overwrite the GCS object if the file size difference is
+  greater than the permitted threshold (10% by default).
+
+  NOTE: this intentionally only catches unexpectedly smaller files, not larger
+  ones.
+
+  Args:
+    bucket: (Bucket): the GCS bucket object to upload to.
+    source_path: (str): the source path to the file to upload.
+    target_path: (str): the target path in Bucket to upload to.
+    safe_delta_pct: (int): the threshold at which to raise an exception.
+
+  Raises:
+    Error: if safe_delta_pct is exceeded
+  """
+
+  source_size = os.stat(source_path).st_size
+  logging.info('Uploading %s', target_path)
+  try:
+    blob = bucket.get_blob(target_path)
+    if blob and blob.size and (source_size / blob.size) * 100 < safe_delta_pct:
+      raise (Error(
+          f'Cowardly refusing to overwrite {blob.name} ({blob.size} bytes) '
+          f'with {source_path} ({source_size} bytes)'))
+    if blob:
+      blob.upload_from_filename(source_path, retry=retry.DEFAULT_RETRY)
+    else:
+      bucket.blob(target_path).upload_from_filename(
+          source_path, retry=retry.DEFAULT_RETRY)
+  except Exception as e:
+    logging.exception('Failed to export: %s', e)
+
+
+def main():
+  parser = argparse.ArgumentParser(description='Exporter')
+  parser.add_argument(
+      '--work_dir', help='Working directory', default=DEFAULT_WORK_DIR)
+  parser.add_argument(
+      '--bucket',
+      help='Bucket name to export to',
+      default=DEFAULT_EXPORT_BUCKET)
+  parser.add_argument(
+      '--ecosystem',
+      required=True,
+      help='Ecosystem to upload, pass the value "list" ' +
+      'to export the ecosystem.txt file')
+  args = parser.parse_args()
+
+  exporter = Exporter(args.work_dir, args.bucket, args.ecosystem)
+  exporter.run()
+
+
+if __name__ == '__main__':
+  _ndb_client = ndb.Client()
+  osv.logs.setup_gcp_logging('exporter')
+  with _ndb_client.context():
+    main()


### PR DESCRIPTION
Reverts google/osv.dev#4482
The website emulator depends on the alias/upstream computation to populate the database / GCS. Trying to fix it is actually quite complicated, so I'm restoring the original alias/upstream code to unblock testing.