### PR TITLE
fix: Actually use gitter

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/gitter.yaml
+++ b/deployment/clouddeploy/gke-workers/base/gitter.yaml
@@ -25,13 +25,13 @@ spec:
         volumeMounts:
         - mountPath: /work
           name: disk-data
-      resources:
-        requests:
-          cpu: "28"
-          memory: "200Gi"
-        limits:
-          cpu: "28"
-          memory: "200Gi"
+        resources:
+          requests:
+            cpu: "28"
+            memory: "200Gi"
+          limits:
+            cpu: "28"
+            memory: "200Gi"
       volumes:
       - name: disk-data
         persistentVolumeClaim:

--- a/deployment/clouddeploy/gke-workers/base/importer.yaml
+++ b/deployment/clouddeploy/gke-workers/base/importer.yaml
@@ -22,6 +22,9 @@ spec:
             volumeMounts:
               - mountPath: "/work"
                 name: "ssd"
+            env:
+              - name: GITTER_HOST
+                value: http://gitter-service:8888
             securityContext:
               privileged: true
             resources:

--- a/deployment/clouddeploy/gke-workers/base/workers.yaml
+++ b/deployment/clouddeploy/gke-workers/base/workers.yaml
@@ -33,6 +33,9 @@ spec:
         volumeMounts:
           - mountPath: "/work"
             name: "ssd"
+        env:
+          - name: GITTER_HOST
+            value: http://gitter-service:8888
         securityContext:
           privileged: true
         resources:


### PR DESCRIPTION
Resources was indented on the wrong level (recoverer is also incorrect @michaelkedar, but avoiding changing this PR in case it breaks recoverer with the new limits)

Also worker and importer are currently ignoring gitter, so fixing that too.
