### PR TITLE
chore(renovate): group dependencies to reduce PR volume

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -43,19 +43,7 @@
       "matchFileNames": [
         "gcp/website/**"
       ],
-      "matchCategories": [
-        "python"
-      ],
-      "groupName": "website-backend"
-    },
-    {
-      "matchFileNames": [
-        "gcp/website/**"
-      ],
-      "matchCategories": [
-        "js"
-      ],
-      "groupName": "website-frontend"
+      "groupName": "website"
     },
     {
       "matchFileNames": [
@@ -68,33 +56,12 @@
     },
     {
       "matchFileNames": [
-        "gcp/api/**"
-      ],
-      "groupName": "api"
-    },
-    {
-      "matchFileNames": [
-        "gcp/functions/**"
-      ],
-      "groupName": "functions"
-    },
-    {
-      "matchFileNames": [
-        "gcp/workers/**"
-      ],
-      "matchCategories": [
-        "python"
-      ],
-      "groupName": "workers"
-    },
-    {
-      "matchFileNames": [
+        "gcp/api/**",
+        "gcp/functions/**",
+        "gcp/workers/**",
         "gcp/indexer/**"
       ],
-      "matchCategories": [
-        "golang"
-      ],
-      "groupName": "indexer"
+      "groupName": "gcp-services"
     },
     {
       "matchFileNames": [
@@ -140,6 +107,40 @@
         "python"
       ],
       "enabled": false
+    },
+    {
+      "matchDatasources": [
+        "docker"
+      ],
+      "groupName": "docker"
+    },
+    {
+      "matchFileNames": [
+        "docker/**"
+      ],
+      "groupName": "docker"
+    },
+    {
+      "matchManagers": [
+        "git-submodules"
+      ],
+      "groupName": "submodules"
+    },
+    {
+      "matchDatasources": [
+        "git-refs"
+      ],
+      "groupName": "submodules"
+    },
+    {
+      "matchFileNames": [
+        "bindings/**",
+        "go/**"
+      ],
+      "matchCategories": [
+        "golang"
+      ],
+      "groupName": "go-libraries"
     },
     {
       "matchDepTypes": ["uses-with"],


### PR DESCRIPTION
Currently Renovate creates ~20 PRs per cycle. This change consolidates groups to reduce that to ~11-12 PRs (~40-45% reduction).

| Before | After |
|--------|-------|
| `website-backend` + `website-frontend` | `website` |
| `api` + `functions` + `workers` + `indexer` | `gcp-services` |
| Docker digests | `docker` |
| git submodules/refs | `submodules` |
| Go modules in `bindings/**`, `go/**` | `go-libraries` |

The expected result based on the current open PRs:
  | Category | Before | After |
  |----------|--------|-------|
  | Lock file maintenance | 10 | ~6-7 |
  | Dependency updates | 10 | ~5 |
  | **Total** | **20** | **~11-12** |
  
  Fixes #4277 