### PR TITLE
fix(importer): sanitize HTML anchor tags from vulnerability details

### DIFF
--- a/osv/sources.py
+++ b/osv/sources.py
@@ -17,6 +17,7 @@ import json
 import hashlib
 import logging
 import os
+import re
 
 import jsonschema
 import pygit2
@@ -178,6 +179,11 @@ def parse_vulnerability_from_dict(data, key_path=None, strict=False):
   if not vulnerability.id:
     raise ValueError('Missing id field. Invalid vulnerability.')
 
+  if vulnerability.summary:
+    vulnerability.summary = _sanitize_string(vulnerability.summary)
+  if vulnerability.details:
+    vulnerability.details = _sanitize_string(vulnerability.details)
+
   return vulnerability
 
 
@@ -228,6 +234,12 @@ def _write_vulnerability_dict(data, output_path,
       raise RuntimeError('Unknown format ' + ext)
 
   os.utime(output_path, (modified_date_timestamp, modified_date_timestamp))
+
+
+def _sanitize_string(text):
+  """Sanitize string by removing anchor tags."""
+  # Remove <a href="...">text</a> and keep text.
+  return re.sub(r'<a [^>]*>(.*?)</a>', r'\1', text, flags=re.IGNORECASE | re.DOTALL)
 
 
 def write_vulnerability(vulnerability: vulnerability_pb2.Vulnerability,


### PR DESCRIPTION
# fix(importer): sanitize HTML anchor tags from vulnerability details

## Description
Fixes #4237.

This PR implements sanitization for `summary` and `details` fields in vulnerability records. It uses a regex-based approach to strip HTML `<a>` tags while preserving the link text. This addresses the issue where some NuGet records (and potentially others) contain raw HTML anchor tags that are not rendered correctly in downstream consumers.

## Changes
- Added `_sanitize_string` helper function in `osv/sources.py`.
- Applied sanitization in `parse_vulnerability_from_dict`.
- Verified with valid and invalid inputs locally.

## Verification
- Created a reproduction test case with a mock NuGet record containing anchor tags.
- Verified that the tags were present before the fix.
- Verified that the tags were stripped (and text preserved) after the fix.
