### PR TITLE
docs: specify which URL failed in REST API fetch for importer updates

### DIFF
--- a/gcp/workers/importer/importer.py
+++ b/gcp/workers/importer/importer.py
@@ -923,7 +923,8 @@ class Importer:
       logging.exception('Exception querying REST API:')
       return
     if request.status_code != 200:
-      logging.error('Failed to fetch REST API: %s', request.status_code)
+      logging.error('Failed to fetch REST API: %s for %s', request.status_code,
+                    source_repo.rest_api_url)
       return
 
     request_last_modified = None


### PR DESCRIPTION
Improved the logging in importer to know exactly which URL failed to fetch with REST API failures.