### PR TITLE
fix: introduced '>' operator not being parsed 

### DIFF
--- a/vulnfeeds/git/versions.go
+++ b/vulnfeeds/git/versions.go
@@ -154,9 +154,13 @@ func ParseVersionRange(versionRange string) (models.AffectedVersion, error) {
 		}
 	} else {
 		// Two constraints
-		if op1 == ">=" {
+		switch op1 {
+		case ">=":
 			av.Introduced = ver1
-		} else {
+		case ">":
+			// this is technically incorrect but better than introduced being 0
+			av.Introduced = ver1
+		default:
 			return models.AffectedVersion{}, fmt.Errorf("unexpected operator at start of range: %s", op1)
 		}
 


### PR DESCRIPTION
While a "> 1.x", '>' is technically not correct, as it would say that the value given is the version before the vuln is introduced, it is still a better range to accept than resorting to introduced = 0.

This should handle this case: https://github.com/google/osv.dev/issues/4569 