### PR TITLE
fix(sitemap): chunk ecosystems oldest first

### DIFF
--- a/go/cmd/generatesitemap/generatesitemap.go
+++ b/go/cmd/generatesitemap/generatesitemap.go
@@ -230,9 +230,9 @@ func generateSitemaps(ctx context.Context, client clients.CloudStorage, outputDi
 
 	for _, eco := range ecosystems {
 		vulns := entries[eco]
-		// Sort by LastModified descending
+		// Sort by LastModified ascending (oldest first)
 		sort.Slice(vulns, func(i, j int) bool {
-			return vulns[i].LastModified.After(vulns[j].LastModified)
+			return vulns[i].LastModified.Before(vulns[j].LastModified)
 		})
 
 		// Split into chunks
@@ -258,7 +258,8 @@ func generateSitemaps(ctx context.Context, client clients.CloudStorage, outputDi
 			// Add to index
 			chunkLastMod := time.Unix(0, 0).UTC()
 			if len(chunk) > 0 {
-				chunkLastMod = chunk[0].LastModified
+				// Since we sort by oldest first, the last item is the newest
+				chunkLastMod = chunk[len(chunk)-1].LastModified
 			}
 
 			sitemapIndexEntries = append(sitemapIndexEntries, SitemapIndexEntry{

--- a/go/cmd/generatesitemap/generatesitemap_test.go
+++ b/go/cmd/generatesitemap/generatesitemap_test.go
@@ -111,9 +111,9 @@ func TestGenerateSitemaps(t *testing.T) {
 	if len(urlSet.URLs) != 2 {
 		t.Errorf("expected 2 URLs in sitemap_Go.xml, got %d", len(urlSet.URLs))
 	}
-	// Verify sorting (descending)
-	if urlSet.URLs[0].Loc != "https://example.com/vulnerability/GO-2" {
-		t.Errorf("expected GO-2 first (newer), got %s", urlSet.URLs[0].Loc)
+	// Verify sorting (ascending)
+	if urlSet.URLs[0].Loc != "https://example.com/vulnerability/GO-1" {
+		t.Errorf("expected GO-1 first (older), got %s", urlSet.URLs[0].Loc)
 	}
 
 	// Verify content of sitemap_index.xml


### PR DESCRIPTION
It just occurred to me that by having the newest vulns in `ECOSYSTEM_1.xml` and later in `ECOSYSTEM_2.xml`, `_3`, etc., every time we get a new vulnerability, every sitemap of that ecosystem will change as the oldest one gets pushed out to the next sitemap chunk.

Reversed the order, so that the oldest vulns are in the first sitemap, which should prevent churn.