### PR TITLE
fix: bump importer memory

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/importer.yaml
+++ b/deployment/clouddeploy/gke-workers/base/importer.yaml
@@ -30,10 +30,10 @@ spec:
             resources:
               requests:
                 cpu: "1"
-                memory: "8G"
+                memory: "24G"
               limits:
-                cpu: "1"
-                memory: "16G"
+                cpu: "2"
+                memory: "32G"
           nodeSelector:
             cloud.google.com/gke-nodepool: importer-pool
           restartPolicy: Never

--- a/deployment/terraform/modules/osv/workers_gke.tf
+++ b/deployment/terraform/modules/osv/workers_gke.tf
@@ -140,7 +140,7 @@ resource "google_container_node_pool" "importer_pool" {
   }
 
   node_config {
-    machine_type    = "n2-highmem-2"
+    machine_type    = "n2-highmem-4"
     disk_type       = "pd-ssd"
     disk_size_gb    = 64
     local_ssd_count = 1


### PR DESCRIPTION
importer has been unable to cope with a large amount of records being kept in memory.
This is a band-aid fix, we should just rewrite it to be better.