### PR TITLE
fix(worker): update modified time if bug was withdrawn.

### DIFF
--- a/gcp/workers/worker/worker.py
+++ b/gcp/workers/worker/worker.py
@@ -450,7 +450,7 @@ class TaskRunner:
 
     logging.info('Marking %s as invalid and withdrawn.', vuln_id)
     bug.status = osv.BugStatus.INVALID
-    if not bug.withdrawn: # in case this was already withdrawn for some reason
+    if not bug.withdrawn:  # in case this was already withdrawn for some reason
       bug.withdrawn = datetime.datetime.now(datetime.UTC)
     if bug.last_modified:
       bug.last_modified = max(bug.withdrawn, bug.last_modified)


### PR DESCRIPTION
Not updating the modified time on the bug when we're withdrawing it was causing the withdrawn bug to not be updated properly.
The importer-deleter should end up cleaning up the current bugs in invalid state once this is merged.