### PR TITLE
chore: try fix race conditions in Cloud Build tests

### DIFF
--- a/gcp/api/cloudbuild.yaml
+++ b/gcp/api/cloudbuild.yaml
@@ -39,10 +39,9 @@ steps:
   dir: gcp/api
   #TODO: Update test scripts to support not supplying a credential.
   args: ['bash', '-ex', 'run_tests.sh', '/workspace/dummy.json']
-  env:
-    - CLOUDBUILD=1
   waitFor: ['init', 'sync']
 
 timeout: 7200s
 options:
-  automapSubstitutions: true
+  env:
+    - CLOUDBUILD=1

--- a/gcp/api/run_tests.sh
+++ b/gcp/api/run_tests.sh
@@ -25,7 +25,7 @@ service docker start
 set -e
 
 # Install dependencies only if not running in Cloud Build
-if [ -z "$BUILD_ID" ]; then
+if [ -z "$CLOUDBUILD" ]; then
   poetry sync
 fi
 poetry run python server_test.py

--- a/gcp/website/cloudbuild.yaml
+++ b/gcp/website/cloudbuild.yaml
@@ -45,4 +45,5 @@ steps:
 
 timeout: 7200s
 options:
-  automapSubstitutions: true
+  env:
+    - CLOUDBUILD=1

--- a/gcp/website/run_tests.sh
+++ b/gcp/website/run_tests.sh
@@ -3,7 +3,7 @@
 export GOOGLE_CLOUD_PROJECT=fake-project123
 
 # Install dependencies only if not running in Cloud Build
-if [ -z "$BUILD_ID" ]; then
+if [ -z "$CLOUDBUILD" ]; then
   poetry sync
 fi
 poetry run python frontend_handlers_test.py

--- a/gcp/workers/alias/run_tests.sh
+++ b/gcp/workers/alias/run_tests.sh
@@ -16,7 +16,7 @@
 cd ../worker
 
 # Install dependencies only if not running in Cloud Build
-if [ -z "$BUILD_ID" ]; then
+if [ -z "$CLOUDBUILD" ]; then
   poetry sync
 fi
 poetry run python ../alias/alias_computation_test.py

--- a/gcp/workers/cloudbuild.yaml
+++ b/gcp/workers/cloudbuild.yaml
@@ -73,4 +73,5 @@ steps:
 timeout: 7200s
 options:
   machineType: E2_HIGHCPU_8
-  automapSubstitutions: true
+  env:
+    - CLOUDBUILD=1

--- a/gcp/workers/importer/run_tests.sh
+++ b/gcp/workers/importer/run_tests.sh
@@ -16,7 +16,7 @@
 cd ../worker
 
 # Install dependencies only if not running in Cloud Build
-if [ -z "$BUILD_ID" ]; then
+if [ -z "$CLOUDBUILD" ]; then
   poetry sync
 fi
 poetry run python ../importer/importer_test.py

--- a/gcp/workers/recoverer/run_tests.sh
+++ b/gcp/workers/recoverer/run_tests.sh
@@ -16,7 +16,7 @@
 cd ../worker
 
 # Install dependencies only if not running in Cloud Build
-if [ -z "$BUILD_ID" ]; then
+if [ -z "$CLOUDBUILD" ]; then
   poetry sync
 fi
 poetry run python ../recoverer/recoverer_test.py

--- a/gcp/workers/worker/run_tests.sh
+++ b/gcp/workers/worker/run_tests.sh
@@ -16,7 +16,7 @@
 export GOOGLE_CLOUD_PROJECT=fake-project123
 
 # Install dependencies only if not running in Cloud Build
-if [ -z "$BUILD_ID" ]; then
+if [ -z "$CLOUDBUILD" ]; then
   poetry sync
 fi
 poetry run python worker_test.py

--- a/go/osv/models/internal/validate/run_validate.sh
+++ b/go/osv/models/internal/validate/run_validate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Install dependencies only if not running in Cloud Build
-if [ -z "$BUILD_ID" ]; then
+if [ -z "$CLOUDBUILD" ]; then
   poetry sync
 fi
 poetry run python validate.py

--- a/osv/cloudbuild.yaml
+++ b/osv/cloudbuild.yaml
@@ -53,4 +53,5 @@ steps:
 timeout: 7200s
 options:
   machineType: E2_HIGHCPU_8
-  automapSubstitutions: true
+  env:
+    - CLOUDBUILD=1

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 # Install dependencies only if not running in Cloud Build
-if [ -z "$BUILD_ID" ]; then
+if [ -z "$CLOUDBUILD" ]; then
   poetry sync
 fi
 poetry run python -m unittest osv.bug_test

--- a/tools/sourcerepo-sync/run_tests.sh
+++ b/tools/sourcerepo-sync/run_tests.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Install dependencies only if not running in Cloud Build
-if [ -z "$BUILD_ID" ]; then
+if [ -z "$CLOUDBUILD" ]; then
   poetry sync
 fi
 poetry run python source_sync.py --kind SourceRepository --project oss-vdb --file ../../source.yaml --verbose --validate


### PR DESCRIPTION
Don't try reinstall dependencies in the `run_tests.sh` files if we're running in Cloud Build (which does installs them in a dedicated step).
Also, replaced `poetry install` with `poetry sync`