### PR TITLE
Add CleanStart source configuration

### DIFF
--- a/osv/ecosystems/_ecosystems.py
+++ b/osv/ecosystems/_ecosystems.py
@@ -41,6 +41,7 @@ _ecosystems = {
     'Bioconductor': Bioconductor,
     'Bitnami': SemverEcosystem,
     'Chainguard': APK,
+    'CleanStart': APK,
     'CRAN': CRAN,
     'crates.io': SemverEcosystem,
     'Debian': Debian,

--- a/source.yaml
+++ b/source.yaml
@@ -116,6 +116,21 @@
   editable: False
   strict_validation: False
 
+- name: 'cleanstart'
+  versions_from_repo: False
+  type: 0
+  ignore_patterns: ['^(?!CLEANSTART-).*$']
+  directory_path: 'advisories'
+  repo_url: 'https://github.com/cleanstart-dev/cleanstart-security-advisories'
+  detect_cherrypicks: False
+  extension: '.json'
+  db_prefix: ['CLEANSTART-']
+  ignore_git: True
+  link: 'https://github.com/cleanstart-dev/cleanstart-security-advisories/blob/main/'
+  editable: False
+  strict_validation: True
+
+
 - name: 'curl'
   versions_from_repo: False
   rest_api_url: 'https://curl.se/docs/vuln.json'

--- a/source_test.yaml
+++ b/source_test.yaml
@@ -116,6 +116,20 @@
   editable: False
   strict_validation: True
 
+- name: 'cleanstart'
+  versions_from_repo: False
+  type: 0
+  ignore_patterns: ['^(?!CLEANSTART-).*$']
+  directory_path: 'advisories'
+  repo_url: 'https://github.com/cleanstart-dev/cleanstart-security-advisories'
+  detect_cherrypicks: False
+  extension: '.json'
+  db_prefix: ['CLEANSTART-']
+  ignore_git: True
+  link: 'https://github.com/cleanstart-dev/cleanstart-security-advisories/blob/main/'
+  editable: False
+  strict_validation: True
+
 - name: 'curl'
   versions_from_repo: False
   rest_api_url: 'https://curl.se/docs/vuln.json'


### PR DESCRIPTION
This PR adds CleanStart as a git-based OSV source.

- Reuses APK ecosystem helper (similar to Alpaquita)
- Adds CleanStart source entry to source.yaml
- Removes purl as suggested by reviewer