### PR TITLE
fix: throw error if VendorProduct doesn't split in two

### DIFF
--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -865,6 +865,9 @@ func ParseCPE(formattedString string) (*models.CPEString, error) {
 
 func (vp *VendorProduct) UnmarshalText(text []byte) error {
 	s := strings.Split(string(text), ":")
+	if len(s) != 2 {
+		return fmt.Errorf("expected 2 parts, got %d", len(s))
+	}
 	vp.Vendor = s[0]
 	vp.Product = s[1]
 


### PR DESCRIPTION
In the unlikely case that UnmarshalText is called and the VendorProduct doesn't have a colon, throw an error.

I don't believe this function is ever used but better safe than sorry. Closes #4661 