### PR TITLE
fix: UnmarshalText should have at least 2 parts

### DIFF
--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -895,8 +895,8 @@ func ParseCPE(formattedString string) (*models.CPEString, error) {
 
 func (vp *VendorProduct) UnmarshalText(text []byte) error {
 	s := strings.Split(string(text), ":")
-	if len(s) != 2 {
-		return fmt.Errorf("expected 2 parts, got %d", len(s))
+	if len(s) < 2 {
+		return fmt.Errorf("expected at least 2 parts, got %d", len(s))
 	}
 	vp.Vendor = s[0]
 	vp.Product = s[1]


### PR DESCRIPTION
Turns out UnmarshalText is used by the CPE Dictionary loader... which has 6 parts. This should prevent panic but still let the text be unmarshalled.

Related to #4661