### PR TITLE
fix: remove csv reference from run_cve_to_osv_generation.sh

### DIFF
--- a/vulnfeeds/cmd/converters/cve/nvd-cve-osv/run_cve_to_osv_generation.sh
+++ b/vulnfeeds/cmd/converters/cve/nvd-cve-osv/run_cve_to_osv_generation.sh
@@ -58,12 +58,6 @@ for (( YEAR = $(date +%Y) ; YEAR >= ${FIRST_INSCOPE_YEAR} ; YEAR-- )); do
   echo "Copying NVD CVE records from ${YEAR} successfully converted to OSV to aggregated staging"
   find "${WORK_DIR}/nvd2osv/${YEAR}" -type f -name \*.json \
     -exec cp '{}' "${WORK_DIR}/nvd2osv/gcs_stage/" \;
-
-  # Copy conversion summary staging area.
-  DURABLE_OUTCOMES_CSV="nvd-conversion-outcomes-${YEAR}-$(date -Iminutes).csv"
-  cp "${WORK_DIR}/nvd2osv/${YEAR}/outcomes.csv" "${WORK_DIR}/nvd2osv/gcs_stage/${DURABLE_OUTCOMES_CSV}"
-
-  echo "Results summary will be available in ${OSV_OUTPUT_GCS_PATH}/${DURABLE_OUTCOMES_CSV}"
 done
 
 # Copy (and remove any missing) results to GCS bucket, with some sanity


### PR DESCRIPTION
we don't produce this csv file anymore so delete it from the bash script