### PR TITLE
chore(docs): update Go to v1.25.6

### DIFF
--- a/docs/go.mod
+++ b/docs/go.mod
@@ -1,6 +1,6 @@
 module osv.dev/tools
 
-go 1.25.5
+go 1.25.6
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3


### PR DESCRIPTION
There are vulnerabilities reported by OSV-Scanner.

```
+-------------------------------------+------+-----------+----------+---------+---------------+-----------------------------------------+
| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE  | VERSION | FIXED VERSION | SOURCE                                  |
+-------------------------------------+------+-----------+----------+---------+---------------+-----------------------------------------+
| https://osv.dev/GO-2026-4340        |      | Go        | stdlib   | 1.25.5  | 1.25.6        | docs/go.mod                             |
| https://osv.dev/GO-2026-4341        |      | Go        | stdlib   | 1.25.5  | 1.25.6        | docs/go.mod                             |
| https://osv.dev/GO-2026-4342        |      | Go        | stdlib   | 1.25.5  | 1.25.6        | docs/go.mod                             |
```