### PR TITLE
fix(exporter): bump number of workers goroutines

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/exporter.yaml
+++ b/deployment/clouddeploy/gke-workers/base/exporter.yaml
@@ -26,7 +26,7 @@ spec:
             imagePullPolicy: Always
             resources:
               requests:
-                cpu: "10"
+                cpu: "12"
                 memory: "40Gi"
               limits:
                 cpu: "20"

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/exporter.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/exporter.yaml
@@ -15,7 +15,7 @@ spec:
             args:
               # TODO(michaelkedar): single source of truth w/ terraform config
               - "--upload-to-gcs=true"
-              - "--workers=400"
+              - "--workers=600"
               - "--bucket=osv-test-vulnerabilities"
               - "--osv-vulns-bucket=osv-test-vulnerabilities"
 

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/exporter.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/exporter.yaml
@@ -14,7 +14,7 @@ spec:
               value: oss-vdb
             args:
               - "--upload-to-gcs=true"
-              - "--workers=400"
+              - "--workers=600"
               - "--bucket=osv-vulnerabilities"
               - "--osv-vulns-bucket=osv-vulnerabilities"
 


### PR DESCRIPTION
The exporter on staging is starting to slightly overrun its 15-minute schedule.
Bump the number of workers (and CPU allocation, but there was already some leeway for the CPU usage)