### PR TITLE
fix: edge case with packagist versioning

### DIFF
--- a/osv/ecosystems/coarse_version_monotonicity_test.py
+++ b/osv/ecosystems/coarse_version_monotonicity_test.py
@@ -143,6 +143,7 @@ class CoarseVersionMonotonicityTest(unittest.TestCase):
     check_coarse_version_monotonic(self, nuget.NuGet(), v1_str, v2_str)
 
   @given(packagist_version_strategy, packagist_version_strategy)
+  @example('0__1', '00')
   def test_packagist(self, v1_str, v2_str):
     check_coarse_version_monotonic(self, packagist.Packagist(), v1_str, v2_str)
 

--- a/osv/ecosystems/packagist.py
+++ b/osv/ecosystems/packagist.py
@@ -147,7 +147,7 @@ class PackagistVersion:
     """
     if version.startswith('v'):
       version = version[1:]
-    replaced = re.sub('[-_+]', '.', version)
+    replaced = re.sub('[-_+.]+', '.', version)
     replaced = re.sub(r'([^\d.])(\d)', r'\1.\2', replaced)
     replaced = re.sub(r'(\d)([^\d.])', r'\1.\2', replaced)
     return replaced


### PR DESCRIPTION
Caught this failure on the coarse version fuzzing test.
Packagist versions collapse repeated separators into one. 