### PR TITLE
Add all CVSS scores and sources from NVD

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -251,6 +251,10 @@ func combineTwoOSVRecords(cve5 *osvschema.Vulnerability, nvd *osvschema.Vulnerab
 		}
 	}
 
+	if len(nvd.GetSeverity()) > 0 {
+		baseOSV.Severity = nvd.GetSeverity()
+	}
+
 	return baseOSV
 }
 

--- a/vulnfeeds/cmd/combine-to-osv/main_test.go
+++ b/vulnfeeds/cmd/combine-to-osv/main_test.go
@@ -379,6 +379,12 @@ func TestCombineTwoOSVRecords(t *testing.T) {
 				Package: &osvschema.Package{Name: "package-a"},
 			},
 		},
+		Severity: []*osvschema.Severity{
+			{
+				Type:  osvschema.Severity_CVSS_V3,
+				Score: "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N",
+			},
+		},
 	}
 
 	nvd := &osvschema.Vulnerability{
@@ -398,6 +404,12 @@ func TestCombineTwoOSVRecords(t *testing.T) {
 				Package: &osvschema.Package{Name: "package-b"},
 			},
 		},
+		Severity: []*osvschema.Severity{
+			{
+				Type:  osvschema.Severity_CVSS_V3,
+				Score: "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:L/A:N",
+			},
+		},
 	}
 
 	expected := &osvschema.Vulnerability{
@@ -411,6 +423,12 @@ func TestCombineTwoOSVRecords(t *testing.T) {
 		},
 		// pickAffectedInformation prefers nvd if it has more packages
 		Affected: nvd.GetAffected(),
+		Severity: []*osvschema.Severity{ // Should take severity from NVD
+			{
+				Type:  osvschema.Severity_CVSS_V3,
+				Score: "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:L/A:N",
+			},
+		},
 	}
 
 	got := combineTwoOSVRecords(cve5, nvd)

--- a/vulnfeeds/cmd/converters/alpine/main.go
+++ b/vulnfeeds/cmd/converters/alpine/main.go
@@ -202,7 +202,7 @@ func generateAlpineOSV(allAlpineSecDb map[string][]VersionAndPkg, allCVEs map[mo
 			continue
 		}
 		if cve.CVE.Metrics != nil {
-			v.AddSeverity(cve.CVE.Metrics)
+			v.AddSingleSeverity(cve.CVE.Metrics)
 		}
 
 		osvVulnerabilities = append(osvVulnerabilities, v)

--- a/vulnfeeds/cmd/converters/debian/main.go
+++ b/vulnfeeds/cmd/converters/debian/main.go
@@ -123,7 +123,7 @@ func generateOSVFromDebianTracker(debianData DebianSecurityTrackerData, debianRe
 					},
 				}
 				if currentNVDCVE.CVE.Metrics != nil {
-					v.AddSeverity(currentNVDCVE.CVE.Metrics)
+					v.AddSingleSeverity(currentNVDCVE.CVE.Metrics)
 				}
 
 				osvCves[cveID] = v

--- a/vulnfeeds/cmd/converters/debian/main_test.go
+++ b/vulnfeeds/cmd/converters/debian/main_test.go
@@ -143,7 +143,7 @@ func TestGenerateOSVFromDebianTracker(t *testing.T) {
 					},
 				},
 				References: []*osvschema.Reference{{Type: osvschema.Reference_ADVISORY, Url: "https://security-tracker.debian.org/tracker/CVE-2016-1585"}},
-				Severity:   []*osvschema.Severity{{Type: osvschema.Severity_CVSS_V3, Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}},
+				Severity:   []*osvschema.Severity{{Type: osvschema.Severity_CVSS_V3, Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", Source: "nvd@nist.gov"}},
 			},
 		},
 		"CVE-2017-6507": {
@@ -192,7 +192,7 @@ func TestGenerateOSVFromDebianTracker(t *testing.T) {
 					},
 				},
 				References: []*osvschema.Reference{{Type: osvschema.Reference_ADVISORY, Url: "https://security-tracker.debian.org/tracker/CVE-2017-6507"}},
-				Severity:   []*osvschema.Severity{{Type: osvschema.Severity_CVSS_V3, Score: "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N"}},
+				Severity:   []*osvschema.Severity{{Type: osvschema.Severity_CVSS_V3, Score: "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N", Source: "nvd@nist.gov"}},
 			},
 		},
 	}

--- a/vulnfeeds/vulns/vulns_test.go
+++ b/vulnfeeds/vulns/vulns_test.go
@@ -414,8 +414,9 @@ func TestAddSeverity(t *testing.T) {
 			inputCVE:    loadTestData2("CVE-2022-34668"),
 			expectedResult: []*osvschema.Severity{
 				{
-					Type:  osvschema.Severity_CVSS_V3,
-					Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					Type:   osvschema.Severity_CVSS_V3,
+					Score:  "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+					Source: "psirt@nvidia.com",
 				},
 			},
 		},
@@ -424,8 +425,25 @@ func TestAddSeverity(t *testing.T) {
 			inputCVE:    loadTestData2("CVE-2023-5341"),
 			expectedResult: []*osvschema.Severity{
 				{
-					Type:  osvschema.Severity_CVSS_V3,
-					Score: "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+					Type:   osvschema.Severity_CVSS_V3,
+					Score:  "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+					Source: "secalert@redhat.com",
+				},
+			},
+		},
+		{
+			description: "CVE with Primary and Secondary CVSS information",
+			inputCVE:    loadTestData2("CVE-2022-36037"),
+			expectedResult: []*osvschema.Severity{
+				{
+					Type:   osvschema.Severity_CVSS_V3,
+					Score:  "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N",
+					Source: "nvd@nist.gov",
+				},
+				{
+					Type:   osvschema.Severity_CVSS_V3,
+					Score:  "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:L/A:N",
+					Source: "security-advisories@github.com",
 				},
 			},
 		},


### PR DESCRIPTION
Hello - just opening this as a suggestion as something I would find highly useful! Am very interested in discussing anything further.

* Note: This PR is dependent on the following change to the OSV schema (addition of a `severity[].source` field): https://github.com/ossf/osv-schema/pull/510

* Certain data sources, such as NVD and the CVE Program, provide multiple CVSS scores in their records that come from different providers or are different CVSS versions.

* This PR adds all of the available CVSS scores from the NVD record, into the severity object, rather than just a single CVSS score. The sources of the CVSS scores are also added into the OSV record, taken from the `Source` field that is provided in the NVD record.

* Including all the available CVSS scores in the OSV record, along with their source, allows consumers of the data to know who issued the score (e.g. NVD or the CNA), as well as being able to choose between them. For example, a consumer may have a preference for scores issued by NVD or the CNA, or they may wish to use a specific CVSS version for better comparability with other vulnerabilities.

* One CVSS score continues to be selected for the Debian and Alpine records.

* In the NVD and CVE5 combining process, the severities are taken from the NVD record (if it has at least 1 severity). Perhaps instead the severities and their sources should be taken from CVE5, and then add any NVD-issued severity on top of that?