### PR TITLE
fix(workflows): add GOTOOLCHAIN=auto env var

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -38,6 +38,8 @@ jobs:
   lint:
     name: Lint and format
     runs-on: ubuntu-latest
+    env:
+        GOTOOLCHAIN: auto
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
The renovate PRs can't seem to update the go version and run the lints because the Go binary is cached? This should allow go to download the correct tool chain at runtime maybe