### PR TITLE
fix(workflows): add GOTOOLCHAIN=auto env var, again...

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -38,8 +38,6 @@ jobs:
   lint:
     name: Lint and format
     runs-on: ubuntu-latest
-    env:
-        GOTOOLCHAIN: auto
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -58,4 +56,6 @@ jobs:
       - name: Set up terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
       - name: Run pylint and yapf, go vet
+        env:
+          GOTOOLCHAIN: auto
         run: poetry run ./tools/lint_and_format.sh


### PR DESCRIPTION
#4755 the job-level `env` seems to be getting overwritten - set the `env` at the step-level