### PR TITLE
feat: add batch query cassette for commit 17b30e96

### DIFF
--- a/tools/apitester/__snapshots__/cassette_batch_query.snap
+++ b/tools/apitester/__snapshots__/cassette_batch_query.snap
@@ -1,0 +1,36 @@
+
+[Test/cassette_batch_query/TestBatchQueryEndpoint/CommitQuery_protobuf - 1]
+{
+  "results": [
+    {
+      "vulns": [
+        {
+          "id": "CVE-2021-22569",
+          "modified": "<RFC3339 date with the year 2026>"
+        },
+        {
+          "id": "CVE-2022-3171",
+          "modified": "<RFC3339 date with the year 2026>"
+        },
+        {
+          "id": "CVE-2022-3509",
+          "modified": "<RFC3339 date with the year 2026>"
+        },
+        {
+          "id": "CVE-2022-3510",
+          "modified": "<RFC3339 date with the year 2026>"
+        },
+        {
+          "id": "CVE-2024-2410",
+          "modified": "<RFC3339 date with the year 2025>"
+        },
+        {
+          "id": "CVE-2024-7254",
+          "modified": "<RFC3339 date with the year 2026>"
+        }
+      ]
+    }
+  ]
+}
+
+---

--- a/tools/apitester/testdata/cassettes/batch_query.yaml
+++ b/tools/apitester/testdata/cassettes/batch_query.yaml
@@ -1,0 +1,12 @@
+---
+version: 2
+interactions:
+- request:
+    host: api.osv.dev
+    body: |
+      { "queries": [ { "commit": "17b30e96476be70b8773b2b807bab857fd3ceb39" } ] }
+    headers:
+      X-Test-Name:
+        - TestBatchQueryEndpoint/CommitQuery_protobuf
+    url: https://api.osv.dev/v1/querybatch
+    method: POST


### PR DESCRIPTION
This PR adds a new batch query cassette to the `apitester` tool to test the commit `17b30e96476be70b8773b2b807bab857fd3ceb39` and captures the current API behavior in a snapshot.

This allows us make commit queries be cassetted in osv-scanner.

---
*PR created automatically by Jules for task [1576992968096852083](https://jules.google.com/task/1576992968096852083) started by @another-rex*