### PR TITLE
fix: add `directory_path` to V8 source

### DIFF
--- a/source.yaml
+++ b/source.yaml
@@ -564,6 +564,7 @@
   versions_from_repo: True
   type: 0
   ignore_patterns: [ '^(?!V8-advisory).*$' ]
+  directory_path: 'advisories'
   repo_url: 'https://github.com/google/chromium-policy-vulnfeed.git'
   detect_cherrypicks: False
   consider_all_branches: True

--- a/source_test.yaml
+++ b/source_test.yaml
@@ -608,6 +608,7 @@
   versions_from_repo: True
   type: 0
   ignore_patterns: [ '^(?!V8-advisory).*$' ]
+  directory_path: 'advisories'
   repo_url: 'https://github.com/google/chromium-policy-vulnfeed.git'
   detect_cherrypicks: False
   consider_all_branches: True


### PR DESCRIPTION
[The V8 advisory file is in the `advisories` folder](https://github.com/google/chromium-policy-vulnfeed/tree/main/advisories).
Adding this so we don't need to solely rely on the negative lookahead (unsupported in go's regex) in `ignore_patterns` to be able to filter out non osv json files.