### PR TITLE
fix: don't sample traces on the exporter

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/exporter.yaml
+++ b/deployment/clouddeploy/gke-workers/base/exporter.yaml
@@ -33,5 +33,5 @@ spec:
                 memory: "64Gi"
             env:
               - name: TRACE_SAMPLE_RATE
-                value: "1.0"
+                value: "0.0"
           restartPolicy: Never


### PR DESCRIPTION
It generates a new sub-span for every GCS upload, which is too many