### PR TITLE
fix(ui): prevent severity CVSS vector strings from overflowing viewport

### DIFF
--- a/gcp/website/frontend3/src/styles.scss
+++ b/gcp/website/frontend3/src/styles.scss
@@ -1270,7 +1270,6 @@ osv-tabs.vulnerability-packages[affordance="collapse"] {
   .severity {
     padding: 0;
     font-family: $osv-heading-font-family;
-    overflow-wrap: anywhere;
   }
 }
 


### PR DESCRIPTION
Fixes an overflow that happens on long severity strings (e.g. [ALPINE-CVE-2026-1642](https://osv.dev/vulnerability/ALPINE-CVE-2026-1642))