### PR TITLE
fix: attach error reporting directly to logs; sourceLocation

### DIFF
--- a/deployment/terraform/modules/osv/gcp_apis.tf
+++ b/deployment/terraform/modules/osv/gcp_apis.tf
@@ -103,9 +103,3 @@ resource "google_project_service" "certificate_manager" {
   service            = "certificatemanager.googleapis.com"
   disable_on_destroy = false
 }
-
-resource "google_project_service" "error_reporting" {
-  project            = var.project_id
-  service            = "clouderrorreporting.googleapis.com"
-  disable_on_destroy = false
-}

--- a/go/go.mod
+++ b/go/go.mod
@@ -4,7 +4,6 @@ go 1.26.0
 
 require (
 	cloud.google.com/go/datastore v1.22.0
-	cloud.google.com/go/errorreporting v0.4.0
 	cloud.google.com/go/monitoring v1.24.3
 	cloud.google.com/go/pubsub/v2 v2.4.0
 	cloud.google.com/go/storage v1.60.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -11,8 +11,6 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 cloud.google.com/go/datastore v1.22.0 h1:FOyx2Ag6ibD2wFkz9S8EiNrmBugia8pQOfpyJxi2yqA=
 cloud.google.com/go/datastore v1.22.0/go.mod h1:aopSX+Whx0lHspWWBj+AjWt68/zjYsPfDe3LjWtqZg8=
-cloud.google.com/go/errorreporting v0.4.0 h1:uLcasn2hKpj6iSPvHrzRjkJcaNVaKx8yKQcP3VTS6aI=
-cloud.google.com/go/errorreporting v0.4.0/go.mod h1:dZGEhqzdHZSRxxWLVjC3Ue5CVaROzvP58D9rU6zbBfw=
 cloud.google.com/go/iam v1.5.3 h1:+vMINPiDF2ognBJ97ABAYYwRgsaqxPbQDlMnbHMjolc=
 cloud.google.com/go/iam v1.5.3/go.mod h1:MR3v9oLkZCTlaqljW6Eb2d3HGDGK5/bDv93jhfISFvU=
 cloud.google.com/go/logging v1.13.1 h1:O7LvmO0kGLaHY/gq8cV7T0dyp6zJhYAOtZPX4TF3QtY=


### PR DESCRIPTION
Add a `@type` field to the error logs in Google cloud to send them to error reporting directly, instead of making a separate API call (see https://docs.cloud.google.com/error-reporting/docs/formatting-error-messages#log-text). This is what python was already doing.

Also, changed the `sourceLocation` field to the more complete key so it gets put into the top-level log instead of within the jsonPayload.