### PR TITLE
fix(linter): redirect linter if on prod to test

### DIFF
--- a/gcp/website/frontend_handlers.py
+++ b/gcp/website/frontend_handlers.py
@@ -220,6 +220,8 @@ def docs():
 
 @blueprint.route('/linter', strict_slashes=False)
 def linter():
+  if request.host_url == 'osv.dev':
+    return redirect(request.url.replace('osv.dev', 'test.osv.dev'), code=302)
   return render_template('linter.html')
 
 

--- a/gcp/website/linter_api.py
+++ b/gcp/website/linter_api.py
@@ -15,7 +15,7 @@
 
 import json
 import logging
-from flask import Blueprint, abort, jsonify
+from flask import Blueprint, abort, jsonify, redirect, request
 from google.cloud import storage
 
 blueprint = Blueprint('linter_api', __name__, url_prefix='/linter-findings')
@@ -23,6 +23,19 @@ blueprint = Blueprint('linter_api', __name__, url_prefix='/linter-findings')
 # TODO: Make this configurable if needed, but for now it matches linter.py
 LINTER_BUCKET = 'osv-test-public-import-logs'
 LINTER_PREFIX = 'linter-result/'
+
+
+@blueprint.before_request
+def redirect_to_test():
+  """Redirect requests from production to test site."""
+  if request.host == 'osv.dev':
+    return redirect(request.url.replace('osv.dev', 'test.osv.dev'), code=302)
+
+  if request.host == 'api.osv.dev':
+    return redirect(
+        request.url.replace('api.osv.dev', 'api.test.osv.dev'), code=302)
+
+  return None
 
 
 def _get_storage_client():


### PR DESCRIPTION
When people attempt the /linter-findings endpoint they are getting 403'ed. A better user journey is to be redirected to the test instance.