### PR TITLE
fix(ui): stop forcing the webpack vendor chunk output path

### DIFF
--- a/gcp/website/frontend3/webpack.dev.js
+++ b/gcp/website/frontend3/webpack.dev.js
@@ -24,7 +24,7 @@ module.exports = {
         vendorsJs: {
           test: /node_modules/,
           chunks: 'initial',
-          filename: 'static/vendors.js',
+          name: 'vendors',
           priority: 1,
           maxInitialRequests: 2,
           minChunks: 1,

--- a/gcp/website/frontend3/webpack.prod.js
+++ b/gcp/website/frontend3/webpack.prod.js
@@ -24,7 +24,7 @@ module.exports = {
         vendorsJs: {
           test: /node_modules/,
           chunks: 'initial',
-          filename: 'static/vendors.[contenthash].js',
+          name: 'vendors',
           priority: 1,
           maxInitialRequests: 2,
           minChunks: 1,


### PR DESCRIPTION
Currently, starting the local development web server in `gcp/website/frontend3` with `npm start` reaches this error:
```
<e> [webpack-dev-middleware] Error: Conflict: Multiple chunks emit assets to the same filename static/vendors.js (chunks vendorsJs-node_modules_mini-css-extract-plugin_dist_hmr_hotModuleReplacement_js-node_modules_-335b30 and vendorsJs-node_modules_hotwired_turbo_dist_turbo_es2017-esm_js-node_modules_github_clipboard--ac61ee)
<e>     at /home/timzh/osv.dev/gcp/website/frontend3/node_modules/webpack/lib/Compilation.js:5154:12
<e>     at /home/timzh/osv.dev/gcp/website/frontend3/node_modules/webpack/lib/Cache.js:98:34
<e>     at Array.<anonymous> (/home/timzh/osv.dev/gcp/website/frontend3/node_modules/webpack/lib/cache/MemoryCachePlugin.js:44:13)
<e>     at /home/timzh/osv.dev/gcp/website/frontend3/node_modules/webpack/lib/Cache.js:98:19
<e>     at Hook.eval [as callAsync] (eval at create (/home/timzh/osv.dev/gcp/website/frontend3/node_modules/tapable/lib/HookCodeFactory.js:31:10), <anonymous>:19:1)
<e>     at Cache.get (/home/timzh/osv.dev/gcp/website/frontend3/node_modules/webpack/lib/Cache.js:82:18)
<e>     at ItemCacheFacade.get (/home/timzh/osv.dev/gcp/website/frontend3/node_modules/webpack/lib/CacheFacade.js:115:15)
<e>     at /home/timzh/osv.dev/gcp/website/frontend3/node_modules/webpack/lib/Compilation.js:5096:22
<e>     at arrayEach (/home/timzh/osv.dev/gcp/website/frontend3/node_modules/neo-async/async.js:2405:9)
<e>     at Object.each (/home/timzh/osv.dev/gcp/website/frontend3/node_modules/neo-async/async.js:2846:9)
```

The issue as I understand it is that webpack tries to write to the same vendor.js file twice independently.

I think ed504ac introduced the issue when it added a second entry point: https://github.com/google/osv.dev/commit/ed504acf4da7f029e94b62ef72d95aa472761eae#diff-9f8239968359c3509ed79cdc472a92a08b4aea2446077d8cd8453fcb59ffd711R11.

Using `name` groups by a logical ID. It doesn't change any build artifacts' paths, so shouldn't affect the frontend's deployment, I think.