### PR TITLE
fix: experiment with gcloud auth token command

### DIFF
--- a/deployment/terraform/modules/osv/scripts/gcloud_build_image
+++ b/deployment/terraform/modules/osv/scripts/gcloud_build_image
@@ -102,7 +102,7 @@ tempdir="$(mktemp -d /tmp/docker.XXXXXX)"
 cd "${tempdir}"
 
 # Be careful about exposing the access token.
-access_token="$(gcloud auth print-access-token)"
+access_token="$(gcloud auth application-default print-access-token)"
 curl --fail -o "service.json" -H @- \
   "https://servicemanagement.googleapis.com/v1/services/${SERVICE}/configs/${CONFIG_ID}?view=FULL" <<EOF || error_exit "Failed to download service config"
 Authorization: Bearer ${access_token}


### PR DESCRIPTION
The previous way of getting access token via `gcloud auth print-access-token` generates a token associated with the gcloud sdk client ID. This works fine if the client credentials are synced to ADC (with `gcloud auth login --update-adc`) 

But if we do:
```
gcloud auth login 
gcloud auth application-default login
```
The two credentials will be different, and in this case the application default credential should be used. 

This PR is also trying to test if the fix will have unexpected consequences.
