### PR TITLE
docs: update CONTRIBUTING.md to split frontend/backend and add emulator info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,7 @@ make run-website
 
 #### Running a local UI instance
 
-For non-internal contributors, you can use the website emulator which does
+For contributors without access to the GCP project, you can use the website emulator which does
 not require Google Cloud project access. This emulator uses a local datastore
 and loads data from a local directory.
 


### PR DESCRIPTION
Updated CONTRIBUTING.md to improve the contributor experience by separating frontend and backend development instructions and providing information on how to use the website emulator for local testing without GCP credentials.
- Split "Contributing code" into "Backend development" and "Frontend development".
- Add instructions for non-internal contributors to use `make run-website-emulator`.
- Mention adding testcase records to `gcp/website/testdata/osv/` for testing edge cases.
- Fix a minor typo in the API server section.

Closes #1427

---
*PR created automatically by Jules for task [4582872313076138700](https://jules.google.com/task/4582872313076138700) started by @jess-lowe*
