### PR TITLE
fix(vulnfeeds): Cache patch

### DIFF
--- a/vulnfeeds/cves/versions.go
+++ b/vulnfeeds/cves/versions.go
@@ -1133,7 +1133,7 @@ func ReposFromReferences(cache *VPRepoCache, vp *VendorProduct, refs []models.Re
 			continue
 		}
 		repos = append(repos, repo)
-		// cache.MaybeUpdate(vp, repo) // TODO: fix this so that only relevant repos to the project are added to cache 
+		// cache.MaybeUpdate(vp, repo) // TODO: fix this so that only relevant repos to the project are added to cache
 	}
 	if len(repos) == 0 {
 		return repos


### PR DESCRIPTION
Sometimes vendor product combinations in the VPRepoCache are given "successful" repos in its cache that are unrelated to the project. I believe this is to do with how larger projects that are affected by the vuln (like Debian/RH etc) are also added to the record. 

With the cache, if a record earlier on resolves a repo, but saves it to a Vendor Product that is unrelated, this might cause a bad cache entry.

This unfortunately might slow things down but its better than bad misses.