### PR TITLE
fix: Make update channel not use Any because we don't need to

### DIFF
--- a/go/cmd/relations/update.go
+++ b/go/cmd/relations/update.go
@@ -242,8 +242,6 @@ ConsumerLoop:
 		}
 		logger.Info("updated vuln", slog.String("id", id))
 	}
-
-	return
 }
 
 func (u *Updater) Finish() {


### PR DESCRIPTION
Also moved the loop out becasue it was breaking my brain. This part is in a separate commit to make it easier to review.

Tests still pass, though I might have missed something obvious.