### PR TITLE
fix(vulnfeeds): reduce # workers until external repo calls reduced

### DIFF
--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/nvd-cve-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/nvd-cve-osv.yaml
@@ -19,4 +19,4 @@ spec:
             - name: OSV_OUTPUT_GCS_PATH
               value: gs://osv-test-cve-osv-conversion/nvd-osv
             - name: NUM_WORKERS
-              value: "10"
+              value: "1"

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/nvd-cve-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/nvd-cve-osv.yaml
@@ -19,4 +19,4 @@ spec:
             - name: OSV_OUTPUT_GCS_PATH
               value: gs://cve-osv-conversion/nvd-osv
             - name: NUM_WORKERS
-              value: "10"
+              value: "1"


### PR DESCRIPTION
NVD conversion is giving frequently bad results due to getting 429ed with the parallel calls. Setting number of workers to 1 until we can reduce the number of calls or gitter is at a stage we can query. 