### PR TITLE
ci: rename "pr title check" workflow and job

### DIFF
--- a/.github/workflows/title.yml
+++ b/.github/workflows/title.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: OSV PR format check
+name: Title
 
 on:
   # `pull_request_target` is only required when editing PRs from forks.


### PR DESCRIPTION
[I did this a while back for osv-scanner](https://github.com/google/osv-scanner/pull/2527) so might as well do it here too:

> Maybe it's just me but I always get this workflow file confused with the `checks` one. I've also adjusted the names so that they (imo) present a bit clearer - they should show up as "Title / check" rather than "OSV PR format check / Validate PR title"