### PR TITLE
fix(importer): use the correct field for modified times for GCS

### DIFF
--- a/go/internal/importer/bucket.go
+++ b/go/internal/importer/bucket.go
@@ -53,7 +53,7 @@ func handleImportBucket(ctx context.Context, ch chan<- WorkItem, config Config, 
 			return err
 		}
 		if hasUpdateTime {
-			if obj.Attrs.Updated.Before(lastUpdated) || obj.Attrs.Updated.Equal(lastUpdated) {
+			if obj.Attrs.Modified.Before(lastUpdated) || obj.Attrs.Modified.Equal(lastUpdated) {
 				continue
 			}
 		}

--- a/go/internal/importer/bucket_test.go
+++ b/go/internal/importer/bucket_test.go
@@ -53,7 +53,7 @@ func TestHandleImportBucket(t *testing.T) {
 	_ = mockBucket.WriteObject(ctx, "a/b/equal.json", []byte(`{}`), &clients.WriteOptions{})
 	// Read the lastUpdated time from the mock object's time.Now() call.
 	attrs, _ := mockBucket.ReadObjectAttrs(ctx, "a/b/equal.json")
-	lastUpdated := attrs.Updated
+	lastUpdated := attrs.Modified
 	// Now write a newer one (after lastUpdated)
 	time.Sleep(50 * time.Millisecond)
 	_ = mockBucket.WriteObject(ctx, "a/b/newer.json", []byte(`{}`), &clients.WriteOptions{})

--- a/go/osv/clients/cloudstorage.go
+++ b/go/osv/clients/cloudstorage.go
@@ -50,8 +50,8 @@ type Attrs struct {
 	CustomTime time.Time
 	// CRC32C is the CRC32 checksum of the object, using the Castagnoli93 polynomial.
 	CRC32C uint32
-	// Updated is the time the object was last updated.
-	Updated time.Time
+	// Modified is the time the object was last modified.
+	Modified time.Time
 }
 
 // Object represents a storage object and its metadata.

--- a/go/osv/clients/gcs_client.go
+++ b/go/osv/clients/gcs_client.go
@@ -89,7 +89,7 @@ func (c *GCSClient) ReadObjectAttrs(ctx context.Context, path string) (*Attrs, e
 		Generation: attrs.Generation,
 		CustomTime: attrs.CustomTime,
 		CRC32C:     attrs.CRC32C,
-		Updated:    attrs.Updated,
+		Modified:   attrs.Created,
 	}, nil
 }
 

--- a/go/testutils/gcs.go
+++ b/go/testutils/gcs.go
@@ -69,7 +69,7 @@ func (c *MockStorage) ReadObjectAttrs(_ context.Context, path string) (*clients.
 		Generation: obj.generation,
 		CustomTime: obj.customTime,
 		CRC32C:     obj.crc32c,
-		Updated:    obj.updated,
+		Modified:   obj.updated,
 	}, nil
 }
 
@@ -143,7 +143,7 @@ func (c *MockStorage) Objects(_ context.Context, prefix string) iter.Seq2[*clien
 					Generation: obj.generation,
 					CustomTime: obj.customTime,
 					CRC32C:     obj.crc32c,
-					Updated:    obj.updated,
+					Modified:   obj.updated,
 				},
 			}
 			if !yield(o, nil) {


### PR DESCRIPTION
Turns out, the GCS `Updated` field is *only* for the metadata, and if that's not specifically written then it's set to the 0 value.
`Created` is what we actually want. I renamed the field in the wrapper the `Modified` which might be less ambiguous.