### PR TITLE
fix(vulnfeeds): combine-2-osv panic with range 0

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -357,6 +357,7 @@ func pickAffectedInformation(cve5Affected []*osvschema.Affected, nvdAffected []*
 		if len(b.GetRanges()) > 0 {
 			repoB = b.GetRanges()[0].GetRepo()
 		}
+
 		return cmp.Compare(repoA, repoB)
 	})
 


### PR DESCRIPTION
If there's no boundary version, there's a panic on an empty array.