### PR TITLE
fix: reset security context

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/workers.yaml
+++ b/deployment/clouddeploy/gke-workers/base/workers.yaml
@@ -36,6 +36,8 @@ spec:
         env:
           - name: GITTER_HOST
             value: http://gitter-service:8888
+        securityContext:
+          privileged: true
         resources:
           requests:
             cpu: 1


### PR DESCRIPTION
This is not really needed, as we can remove most oss-fuzz code, but for safety going to revert this change temporarily before the release.