### PR TITLE
fix(vulnfeeds): ignore empty reference URLs in nvd conversion

### DIFF
--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -686,6 +686,10 @@ func ClassifyReferences(refs []models.Reference) []*osvschema.Reference {
 	bestTypes := make(map[string]osvschema.Reference_Type)
 
 	for _, ref := range refs {
+		if ref.URL == "" {
+			continue
+		}
+
 		if len(ref.Tags) > 0 {
 			for _, tag := range ref.Tags {
 				refType := ClassifyReferenceLink(ref.URL, tag)

--- a/vulnfeeds/vulns/vulns_test.go
+++ b/vulnfeeds/vulns/vulns_test.go
@@ -139,6 +139,19 @@ func TestClassifyReferences(t *testing.T) {
 				{Url: "http://www.openwall.com/lists/oss-security/2023/07/20/1", Type: osvschema.Reference_ARTICLE},
 			},
 		},
+		{
+			refData: []models.Reference{
+				{
+					Source: "https://example.com/some/valid/link", URL: "https://example.com/some/valid/link", Tags: []string{"mailing-list"},
+				},
+				{
+					Source: "https://example.com/some/invalid/link", URL: "", Tags: []string{"mailing-list"},
+				},
+			},
+			references: []*osvschema.Reference{
+				{Url: "https://example.com/some/valid/link", Type: osvschema.Reference_ARTICLE},
+			},
+		},
 	}
 	for _, tc := range testcases {
 		references := ClassifyReferences(tc.refData)


### PR DESCRIPTION
Update `ClassifyReferences` in `vulnfeeds/vulns/vulns.go` to explicitly skip references that have a blank/empty URL before categorizing them. This prevents the output from containing blank reference objects that lack a valid URL. Also added a test case in `vulns_test.go` to verify this behavior.