### PR TITLE
fix(website): correct external nav link targets

### DIFF
--- a/gcp/website/frontend3/src/base.html
+++ b/gcp/website/frontend3/src/base.html
@@ -62,10 +62,10 @@
           <a href="{{ url_for('frontend_handlers.blog') }}">Blog</a>
         </li>
         <li class="{{ 'active' if active_section == 'faq' else '' }} page-link external-link">
-          <a href="https://google.github.io/osv.dev/faq/" target=”_blank” >FAQ</a>
+          <a href="https://google.github.io/osv.dev/faq/" target="_blank">FAQ</a>
         </li>
         <li class="{{ 'active' if active_section == 'docs' else '' }} page-link external-link">
-          <a href="https://google.github.io/osv.dev/" target=”_blank” >Docs</a>
+          <a href="https://google.github.io/osv.dev/" target="_blank">Docs</a>
         </li>
         
         <ul class="push social-icons">


### PR DESCRIPTION
The target attributes in the website header were using curly quotes instead of normal ones which made the new tab behavior broken (both links would open in the same new tab).