### PR TITLE
fix: set CustomTime when writing relations

### DIFF
--- a/go/cmd/relations/update.go
+++ b/go/cmd/relations/update.go
@@ -222,6 +222,7 @@ ConsumerLoop:
 		}
 		opts := &clients.WriteOptions{
 			IfGenerationMatches: &attrs.Generation,
+			CustomTime:          &modified,
 		}
 		if err := u.gcsClient.WriteObject(ctx, path, newData, opts); err != nil {
 			logger.Error("failed to write vuln to GCS", slog.String("id", id), slog.Any("err", err))


### PR DESCRIPTION
This was basically doubling the amount of work the workers had to do, since the record checker uses this field to see if the modified in GCS matches datastore 🤦 

i.e.
- A record gets ingested
- The relations job computes new upstream/alias/related fields
- It uploads the record with computed fields to GCS (but does not set the CustomTime field)
- The record-checker runs. It compares the CustomTime field (empty) with the modified field in the Vulnerability datastore entity
- Since they don't match, it sends a `gcs_mismatch` task to the recoverer
- The recoverer picks up the `gcs_mismatch` task, and sends a reimport job to the worker
- (since the alias/upstream/related have already been computed, this isn't an infinite loop)