### PR TITLE
fix: skip vulnerabilities with empty affected ranges in combine-to-osv

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -370,6 +370,7 @@ func hasRanges(affected []*osvschema.Affected) bool {
 			return true
 		}
 	}
+
 	return false
 }
 

--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -191,7 +191,7 @@ func combineIntoOSV(cve5osv map[models.CVEID]*osvschema.Vulnerability, nvdosv ma
 			baseOSV = cve5
 		}
 
-		if len(baseOSV.GetAffected()) == 0 {
+		if len(baseOSV.GetAffected()) == 0 || !hasRanges(baseOSV.GetAffected()) {
 			// check if part exists.
 			if !slices.Contains(mandatoryCVEIDs, string(cveID)) {
 				continue
@@ -202,7 +202,7 @@ func combineIntoOSV(cve5osv map[models.CVEID]*osvschema.Vulnerability, nvdosv ma
 
 	// Add any remaining CVEs from NVD that were not in the advisory data.
 	for cveID, nvd := range nvdosv {
-		if len(nvd.GetAffected()) == 0 {
+		if len(nvd.GetAffected()) == 0 || !hasRanges(nvd.GetAffected()) {
 			continue
 		}
 		osvRecords[cveID] = nvd
@@ -362,6 +362,15 @@ func pickAffectedInformation(cve5Affected []*osvschema.Affected, nvdAffected []*
 	})
 
 	return combinedAffected
+}
+
+func hasRanges(affected []*osvschema.Affected) bool {
+	for _, a := range affected {
+		if len(a.GetRanges()) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // getRangeBoundaryVersions extracts the introduced and fixed versions from a slice of OSV events.

--- a/vulnfeeds/cmd/combine-to-osv/main_test.go
+++ b/vulnfeeds/cmd/combine-to-osv/main_test.go
@@ -49,8 +49,8 @@ func TestCombineIntoOSV(t *testing.T) {
 	// CVE-2023-0002: from nvd only
 	// CVE-2023-0003: from cve5, no affected, but in noPkgCVEs
 	// CVE-2023-0004: from cve5, no affected, not in noPkgCVEs, so skipped
-	if len(combined) != 4 {
-		t.Errorf("Expected 4 combined vulnerabilities, got %d", len(combined))
+	if len(combined) != 2 {
+		t.Errorf("Expected 2 combined vulnerabilities, got %d", len(combined))
 	}
 
 	// Test case 1: Merged CVE
@@ -109,22 +109,22 @@ func TestCombineIntoOSV(t *testing.T) {
 		t.Errorf("CVE-2023-1234: affected range mismatch (-want +got):\n%s", diff)
 	}
 
-	// Test case 2: CVE only in cve5
-	if _, ok = combined["CVE-2023-0001"]; !ok {
-		t.Error("Expected combined map to contain CVE-2023-0001")
+	// Test case 2: CVE only in cve5 (has no ranges, so it should be skipped)
+	if _, ok = combined["CVE-2023-0001"]; ok {
+		t.Error("Expected combined map to NOT contain CVE-2023-0001 because it has no ranges")
 	}
 
-	// Test case 3: CVE only in nvd
-	if _, ok = combined["CVE-2023-0002"]; !ok {
-		t.Error("Expected combined map to contain CVE-2023-0002")
+	// Test case 3: CVE only in nvd (has no ranges, so it should be skipped)
+	if _, ok = combined["CVE-2023-0002"]; ok {
+		t.Error("Expected combined map to NOT contain CVE-2023-0002 because it has no ranges")
 	}
 
-	// Test case 4: No affected, in noPkgCVEs
+	// Test case 4: No ranges, in noPkgCVEs (should be kept)
 	if _, ok = combined["CVE-2023-0003"]; !ok {
 		t.Error("Expected combined map to contain CVE-2023-0003")
 	}
 
-	// Test case 5: No affected, not in noPkgCVEs
+	// Test case 5: No ranges, not in noPkgCVEs (should be skipped)
 	if _, ok = combined["CVE-2023-0004"]; ok {
 		t.Error("Expected combined map to NOT contain CVE-2023-0004")
 	}


### PR DESCRIPTION
Added a helper `hasRanges` to ensure that vulnerabilities missing ranges in their `affected` blocks are skipped and not uploaded unless they are explicitly included in the `mandatoryCVEIDs` slice. Also updated `main_test.go` to assert this new logic correctly.

deals with https://osv.dev/vulnerability/CVE-2024-2002 having no ranges