### PR TITLE
fix: introduced isn't required

### DIFF
--- a/vulnfeeds/conversion/common.go
+++ b/vulnfeeds/conversion/common.go
@@ -231,7 +231,7 @@ func GitVersionsToCommits(versionRanges []*osvschema.Range, repos []string, metr
 				metrics.AddNote("error resolving version to commit - %s - %s", lastAffected, err)
 			}
 
-			if introducedCommit != "" && (fixedCommit != "" || lastAffectedCommit != "") {
+			if fixedCommit != "" || lastAffectedCommit != "" {
 				var newVR *osvschema.Range
 
 				if fixedCommit != "" {


### PR DESCRIPTION
This was causing records whose introduced tag doesn't resolve but their fixed tag resolving to just give unresolved ranges instead of setting introduced to 0

Example:
https://api.osv.dev/v1/vulns/CVE-2024-2002 -> 0.1.0 doesnt resolve a commit because it doesnt exist on the repo for some reason, but 0.9.2 does resolve a commit. therefore introduced = "" and it doesnt save the 0.9.2 commit that was extracted