### PR TITLE
feat: update ConversionOutcome to output as string in JSON

### DIFF
--- a/vulnfeeds/models/metrics.go
+++ b/vulnfeeds/models/metrics.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 
@@ -36,8 +37,33 @@ var RefTagDenyList = []string{
 	"Broken Link", // Actively ignore these.
 }
 
+var conversionOutcomeStrings = [...]string{
+	"ConversionUnknown", "Successful", "Rejected", "NoSoftware", "NoRepos", "NoCommitRanges", "NoRanges", "FixUnresolvable", "Error",
+}
+
 func (c ConversionOutcome) String() string {
-	return [...]string{"ConversionUnknown", "Successful", "Rejected", "NoSoftware", "NoRepos", "NoCommitRanges", "NoRanges", "FixUnresolvable", "Error"}[c]
+	if int(c) >= 0 && int(c) < len(conversionOutcomeStrings) {
+		return conversionOutcomeStrings[c]
+	}
+	return fmt.Sprintf("ConversionOutcome(%d)", c)
+}
+
+func (c ConversionOutcome) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.String())
+}
+
+func (c *ConversionOutcome) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	for i, val := range conversionOutcomeStrings {
+		if val == s {
+			*c = ConversionOutcome(i)
+			return nil
+		}
+	}
+	return fmt.Errorf("invalid ConversionOutcome %q", s)
 }
 
 // ConversionMetrics holds the collected data about the conversion process for a single CVE.

--- a/vulnfeeds/models/metrics.go
+++ b/vulnfeeds/models/metrics.go
@@ -47,7 +47,7 @@ func (c ConversionOutcome) String() string {
 		return conversionOutcomeStrings[c]
 	}
 
-	return fmt.Sprintf("ConversionOutcome(%d)", c)
+	return conversionOutcomeStrings[ConversionUnknown]
 }
 
 func (c ConversionOutcome) MarshalJSON() ([]byte, error) {

--- a/vulnfeeds/models/metrics.go
+++ b/vulnfeeds/models/metrics.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
 )
 
+//nolint:recvcheck
 type ConversionOutcome int
 
 const (
@@ -53,7 +54,6 @@ func (c ConversionOutcome) MarshalJSON() ([]byte, error) {
 	return json.Marshal(c.String())
 }
 
-//nolint:recvcheck // UnmarshalJSON requires a pointer receiver
 func (c *ConversionOutcome) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {

--- a/vulnfeeds/models/metrics.go
+++ b/vulnfeeds/models/metrics.go
@@ -45,6 +45,7 @@ func (c ConversionOutcome) String() string {
 	if int(c) >= 0 && int(c) < len(conversionOutcomeStrings) {
 		return conversionOutcomeStrings[c]
 	}
+
 	return fmt.Sprintf("ConversionOutcome(%d)", c)
 }
 
@@ -52,6 +53,7 @@ func (c ConversionOutcome) MarshalJSON() ([]byte, error) {
 	return json.Marshal(c.String())
 }
 
+//nolint:recvcheck // UnmarshalJSON requires a pointer receiver
 func (c *ConversionOutcome) UnmarshalJSON(b []byte) error {
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
@@ -60,9 +62,11 @@ func (c *ConversionOutcome) UnmarshalJSON(b []byte) error {
 	for i, val := range conversionOutcomeStrings {
 		if val == s {
 			*c = ConversionOutcome(i)
+
 			return nil
 		}
 	}
+
 	return fmt.Errorf("invalid ConversionOutcome %q", s)
 }
 


### PR DESCRIPTION
This implements the json.Marshaler and json.Unmarshaler interfaces for the `ConversionOutcome` enum so that the `outcome` field in the `ConversionMetrics` output shows the string value (e.g. "Successful") instead of its integer value.

This makes it easier to read what caused a failure in the metrics output