### PR TITLE
fix: markdown exception causing website 500

### DIFF
--- a/gcp/website/frontend_handlers.py
+++ b/gcp/website/frontend_handlers.py
@@ -901,7 +901,7 @@ def markdown(text):
       # space rather than %2B
       # See: https://github.com/trentm/python-markdown2/issues/621
       md = _URL_MARKDOWN_REPLACER.sub(r'\1/+/\3', md)
-      # Removes empty anchor tags that cause visual artifacts 
+      # Removes empty anchor tags that cause visual artifacts
       # in rendered markdown
       # See: https://github.com/google/osv.dev/issues/4237
       md = _ANCHOR_TAG_REPLACER.sub('', md)


### PR DESCRIPTION
If markdown rendering fails due to an exception in the underlying library, we should just return the raw markdown text rather than 500ing

Currently record: GHSA-9rp6-23gf-4c3h