### PR TITLE
feat: log successful uploads in combine-to-osv

### DIFF
--- a/vulnfeeds/upload/cveworker.go
+++ b/vulnfeeds/upload/cveworker.go
@@ -41,6 +41,7 @@ func writeToDisk(v *osvschema.Vulnerability, preModifiedBuf []byte, outputPrefix
 		logger.Error("Failed to write OSV file", slog.Any("err", err), slog.String("path", filePath))
 		return false
 	}
+
 	return true
 }
 

--- a/vulnfeeds/upload/cveworker.go
+++ b/vulnfeeds/upload/cveworker.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -32,17 +33,19 @@ const (
 )
 
 // writeToDisk writes the vulnerability to a local file.
-func writeToDisk(v *osvschema.Vulnerability, preModifiedBuf []byte, outputPrefix string) {
+func writeToDisk(v *osvschema.Vulnerability, preModifiedBuf []byte, outputPrefix string) bool {
 	filename := v.GetId() + ".json"
 	filePath := path.Join(outputPrefix, filename)
 	err := os.WriteFile(filePath, preModifiedBuf, 0600)
 	if err != nil {
 		logger.Error("Failed to write OSV file", slog.Any("err", err), slog.String("path", filePath))
+		return false
 	}
+	return true
 }
 
 // uploadToGCS uploads the vulnerability to a GCS bucket.
-func uploadToGCS(ctx context.Context, v *osvschema.Vulnerability, preModifiedBuf []byte, outBkt *storage.BucketHandle, outputPrefix string) {
+func uploadToGCS(ctx context.Context, v *osvschema.Vulnerability, preModifiedBuf []byte, outBkt *storage.BucketHandle, outputPrefix string) bool {
 	vulnID := v.GetId()
 	filename := vulnID + ".json"
 
@@ -58,11 +61,11 @@ func uploadToGCS(ctx context.Context, v *osvschema.Vulnerability, preModifiedBuf
 		// Object exists, check hash.
 		if attrs.Metadata != nil && attrs.Metadata[hashMetadataKey] == hexHash {
 			logger.Info("Skipping upload, hash matches", slog.String("id", vulnID))
-			return
+			return false
 		}
 	} else if !errors.Is(err, storage.ErrObjectNotExist) {
 		logger.Error("failed to get object attributes", slog.String("id", vulnID), slog.Any("err", err))
-		return
+		return false
 	}
 
 	// Object does not exist or hash differs, upload.
@@ -71,7 +74,7 @@ func uploadToGCS(ctx context.Context, v *osvschema.Vulnerability, preModifiedBuf
 	var buf bytes.Buffer
 	if err := vuln.ToJSON(&buf); err != nil {
 		logger.Error("failed to marshal vulnerability with modified time", slog.String("id", vulnID), slog.Any("err", err))
-		return
+		return false
 	}
 	postModifiedBuf := buf.Bytes()
 
@@ -89,12 +92,15 @@ func uploadToGCS(ctx context.Context, v *osvschema.Vulnerability, preModifiedBuf
 			logger.Error("failed to close GCS writer after write error", slog.String("id", vulnID), slog.Any("err", closeErr))
 		}
 
-		return
+		return false
 	}
 
 	if err := wc.Close(); err != nil {
 		logger.Error("failed to close GCS writer", slog.String("id", vulnID), slog.Any("err", err))
+		return false
 	}
+
+	return true
 }
 
 // handleOverride checks for and applies a vulnerability override if it exists.
@@ -144,7 +150,7 @@ func handleOverride(ctx context.Context, v *osvschema.Vulnerability, overridesBk
 // For GCS uploads, it calculates a hash of the vulnerability (excluding the modified time) and compares it
 // with the existing object's hash. The vulnerability is uploaded only if the hashes differ, with the
 // modified time updated. This prevents updating the modified time for vulnerabilities with no content changes.
-func Worker(ctx context.Context, vulnChan <-chan *osvschema.Vulnerability, outBkt, overridesBkt *storage.BucketHandle, outputPrefix string) {
+func Worker(ctx context.Context, vulnChan <-chan *osvschema.Vulnerability, outBkt, overridesBkt *storage.BucketHandle, outputPrefix string, counter *atomic.Uint64) {
 	for v := range vulnChan {
 		vulnID := v.GetId()
 		if len(v.GetAffected()) == 0 {
@@ -174,12 +180,17 @@ func Worker(ctx context.Context, vulnChan <-chan *osvschema.Vulnerability, outBk
 			preModifiedBuf = buf.Bytes()
 		}
 
+		var success bool
 		if outBkt == nil {
 			// Write to local disk
-			writeToDisk(vulnToProcess, preModifiedBuf, outputPrefix)
+			success = writeToDisk(vulnToProcess, preModifiedBuf, outputPrefix)
 		} else {
 			// Upload to GCS
-			uploadToGCS(ctx, vulnToProcess, preModifiedBuf, outBkt, outputPrefix)
+			success = uploadToGCS(ctx, vulnToProcess, preModifiedBuf, outBkt, outputPrefix)
+		}
+
+		if success && counter != nil {
+			counter.Add(1)
 		}
 	}
 }
@@ -212,13 +223,14 @@ func Upload(
 		}
 	}
 	var wg sync.WaitGroup
+	var successCount atomic.Uint64
 	vulnChan := make(chan *osvschema.Vulnerability, numWorkers)
 
 	for range numWorkers {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			Worker(ctx, vulnChan, outBkt, overridesBkt, osvOutputPath)
+			Worker(ctx, vulnChan, outBkt, overridesBkt, osvOutputPath, &successCount)
 		}()
 	}
 
@@ -229,6 +241,7 @@ func Upload(
 	close(vulnChan)
 	wg.Wait()
 	logger.Info("Successfully processed "+jobName, slog.Int("count", len(vulnerabilities)))
+	logger.Info("Successfully uploaded records", slog.Uint64("count", successCount.Load()))
 }
 
 func handleDeletion(ctx context.Context, outBkt *storage.BucketHandle, osvOutputPath string, vulnerabilities []*osvschema.Vulnerability) {

--- a/vulnfeeds/upload/cveworker.go
+++ b/vulnfeeds/upload/cveworker.go
@@ -33,6 +33,7 @@ const (
 )
 
 // writeToDisk writes the vulnerability to a local file.
+// It returns true if the file was written successfully, and false otherwise.
 func writeToDisk(v *osvschema.Vulnerability, preModifiedBuf []byte, outputPrefix string) bool {
 	filename := v.GetId() + ".json"
 	filePath := path.Join(outputPrefix, filename)
@@ -46,6 +47,8 @@ func writeToDisk(v *osvschema.Vulnerability, preModifiedBuf []byte, outputPrefix
 }
 
 // uploadToGCS uploads the vulnerability to a GCS bucket.
+// It returns true if the object was uploaded successfully (either it did not exist or the hash differed),
+// and false if the upload was skipped (e.g., hash matches) or an error occurred.
 func uploadToGCS(ctx context.Context, v *osvschema.Vulnerability, preModifiedBuf []byte, outBkt *storage.BucketHandle, outputPrefix string) bool {
 	vulnID := v.GetId()
 	filename := vulnID + ".json"

--- a/vulnfeeds/upload/cveworker.go
+++ b/vulnfeeds/upload/cveworker.go
@@ -32,24 +32,27 @@ const (
 	overrideFolder  = "osv-output-overrides" // location of overrides within bucket
 )
 
+// ErrUploadSkipped indicates that an upload was intentionally skipped because
+// the vulnerability payload is unchanged.
+var ErrUploadSkipped = errors.New("upload skipped")
+
 // writeToDisk writes the vulnerability to a local file.
-// It returns true if the file was written successfully, and false otherwise.
-func writeToDisk(v *osvschema.Vulnerability, preModifiedBuf []byte, outputPrefix string) bool {
+// It returns an error if the file could not be written.
+func writeToDisk(v *osvschema.Vulnerability, preModifiedBuf []byte, outputPrefix string) error {
 	filename := v.GetId() + ".json"
 	filePath := path.Join(outputPrefix, filename)
 	err := os.WriteFile(filePath, preModifiedBuf, 0600)
 	if err != nil {
-		logger.Error("Failed to write OSV file", slog.Any("err", err), slog.String("path", filePath))
-		return false
+		return fmt.Errorf("failed to write OSV file at %s: %w", filePath, err)
 	}
 
-	return true
+	return nil
 }
 
 // uploadToGCS uploads the vulnerability to a GCS bucket.
-// It returns true if the object was uploaded successfully (either it did not exist or the hash differed),
-// and false if the upload was skipped (e.g., hash matches) or an error occurred.
-func uploadToGCS(ctx context.Context, v *osvschema.Vulnerability, preModifiedBuf []byte, outBkt *storage.BucketHandle, outputPrefix string) bool {
+// It returns an error if the upload failed, or ErrUploadSkipped if the upload
+// was intentionally avoided (e.g. because the GCS object has a matching hash).
+func uploadToGCS(ctx context.Context, v *osvschema.Vulnerability, preModifiedBuf []byte, outBkt *storage.BucketHandle, outputPrefix string) error {
 	vulnID := v.GetId()
 	filename := vulnID + ".json"
 
@@ -64,12 +67,10 @@ func uploadToGCS(ctx context.Context, v *osvschema.Vulnerability, preModifiedBuf
 	if err == nil {
 		// Object exists, check hash.
 		if attrs.Metadata != nil && attrs.Metadata[hashMetadataKey] == hexHash {
-			logger.Info("Skipping upload, hash matches", slog.String("id", vulnID))
-			return false
+			return ErrUploadSkipped
 		}
 	} else if !errors.Is(err, storage.ErrObjectNotExist) {
-		logger.Error("failed to get object attributes", slog.String("id", vulnID), slog.Any("err", err))
-		return false
+		return fmt.Errorf("failed to get object attributes for %s: %w", vulnID, err)
 	}
 
 	// Object does not exist or hash differs, upload.
@@ -77,12 +78,10 @@ func uploadToGCS(ctx context.Context, v *osvschema.Vulnerability, preModifiedBuf
 	vuln := vulns.Vulnerability{Vulnerability: v}
 	var buf bytes.Buffer
 	if err := vuln.ToJSON(&buf); err != nil {
-		logger.Error("failed to marshal vulnerability with modified time", slog.String("id", vulnID), slog.Any("err", err))
-		return false
+		return fmt.Errorf("failed to marshal vulnerability with modified time for %s: %w", vulnID, err)
 	}
 	postModifiedBuf := buf.Bytes()
 
-	logger.Info("Uploading", slog.String("id", vulnID))
 	wc := obj.NewWriter(ctx)
 	wc.Metadata = map[string]string{
 		hashMetadataKey: hexHash,
@@ -90,21 +89,18 @@ func uploadToGCS(ctx context.Context, v *osvschema.Vulnerability, preModifiedBuf
 	wc.ContentType = "application/json"
 
 	if _, err := wc.Write(postModifiedBuf); err != nil {
-		logger.Error("failed to write to GCS object", slog.String("id", vulnID), slog.Any("err", err))
 		// Try to close writer even if write failed.
 		if closeErr := wc.Close(); closeErr != nil {
 			logger.Error("failed to close GCS writer after write error", slog.String("id", vulnID), slog.Any("err", closeErr))
 		}
-
-		return false
+		return fmt.Errorf("failed to write to GCS object for %s: %w", vulnID, err)
 	}
 
 	if err := wc.Close(); err != nil {
-		logger.Error("failed to close GCS writer", slog.String("id", vulnID), slog.Any("err", err))
-		return false
+		return fmt.Errorf("failed to close GCS writer for %s: %w", vulnID, err)
 	}
 
-	return true
+	return nil
 }
 
 // handleOverride checks for and applies a vulnerability override if it exists.
@@ -184,17 +180,24 @@ func Worker(ctx context.Context, vulnChan <-chan *osvschema.Vulnerability, outBk
 			preModifiedBuf = buf.Bytes()
 		}
 
-		var success bool
+		var writeErr error
 		if outBkt == nil {
 			// Write to local disk
-			success = writeToDisk(vulnToProcess, preModifiedBuf, outputPrefix)
+			writeErr = writeToDisk(vulnToProcess, preModifiedBuf, outputPrefix)
 		} else {
 			// Upload to GCS
-			success = uploadToGCS(ctx, vulnToProcess, preModifiedBuf, outBkt, outputPrefix)
+			writeErr = uploadToGCS(ctx, vulnToProcess, preModifiedBuf, outBkt, outputPrefix)
 		}
 
-		if success && counter != nil {
-			counter.Add(1)
+		if writeErr == nil {
+			logger.Info("Uploaded successfully", slog.String("id", vulnID))
+			if counter != nil {
+				counter.Add(1)
+			}
+		} else if errors.Is(writeErr, ErrUploadSkipped) {
+			logger.Info("Skipping upload, hash matches", slog.String("id", vulnID))
+		} else {
+			logger.Error("Failed to upload/write", slog.String("id", vulnID), slog.Any("err", writeErr))
 		}
 	}
 }

--- a/vulnfeeds/upload/cveworker.go
+++ b/vulnfeeds/upload/cveworker.go
@@ -93,6 +93,7 @@ func uploadToGCS(ctx context.Context, v *osvschema.Vulnerability, preModifiedBuf
 		if closeErr := wc.Close(); closeErr != nil {
 			logger.Error("failed to close GCS writer after write error", slog.String("id", vulnID), slog.Any("err", closeErr))
 		}
+
 		return fmt.Errorf("failed to write to GCS object for %s: %w", vulnID, err)
 	}
 

--- a/vulnfeeds/upload/cveworker_test.go
+++ b/vulnfeeds/upload/cveworker_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path"
@@ -81,7 +82,7 @@ func TestUploadToGCS(t *testing.T) {
 		// Modify the vulnerability to simulate a change in modified time but not content
 		v.Modified = timestamppb.New(time.Now().Add(1 * time.Hour))
 		err := uploadToGCS(ctx, v, preModifiedBuf, bkt, "")
-		if err != ErrUploadSkipped {
+		if !errors.Is(err, ErrUploadSkipped) {
 			t.Errorf("Expected uploadToGCS to return ErrUploadSkipped when hash matches, got %v", err)
 		}
 

--- a/vulnfeeds/upload/cveworker_test.go
+++ b/vulnfeeds/upload/cveworker_test.go
@@ -26,9 +26,9 @@ func TestWriteToDisk(t *testing.T) {
 	}
 	preModifiedBuf := []byte(`{"id":"CVE-2023-1234"}`)
 
-	success := writeToDisk(v, preModifiedBuf, tempDir)
-	if !success {
-		t.Errorf("Expected writeToDisk to return true, got false")
+	err := writeToDisk(v, preModifiedBuf, tempDir)
+	if err != nil {
+		t.Errorf("Expected writeToDisk to return nil, got %v", err)
 	}
 
 	filePath := path.Join(tempDir, "CVE-2023-1234.json")
@@ -58,9 +58,9 @@ func TestUploadToGCS(t *testing.T) {
 	preModifiedBuf := []byte(`{"id":"CVE-2023-1234"}`)
 
 	t.Run("Upload new object", func(t *testing.T) {
-		success := uploadToGCS(ctx, v, preModifiedBuf, bkt, "")
-		if !success {
-			t.Errorf("Expected uploadToGCS to return true for new object")
+		err := uploadToGCS(ctx, v, preModifiedBuf, bkt, "")
+		if err != nil {
+			t.Errorf("Expected uploadToGCS to return nil for new object, got %v", err)
 		}
 
 		obj := bkt.Object("CVE-2023-1234.json")
@@ -80,9 +80,9 @@ func TestUploadToGCS(t *testing.T) {
 	t.Run("Skip upload if hash matches", func(t *testing.T) {
 		// Modify the vulnerability to simulate a change in modified time but not content
 		v.Modified = timestamppb.New(time.Now().Add(1 * time.Hour))
-		success := uploadToGCS(ctx, v, preModifiedBuf, bkt, "")
-		if success {
-			t.Errorf("Expected uploadToGCS to return false when hash matches")
+		err := uploadToGCS(ctx, v, preModifiedBuf, bkt, "")
+		if err != ErrUploadSkipped {
+			t.Errorf("Expected uploadToGCS to return ErrUploadSkipped when hash matches, got %v", err)
 		}
 
 		obj := bkt.Object("CVE-2023-1234.json")
@@ -100,9 +100,9 @@ func TestUploadToGCS(t *testing.T) {
 
 	t.Run("Upload if hash differs", func(t *testing.T) {
 		preModifiedBuf2 := []byte(`{"id":"CVE-2023-1234", "summary": "updated"}`)
-		success := uploadToGCS(ctx, v, preModifiedBuf2, bkt, "")
-		if !success {
-			t.Errorf("Expected uploadToGCS to return true when hash differs")
+		err := uploadToGCS(ctx, v, preModifiedBuf2, bkt, "")
+		if err != nil {
+			t.Errorf("Expected uploadToGCS to return nil when hash differs, got %v", err)
 		}
 
 		obj := bkt.Object("CVE-2023-1234.json")

--- a/vulnfeeds/upload/cveworker_test.go
+++ b/vulnfeeds/upload/cveworker_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -25,7 +26,10 @@ func TestWriteToDisk(t *testing.T) {
 	}
 	preModifiedBuf := []byte(`{"id":"CVE-2023-1234"}`)
 
-	writeToDisk(v, preModifiedBuf, tempDir)
+	success := writeToDisk(v, preModifiedBuf, tempDir)
+	if !success {
+		t.Errorf("Expected writeToDisk to return true, got false")
+	}
 
 	filePath := path.Join(tempDir, "CVE-2023-1234.json")
 	content, err := os.ReadFile(filePath)
@@ -54,7 +58,10 @@ func TestUploadToGCS(t *testing.T) {
 	preModifiedBuf := []byte(`{"id":"CVE-2023-1234"}`)
 
 	t.Run("Upload new object", func(t *testing.T) {
-		uploadToGCS(ctx, v, preModifiedBuf, bkt, "")
+		success := uploadToGCS(ctx, v, preModifiedBuf, bkt, "")
+		if !success {
+			t.Errorf("Expected uploadToGCS to return true for new object")
+		}
 
 		obj := bkt.Object("CVE-2023-1234.json")
 		attrs, err := obj.Attrs(ctx)
@@ -73,7 +80,10 @@ func TestUploadToGCS(t *testing.T) {
 	t.Run("Skip upload if hash matches", func(t *testing.T) {
 		// Modify the vulnerability to simulate a change in modified time but not content
 		v.Modified = timestamppb.New(time.Now().Add(1 * time.Hour))
-		uploadToGCS(ctx, v, preModifiedBuf, bkt, "")
+		success := uploadToGCS(ctx, v, preModifiedBuf, bkt, "")
+		if success {
+			t.Errorf("Expected uploadToGCS to return false when hash matches")
+		}
 
 		obj := bkt.Object("CVE-2023-1234.json")
 		attrs2, err := obj.Attrs(ctx)
@@ -90,7 +100,10 @@ func TestUploadToGCS(t *testing.T) {
 
 	t.Run("Upload if hash differs", func(t *testing.T) {
 		preModifiedBuf2 := []byte(`{"id":"CVE-2023-1234", "summary": "updated"}`)
-		uploadToGCS(ctx, v, preModifiedBuf2, bkt, "")
+		success := uploadToGCS(ctx, v, preModifiedBuf2, bkt, "")
+		if !success {
+			t.Errorf("Expected uploadToGCS to return true when hash differs")
+		}
 
 		obj := bkt.Object("CVE-2023-1234.json")
 		attrs3, err := obj.Attrs(ctx)
@@ -229,7 +242,12 @@ func TestWorker(t *testing.T) {
 	}
 	w.Close()
 
-	Worker(ctx, vulnChan, outBkt, overridesBkt, "")
+	var counter atomic.Uint64
+	Worker(ctx, vulnChan, outBkt, overridesBkt, "", &counter)
+
+	if counter.Load() != 2 {
+		t.Errorf("Expected counter to be 2, got %d", counter.Load())
+	}
 
 	// Check v1
 	obj1 := outBkt.Object("CVE-2023-1234.json")


### PR DESCRIPTION
It's nice to know how many records were actually changed on the combine to osv run