### PR TITLE
chore: suspend combine to osv for now

### DIFF
--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/combine-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/combine-to-osv.yaml
@@ -3,6 +3,7 @@ kind: CronJob
 metadata:
   name: combine-to-osv
 spec:
+  suspend: true
   jobTemplate:
     spec:
       template:

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/combine-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/combine-to-osv.yaml
@@ -3,6 +3,7 @@ kind: CronJob
 metadata:
   name: combine-to-osv
 spec:
+  suspend: true
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
We are suspending combine-to-osv temporarily while the records are fluctuating, and resuming it once there are less changes