### PR TITLE
fix(oss-fuzz, maybe): update docker & gvisor

### DIFF
--- a/docker/worker-base/Dockerfile
+++ b/docker/worker-base/Dockerfile
@@ -51,8 +51,6 @@ RUN python3 -m venv $POETRY_HOME && \
 ENV POETRY_VIRTUALENVS_IN_PROJECT=true
 
 # Install Docker.
-# Pin the version to an older one due to gVisor incompatibilities.
-# See https://github.com/google/osv.dev/issues/1019#issuecomment-1427418758
 ARG DOCKER_VERSION=5:29.3.0-1~ubuntu.24.04~noble
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/trusted.gpg.d/docker.gpg && \
     add-apt-repository \


### PR DESCRIPTION
We recently have seen oss-fuzz stuff be broken on GKE for some mysterious reason.
With some playing around with this, updating Docker/gvisor seems to atleast allow `docker build` to run.

These versions basically haven't been touched since the beginning of time, so hopefully nothing dramatic breaks.
Docker's using buildkit now, so the logs may be noisier
