### PR TITLE
fix(ksm): double memory limits to prevent OOM

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/ksm_stateful_set.yaml
+++ b/deployment/clouddeploy/gke-workers/base/ksm_stateful_set.yaml
@@ -57,9 +57,9 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 190Mi
+            memory: 380Mi
           limits:
-            memory: 250Mi
+            memory: 500Mi
         securityContext:
           allowPrivilegeEscalation: false
           privileged: false


### PR DESCRIPTION
This PR increases the memory resources for the `kube-state-metric` container. The container was failing with exit code 137, indicating it was being terminated due to Out-Of-Memory issues.

The memory requests and limits for the `kube-state-metric` container in `deployment/clouddeploy/gke-workers/base/ksm_stateful_set.yaml` have been doubled:
 - Memory Request: 190Mi -> 380Mi
 - Memory Limit: 250Mi -> 500Mi