### PR TITLE
fix(importer): Check modified times against database instead of importer run.

### DIFF
--- a/go/internal/database/datastore/vulnerability.go
+++ b/go/internal/database/datastore/vulnerability.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"iter"
 	"strings"
+	"time"
 
 	"cloud.google.com/go/datastore"
 	"github.com/google/osv.dev/go/internal/models"
@@ -63,4 +64,18 @@ func (s *VulnerabilityStore) ListBySource(ctx context.Context, source string, sk
 			}
 		}
 	}
+}
+
+func (s *VulnerabilityStore) GetSourceModified(ctx context.Context, id string) (time.Time, error) {
+	key := datastore.NameKey("Vulnerability", id, nil)
+	var v Vulnerability
+	if err := s.client.Get(ctx, key, &v); err != nil {
+		if errors.Is(err, datastore.ErrNoSuchEntity) {
+			return time.Time{}, models.ErrNotFound
+		}
+
+		return time.Time{}, err
+	}
+
+	return v.ModifiedRaw, nil
 }

--- a/go/internal/importer/bucket.go
+++ b/go/internal/importer/bucket.go
@@ -40,11 +40,11 @@ func handleImportBucket(ctx context.Context, ch chan<- WorkItem, config Config, 
 
 	compiledIgnorePatterns := compileIgnorePatterns(sourceRepo)
 	bucket := config.GCSProvider.Bucket(sourceRepo.Bucket.Name)
-	hasUpdateTime := false
+	reimport := true
 	var lastUpdated time.Time
 	if !sourceRepo.Bucket.IgnoreLastImportTime && sourceRepo.Bucket.LastUpdated != nil {
 		lastUpdated = *sourceRepo.Bucket.LastUpdated
-		hasUpdateTime = true
+		reimport = false
 	}
 	format := extensionToFormat(sourceRepo.Extension)
 	timeOfRun := time.Now()
@@ -52,8 +52,8 @@ func handleImportBucket(ctx context.Context, ch chan<- WorkItem, config Config, 
 		if err != nil {
 			return err
 		}
-		if hasUpdateTime {
-			if obj.Attrs.Updated.Before(lastUpdated) || obj.Attrs.Updated.Equal(lastUpdated) {
+		if !reimport {
+			if !obj.Attrs.Updated.After(lastUpdated) {
 				continue
 			}
 		}
@@ -70,14 +70,13 @@ func handleImportBucket(ctx context.Context, ch chan<- WorkItem, config Config, 
 				bucket:     bucket,
 				objectPath: obj.Name,
 			},
-			SourceRepository: sourceRepo.Name,
-			SourcePath:       obj.Name,
-			LastUpdated:      lastUpdated,
-			HasLastUpdated:   hasUpdateTime,
-			Format:           format,
-			KeyPath:          sourceRepo.KeyPath,
-			Strict:           sourceRepo.Strictness,
-			IsReimport:       !hasUpdateTime,
+			SourceRepository:       sourceRepo.Name,
+			SourcePath:             obj.Name,
+			CompareAgainstDatabase: !reimport,
+			Format:                 format,
+			KeyPath:                sourceRepo.KeyPath,
+			Strict:                 sourceRepo.Strictness,
+			IsReimport:             reimport,
 		}
 	}
 

--- a/go/internal/importer/importer.go
+++ b/go/internal/importer/importer.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -176,15 +177,14 @@ type WorkItem struct {
 	Context      context.Context //nolint:containedctx
 	SourceRecord SourceRecord
 
-	SourceRepository string
-	SourcePath       string
-	Format           RecordFormat
-	KeyPath          string
-	Strict           bool
-	IsDeleted        bool
-	LastUpdated      time.Time
-	HasLastUpdated   bool
-	IsReimport       bool
+	SourceRepository       string
+	SourcePath             string
+	Format                 RecordFormat
+	KeyPath                string
+	Strict                 bool
+	IsDeleted              bool
+	CompareAgainstDatabase bool
+	IsReimport             bool
 }
 
 func importerWorker(ctx context.Context, ch <-chan WorkItem, config Config) {
@@ -320,8 +320,19 @@ func processUpdate(ctx context.Context, config Config, item WorkItem) {
 	}
 	// Skip if the record is older than the last update time
 	modified := vulnProto.GetModified().AsTime()
-	if item.HasLastUpdated {
-		if item.LastUpdated.After(modified) {
+	if item.CompareAgainstDatabase {
+		dbModified, err := config.VulnerabilityStore.GetSourceModified(ctx, vulnProto.GetId())
+		// only update if modified is strictly after dbModified (or if the vuln is new)
+		if err == nil && !modified.After(dbModified) {
+			return
+		}
+		if err != nil && !errors.Is(err, models.ErrNotFound) {
+			logger.ErrorContext(ctx, "Failed to get source modified",
+				slog.Any("error", err),
+				slog.String("source", sourceRepoName),
+				slog.String("path", sourcePath),
+				slog.String("id", vulnProto.GetId()))
+
 			return
 		}
 	}

--- a/go/internal/importer/importer_test.go
+++ b/go/internal/importer/importer_test.go
@@ -162,6 +162,11 @@ func TestImporterWorker(t *testing.T) {
 	mockPublisher := &testutils.MockPublisher{}
 	config := Config{
 		Publisher: mockPublisher,
+		VulnerabilityStore: &mockVulnerabilityStore{
+			RawMods: map[string]time.Time{
+				"CVE-2023-1237": time.Date(2023, time.January, 5, 0, 0, 0, 0, time.UTC),
+			},
+		},
 	}
 	ctx := t.Context()
 	ch := make(chan WorkItem, 10)
@@ -172,9 +177,10 @@ func TestImporterWorker(t *testing.T) {
 		SourceRecord: mockSourceRecord{
 			DataToRead: []byte(`{"id": "CVE-2023-1234", "modified": "2023-01-01T00:00:00Z"}`),
 		},
-		Format:           RecordFormatJSON,
-		SourceRepository: "repo1",
-		SourcePath:       "1.json",
+		Format:                 RecordFormatJSON,
+		CompareAgainstDatabase: true,
+		SourceRepository:       "repo1",
+		SourcePath:             "1.json",
 	}
 
 	// Test 2: YAML format
@@ -206,19 +212,40 @@ func TestImporterWorker(t *testing.T) {
 		SourceRecord: mockSourceRecord{
 			DataToRead: []byte(`{"id": "CVE-2023-1237", "modified": "2023-01-04T00:00:00Z"}`),
 		},
-		Format:           RecordFormatJSON,
-		LastUpdated:      time.Date(2023, 1, 5, 0, 0, 0, 0, time.UTC),
-		HasLastUpdated:   true,
-		SourceRepository: "repo4",
-		SourcePath:       "4.json",
+		Format:                 RecordFormatJSON,
+		CompareAgainstDatabase: true,
+		SourceRepository:       "repo4",
+		SourcePath:             "4.json",
+	}
+	// Test 5: Skip record equal time
+	ch <- WorkItem{
+		Context: ctx,
+		SourceRecord: mockSourceRecord{
+			DataToRead: []byte(`{"id": "CVE-2023-1237", "modified": "2023-01-05T00:00:00Z"}`),
+		},
+		Format:                 RecordFormatJSON,
+		CompareAgainstDatabase: true,
+		SourceRepository:       "repo4",
+		SourcePath:             "4.json",
+	}
+	// Test 6: Don't skip newer record
+	ch <- WorkItem{
+		Context: ctx,
+		SourceRecord: mockSourceRecord{
+			DataToRead: []byte(`{"id": "CVE-2023-1237", "modified": "2023-01-06T00:00:00Z"}`),
+		},
+		Format:                 RecordFormatJSON,
+		CompareAgainstDatabase: true,
+		SourceRepository:       "repo4",
+		SourcePath:             "4.json",
 	}
 	close(ch)
 
 	importerWorker(ctx, ch, config)
 
-	// Since Test 4 is skipped (modified before last update), we expect only 3 messages
-	if len(mockPublisher.Messages) != 3 {
-		t.Fatalf("Expected 3 messages published, got %d", len(mockPublisher.Messages))
+	// Since Test 4&5 are skipped (modified before last update), we expect only 4 messages
+	if len(mockPublisher.Messages) != 4 {
+		t.Fatalf("Expected 4 messages published, got %d", len(mockPublisher.Messages))
 	}
 
 	// Message 1 verification
@@ -234,5 +261,10 @@ func TestImporterWorker(t *testing.T) {
 	// Message 3 verification
 	if mockPublisher.Messages[2].Attributes["path"] != "3.json" {
 		t.Errorf("Expected path 3.json, got %s", mockPublisher.Messages[2].Attributes["path"])
+	}
+
+	// Message 4 verification
+	if mockPublisher.Messages[3].Attributes["path"] != "4.json" {
+		t.Errorf("Expected path 4.json, got %s", mockPublisher.Messages[3].Attributes["path"])
 	}
 }

--- a/go/internal/importer/mock_test.go
+++ b/go/internal/importer/mock_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"iter"
+	"time"
 
 	"github.com/google/osv.dev/go/internal/models"
 )
@@ -30,6 +31,7 @@ func (m *mockSourceRepositoryStore) Update(_ context.Context, name string, repo 
 
 type mockVulnerabilityStore struct {
 	Entries map[string][]*models.VulnSourceRef
+	RawMods map[string]time.Time
 }
 
 func (m *mockVulnerabilityStore) ListBySource(_ context.Context, source string, _ bool) iter.Seq2[*models.VulnSourceRef, error] {
@@ -41,6 +43,14 @@ func (m *mockVulnerabilityStore) ListBySource(_ context.Context, source string, 
 			}
 		}
 	}
+}
+
+func (m *mockVulnerabilityStore) GetSourceModified(_ context.Context, vuln string) (time.Time, error) {
+	if mod, ok := m.RawMods[vuln]; ok {
+		return mod, nil
+	}
+
+	return time.Time{}, models.ErrNotFound
 }
 
 type mockSourceRecord struct {

--- a/go/internal/importer/rest.go
+++ b/go/internal/importer/rest.go
@@ -136,14 +136,13 @@ func handleImportREST(ctx context.Context, ch chan<- WorkItem, config Config, so
 				urlBase: sourceRepo.Link,
 				urlPath: path,
 			},
-			SourceRepository: sourceRepo.Name,
-			SourcePath:       path,
-			LastUpdated:      lastUpdated,
-			HasLastUpdated:   hasUpdateTime,
-			Format:           RecordFormatJSON,
-			KeyPath:          sourceRepo.KeyPath,
-			Strict:           sourceRepo.Strictness,
-			IsReimport:       !hasUpdateTime,
+			SourceRepository:       sourceRepo.Name,
+			SourcePath:             path,
+			CompareAgainstDatabase: hasUpdateTime,
+			Format:                 RecordFormatJSON,
+			KeyPath:                sourceRepo.KeyPath,
+			Strict:                 sourceRepo.Strictness,
+			IsReimport:             !hasUpdateTime,
 		}
 
 		return true

--- a/go/internal/models/vulnerability.go
+++ b/go/internal/models/vulnerability.go
@@ -4,6 +4,7 @@ package models
 import (
 	"context"
 	"iter"
+	"time"
 )
 
 // VulnSourceRef represents a minimal vulnerability entry for indexing/reconciliation.
@@ -16,4 +17,7 @@ type VulnSourceRef struct {
 type VulnerabilityStore interface {
 	// ListBySource returns an iterator over vulnerabilities for a given source.
 	ListBySource(ctx context.Context, source string, skipWithdrawn bool) iter.Seq2[*VulnSourceRef, error]
+	// GetSourceModified returns the modified time of a vulnerability according to the source.
+	// Returns ErrNotFound if the vulnerability is not found.
+	GetSourceModified(ctx context.Context, id string) (time.Time, error)
 }


### PR DESCRIPTION
Bucket updates were ended up being skipped due to records with modified times before the importer last run being uploaded after that importer run.

Now, check each record against what we have in database, instead of against the importer time.