### PR TITLE
fix(importer): make isreimport logic more explicit

### DIFF
--- a/go/internal/importer/importer.go
+++ b/go/internal/importer/importer.go
@@ -320,7 +320,7 @@ func processUpdate(ctx context.Context, config Config, item WorkItem) {
 	}
 	// Skip if the record is older than the last update time
 	modified := vulnProto.GetModified().AsTime()
-	if item.CompareAgainstDatabase {
+	if !item.IsReimport && item.CompareAgainstDatabase {
 		dbModified, err := config.VulnerabilityStore.GetSourceModified(ctx, vulnProto.GetId())
 		// only update if modified is strictly after dbModified (or if the vuln is new)
 		if err == nil && !modified.After(dbModified) {


### PR DESCRIPTION
I should've done this in #5058 before merging.

`CompareAgainstDatabase` implies `!IsReimport`, but I should make this logic explicit.