### PR TITLE
fix(oss-fuzz, maybe, again): add all securityContext capabilities

### DIFF
--- a/deployment/clouddeploy/oss-fuzz-workers/workers.yaml
+++ b/deployment/clouddeploy/oss-fuzz-workers/workers.yaml
@@ -31,6 +31,9 @@ spec:
           - mountPath: "/secrets"
             name: "secrets"
         securityContext:
+          capabilities:
+            add:
+            - all
           privileged: true
         resources:
           requests:


### PR DESCRIPTION
Something we never noticed when we moved oss-fuzz to its own cluster is this log happening in the fixed/regressed tasks:
```
sysctl: cannot stat /proc/sys/vm/mmap_rnd_bits: No such file or directory
```

I have approximately 0 ideas on how to properly debug this.

This `capabilities: {add: [all]}` is set in the non-oss-fuzz worker yaml when viewed on GCP, despite not actually being in the yaml we deploy.

Gemini insists adding this will fix the issue, but I am doubtful.