### PR TITLE
fix: cap ListedVulnerability search_indices and autocomplete_tags

### DIFF
--- a/go/osv/models/listedvulnerability.go
+++ b/go/osv/models/listedvulnerability.go
@@ -92,17 +92,6 @@ func NewListedVulnerabilityFromProto(vuln *osvschema.Vulnerability) *ListedVulne
 	pkgSearchIndices := make(map[string]struct{})
 	repoSearchIndices := make(map[string]struct{})
 
-	for _, alias := range vuln.GetAliases() {
-		for _, t := range tokenize(alias) {
-			searchIndices[t] = struct{}{}
-		}
-	}
-	for _, upstream := range vuln.GetUpstream() {
-		for _, t := range tokenize(upstream) {
-			searchIndices[t] = struct{}{}
-		}
-	}
-
 	for _, affected := range vuln.GetAffected() {
 		if affected.GetPackage().GetName() != "" {
 			pkgNameLower := strings.ToLower(affected.GetPackage().GetName())
@@ -198,6 +187,24 @@ func NewListedVulnerabilityFromProto(vuln *osvschema.Vulnerability) *ListedVulne
 			}
 		}
 	}
+
+	for _, alias := range vuln.GetAliases() {
+		for _, t := range tokenize(alias) {
+			if len(searchIndices) >= maxIndices {
+				break
+			}
+			searchIndices[t] = struct{}{}
+		}
+	}
+	for _, upstream := range vuln.GetUpstream() {
+		for _, t := range tokenize(upstream) {
+			if len(searchIndices) >= maxIndices {
+				break
+			}
+			searchIndices[t] = struct{}{}
+		}
+	}
+	// related intentionally omitted
 
 	ecosystems := make([]string, 0, len(allEcosystems))
 	for eco := range allEcosystems {

--- a/osv/models.py
+++ b/osv/models.py
@@ -1075,12 +1075,6 @@ class ListedVulnerability(ndb.Model):
     repo_search_indices = set()
     autocomplete_tags = {vulnerability.id.lower()}
 
-    for alias in vulnerability.aliases:
-      search_indices.update(_tokenize(alias))
-    for upstream in vulnerability.upstream:
-      search_indices.update(_tokenize(upstream))
-    # related intentionally omitted
-
     for affected in vulnerability.affected:
       if affected.package.name:
         pkg_search_indices.add(affected.package.name.lower())
@@ -1150,6 +1144,20 @@ class ListedVulnerability(ndb.Model):
           if len(search_indices) >= cls._MAX_INDICES:
             break
           search_indices.add(t)
+
+    for alias in vulnerability.aliases:
+      to_add = _tokenize(alias)
+      for t in to_add:
+        if len(search_indices) >= cls._MAX_INDICES:
+          break
+        search_indices.add(t)
+    for upstream in vulnerability.upstream:
+      to_add = _tokenize(upstream)
+      for t in to_add:
+        if len(search_indices) >= cls._MAX_INDICES:
+          break
+        search_indices.add(t)
+    # related intentionally omitted
 
     ecos = sorted({ecosystems.normalize(e) for e in all_ecosystems})
     pkgs = sorted(all_packages)


### PR DESCRIPTION
Capping the number of indexed properties in the Datastore entities because we've run into a hard limit.
Be a bit smart, and add the untokenized package names/repos first, then the token parts, then the aliases/upstream. 