### PR TITLE
feat: add Australia/Sydney timezone to base cronjobs

### DIFF
--- a/deployment/clouddeploy/gke-indexer/base/indexer-controller.yaml
+++ b/deployment/clouddeploy/gke-indexer/base/indexer-controller.yaml
@@ -17,6 +17,7 @@ kind: CronJob
 metadata:
   name: indexer-controller
 spec:
+  timeZone: "Australia/Sydney"
   schedule: "0 0 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/deployment/clouddeploy/gke-workers/base/alpine-cve-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/base/alpine-cve-convert.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "180"
 spec:
+  timeZone: "Australia/Sydney"
   schedule: "17 * * * *"
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/deployment/clouddeploy/gke-workers/base/backup.yaml
+++ b/deployment/clouddeploy/gke-workers/base/backup.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "2880"
 spec:
+  timeZone: "Australia/Sydney"
   schedule: "0 18 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/deployment/clouddeploy/gke-workers/base/cpe-repo-gen.yaml
+++ b/deployment/clouddeploy/gke-workers/base/cpe-repo-gen.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "2880"
 spec:
+  timeZone: "Australia/Sydney"
   schedule: "15 5 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/deployment/clouddeploy/gke-workers/base/custommetrics.yaml
+++ b/deployment/clouddeploy/gke-workers/base/custommetrics.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "5"
 spec:
+  timeZone: "Australia/Sydney"
   schedule: "* * * * *"
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/deployment/clouddeploy/gke-workers/base/debian-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/base/debian-convert.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "180"
 spec:
+  timeZone: "Australia/Sydney"
   schedule: "0 * * * *"
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/deployment/clouddeploy/gke-workers/base/debian-copyright-mirror.yaml
+++ b/deployment/clouddeploy/gke-workers/base/debian-copyright-mirror.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "2880"
 spec:
+  timeZone: "Australia/Sydney"
   schedule: "0 5 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/deployment/clouddeploy/gke-workers/base/debian-cve-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/base/debian-cve-convert.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "120"
 spec:
+  timeZone: "Australia/Sydney"
   schedule: "47 * * * *"
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/deployment/clouddeploy/gke-workers/base/debian-first-version.yaml
+++ b/deployment/clouddeploy/gke-workers/base/debian-first-version.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "2880"
 spec:
+  timeZone: "Australia/Sydney"
   schedule: "0 1 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/deployment/clouddeploy/gke-workers/base/exporter.yaml
+++ b/deployment/clouddeploy/gke-workers/base/exporter.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "30"
 spec:
+  timeZone: "Australia/Sydney"
   schedule: "*/15 * * * *"
   concurrencyPolicy: Forbid
   # If the previous job overruns by more than a minute,

--- a/deployment/clouddeploy/gke-workers/base/generate-sitemap.yaml
+++ b/deployment/clouddeploy/gke-workers/base/generate-sitemap.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "2880"
 spec:
+  timeZone: "Australia/Sydney"
   schedule: "30 8 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/deployment/clouddeploy/gke-workers/base/importer-deleter.yaml
+++ b/deployment/clouddeploy/gke-workers/base/importer-deleter.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "360"
 spec:
+  timeZone: "Australia/Sydney"
   schedule: "0 */6 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/deployment/clouddeploy/gke-workers/base/importer-reconciler.yaml
+++ b/deployment/clouddeploy/gke-workers/base/importer-reconciler.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "1500" # Expected latency once a day
 spec:
+  timeZone: "Australia/Sydney"
   schedule: "23 4 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/deployment/clouddeploy/gke-workers/base/importer.yaml
+++ b/deployment/clouddeploy/gke-workers/base/importer.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "90"
 spec:
+  timeZone: "Australia/Sydney"
   schedule: "*/15 * * * *"
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/deployment/clouddeploy/gke-workers/base/nvd-mirror.yaml
+++ b/deployment/clouddeploy/gke-workers/base/nvd-mirror.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "240"
 spec:
+  timeZone: "Australia/Sydney"
   schedule: "5 */2 * * *"
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 3

--- a/deployment/clouddeploy/gke-workers/base/record-checker.yaml
+++ b/deployment/clouddeploy/gke-workers/base/record-checker.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "90"
 spec:
+  timeZone: "Australia/Sydney"
   schedule: "10/15 * * * *"
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/deployment/clouddeploy/gke-workers/base/relations.yaml
+++ b/deployment/clouddeploy/gke-workers/base/relations.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     cronLastSuccessfulTimeMins: "45"
 spec:
+  timeZone: "Australia/Sydney"
   schedule: "10/15 * * * *"
   concurrencyPolicy: Forbid
   jobTemplate:


### PR DESCRIPTION
Add `timeZone: "Australia/Sydney"` to all CronJob configurations under `deployment/clouddeploy/gke-indexer/base/` and `deployment/clouddeploy/gke-workers/base/` directories. This configures the cron schedules to evaluate against Sydney time instead of UTC.

---
*PR created automatically by Jules for task [12924298385411470107](https://jules.google.com/task/12924298385411470107) started by @another-rex*