### PR TITLE
chore(gitter): some renames in proto

### DIFF
--- a/go/cmd/gitter/gitter.go
+++ b/go/cmd/gitter/gitter.go
@@ -682,15 +682,15 @@ func affectedCommitsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := &pb.AffectedCommitsResponse{
-		Commits: make([]*pb.AffectedCommit, 0, len(affectedCommits)),
-		Refs:    make([]*pb.AffectedRefs, 0),
+		Commits: make([]*pb.Commit, 0, len(affectedCommits)),
+		Refs:    make([]*pb.Ref, 0),
 	}
 	for _, c := range affectedCommits {
-		resp.Commits = append(resp.Commits, &pb.AffectedCommit{
+		resp.Commits = append(resp.Commits, &pb.Commit{
 			Hash: c.Hash[:],
 		})
 		for _, ref := range c.Refs {
-			resp.Refs = append(resp.Refs, &pb.AffectedRefs{
+			resp.Refs = append(resp.Refs, &pb.Ref{
 				Ref:  ref,
 				Hash: c.Hash[:],
 			})

--- a/go/cmd/gitter/pb/repository/repository.pb.go
+++ b/go/cmd/gitter/pb/repository/repository.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.11
 // 	protoc        v3.21.12
-// source: repository.proto
+// source: pb/repository/repository.proto
 
 package repository
 
@@ -57,11 +57,11 @@ func (x EventType) String() string {
 }
 
 func (EventType) Descriptor() protoreflect.EnumDescriptor {
-	return file_repository_proto_enumTypes[0].Descriptor()
+	return file_pb_repository_repository_proto_enumTypes[0].Descriptor()
 }
 
 func (EventType) Type() protoreflect.EnumType {
-	return &file_repository_proto_enumTypes[0]
+	return &file_pb_repository_repository_proto_enumTypes[0]
 }
 
 func (x EventType) Number() protoreflect.EnumNumber {
@@ -70,7 +70,7 @@ func (x EventType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use EventType.Descriptor instead.
 func (EventType) EnumDescriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{0}
+	return file_pb_repository_repository_proto_rawDescGZIP(), []int{0}
 }
 
 type CommitDetail struct {
@@ -83,7 +83,7 @@ type CommitDetail struct {
 
 func (x *CommitDetail) Reset() {
 	*x = CommitDetail{}
-	mi := &file_repository_proto_msgTypes[0]
+	mi := &file_pb_repository_repository_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -95,7 +95,7 @@ func (x *CommitDetail) String() string {
 func (*CommitDetail) ProtoMessage() {}
 
 func (x *CommitDetail) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[0]
+	mi := &file_pb_repository_repository_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -108,7 +108,7 @@ func (x *CommitDetail) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CommitDetail.ProtoReflect.Descriptor instead.
 func (*CommitDetail) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{0}
+	return file_pb_repository_repository_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *CommitDetail) GetHash() []byte {
@@ -136,7 +136,7 @@ type RepositoryCache struct {
 
 func (x *RepositoryCache) Reset() {
 	*x = RepositoryCache{}
-	mi := &file_repository_proto_msgTypes[1]
+	mi := &file_pb_repository_repository_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -148,7 +148,7 @@ func (x *RepositoryCache) String() string {
 func (*RepositoryCache) ProtoMessage() {}
 
 func (x *RepositoryCache) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[1]
+	mi := &file_pb_repository_repository_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -161,7 +161,7 @@ func (x *RepositoryCache) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RepositoryCache.ProtoReflect.Descriptor instead.
 func (*RepositoryCache) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{1}
+	return file_pb_repository_repository_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *RepositoryCache) GetCommits() []*CommitDetail {
@@ -171,28 +171,28 @@ func (x *RepositoryCache) GetCommits() []*CommitDetail {
 	return nil
 }
 
-type AffectedCommit struct {
+type Commit struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Hash          []byte                 `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *AffectedCommit) Reset() {
-	*x = AffectedCommit{}
-	mi := &file_repository_proto_msgTypes[2]
+func (x *Commit) Reset() {
+	*x = Commit{}
+	mi := &file_pb_repository_repository_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *AffectedCommit) String() string {
+func (x *Commit) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*AffectedCommit) ProtoMessage() {}
+func (*Commit) ProtoMessage() {}
 
-func (x *AffectedCommit) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[2]
+func (x *Commit) ProtoReflect() protoreflect.Message {
+	mi := &file_pb_repository_repository_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -203,19 +203,19 @@ func (x *AffectedCommit) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use AffectedCommit.ProtoReflect.Descriptor instead.
-func (*AffectedCommit) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{2}
+// Deprecated: Use Commit.ProtoReflect.Descriptor instead.
+func (*Commit) Descriptor() ([]byte, []int) {
+	return file_pb_repository_repository_proto_rawDescGZIP(), []int{2}
 }
 
-func (x *AffectedCommit) GetHash() []byte {
+func (x *Commit) GetHash() []byte {
 	if x != nil {
 		return x.Hash
 	}
 	return nil
 }
 
-type AffectedRefs struct {
+type Ref struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Ref           string                 `protobuf:"bytes,1,opt,name=ref,proto3" json:"ref,omitempty"`
 	Hash          []byte                 `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`
@@ -223,21 +223,21 @@ type AffectedRefs struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *AffectedRefs) Reset() {
-	*x = AffectedRefs{}
-	mi := &file_repository_proto_msgTypes[3]
+func (x *Ref) Reset() {
+	*x = Ref{}
+	mi := &file_pb_repository_repository_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *AffectedRefs) String() string {
+func (x *Ref) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*AffectedRefs) ProtoMessage() {}
+func (*Ref) ProtoMessage() {}
 
-func (x *AffectedRefs) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[3]
+func (x *Ref) ProtoReflect() protoreflect.Message {
+	mi := &file_pb_repository_repository_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -248,19 +248,19 @@ func (x *AffectedRefs) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use AffectedRefs.ProtoReflect.Descriptor instead.
-func (*AffectedRefs) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{3}
+// Deprecated: Use Ref.ProtoReflect.Descriptor instead.
+func (*Ref) Descriptor() ([]byte, []int) {
+	return file_pb_repository_repository_proto_rawDescGZIP(), []int{3}
 }
 
-func (x *AffectedRefs) GetRef() string {
+func (x *Ref) GetRef() string {
 	if x != nil {
 		return x.Ref
 	}
 	return ""
 }
 
-func (x *AffectedRefs) GetHash() []byte {
+func (x *Ref) GetHash() []byte {
 	if x != nil {
 		return x.Hash
 	}
@@ -269,15 +269,15 @@ func (x *AffectedRefs) GetHash() []byte {
 
 type AffectedCommitsResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Commits       []*AffectedCommit      `protobuf:"bytes,1,rep,name=commits,proto3" json:"commits,omitempty"`
-	Refs          []*AffectedRefs        `protobuf:"bytes,2,rep,name=refs,proto3" json:"refs,omitempty"`
+	Commits       []*Commit              `protobuf:"bytes,1,rep,name=commits,proto3" json:"commits,omitempty"`
+	Refs          []*Ref                 `protobuf:"bytes,2,rep,name=refs,proto3" json:"refs,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *AffectedCommitsResponse) Reset() {
 	*x = AffectedCommitsResponse{}
-	mi := &file_repository_proto_msgTypes[4]
+	mi := &file_pb_repository_repository_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -289,7 +289,7 @@ func (x *AffectedCommitsResponse) String() string {
 func (*AffectedCommitsResponse) ProtoMessage() {}
 
 func (x *AffectedCommitsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[4]
+	mi := &file_pb_repository_repository_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -302,17 +302,17 @@ func (x *AffectedCommitsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AffectedCommitsResponse.ProtoReflect.Descriptor instead.
 func (*AffectedCommitsResponse) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{4}
+	return file_pb_repository_repository_proto_rawDescGZIP(), []int{4}
 }
 
-func (x *AffectedCommitsResponse) GetCommits() []*AffectedCommit {
+func (x *AffectedCommitsResponse) GetCommits() []*Commit {
 	if x != nil {
 		return x.Commits
 	}
 	return nil
 }
 
-func (x *AffectedCommitsResponse) GetRefs() []*AffectedRefs {
+func (x *AffectedCommitsResponse) GetRefs() []*Ref {
 	if x != nil {
 		return x.Refs
 	}
@@ -329,7 +329,7 @@ type Event struct {
 
 func (x *Event) Reset() {
 	*x = Event{}
-	mi := &file_repository_proto_msgTypes[5]
+	mi := &file_pb_repository_repository_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -341,7 +341,7 @@ func (x *Event) String() string {
 func (*Event) ProtoMessage() {}
 
 func (x *Event) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[5]
+	mi := &file_pb_repository_repository_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -354,7 +354,7 @@ func (x *Event) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Event.ProtoReflect.Descriptor instead.
 func (*Event) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{5}
+	return file_pb_repository_repository_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *Event) GetEventType() EventType {
@@ -381,7 +381,7 @@ type CacheRequest struct {
 
 func (x *CacheRequest) Reset() {
 	*x = CacheRequest{}
-	mi := &file_repository_proto_msgTypes[6]
+	mi := &file_pb_repository_repository_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -393,7 +393,7 @@ func (x *CacheRequest) String() string {
 func (*CacheRequest) ProtoMessage() {}
 
 func (x *CacheRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[6]
+	mi := &file_pb_repository_repository_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -406,7 +406,7 @@ func (x *CacheRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CacheRequest.ProtoReflect.Descriptor instead.
 func (*CacheRequest) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{6}
+	return file_pb_repository_repository_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *CacheRequest) GetUrl() string {
@@ -437,7 +437,7 @@ type AffectedCommitsRequest struct {
 
 func (x *AffectedCommitsRequest) Reset() {
 	*x = AffectedCommitsRequest{}
-	mi := &file_repository_proto_msgTypes[7]
+	mi := &file_pb_repository_repository_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -449,7 +449,7 @@ func (x *AffectedCommitsRequest) String() string {
 func (*AffectedCommitsRequest) ProtoMessage() {}
 
 func (x *AffectedCommitsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[7]
+	mi := &file_pb_repository_repository_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -462,7 +462,7 @@ func (x *AffectedCommitsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AffectedCommitsRequest.ProtoReflect.Descriptor instead.
 func (*AffectedCommitsRequest) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{7}
+	return file_pb_repository_repository_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *AffectedCommitsRequest) GetUrl() string {
@@ -507,24 +507,24 @@ func (x *AffectedCommitsRequest) GetForceUpdate() bool {
 	return false
 }
 
-var File_repository_proto protoreflect.FileDescriptor
+var File_pb_repository_repository_proto protoreflect.FileDescriptor
 
-const file_repository_proto_rawDesc = "" +
+const file_pb_repository_repository_proto_rawDesc = "" +
 	"\n" +
-	"\x10repository.proto\x12\x06gitter\"=\n" +
+	"\x1epb/repository/repository.proto\x12\x06gitter\"=\n" +
 	"\fCommitDetail\x12\x12\n" +
 	"\x04hash\x18\x01 \x01(\fR\x04hash\x12\x19\n" +
 	"\bpatch_id\x18\x02 \x01(\fR\apatchId\"A\n" +
 	"\x0fRepositoryCache\x12.\n" +
-	"\acommits\x18\x01 \x03(\v2\x14.gitter.CommitDetailR\acommits\"$\n" +
-	"\x0eAffectedCommit\x12\x12\n" +
-	"\x04hash\x18\x01 \x01(\fR\x04hash\"4\n" +
-	"\fAffectedRefs\x12\x10\n" +
+	"\acommits\x18\x01 \x03(\v2\x14.gitter.CommitDetailR\acommits\"\x1c\n" +
+	"\x06Commit\x12\x12\n" +
+	"\x04hash\x18\x01 \x01(\fR\x04hash\"+\n" +
+	"\x03Ref\x12\x10\n" +
 	"\x03ref\x18\x01 \x01(\tR\x03ref\x12\x12\n" +
-	"\x04hash\x18\x02 \x01(\fR\x04hash\"u\n" +
-	"\x17AffectedCommitsResponse\x120\n" +
-	"\acommits\x18\x01 \x03(\v2\x16.gitter.AffectedCommitR\acommits\x12(\n" +
-	"\x04refs\x18\x02 \x03(\v2\x14.gitter.AffectedRefsR\x04refs\"M\n" +
+	"\x04hash\x18\x02 \x01(\fR\x04hash\"d\n" +
+	"\x17AffectedCommitsResponse\x12(\n" +
+	"\acommits\x18\x01 \x03(\v2\x0e.gitter.CommitR\acommits\x12\x1f\n" +
+	"\x04refs\x18\x02 \x03(\v2\v.gitter.RefR\x04refs\"M\n" +
 	"\x05Event\x120\n" +
 	"\n" +
 	"event_type\x18\x01 \x01(\x0e2\x11.gitter.EventTypeR\teventType\x12\x12\n" +
@@ -547,34 +547,34 @@ const file_repository_proto_rawDesc = "" +
 	"\x05LIMIT\x10\x03B\x0eZ\f./repositoryb\x06proto3"
 
 var (
-	file_repository_proto_rawDescOnce sync.Once
-	file_repository_proto_rawDescData []byte
+	file_pb_repository_repository_proto_rawDescOnce sync.Once
+	file_pb_repository_repository_proto_rawDescData []byte
 )
 
-func file_repository_proto_rawDescGZIP() []byte {
-	file_repository_proto_rawDescOnce.Do(func() {
-		file_repository_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_repository_proto_rawDesc), len(file_repository_proto_rawDesc)))
+func file_pb_repository_repository_proto_rawDescGZIP() []byte {
+	file_pb_repository_repository_proto_rawDescOnce.Do(func() {
+		file_pb_repository_repository_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pb_repository_repository_proto_rawDesc), len(file_pb_repository_repository_proto_rawDesc)))
 	})
-	return file_repository_proto_rawDescData
+	return file_pb_repository_repository_proto_rawDescData
 }
 
-var file_repository_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_repository_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
-var file_repository_proto_goTypes = []any{
+var file_pb_repository_repository_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_pb_repository_repository_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_pb_repository_repository_proto_goTypes = []any{
 	(EventType)(0),                  // 0: gitter.EventType
 	(*CommitDetail)(nil),            // 1: gitter.CommitDetail
 	(*RepositoryCache)(nil),         // 2: gitter.RepositoryCache
-	(*AffectedCommit)(nil),          // 3: gitter.AffectedCommit
-	(*AffectedRefs)(nil),            // 4: gitter.AffectedRefs
+	(*Commit)(nil),                  // 3: gitter.Commit
+	(*Ref)(nil),                     // 4: gitter.Ref
 	(*AffectedCommitsResponse)(nil), // 5: gitter.AffectedCommitsResponse
 	(*Event)(nil),                   // 6: gitter.Event
 	(*CacheRequest)(nil),            // 7: gitter.CacheRequest
 	(*AffectedCommitsRequest)(nil),  // 8: gitter.AffectedCommitsRequest
 }
-var file_repository_proto_depIdxs = []int32{
+var file_pb_repository_repository_proto_depIdxs = []int32{
 	1, // 0: gitter.RepositoryCache.commits:type_name -> gitter.CommitDetail
-	3, // 1: gitter.AffectedCommitsResponse.commits:type_name -> gitter.AffectedCommit
-	4, // 2: gitter.AffectedCommitsResponse.refs:type_name -> gitter.AffectedRefs
+	3, // 1: gitter.AffectedCommitsResponse.commits:type_name -> gitter.Commit
+	4, // 2: gitter.AffectedCommitsResponse.refs:type_name -> gitter.Ref
 	0, // 3: gitter.Event.event_type:type_name -> gitter.EventType
 	6, // 4: gitter.AffectedCommitsRequest.events:type_name -> gitter.Event
 	5, // [5:5] is the sub-list for method output_type
@@ -584,27 +584,27 @@ var file_repository_proto_depIdxs = []int32{
 	0, // [0:5] is the sub-list for field type_name
 }
 
-func init() { file_repository_proto_init() }
-func file_repository_proto_init() {
-	if File_repository_proto != nil {
+func init() { file_pb_repository_repository_proto_init() }
+func file_pb_repository_repository_proto_init() {
+	if File_pb_repository_repository_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_repository_proto_rawDesc), len(file_repository_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pb_repository_repository_proto_rawDesc), len(file_pb_repository_repository_proto_rawDesc)),
 			NumEnums:      1,
 			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_repository_proto_goTypes,
-		DependencyIndexes: file_repository_proto_depIdxs,
-		EnumInfos:         file_repository_proto_enumTypes,
-		MessageInfos:      file_repository_proto_msgTypes,
+		GoTypes:           file_pb_repository_repository_proto_goTypes,
+		DependencyIndexes: file_pb_repository_repository_proto_depIdxs,
+		EnumInfos:         file_pb_repository_repository_proto_enumTypes,
+		MessageInfos:      file_pb_repository_repository_proto_msgTypes,
 	}.Build()
-	File_repository_proto = out.File
-	file_repository_proto_goTypes = nil
-	file_repository_proto_depIdxs = nil
+	File_pb_repository_repository_proto = out.File
+	file_pb_repository_repository_proto_goTypes = nil
+	file_pb_repository_repository_proto_depIdxs = nil
 }

--- a/go/cmd/gitter/pb/repository/repository.proto
+++ b/go/cmd/gitter/pb/repository/repository.proto
@@ -15,18 +15,18 @@ message RepositoryCache {
     repeated CommitDetail commits = 1;
 }
 
-message AffectedCommit {
+message Commit {
     bytes hash = 1;
 }
 
-message AffectedRefs {
+message Ref {
     string ref = 1;
     bytes hash = 2;
 }
 
 message AffectedCommitsResponse {
-    repeated AffectedCommit commits = 1;
-    repeated AffectedRefs refs = 2;
+    repeated Commit commits = 1;
+    repeated Ref refs = 2;
 }
 
 enum EventType {


### PR DESCRIPTION
Rename gitter proto message names to be a bit more generic so it can be reused. 