### PR TITLE
fix(gitter): return tags instead of refs that includes heads

### DIFF
--- a/go/cmd/gitter/gitter.go
+++ b/go/cmd/gitter/gitter.go
@@ -123,7 +123,7 @@ func repoCostBytes(repo *Repository) int64 {
 	// Mutex (8 bytes), string for repo path (say 128 bytes), root commit (assume 1 root only, 32 bytes)
 	repoOverhead := 168
 	// Assuming per commit adds:
-	// - Commit struct (Hash, PatchID, Parent []int of size 1, Refs []string)
+	// - Commit struct (Hash, PatchID, Parent []int of size 1, Tags []string)
 	//   = 20 + 20 + 24 + 8 + 24 + <string len> ~= 128 bytes
 	// - 1 pointer into []*Commit
 	//   = 8 bytes
@@ -707,17 +707,17 @@ func affectedCommitsHandler(w http.ResponseWriter, r *http.Request) {
 
 	resp := &pb.AffectedCommitsResponse{
 		Commits:            make([]*pb.Commit, 0, len(affectedCommits)),
-		Refs:               make([]*pb.Ref, 0),
+		Tags:               make([]*pb.Ref, 0),
 		CherryPickedEvents: cherryPickedEvents,
 	}
 	for _, c := range affectedCommits {
 		resp.Commits = append(resp.Commits, &pb.Commit{
 			Hash: c.Hash[:],
 		})
-		for _, ref := range c.Refs {
-			resp.Refs = append(resp.Refs, &pb.Ref{
-				Ref:  ref,
-				Hash: c.Hash[:],
+		for _, tag := range c.Tags {
+			resp.Tags = append(resp.Tags, &pb.Ref{
+				Label: tag,
+				Hash:  c.Hash[:],
 			})
 		}
 	}

--- a/go/cmd/gitter/pb/repository/repository.pb.go
+++ b/go/cmd/gitter/pb/repository/repository.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.11
 // 	protoc        v3.21.12
-// source: pb/repository/repository.proto
+// source: repository.proto
 
 package repository
 
@@ -57,11 +57,11 @@ func (x EventType) String() string {
 }
 
 func (EventType) Descriptor() protoreflect.EnumDescriptor {
-	return file_pb_repository_repository_proto_enumTypes[0].Descriptor()
+	return file_repository_proto_enumTypes[0].Descriptor()
 }
 
 func (EventType) Type() protoreflect.EnumType {
-	return &file_pb_repository_repository_proto_enumTypes[0]
+	return &file_repository_proto_enumTypes[0]
 }
 
 func (x EventType) Number() protoreflect.EnumNumber {
@@ -70,7 +70,7 @@ func (x EventType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use EventType.Descriptor instead.
 func (EventType) EnumDescriptor() ([]byte, []int) {
-	return file_pb_repository_repository_proto_rawDescGZIP(), []int{0}
+	return file_repository_proto_rawDescGZIP(), []int{0}
 }
 
 type CommitDetail struct {
@@ -83,7 +83,7 @@ type CommitDetail struct {
 
 func (x *CommitDetail) Reset() {
 	*x = CommitDetail{}
-	mi := &file_pb_repository_repository_proto_msgTypes[0]
+	mi := &file_repository_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -95,7 +95,7 @@ func (x *CommitDetail) String() string {
 func (*CommitDetail) ProtoMessage() {}
 
 func (x *CommitDetail) ProtoReflect() protoreflect.Message {
-	mi := &file_pb_repository_repository_proto_msgTypes[0]
+	mi := &file_repository_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -108,7 +108,7 @@ func (x *CommitDetail) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CommitDetail.ProtoReflect.Descriptor instead.
 func (*CommitDetail) Descriptor() ([]byte, []int) {
-	return file_pb_repository_repository_proto_rawDescGZIP(), []int{0}
+	return file_repository_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *CommitDetail) GetHash() []byte {
@@ -136,7 +136,7 @@ type RepositoryCache struct {
 
 func (x *RepositoryCache) Reset() {
 	*x = RepositoryCache{}
-	mi := &file_pb_repository_repository_proto_msgTypes[1]
+	mi := &file_repository_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -148,7 +148,7 @@ func (x *RepositoryCache) String() string {
 func (*RepositoryCache) ProtoMessage() {}
 
 func (x *RepositoryCache) ProtoReflect() protoreflect.Message {
-	mi := &file_pb_repository_repository_proto_msgTypes[1]
+	mi := &file_repository_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -161,7 +161,7 @@ func (x *RepositoryCache) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RepositoryCache.ProtoReflect.Descriptor instead.
 func (*RepositoryCache) Descriptor() ([]byte, []int) {
-	return file_pb_repository_repository_proto_rawDescGZIP(), []int{1}
+	return file_repository_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *RepositoryCache) GetCommits() []*CommitDetail {
@@ -180,7 +180,7 @@ type Commit struct {
 
 func (x *Commit) Reset() {
 	*x = Commit{}
-	mi := &file_pb_repository_repository_proto_msgTypes[2]
+	mi := &file_repository_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -192,7 +192,7 @@ func (x *Commit) String() string {
 func (*Commit) ProtoMessage() {}
 
 func (x *Commit) ProtoReflect() protoreflect.Message {
-	mi := &file_pb_repository_repository_proto_msgTypes[2]
+	mi := &file_repository_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -205,7 +205,7 @@ func (x *Commit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Commit.ProtoReflect.Descriptor instead.
 func (*Commit) Descriptor() ([]byte, []int) {
-	return file_pb_repository_repository_proto_rawDescGZIP(), []int{2}
+	return file_repository_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *Commit) GetHash() []byte {
@@ -217,7 +217,7 @@ func (x *Commit) GetHash() []byte {
 
 type Ref struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Ref           string                 `protobuf:"bytes,1,opt,name=ref,proto3" json:"ref,omitempty"`
+	Label         string                 `protobuf:"bytes,1,opt,name=label,proto3" json:"label,omitempty"`
 	Hash          []byte                 `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -225,7 +225,7 @@ type Ref struct {
 
 func (x *Ref) Reset() {
 	*x = Ref{}
-	mi := &file_pb_repository_repository_proto_msgTypes[3]
+	mi := &file_repository_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -237,7 +237,7 @@ func (x *Ref) String() string {
 func (*Ref) ProtoMessage() {}
 
 func (x *Ref) ProtoReflect() protoreflect.Message {
-	mi := &file_pb_repository_repository_proto_msgTypes[3]
+	mi := &file_repository_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -250,12 +250,12 @@ func (x *Ref) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Ref.ProtoReflect.Descriptor instead.
 func (*Ref) Descriptor() ([]byte, []int) {
-	return file_pb_repository_repository_proto_rawDescGZIP(), []int{3}
+	return file_repository_proto_rawDescGZIP(), []int{3}
 }
 
-func (x *Ref) GetRef() string {
+func (x *Ref) GetLabel() string {
 	if x != nil {
-		return x.Ref
+		return x.Label
 	}
 	return ""
 }
@@ -270,7 +270,7 @@ func (x *Ref) GetHash() []byte {
 type AffectedCommitsResponse struct {
 	state              protoimpl.MessageState `protogen:"open.v1"`
 	Commits            []*Commit              `protobuf:"bytes,1,rep,name=commits,proto3" json:"commits,omitempty"`
-	Refs               []*Ref                 `protobuf:"bytes,2,rep,name=refs,proto3" json:"refs,omitempty"`
+	Tags               []*Ref                 `protobuf:"bytes,2,rep,name=tags,proto3" json:"tags,omitempty"`
 	CherryPickedEvents []*Event               `protobuf:"bytes,3,rep,name=cherry_picked_events,json=cherryPickedEvents,proto3" json:"cherry_picked_events,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
@@ -278,7 +278,7 @@ type AffectedCommitsResponse struct {
 
 func (x *AffectedCommitsResponse) Reset() {
 	*x = AffectedCommitsResponse{}
-	mi := &file_pb_repository_repository_proto_msgTypes[4]
+	mi := &file_repository_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -290,7 +290,7 @@ func (x *AffectedCommitsResponse) String() string {
 func (*AffectedCommitsResponse) ProtoMessage() {}
 
 func (x *AffectedCommitsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_pb_repository_repository_proto_msgTypes[4]
+	mi := &file_repository_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -303,7 +303,7 @@ func (x *AffectedCommitsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AffectedCommitsResponse.ProtoReflect.Descriptor instead.
 func (*AffectedCommitsResponse) Descriptor() ([]byte, []int) {
-	return file_pb_repository_repository_proto_rawDescGZIP(), []int{4}
+	return file_repository_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *AffectedCommitsResponse) GetCommits() []*Commit {
@@ -313,9 +313,9 @@ func (x *AffectedCommitsResponse) GetCommits() []*Commit {
 	return nil
 }
 
-func (x *AffectedCommitsResponse) GetRefs() []*Ref {
+func (x *AffectedCommitsResponse) GetTags() []*Ref {
 	if x != nil {
-		return x.Refs
+		return x.Tags
 	}
 	return nil
 }
@@ -337,7 +337,7 @@ type Event struct {
 
 func (x *Event) Reset() {
 	*x = Event{}
-	mi := &file_pb_repository_repository_proto_msgTypes[5]
+	mi := &file_repository_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -349,7 +349,7 @@ func (x *Event) String() string {
 func (*Event) ProtoMessage() {}
 
 func (x *Event) ProtoReflect() protoreflect.Message {
-	mi := &file_pb_repository_repository_proto_msgTypes[5]
+	mi := &file_repository_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -362,7 +362,7 @@ func (x *Event) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Event.ProtoReflect.Descriptor instead.
 func (*Event) Descriptor() ([]byte, []int) {
-	return file_pb_repository_repository_proto_rawDescGZIP(), []int{5}
+	return file_repository_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *Event) GetEventType() EventType {
@@ -389,7 +389,7 @@ type CacheRequest struct {
 
 func (x *CacheRequest) Reset() {
 	*x = CacheRequest{}
-	mi := &file_pb_repository_repository_proto_msgTypes[6]
+	mi := &file_repository_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -401,7 +401,7 @@ func (x *CacheRequest) String() string {
 func (*CacheRequest) ProtoMessage() {}
 
 func (x *CacheRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pb_repository_repository_proto_msgTypes[6]
+	mi := &file_repository_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -414,7 +414,7 @@ func (x *CacheRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CacheRequest.ProtoReflect.Descriptor instead.
 func (*CacheRequest) Descriptor() ([]byte, []int) {
-	return file_pb_repository_repository_proto_rawDescGZIP(), []int{6}
+	return file_repository_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *CacheRequest) GetUrl() string {
@@ -445,7 +445,7 @@ type AffectedCommitsRequest struct {
 
 func (x *AffectedCommitsRequest) Reset() {
 	*x = AffectedCommitsRequest{}
-	mi := &file_pb_repository_repository_proto_msgTypes[7]
+	mi := &file_repository_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -457,7 +457,7 @@ func (x *AffectedCommitsRequest) String() string {
 func (*AffectedCommitsRequest) ProtoMessage() {}
 
 func (x *AffectedCommitsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pb_repository_repository_proto_msgTypes[7]
+	mi := &file_repository_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -470,7 +470,7 @@ func (x *AffectedCommitsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AffectedCommitsRequest.ProtoReflect.Descriptor instead.
 func (*AffectedCommitsRequest) Descriptor() ([]byte, []int) {
-	return file_pb_repository_repository_proto_rawDescGZIP(), []int{7}
+	return file_repository_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *AffectedCommitsRequest) GetUrl() string {
@@ -515,24 +515,24 @@ func (x *AffectedCommitsRequest) GetForceUpdate() bool {
 	return false
 }
 
-var File_pb_repository_repository_proto protoreflect.FileDescriptor
+var File_repository_proto protoreflect.FileDescriptor
 
-const file_pb_repository_repository_proto_rawDesc = "" +
+const file_repository_proto_rawDesc = "" +
 	"\n" +
-	"\x1epb/repository/repository.proto\x12\x06gitter\"=\n" +
+	"\x10repository.proto\x12\x06gitter\"=\n" +
 	"\fCommitDetail\x12\x12\n" +
 	"\x04hash\x18\x01 \x01(\fR\x04hash\x12\x19\n" +
 	"\bpatch_id\x18\x02 \x01(\fR\apatchId\"A\n" +
 	"\x0fRepositoryCache\x12.\n" +
 	"\acommits\x18\x01 \x03(\v2\x14.gitter.CommitDetailR\acommits\"\x1c\n" +
 	"\x06Commit\x12\x12\n" +
-	"\x04hash\x18\x01 \x01(\fR\x04hash\"+\n" +
-	"\x03Ref\x12\x10\n" +
-	"\x03ref\x18\x01 \x01(\tR\x03ref\x12\x12\n" +
+	"\x04hash\x18\x01 \x01(\fR\x04hash\"/\n" +
+	"\x03Ref\x12\x14\n" +
+	"\x05label\x18\x01 \x01(\tR\x05label\x12\x12\n" +
 	"\x04hash\x18\x02 \x01(\fR\x04hash\"\xa5\x01\n" +
 	"\x17AffectedCommitsResponse\x12(\n" +
 	"\acommits\x18\x01 \x03(\v2\x0e.gitter.CommitR\acommits\x12\x1f\n" +
-	"\x04refs\x18\x02 \x03(\v2\v.gitter.RefR\x04refs\x12?\n" +
+	"\x04tags\x18\x02 \x03(\v2\v.gitter.RefR\x04tags\x12?\n" +
 	"\x14cherry_picked_events\x18\x03 \x03(\v2\r.gitter.EventR\x12cherryPickedEvents\"M\n" +
 	"\x05Event\x120\n" +
 	"\n" +
@@ -556,20 +556,20 @@ const file_pb_repository_repository_proto_rawDesc = "" +
 	"\x05LIMIT\x10\x03B\x0eZ\f./repositoryb\x06proto3"
 
 var (
-	file_pb_repository_repository_proto_rawDescOnce sync.Once
-	file_pb_repository_repository_proto_rawDescData []byte
+	file_repository_proto_rawDescOnce sync.Once
+	file_repository_proto_rawDescData []byte
 )
 
-func file_pb_repository_repository_proto_rawDescGZIP() []byte {
-	file_pb_repository_repository_proto_rawDescOnce.Do(func() {
-		file_pb_repository_repository_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pb_repository_repository_proto_rawDesc), len(file_pb_repository_repository_proto_rawDesc)))
+func file_repository_proto_rawDescGZIP() []byte {
+	file_repository_proto_rawDescOnce.Do(func() {
+		file_repository_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_repository_proto_rawDesc), len(file_repository_proto_rawDesc)))
 	})
-	return file_pb_repository_repository_proto_rawDescData
+	return file_repository_proto_rawDescData
 }
 
-var file_pb_repository_repository_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_pb_repository_repository_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
-var file_pb_repository_repository_proto_goTypes = []any{
+var file_repository_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_repository_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_repository_proto_goTypes = []any{
 	(EventType)(0),                  // 0: gitter.EventType
 	(*CommitDetail)(nil),            // 1: gitter.CommitDetail
 	(*RepositoryCache)(nil),         // 2: gitter.RepositoryCache
@@ -580,10 +580,10 @@ var file_pb_repository_repository_proto_goTypes = []any{
 	(*CacheRequest)(nil),            // 7: gitter.CacheRequest
 	(*AffectedCommitsRequest)(nil),  // 8: gitter.AffectedCommitsRequest
 }
-var file_pb_repository_repository_proto_depIdxs = []int32{
+var file_repository_proto_depIdxs = []int32{
 	1, // 0: gitter.RepositoryCache.commits:type_name -> gitter.CommitDetail
 	3, // 1: gitter.AffectedCommitsResponse.commits:type_name -> gitter.Commit
-	4, // 2: gitter.AffectedCommitsResponse.refs:type_name -> gitter.Ref
+	4, // 2: gitter.AffectedCommitsResponse.tags:type_name -> gitter.Ref
 	6, // 3: gitter.AffectedCommitsResponse.cherry_picked_events:type_name -> gitter.Event
 	0, // 4: gitter.Event.event_type:type_name -> gitter.EventType
 	6, // 5: gitter.AffectedCommitsRequest.events:type_name -> gitter.Event
@@ -594,27 +594,27 @@ var file_pb_repository_repository_proto_depIdxs = []int32{
 	0, // [0:6] is the sub-list for field type_name
 }
 
-func init() { file_pb_repository_repository_proto_init() }
-func file_pb_repository_repository_proto_init() {
-	if File_pb_repository_repository_proto != nil {
+func init() { file_repository_proto_init() }
+func file_repository_proto_init() {
+	if File_repository_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pb_repository_repository_proto_rawDesc), len(file_pb_repository_repository_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_repository_proto_rawDesc), len(file_repository_proto_rawDesc)),
 			NumEnums:      1,
 			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pb_repository_repository_proto_goTypes,
-		DependencyIndexes: file_pb_repository_repository_proto_depIdxs,
-		EnumInfos:         file_pb_repository_repository_proto_enumTypes,
-		MessageInfos:      file_pb_repository_repository_proto_msgTypes,
+		GoTypes:           file_repository_proto_goTypes,
+		DependencyIndexes: file_repository_proto_depIdxs,
+		EnumInfos:         file_repository_proto_enumTypes,
+		MessageInfos:      file_repository_proto_msgTypes,
 	}.Build()
-	File_pb_repository_repository_proto = out.File
-	file_pb_repository_repository_proto_goTypes = nil
-	file_pb_repository_repository_proto_depIdxs = nil
+	File_repository_proto = out.File
+	file_repository_proto_goTypes = nil
+	file_repository_proto_depIdxs = nil
 }

--- a/go/cmd/gitter/pb/repository/repository.proto
+++ b/go/cmd/gitter/pb/repository/repository.proto
@@ -20,13 +20,13 @@ message Commit {
 }
 
 message Ref {
-    string ref = 1;
+    string label = 1;
     bytes hash = 2;
 }
 
 message AffectedCommitsResponse {
     repeated Commit commits = 1;
-    repeated Ref refs = 2;
+    repeated Ref tags = 2;
     repeated Event cherry_picked_events = 3;
 }
 

--- a/go/cmd/gitter/repository.go
+++ b/go/cmd/gitter/repository.go
@@ -23,7 +23,7 @@ type Commit struct {
 	Hash    SHA1
 	PatchID SHA1
 	Parents []int
-	Refs    []string
+	Tags    []string
 }
 
 // Repository holds the commit graph and other details for a git repository.
@@ -38,8 +38,8 @@ type Repository struct {
 	commitGraph [][]int
 	// Map of commit hash to its index in the commits slice
 	hashToIndex map[SHA1]int
-	// Store refs to commit because it's useful for CVE conversion
-	refToCommit map[string]int
+	// Store tags to commit index
+	tagToCommit map[string]int
 	// For cherry-pick detection: PatchID -> []commit indexes
 	patchIDToCommits map[SHA1][]int
 	// Root commits (commits with no parents)
@@ -59,7 +59,7 @@ func NewRepository(repoPath string) *Repository {
 	return &Repository{
 		repoPath:         repoPath,
 		hashToIndex:      make(map[SHA1]int),
-		refToCommit:      make(map[string]int),
+		tagToCommit:      make(map[string]int),
 		patchIDToCommits: make(map[SHA1][]int),
 	}
 }
@@ -179,20 +179,20 @@ func (r *Repository) buildCommitGraph(ctx context.Context, cache *pb.RepositoryC
 
 		var childHash SHA1
 		parentHashes := []SHA1{}
-		refs := []string{}
+		tags := []string{}
 
 		switch len(commitInfo) {
 		case 3:
-			// refs are separated by commas
+			// tags are separated by commas
 			rawRefs := strings.Split(commitInfo[2], ", ")
 			for _, ref := range rawRefs {
 				if ref == "" {
 					continue
 				}
-				// Remove prefixes from tags, other refs such as branches will be left as is
-				ref = strings.TrimPrefix(ref, "tag: ")
-				ref = strings.TrimPrefix(ref, "HEAD -> ") // clean up HEAD -> branch-name to just keep the branch name
-				refs = append(refs, ref)
+				// Only keep tags
+				if strings.HasPrefix(ref, "tag: ") {
+					tags = append(tags, strings.TrimPrefix(ref, "tag: "))
+				}
 			}
 
 			fallthrough
@@ -224,7 +224,7 @@ func (r *Repository) buildCommitGraph(ctx context.Context, cache *pb.RepositoryC
 
 		childIdx := r.getOrCreateIndex(childHash)
 		commit := r.commits[childIdx]
-		commit.Refs = refs
+		commit.Tags = tags
 
 		// We want to keep the root commit (no parent) easily accessible for introduced=0
 		if len(parentHashes) == 0 {
@@ -249,9 +249,9 @@ func (r *Repository) buildCommitGraph(ctx context.Context, cache *pb.RepositoryC
 			newCommits = append(newCommits, childIdx)
 		}
 
-		// Also populate the ref-to-commit map
-		for _, ref := range refs {
-			r.refToCommit[ref] = childIdx
+		// Also populate the tag-to-commit map
+		for _, tag := range tags {
+			r.tagToCommit[tag] = childIdx
 		}
 	}
 

--- a/go/cmd/gitter/repository_test.go
+++ b/go/cmd/gitter/repository_test.go
@@ -78,9 +78,9 @@ func TestBuildCommitGraph(t *testing.T) {
 		t.Errorf("expected 3 commits, got %d", len(r.commits))
 	}
 
-	// 2 tags + main branch
-	if len(r.refToCommit) != 3 {
-		t.Errorf("expected 3 refs, got %d", len(r.refToCommit))
+	// 2 tags
+	if len(r.tagToCommit) != 2 {
+		t.Errorf("expected 2 tags, got %d", len(r.tagToCommit))
 	}
 }
 


### PR DESCRIPTION
Response from `/affected-commits` now looks like:
```
{
    "commits":[{"hash":"8GU+8WiJW0syu/giWz873lL5h2M="},{"hash":"D5gAYe7fHs9n5+tW1aQYFVzSNgo="},{"hash":"1jxDMipXDPlNio0iNu14AtvxekY="}],
    "tags":[{"label":"v2026.03.18","hash":"GyZv9MbJYyFnGo3Jq5JzVMo58M8="}]
}
```