### PR TITLE
test: robust gitter setup

### DIFF
--- a/gcp/workers/worker/worker.py
+++ b/gcp/workers/worker/worker.py
@@ -551,7 +551,6 @@ class TaskRunner:
                     vulnerability.id)
     raise UpdateConflictError
 
-  # TODO: dummy comment
   def _generate_vanir_signatures(
       self, vulnerability: vulnerability_pb2.Vulnerability
   ) -> vulnerability_pb2.Vulnerability:


### PR DESCRIPTION
This PR improves the previous setup logic for gitter in `osv/tests.py`:
 - Implements a 60-second maximum wait time to accommodate compilation/startup in CI environments.
 - Uses `socket.connect_ex` to verify the port is open before proceeding.
 - Prints the exact time taken for the service to become ready.