### PR TITLE
fix: prevent 0001-01-01 published dates in Debian converter

### DIFF
--- a/vulnfeeds/cmd/converters/debian/main.go
+++ b/vulnfeeds/cmd/converters/debian/main.go
@@ -111,10 +111,9 @@ func generateOSVFromDebianTracker(debianData DebianSecurityTrackerData, debianRe
 			if !ok {
 				v = &vulns.Vulnerability{
 					Vulnerability: &osvschema.Vulnerability{
-						Id:        "DEBIAN-" + cveID,
-						Upstream:  []string{cveID},
-						Published: timestamppb.New(currentNVDCVE.CVE.Published.Time),
-						Details:   cveData.Description,
+						Id:       "DEBIAN-" + cveID,
+						Upstream: []string{cveID},
+						Details:  cveData.Description,
 						References: []*osvschema.Reference{
 							{
 								Type: osvschema.Reference_ADVISORY,
@@ -123,6 +122,11 @@ func generateOSVFromDebianTracker(debianData DebianSecurityTrackerData, debianRe
 						},
 					},
 				}
+
+				if !currentNVDCVE.CVE.Published.Time.IsZero() {
+					v.Published = timestamppb.New(currentNVDCVE.CVE.Published.Time)
+				}
+
 				if currentNVDCVE.CVE.Metrics != nil {
 					v.AddSeverity(currentNVDCVE.CVE.Metrics)
 				}

--- a/vulnfeeds/cmd/converters/debian/main.go
+++ b/vulnfeeds/cmd/converters/debian/main.go
@@ -123,7 +123,7 @@ func generateOSVFromDebianTracker(debianData DebianSecurityTrackerData, debianRe
 					},
 				}
 
-				if !currentNVDCVE.CVE.Published.Time.IsZero() {
+				if !currentNVDCVE.CVE.Published.IsZero() {
 					v.Published = timestamppb.New(currentNVDCVE.CVE.Published.Time)
 				}
 


### PR DESCRIPTION
Modify `vulnfeeds/cmd/converters/debian/main.go` to only set the `Published` field if the associated NVD CVE published time is not zero. This avoids generating `0001-01-01T00:00:00Z` dates which hide records from the /list page and trigger schema validation warnings.

Some of these cases don't even have valid upstream CVEs: https://github.com/google/osv.dev/issues/4694, which is weird. Maybe we shouldn't be publishing them at all?

Making this PR anyway to catch the cases that should be valid.

this should close https://github.com/google/osv.dev/issues/4694