### PR TITLE
chore: Add Azure Linux (AZL) source to test instance

### DIFF
--- a/source_test.yaml
+++ b/source_test.yaml
@@ -72,6 +72,20 @@
   editable: False
   strict_validation: True
 
+- name: 'azurelinux'
+  versions_from_repo: False
+  type: 0
+  ignore_patterns: ['^(?!AZL-).*$']
+  directory_path: 'osv'
+  repo_url: 'https://github.com/microsoft/AzureLinuxVulnerabilityData.git'
+  detect_cherrypicks: False
+  extension: '.json'
+  db_prefix: ['AZL-']
+  ignore_git: False
+  link: 'https://github.com/microsoft/AzureLinuxVulnerabilityData/blob/main/'
+  editable: False
+  strict_validation: True
+
 - name: 'bellsoft'
   versions_from_repo: False
   type: 0


### PR DESCRIPTION
## Overview

Add Azure Linux as a source in the test instance so we can start importing AZL advisories.

## Details

We publish Azure Linux vulnerability data as OSV-format JSON files in [microsoft/AzureLinuxVulnerabilityData](https://github.com/microsoft/AzureLinuxVulnerabilityData). The repo has ~12,000 advisories in an osv directory, all prefixed `AZL-`.

The ecosystem (`Azure Linux`) and its RPM-based version comparison already exist in the codebase, so this is just the source config to wire up the import.

This only touches source_test.yaml (test instance). A follow-up PR will add it to source.yaml for production once we confirm the import works.

## Testing

- Verified the entry matches the structure of other Git-based sources (type 0) like `almalinux`, `bellsoft`, etc.
- Confirmed the repo URL, directory path (osv), prefix (`AZL-`), and extension (`.json`) match what's actually in the upstream repo.
- Confirmed `Azure Linux` ecosystem support already exists in _ecosystems.py, purl_helpers.py, and the Go importer schema.