### PR TITLE
feat(gitter): parse repo url and enable more ways to validate

### DIFF
--- a/go/cmd/gitter/gitter.go
+++ b/go/cmd/gitter/gitter.go
@@ -20,7 +20,6 @@ import (
 	"os/signal"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"sync"
 	"syscall"
@@ -70,8 +69,6 @@ var (
 	repoCacheMaxCostBytes int64
 )
 
-var validURLRegex = regexp.MustCompile(`^(https?|git)://`)
-
 const shutdownTimeout = 10 * time.Second
 
 type SeparatedEvents struct {
@@ -113,8 +110,8 @@ func separateEvents(events []*pb.Event) (*SeparatedEvents, error) {
 // - Allowing multiple concurrent reads.
 var repoLocks sync.Map
 
-func GetRepoLock(url string) *sync.RWMutex {
-	lock, _ := repoLocks.LoadOrStore(url, &sync.RWMutex{})
+func GetRepoLock(repoURL string) *sync.RWMutex {
+	lock, _ := repoLocks.LoadOrStore(repoURL, &sync.RWMutex{})
 	return lock.(*sync.RWMutex)
 }
 
@@ -255,11 +252,11 @@ func prepareURL(r *http.Request, repoURL string) (string, error) {
 	return u.String(), nil
 }
 
-func getRepoDirName(url string) string {
-	base := path.Base(url)
+func getRepoDirName(repoURL string) string {
+	base := path.Base(repoURL)
 	base = filepath.Base(base)
 	base = strings.TrimSuffix(base, ".git")
-	hash := sha256.Sum256([]byte(url))
+	hash := sha256.Sum256([]byte(repoURL))
 
 	return fmt.Sprintf("%s-%s", base, hex.EncodeToString(hash[:]))
 }
@@ -306,9 +303,9 @@ func marshalResponse(r *http.Request, m proto.Message) ([]byte, error) {
 	return proto.Marshal(m)
 }
 
-func doFetch(ctx context.Context, w http.ResponseWriter, url string, forceUpdate bool) error {
-	_, err, _ := gFetch.Do(url, func() (any, error) {
-		return nil, FetchRepo(ctx, url, forceUpdate)
+func doFetch(ctx context.Context, w http.ResponseWriter, repoURL string, forceUpdate bool) error {
+	_, err, _ := gFetch.Do(repoURL, func() (any, error) {
+		return nil, FetchRepo(ctx, repoURL, forceUpdate)
 	})
 	if err != nil {
 		logger.ErrorContext(ctx, "Error fetching blob", slog.Any("error", err))
@@ -327,24 +324,24 @@ func doFetch(ctx context.Context, w http.ResponseWriter, url string, forceUpdate
 // getFreshRepo handles fetching and loading of a repository
 // If forceUpdate is true, it will always refetch and rebuild the repository (commit graph, patch ID, etc)
 // Otherwise, it will use a cache if available
-func getFreshRepo(ctx context.Context, w http.ResponseWriter, url string, forceUpdate bool) (*Repository, error) {
-	repoDirName := getRepoDirName(url)
+func getFreshRepo(ctx context.Context, w http.ResponseWriter, repoURL string, forceUpdate bool) (*Repository, error) {
+	repoDirName := getRepoDirName(repoURL)
 	repoPath := filepath.Join(gitStorePath, repoDirName)
 
 	if !forceUpdate {
-		if repo, ok := repoCache.Get(url); ok {
+		if repo, ok := repoCache.Get(repoURL); ok {
 			// repoCache.Get() will not return expired items, so we can safely return the repo
 			logger.DebugContext(ctx, "Repository already in cache, skipping fetch and load")
 			return repo, nil
 		}
 	}
 
-	if err := doFetch(ctx, w, url, forceUpdate); err != nil {
+	if err := doFetch(ctx, w, repoURL, forceUpdate); err != nil {
 		return nil, err
 	}
 
 	repoAny, err, _ := gLoad.Do(repoPath, func() (any, error) {
-		repoLock := GetRepoLock(url)
+		repoLock := GetRepoLock(repoURL)
 		repoLock.RLock()
 		defer repoLock.RUnlock()
 
@@ -357,24 +354,24 @@ func getFreshRepo(ctx context.Context, w http.ResponseWriter, url string, forceU
 		return nil, err
 	}
 	repo := repoAny.(*Repository)
-	repoCache.SetWithTTL(url, repo, 0, repoTTL)
+	repoCache.SetWithTTL(repoURL, repo, 0, repoTTL)
 
 	return repo, nil
 }
 
-func FetchRepo(ctx context.Context, url string, forceUpdate bool) error {
+func FetchRepo(ctx context.Context, repoURL string, forceUpdate bool) error {
 	logger.InfoContext(ctx, "Starting fetch repo")
 	start := time.Now()
 
-	repoDirName := getRepoDirName(url)
+	repoDirName := getRepoDirName(repoURL)
 	repoPath := filepath.Join(gitStorePath, repoDirName)
 
-	repoLock := GetRepoLock(url)
+	repoLock := GetRepoLock(repoURL)
 	repoLock.Lock()
 	defer repoLock.Unlock()
 
 	lastFetchMu.Lock()
-	accessTime, ok := lastFetch[url]
+	accessTime, ok := lastFetch[repoURL]
 	lastFetchMu.Unlock()
 
 	// Check if we need to fetch
@@ -383,7 +380,7 @@ func FetchRepo(ctx context.Context, url string, forceUpdate bool) error {
 		if _, err := os.Stat(filepath.Join(repoPath, ".git")); os.IsNotExist(err) {
 			// Clone
 			logger.InfoContext(ctx, "Cloning git repository", slog.Duration("sinceAccessTime", time.Since(accessTime)))
-			err := runCmd(ctx, "", []string{"GIT_TERMINAL_PROMPT=0"}, "git", "clone", "--", url, repoPath)
+			err := runCmd(ctx, "", []string{"GIT_TERMINAL_PROMPT=0"}, "git", "clone", "--", repoURL, repoPath)
 			if err != nil {
 				return fmt.Errorf("git clone failed: %w", err)
 			}
@@ -413,14 +410,14 @@ func FetchRepo(ctx context.Context, url string, forceUpdate bool) error {
 			}
 		}
 
-		updateLastFetch(url)
+		updateLastFetch(repoURL)
 	}
 
 	// Double check if the git directory exist
 	_, err := os.Stat(filepath.Join(repoPath, ".git"))
 	if err != nil {
 		if os.IsNotExist(err) {
-			deleteLastFetch(url)
+			deleteLastFetch(repoURL)
 		}
 
 		return fmt.Errorf("failed to read file: %w", err)
@@ -431,17 +428,17 @@ func FetchRepo(ctx context.Context, url string, forceUpdate bool) error {
 	return nil
 }
 
-func ArchiveRepo(ctx context.Context, url string) ([]byte, error) {
-	repoDirName := getRepoDirName(url)
+func ArchiveRepo(ctx context.Context, repoURL string) ([]byte, error) {
+	repoDirName := getRepoDirName(repoURL)
 	repoPath := filepath.Join(gitStorePath, repoDirName)
 	archivePath := repoPath + ".zst"
 
-	repoLock := GetRepoLock(url)
+	repoLock := GetRepoLock(repoURL)
 	repoLock.RLock()
 	defer repoLock.RUnlock()
 
 	lastFetchMu.Lock()
-	accessTime := lastFetch[url]
+	accessTime := lastFetch[repoURL]
 	lastFetchMu.Unlock()
 
 	// Check if archive needs update
@@ -561,14 +558,14 @@ func main() {
 }
 
 func gitHandler(w http.ResponseWriter, r *http.Request) {
-	url, err := prepareURL(r, r.URL.Query().Get("url"))
+	repoURL, err := prepareURL(r, r.URL.Query().Get("url"))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	forceUpdate := r.URL.Query().Get("force-update") == "true"
 
-	ctx := context.WithValue(r.Context(), urlKey, url)
+	ctx := context.WithValue(r.Context(), urlKey, repoURL)
 	logger.InfoContext(ctx, "Received request: /git", slog.Bool("forceUpdate", forceUpdate), slog.String("remoteAddr", r.RemoteAddr))
 
 	select {
@@ -583,13 +580,13 @@ func gitHandler(w http.ResponseWriter, r *http.Request) {
 	logger.DebugContext(ctx, "Concurrent requests", slog.Int("count", len(semaphore)))
 
 	// Fetch repo first
-	if err := doFetch(ctx, w, url, forceUpdate); err != nil {
+	if err := doFetch(ctx, w, repoURL, forceUpdate); err != nil {
 		return
 	}
 
 	// Archive repo
-	fileDataAny, err, _ := gArchive.Do(url, func() (any, error) {
-		return ArchiveRepo(ctx, url)
+	fileDataAny, err, _ := gArchive.Do(repoURL, func() (any, error) {
+		return ArchiveRepo(ctx, repoURL)
 	})
 	if err != nil {
 		logger.ErrorContext(ctx, "Error archiving blob", slog.Any("error", err))
@@ -620,13 +617,13 @@ func cacheHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	url, err := prepareURL(r, body.GetUrl())
+	repoURL, err := prepareURL(r, body.GetUrl())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	ctx := context.WithValue(r.Context(), urlKey, url)
+	ctx := context.WithValue(r.Context(), urlKey, repoURL)
 	logger.InfoContext(ctx, "Received request: /cache")
 
 	select {
@@ -640,7 +637,7 @@ func cacheHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	logger.DebugContext(ctx, "Concurrent requests", slog.Int("count", len(semaphore)))
 
-	if _, err := getFreshRepo(ctx, w, url, body.GetForceUpdate()); err != nil {
+	if _, err := getFreshRepo(ctx, w, repoURL, body.GetForceUpdate()); err != nil {
 		return
 	}
 
@@ -656,7 +653,7 @@ func affectedCommitsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	url, err := prepareURL(r, body.GetUrl())
+	repoURL, err := prepareURL(r, body.GetUrl())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -672,7 +669,7 @@ func affectedCommitsHandler(w http.ResponseWriter, r *http.Request) {
 	cherrypickFixed := body.GetDetectCherrypicksFixed()
 	cherrypickLimit := body.GetDetectCherrypicksLimit()
 
-	ctx := context.WithValue(r.Context(), urlKey, url)
+	ctx := context.WithValue(r.Context(), urlKey, repoURL)
 	logger.InfoContext(ctx, "Received request: /affected-commits", slog.Any("introduced", se.Introduced), slog.Any("fixed", se.Fixed), slog.Any("last_affected", se.LastAffected), slog.Any("limit", se.Limit), slog.Bool("cherrypickIntro", cherrypickIntro), slog.Bool("cherrypickFixed", cherrypickFixed), slog.Bool("cherrypickLimit", cherrypickLimit))
 
 	select {
@@ -686,7 +683,7 @@ func affectedCommitsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	logger.DebugContext(ctx, "Concurrent requests", slog.Int("count", len(semaphore)))
 
-	repo, err := getFreshRepo(ctx, w, url, body.GetForceUpdate())
+	repo, err := getFreshRepo(ctx, w, repoURL, body.GetForceUpdate())
 	if err != nil {
 		return
 	}

--- a/go/cmd/gitter/gitter_test.go
+++ b/go/cmd/gitter/gitter_test.go
@@ -103,7 +103,7 @@ func TestPrepareURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "/test", nil)
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
 			result, err := prepareURL(req, tt.url)
 			if tt.expectErr {
 				if err == nil {


### PR DESCRIPTION
We have some records with repo url that looks like this: `https://<repoURL>#<hashes or something>`
e.g.: https://github.com/pypa/advisory-database/blob/main/vulns/lxml/PYSEC-2021-852.yaml

If we parse repoURL as `net/url` then we can easily remove the queries and fragments from it. 
Also no regex for the http(s) / git protocol matching (so clear!)