### PR TITLE
chore: Add minimumReleaseAge of 7 days to renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
   ],
   "prHourlyLimit": 0,
   "prConcurrentLimit": 20,
+  "minimumReleaseAge": "7 days",
   "labels": [
     "dependencies"
   ],


### PR DESCRIPTION
Adds `minimumReleaseAge: "7 days"` to the root of `renovate.json` to enforce a 7-day delay on non-security updates across all dependencies, helping mitigate the risk of pulling in malicious packages.

---
*PR created automatically by Jules for task [15104474353265659662](https://jules.google.com/task/15104474353265659662) started by @another-rex*