### PR TITLE
feat(ui): add copy button feedback on homepage

### DIFF
--- a/gcp/website/frontend3/src/index.js
+++ b/gcp/website/frontend3/src/index.js
@@ -9,6 +9,16 @@ import { MdFilledTextField } from '@material/web/textfield/filled-text-field.js'
 import { LitElement, html } from 'lit';
 import { ExpandableSearch, SearchSuggestionsManager } from './search.js';
 
+const COPY_ICON_RESET_MS = 1500;
+
+document.addEventListener('clipboard-copy', ({target}) => {
+  const icon = target.querySelector('md-icon');
+  if (!icon) return;
+  clearTimeout(target._copyResetTimer);
+  icon.textContent = 'check';
+  target._copyResetTimer = setTimeout(() => { icon.textContent = 'content_copy'; }, COPY_ICON_RESET_MS);
+});
+
 // Submits a form in a way such that Turbo can intercept the event.
 // Triggering submit on the form directly would still give a correct resulting
 // page, but we want to let Turbo speed up renders as intended.


### PR DESCRIPTION
Copy buttons on homepage had no visual feedback of success. This swaps the copy icon to a checkmark momentarily indicating success on copy.

<img width="2325" height="693" alt="image" src="https://github.com/user-attachments/assets/a948429c-7d67-4fa8-af5f-eb41f4db352a" />
