### PR TITLE
fix: Add rel=nofollow to external facing links on website

### DIFF
--- a/gcp/website/blog/layouts/_default/_markup/render-link.html
+++ b/gcp/website/blog/layouts/_default/_markup/render-link.html
@@ -1,0 +1,22 @@
+{{- $url := .Destination -}}
+{{- $isExternal := or (hasPrefix $url "http://") (hasPrefix $url "https://") -}}
+{{- $isTrusted := false -}}
+{{- if $isExternal -}}
+  {{- $isTrusted = or
+    (hasPrefix $url "https://google.github.io/")
+    (hasPrefix $url "https://ossf.github.io/")
+    (hasPrefix $url "https://deps.dev/")
+    (hasPrefix $url "https://security.googleblog.com/")
+    (hasPrefix $url "https://github.com/google/")
+    (hasPrefix $url "https://osv.dev/")
+    (hasPrefix $url "https://api.osv.dev/")
+  -}}
+{{- end -}}
+<a href="{{ .Destination | safeURL }}"
+  {{- with .Title }} title="{{ . }}"{{ end -}}
+  {{- if $isExternal }} target="_blank"
+    {{- if $isTrusted }} rel="noopener noreferrer"
+    {{- else }} rel="nofollow noopener noreferrer"
+    {{- end -}}
+  {{- end -}}
+>{{ .Text | safeHTML }}</a>

--- a/gcp/website/frontend3/src/templates/home.html
+++ b/gcp/website/frontend3/src/templates/home.html
@@ -139,10 +139,10 @@
       <p class="description">
         This infrastructure serves as an aggregator of vulnerability databases
         that have adopted the <a href="https://ossf.github.io/osv-schema/">OSV schema</a>, including
-        <a href="https://github.com/github/advisory-database">GitHub Security Advisories</a>,
-        <a href="https://github.com/pypa/advisory-database">PyPA</a>,
-        <a href="https://github.com/RustSec/advisory-db">RustSec</a>, and
-        <a href="https://github.com/cloudsecurityalliance/gsd-database">Global Security Database</a>, and
+        <a href="https://github.com/github/advisory-database" rel="nofollow">GitHub Security Advisories</a>,
+        <a href="https://github.com/pypa/advisory-database" rel="nofollow">PyPA</a>,
+        <a href="https://github.com/RustSec/advisory-db" rel="nofollow">RustSec</a>, and
+        <a href="https://github.com/cloudsecurityalliance/gsd-database" rel="nofollow">Global Security Database</a>, and
         more.
       </p>
       <div class="cta">

--- a/gcp/website/frontend3/src/templates/linter/index.html
+++ b/gcp/website/frontend3/src/templates/linter/index.html
@@ -25,7 +25,7 @@
                 </div>
             </div>
             <div id="header-right">
-                <a class="improvement-link" href="https://github.com/ossf/osv-schema/tree/main/tools/osv-linter">Run OSV-Linter</a>
+                <a class="improvement-link" href="https://github.com/ossf/osv-schema/tree/main/tools/osv-linter" rel="nofollow">Run OSV-Linter</a>
             </div>
         </header>
         <main>

--- a/gcp/website/frontend3/src/templates/vulnerability.html
+++ b/gcp/website/frontend3/src/templates/vulnerability.html
@@ -14,7 +14,7 @@
           {{ vulnerability.id }}
         </h1>
         {% if vulnerability.human_source_link and vulnerability.human_source_link.startswith("https://github.com/advisories/") -%}
-          <a class="vulnerability-improvement-link" href="{{ vulnerability.human_source_link }}/improve">
+          <a class="vulnerability-improvement-link" href="{{ vulnerability.human_source_link }}/improve" rel="nofollow">
             Suggest an improvement
           </a>
         {% elif vulnerability.human_source_link and not vulnerability.id.startswith("openSUSE-") -%}
@@ -23,7 +23,7 @@
             See a problem?
           </a>
           <br/>
-          Please try reporting it <a href="{{ vulnerability.human_source_link}}" target="_blank" rel="noopener noreferrer">to the source</a> first.
+          Please try reporting it <a href="{{ vulnerability.human_source_link}}" target="_blank" rel="nofollow noopener noreferrer">to the source</a> first.
         </div>
         {% else -%}
           <a class="vulnerability-improvement-link" href="https://google.github.io/osv.dev/faq/#ive-found-something-wrong-with-the-data" target="_blank" rel="noopener noreferrer">
@@ -35,12 +35,12 @@
         <dl class="vulnerability-details">
           {%- if vulnerability.human_source_link and not vulnerability.id.startswith("openSUSE-") -%}
           <dt>Source</dt>
-          <dd><a href="{{ vulnerability.human_source_link }}" target="_blank" rel="noopener noreferrer">{{
+          <dd><a href="{{ vulnerability.human_source_link }}" target="_blank" rel="nofollow noopener noreferrer">{{
               vulnerability.human_source_link }}</a>
           </dd>
           {%- endif -%}
           <dt>Import Source</dt>
-          <dd><a href="{{ vulnerability.source_link }}" target="_blank" rel="noopener noreferrer">{{
+          <dd><a href="{{ vulnerability.source_link }}" target="_blank" rel="nofollow noopener noreferrer">{{
               vulnerability.source }}</a></dd>
 
           <dt>JSON Data</dt>
@@ -107,7 +107,7 @@
                 {% if item | is_cvss %}
                   <span class="severity-level severity-{{ item | severity_level }}">{{ item | display_severity_rating }}</span>
                   {{ item.type }} - {{ item.score }}
-                  <a href="{{ item | cvss_calculator_url }}" target="_blank" rel="noopener noreferrer">
+                  <a href="{{ item | cvss_calculator_url }}" target="_blank" rel="nofollow noopener noreferrer">
                     CVSS Calculator</a>
                 {% else %}
                   <span class="severity-level severity-invalid">{{ item.type }} - {{ item.score }}</span>
@@ -141,7 +141,7 @@
           <dd>
             <ul class="links">
               {% for reference in vulnerability.references -%}
-              <li><a href="{{ reference.url }}" target="_blank" rel="noopener noreferrer">{{ reference.url }}</a></li>
+              <li><a href="{{ reference.url }}" target="_blank" rel="nofollow noopener noreferrer">{{ reference.url }}</a></li>
               {% endfor -%}
             </ul>
           </dd>
@@ -157,7 +157,7 @@
                   <li>
                     <ul class="contact">
                       {%- for item in credit.contact -%}
-                      <li><a href="{{ item }}" target="_blank" rel="noopener noreferrer">{{ item }}</a></li>
+                      <li><a href="{{ item }}" target="_blank" rel="nofollow noopener noreferrer">{{ item }}</a></li>
                       {%- endfor -%}
                     </ul>
                   </li>
@@ -227,7 +227,7 @@
                         {% if item | is_cvss %}
                           <span class="severity-level severity-{{ item | severity_level }}">{{ item | display_severity_rating }}</span>
                           {{ item.type }} - {{ item.score }}
-                          <a href="{{ item | cvss_calculator_url }}" target="_blank" rel="noopener noreferrer">
+                          <a href="{{ item | cvss_calculator_url }}" target="_blank" rel="nofollow noopener noreferrer">
                             CVSS Calculator</a>
                         {% else %}
                           <span class="severity-level severity-invalid">{{ item.type }} - {{ item.score }}</span>
@@ -257,7 +257,7 @@
                             <div class="mdc-layout-grid__cell--span-9 version-value">
                               {% set link = event | event_link -%}
                               {% if link -%}
-                                <a href="{{ link }}">{{ event | event_value -}}</a>
+                                <a href="{{ link }}" rel="nofollow">{{ event | event_value -}}</a>
                               {% elif event | event_type == 'Introduced' and event | event_value == '0' -%}
                                 <div class="tooltip">{{ event | event_value -}}
                                   {% if range.type == 'GIT' %}
@@ -364,7 +364,7 @@
             <dl>
               <dt>Name</dt>
               {%- if affected.package | package_in_ecosystem -%}
-              <dd><a href="{{ affected.package | package_in_ecosystem }}" target="_blank" rel="noopener noreferrer">{{
+              <dd><a href="{{ affected.package | package_in_ecosystem }}" target="_blank" rel="nofollow noopener noreferrer">{{
                   affected.package.name }}</a></dd>
               {%- else -%}
               <dd>{{ affected.package.name }}</dd>
@@ -393,7 +393,7 @@
                 {% if item | is_cvss %}
                   <span class="severity-level severity-{{ item | severity_level }}">{{ item | display_severity_rating }}</span>
                   {{ item.type }} - {{ item.score }}
-                  <a href="{{ item | cvss_calculator_url }}" target="_blank" rel="noopener noreferrer">
+                  <a href="{{ item | cvss_calculator_url }}" target="_blank" rel="nofollow noopener noreferrer">
                     CVSS Calculator</a>
                 {% else %}
                   <span class="severity-level severity-invalid">{{ item.type }} - {{ item.score }}</span>
@@ -430,7 +430,7 @@
                     <div class="mdc-layout-grid__cell--span-9 version-value">
                       {% set link = event | event_link -%}
                       {% if link -%}
-                        <a href="{{ link }}">
+                        <a href="{{ link }}" rel="nofollow">
                           {{ event | event_value -}}
                         </a>
                       {% elif event | event_type == 'Introduced' and event | event_value == '0' -%}


### PR DESCRIPTION
## Summary

Adds `rel="nofollow"` to external-facing links on the OSV website to discourage search engine crawlers from promoting potentially malicious pages linked from vulnerability references.

Fixes #4644

## Changes

### Templates (`gcp/website/frontend3/src/templates/`)

- **vulnerability.html**: Added `nofollow` to all data-driven links:
  - Source links (`human_source_link`, `source_link`)
  - Vulnerability reference URLs (`reference.url`)
  - Credit contact links
  - CVSS calculator links
  - Commit/version links in affected ranges
  - Package ecosystem links (`package_in_ecosystem`)
- **home.html**: Added `nofollow` to third-party data source repository links (GitHub Advisory Database, PyPA, RustSec, Cloud Security Alliance)
- **linter/index.html**: Added `nofollow` to external OSV-Linter tool link

### Blog (`gcp/website/blog/`)

- Added Hugo link render hook (`layouts/_default/_markup/render-link.html`) that automatically applies `nofollow` to external links in blog post markdown content

### Trusted Domain Allowlist

The following domains are considered trusted and do **not** receive `nofollow`:
- `google.github.io` (OSV docs, scanner docs)
- `ossf.github.io` (OSV schema specification)
- `deps.dev` (open source insights)
- `security.googleblog.com`
- `github.com/google/*` (Google repositories)
- `osv.dev` / `api.osv.dev`

## Test Plan

- [ ] Verify vulnerability pages render with `rel="nofollow noopener noreferrer"` on reference URLs and source links
- [ ] Verify trusted domain links (e.g., deps.dev, Google docs) do NOT have `nofollow`
- [ ] Verify blog posts render external links with `nofollow`
- [ ] Verify home page third-party links have `nofollow`