### PR TITLE
chore: Update vanir-signatures cron schedule to 6 hours

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/vanir-signatures.yaml
+++ b/deployment/clouddeploy/gke-workers/base/vanir-signatures.yaml
@@ -3,9 +3,9 @@ kind: CronJob
 metadata:
   name: vanir-signatures
   labels:
-    cronLastSuccessfulTimeMins: "1500"
+    cronLastSuccessfulTimeMins: "400"
 spec:
-  schedule: "0 9 * * *"
+  schedule: "0 */6 * * *"
   timeZone: "Australia/Sydney"
   concurrencyPolicy: Forbid
   jobTemplate:


### PR DESCRIPTION
This PR updates the `vanir-signatures` CronJob schedule to run every six hours instead of daily. It also adjusts the `cronLastSuccessfulTimeMins` monitoring label to 400 minutes to reflect the new frequency.

---
*PR created automatically by Jules for task [4706727212944286976](https://jules.google.com/task/4706727212944286976) started by @cuixq*