### PR TITLE
fix: update commit query test expectations to include CVE-2020-15866

### DIFF
--- a/gcp/api/integration_tests.py
+++ b/gcp/api/integration_tests.py
@@ -733,6 +733,8 @@ class IntegrationTests(unittest.TestCase,
                 {},
                 {
                     'vulns': [{
+                        'id': 'CVE-2020-15866',
+                    }, {
                         'id': 'CVE-2020-36401',
                     }, {
                         'id': 'CVE-2021-4110',


### PR DESCRIPTION
The commit query seems to be mruby around 2.1.1 so it probably is affected