### PR TITLE
feat: update osv_vulnerabilities_export terraform config to match prod

### DIFF
--- a/deployment/terraform/modules/osv/main.tf
+++ b/deployment/terraform/modules/osv/main.tf
@@ -103,6 +103,30 @@ resource "google_storage_bucket" "osv_vulnerabilities_export" {
   location                    = "US"
   uniform_bucket_level_access = true
 
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      num_newer_versions = 673
+      with_state         = "ARCHIVED"
+    }
+  }
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      days_since_noncurrent_time = 7
+      with_state                 = "ANY"
+    }
+  }
+
   lifecycle {
     prevent_destroy = true
   }


### PR DESCRIPTION
Updates the `osv_vulnerabilities_export` bucket configuration to include:
- `versioning { enabled = true }`
- `lifecycle_rule` to delete objects with `num_newer_versions = 673` and `with_state = "ARCHIVED"`
- `lifecycle_rule` to delete objects with `days_since_noncurrent_time = 7` and `with_state = "ANY"`

---
*PR created automatically by Jules for task [11623816002459219893](https://jules.google.com/task/11623816002459219893) started by @another-rex*