### PR TITLE
chore: increase vanir-signatures cron job alert threshold to 5 hours

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/vanir-signatures.yaml
+++ b/deployment/clouddeploy/gke-workers/base/vanir-signatures.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: vanir-signatures
   labels:
-    cronLastSuccessfulTimeMins: "400"
+    cronLastSuccessfulTimeMins: "660"
 spec:
   schedule: "0 */6 * * *"
   timeZone: "Australia/Sydney"


### PR DESCRIPTION
This PR increases the `cronLastSuccessfulTimeMins` threshold for the vanir-signatures cron job from 400 minutes to 660 minutes.

The job is scheduled to run every 6 hours (360 minutes). With the previous threshold of 400 minutes, the job was only allowed a 40-minute execution window before triggering an alert.

During periods of high data volume, the job has been observed to take between 4 and 5 hours to complete successfully. This was causing frequent "false positive" alerts even when the job was processing correctly.