### PR TITLE
fix: improve styling for list page and accordion view

### DIFF
--- a/gcp/website/frontend3/src/styles.scss
+++ b/gcp/website/frontend3/src/styles.scss
@@ -636,7 +636,7 @@ md-icon-button.mdc-data-table__sort-icon-button {
   --md-icon-button-disabled-icon-color: $osv-grey-600;
   --md-icon-button-disabled-icon-opacity: 1;
 
-  md-icon {
+  &[disabled] md-icon {
     color: $osv-grey-600;
   }
 }
@@ -1207,22 +1207,23 @@ osv-tabs.vulnerability-packages[affordance="collapse"] {
       html[data-theme="light"] & {
         background: $osv-grey-200;
         color: $osv-white;
+
+        &::before {
+          background-color: $osv-white;
+        }
+
+        &:hover {
+          background: $osv-grey-300;
+        }
       }
 
       &::before {
         transform: rotate(90deg);
         background-color: $osv-accent-color;
-
-        html[data-theme="light"] & {
-          background-color: $osv-white;
-        }
       }
 
       &:hover {
         background: $osv-grey-200;
-        html[data-theme="light"] & {
-          background: $osv-grey-300;
-        }
       }
     }
 

--- a/gcp/website/frontend3/src/styles.scss
+++ b/gcp/website/frontend3/src/styles.scss
@@ -634,6 +634,11 @@ md-icon-button.mdc-data-table__sort-icon-button {
   --md-icon-button-icon-size: 18px;
   --md-icon-button-icon-color: $osv-text-color;
   --md-icon-button-disabled-icon-color: $osv-grey-600;
+  --md-icon-button-disabled-icon-opacity: 1;
+
+  md-icon {
+    color: $osv-grey-600;
+  }
 }
 
 .vuln-table-container {
@@ -1200,18 +1205,23 @@ osv-tabs.vulnerability-packages[affordance="collapse"] {
       font-weight: bold;
 
       html[data-theme="light"] & {
-        background: $osv-grey-600;
+        background: $osv-grey-200;
+        color: $osv-white;
       }
 
       &::before {
         transform: rotate(90deg);
         background-color: $osv-accent-color;
+
+        html[data-theme="light"] & {
+          background-color: $osv-white;
+        }
       }
 
       &:hover {
         background: $osv-grey-200;
         html[data-theme="light"] & {
-          background: $osv-grey-500;
+          background: $osv-grey-300;
         }
       }
     }
@@ -1232,8 +1242,8 @@ osv-tabs.vulnerability-packages[affordance="collapse"] {
       }
     }
 
-    $last-ecosystem-border-offset: 12px;
-    $last-ecosystem-border-gap: 16px;
+    $last-ecosystem-border-offset: 4px;
+    $last-ecosystem-border-gap: 8px;
     $last-ecosystem-border-thickness: 1px;
 
     .ecosystem-content-panel--last {


### PR DESCRIPTION
Applies some tiny improvements for styling after light-mode implementation

---

Fixes 'Published' sort arrow icon visibility in dark mode on the /list page:

**(Before)** 
<img width="2375" height="114" alt="image" src="https://github.com/user-attachments/assets/4017b60e-2840-4598-97d1-6ac4f343229f" />

**(After)**
<img width="2424" height="92" alt="image" src="https://github.com/user-attachments/assets/e40806a0-69e7-4731-8905-7f8a22aea7b0" />

---

Fixes accordion open state styling in light mode with proper background/text contrast:

**(Before)**
<img width="2493" height="1329" alt="image" src="https://github.com/user-attachments/assets/1031878f-9aad-4d4a-a469-b60640e9b047" />


**(After)**
<img width="2482" height="1350" alt="image" src="https://github.com/user-attachments/assets/7420eb88-a14f-443f-be3a-8c97b248522f" />

---

Also, unrelated to theming, reduced the tree structure ending line distance from last child item in accordion view because it looked too spacious.