### PR TITLE
fix(go-relations): ListedVuln ecosystems not being correctly generated

### DIFF
--- a/go/osv/models/listedvulnerability.go
+++ b/go/osv/models/listedvulnerability.go
@@ -208,7 +208,8 @@ func NewListedVulnerabilityFromProto(vuln *osvschema.Vulnerability) *ListedVulne
 
 	ecosystems := make([]string, 0, len(allEcosystems))
 	for eco := range allEcosystems {
-		ecosystems = append(ecosystems, eco)
+		normalized, _, _ := strings.Cut(eco, ":")
+		ecosystems = append(ecosystems, normalized)
 	}
 	slices.Sort(ecosystems)
 


### PR DESCRIPTION
[This line](https://github.com/google/osv.dev/blob/3d5779cd03c8c104ce60680b90b623a30f95040c/osv/models.py#L1169) is important and was missing from the go implementation