### PR TITLE
fix: slight differences between python/go ListedVulnerabilty

### DIFF
--- a/go/osv/models/listedvulnerability.go
+++ b/go/osv/models/listedvulnerability.go
@@ -212,6 +212,7 @@ func NewListedVulnerabilityFromProto(vuln *osvschema.Vulnerability) *ListedVulne
 		ecosystems = append(ecosystems, normalized)
 	}
 	slices.Sort(ecosystems)
+	ecosystems = slices.Compact(ecosystems)
 
 	packages := make([]string, 0, len(allPackages))
 	for pkg := range allPackages {

--- a/osv/models.py
+++ b/osv/models.py
@@ -922,7 +922,7 @@ def _tokenize(value):
   # Deconstructs the id given into parts by retrieving parts that are
   # alphanumeric.
   # This addresses special cases like SUSE that include ':' in their id suffix
-  tokens = {token for token in re.split(r'\W+', value_lower) if token}
+  tokens = {token for token in re.split(r'[^a-zA-Z0-9]+', value_lower) if token}
   tokens.add(value_lower)
 
   # Add subsection combinations from id (split at '-') in the search indices


### PR DESCRIPTION
- Go wasn't de-duplicating the `ecosystems` list, which has been fixed
- Go's tokenisation regex used `[^a-zA-Z0-9]`, where Python's used `\W` (which is the same plus `_`). Changed Python to use the Go regex