### PR TITLE
fix(ui): restore red accent on accordion headers

### DIFF
--- a/gcp/website/frontend3/src/styles.scss
+++ b/gcp/website/frontend3/src/styles.scss
@@ -1205,15 +1205,15 @@ osv-tabs.vulnerability-packages[affordance="collapse"] {
       font-weight: bold;
 
       html[data-theme="light"] & {
-        background: $osv-grey-700;
-        color: $osv-accent-color;
+        background: #c4c4c4;
+        color: $osv-red-700;
 
         &::before {
-          background-color: $osv-accent-color;
+          background-color: $osv-red-700;
         }
 
         &:hover {
-          background: $osv-grey-600;
+          background: $osv-grey-500;
         }
       }
 

--- a/gcp/website/frontend3/src/styles.scss
+++ b/gcp/website/frontend3/src/styles.scss
@@ -249,10 +249,10 @@ pre {
   position: relative;
   display: inline-block;
   width: 650px;
-  color: $osv-white;
 }
 
 .tooltip .tooltiptext {
+  color: $osv-white;
   background: $osv-tooltip-bg;
   visibility: hidden;
   width: 120px;
@@ -1205,15 +1205,15 @@ osv-tabs.vulnerability-packages[affordance="collapse"] {
       font-weight: bold;
 
       html[data-theme="light"] & {
-        background: $osv-grey-200;
-        color: $osv-white;
+        background: $osv-grey-700;
+        color: $osv-accent-color;
 
         &::before {
-          background-color: $osv-white;
+          background-color: $osv-accent-color;
         }
 
         &:hover {
-          background: $osv-grey-300;
+          background: $osv-grey-600;
         }
       }
 


### PR DESCRIPTION
Follow up on #5252 

Adds back the red accent to accordion headers by using darker red text on a lighter gray.

**(Before)**
<img width="2038" height="1158" alt="image" src="https://github.com/user-attachments/assets/2ed3f6f6-2be4-41b1-b7d2-8cb1e1732d9d" />

**(After)**
<img width="2061" height="1154" alt="image" src="https://github.com/user-attachments/assets/0cce2541-b19a-42f2-96e7-e0af8d9aba23" />


Also noticed an issue with the "Introduced" field value being white in light mode, so this was fixed too.