### PR TITLE
fix(oss-fuzz): add defensive guards against zero-length commit range strings

### DIFF
--- a/gcp/workers/oss_fuzz_worker/oss_fuzz.py
+++ b/gcp/workers/oss_fuzz_worker/oss_fuzz.py
@@ -194,7 +194,7 @@ def process_bisect_task(oss_fuzz_dir, bisect_type, source_id, message):
 
   if result and result.commit:
     if ':' in result.commit:
-      range_start, range_end = result.commit.split(':')
+      range_start, range_end = result.commit.split(':', 1)
       if range_start == range_end:
         logging.warning(
             'Bisect produced a zero-length range for %s, ignoring result.',

--- a/gcp/workers/oss_fuzz_worker/oss_fuzz.py
+++ b/gcp/workers/oss_fuzz_worker/oss_fuzz.py
@@ -193,6 +193,15 @@ def process_bisect_task(oss_fuzz_dir, bisect_type, source_id, message):
   _set_result_attributes(oss_fuzz_dir, message, entity)
 
   if result and result.commit:
+    if ':' in result.commit:
+      range_start, range_end = result.commit.split(':')
+      if range_start == range_end:
+        logging.warning(
+            'Bisect produced a zero-length range for %s, ignoring result.',
+            source_id)
+        result = None
+
+  if result and result.commit:
     logging.info('Bisected to %s', result.commit)
     entity.commit = result.commit
     entity.repo_url = result.repo_url
@@ -253,6 +262,11 @@ def _get_commit_range(repo, commit_or_range):
   if start_commit == UNKNOWN_COMMIT:
     # Special case: No information about earlier builds. Assume the end_commit
     # is the regressing commit as that's the best we can do.
+    return [end_commit]
+
+  if start_commit == end_commit:
+    # Zero-length range: start and end are the same commit. Return just the
+    # single commit rather than producing an empty list.
     return [end_commit]
 
   commits, _ = osv.get_commit_and_tag_list(repo, start_commit, end_commit)

--- a/gcp/workers/oss_fuzz_worker/worker_test.py
+++ b/gcp/workers/oss_fuzz_worker/worker_test.py
@@ -141,6 +141,25 @@ class OssFuzzDetailsTest(unittest.TestCase):
     )
 
 
+class FormatCommitRangeTest(unittest.TestCase):
+  """Tests for format_commit_range."""
+
+  def test_same_commit_returns_single(self):
+    """Same old and new commit should return just the single commit hash."""
+    commit = 'abc123'
+    self.assertEqual(commit, oss_fuzz.format_commit_range(commit, commit))
+
+  def test_different_commits_returns_range(self):
+    """Different commits should produce a colon-separated range."""
+    result = oss_fuzz.format_commit_range('abc123', 'def456')
+    self.assertEqual('abc123:def456', result)
+
+  def test_no_old_commit_uses_unknown(self):
+    """Missing old commit should use UNKNOWN_COMMIT sentinel."""
+    result = oss_fuzz.format_commit_range('', 'def456')
+    self.assertEqual('unknown:def456', result)
+
+
 class ImpactTest(unittest.TestCase, tests.ExpectationTest(TEST_DATA_DIR)):
   """Impact task tests."""
 

--- a/gcp/workers/worker/oss_fuzz.py
+++ b/gcp/workers/worker/oss_fuzz.py
@@ -194,7 +194,7 @@ def process_bisect_task(oss_fuzz_dir, bisect_type, source_id, message):
 
   if result and result.commit:
     if ':' in result.commit:
-      range_start, range_end = result.commit.split(':')
+      range_start, range_end = result.commit.split(':', 1)
       if range_start == range_end:
         logging.warning(
             'Bisect produced a zero-length range for %s, ignoring result.',

--- a/gcp/workers/worker/oss_fuzz.py
+++ b/gcp/workers/worker/oss_fuzz.py
@@ -193,6 +193,15 @@ def process_bisect_task(oss_fuzz_dir, bisect_type, source_id, message):
   _set_result_attributes(oss_fuzz_dir, message, entity)
 
   if result and result.commit:
+    if ':' in result.commit:
+      range_start, range_end = result.commit.split(':')
+      if range_start == range_end:
+        logging.warning(
+            'Bisect produced a zero-length range for %s, ignoring result.',
+            source_id)
+        result = None
+
+  if result and result.commit:
     logging.info('Bisected to %s', result.commit)
     entity.commit = result.commit
     entity.repo_url = result.repo_url
@@ -253,6 +262,11 @@ def _get_commit_range(repo, commit_or_range):
   if start_commit == UNKNOWN_COMMIT:
     # Special case: No information about earlier builds. Assume the end_commit
     # is the regressing commit as that's the best we can do.
+    return [end_commit]
+
+  if start_commit == end_commit:
+    # Zero-length range: start and end are the same commit. Return just the
+    # single commit rather than producing an empty list.
     return [end_commit]
 
   commits, _ = osv.get_commit_and_tag_list(repo, start_commit, end_commit)


### PR DESCRIPTION
**Note**: After reviewer feedback, this PR does *not* fix the core issue in #2232 (see comments). It adds two narrower defensive guards described below; the main fix is tracked for a follow-up.

---

Two defensive guards are added against zero-length `A:A` range strings:

1. **`_get_commit_range`**: when a stored range string has identical start and end (e.g. `"A:A"`, neither being the `unknown` sentinel), the git walker would hide the only commit and return an empty list, silently losing the commit. The guard returns `[end_commit]` instead.

2. **`process_bisect_task`**: when the bisector returns a `result.commit` that is already a colon-separated range with equal start and end, it would previously be written straight to the datastore. The guard treats it as a bisect failure and falls back to the request range with an error marker.

The root cause of #2232 — `RegressResult` and `FixResult` being independently bisected to the same single commit hash, causing `process_impact_task` to emit `introduced=X, fixed=X` — is **not** addressed here and requires a separate fix in `process_impact_task`.