### PR TITLE
fix: return original tag from normalize_tag when no version components found

### DIFF
--- a/osv/bug.py
+++ b/osv/bug.py
@@ -37,6 +37,10 @@ def normalize_tag(tag):
   if tag.startswith('.'):
     tag = '0' + tag
   components = VERSION_COMPONENT_REGEX.findall(tag)
+  if not components:
+    # Don't collapse tags with no version-like components to '', otherwise any
+    # digit-free query would fuzzy-match any digit-free tag.
+    return tag
   return '-'.join(components)
 
 

--- a/osv/bug_test.py
+++ b/osv/bug_test.py
@@ -55,6 +55,15 @@ class NormalizeTest(unittest.TestCase):
         '10-0-0-10',
     ], bug.normalize_tags(tags))
 
+  def test_normalize_no_version_components(self):
+    """Tags with no version-like components are returned unmodified rather than
+    collapsing to ''."""
+    self.assertEqual('last-cvs-commit', bug.normalize_tag('last-cvs-commit'))
+    self.assertEqual('deadbeef', bug.normalize_tag('deadbeef'))
+    self.assertEqual('', bug.normalize_tag(''))
+    self.assertNotEqual(
+        bug.normalize_tag('deadbeef'), bug.normalize_tag('last-cvs-commit'))
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
`normalize_tag` returned `''` for any input with no digit or rc/alpha/beta/preview component. In `_match_versions` that meant any digit-free query version matched any digit-free tag in a repo's affected versions, e.g. querying icu for `deadbeef` matched the `last-cvs-commit` tag and returned 7 vulns.

Now the original string is returned when normalisation finds no version components, so unrelated digit-free strings no longer collide.

Fixes #5230