### PR TITLE
fix: increase nvd-cve-osv CPUs and moved to highend nodepool 

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/nvd-cve-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/nvd-cve-osv.yaml
@@ -13,17 +13,23 @@ spec:
       activeDeadlineSeconds: 86400
       template:
         spec:
+          tolerations:
+          - key: workloadType
+            operator: Equal
+            value: highend
+          nodeSelector:
+            cloud.google.com/gke-nodepool: highend
           containers:
           - name: nvd-cve-osv
             image: nvd-cve-osv
             imagePullPolicy: Always
             resources:
               requests:
-                cpu: "1"
-                memory: "2G"
+                cpu: "8"
+                memory: "8G"
               limits:
-                cpu: "1"
-                memory: "4G"
+                cpu: "8"
+                memory: "16G"
             env:
               - name: WORK_DIR
                 value: /tmp


### PR DESCRIPTION
nvd-cve-osv Cron job doesn't seem to be successfully finishing - it is currently taking forever to upload and go threshold checks. This should speed things up hopefully, while waiting for #5099 