### PR TITLE
perf: optimize memory usage during Debian CVE conversion

### DIFF
--- a/vulnfeeds/cmd/converters/alpine/main.go
+++ b/vulnfeeds/cmd/converters/alpine/main.go
@@ -50,8 +50,16 @@ func main() {
 		logger.Fatal("Can't create output path", slog.Any("err", err))
 	}
 
-	allCVEs := vulns.LoadAllCVEs(defaultCvePath)
 	allAlpineSecDB := getAlpineSecDBData()
+
+	targetCVEs := make(map[string]bool)
+	for cveID := range allAlpineSecDB {
+		if strings.HasPrefix(cveID, "CVE") {
+			targetCVEs[cveID] = true
+		}
+	}
+
+	allCVEs := vulns.LoadTargetCVEs(defaultCvePath, targetCVEs)
 	osvVulnerabilities := generateAlpineOSV(allAlpineSecDB, allCVEs)
 
 	vulnerabilities := make([]*osvschema.Vulnerability, 0, len(osvVulnerabilities))

--- a/vulnfeeds/cmd/converters/debian/main.go
+++ b/vulnfeeds/cmd/converters/debian/main.go
@@ -57,7 +57,16 @@ func main() {
 		logger.Fatal("Failed to get Debian distro info data", slog.Any("err", err))
 	}
 
-	allCVEs := vulns.LoadAllCVEs(defaultCvePath)
+	targetCVEs := make(map[string]bool)
+	for _, pkg := range debianData {
+		for cveID := range pkg {
+			if strings.HasPrefix(cveID, "CVE") {
+				targetCVEs[cveID] = true
+			}
+		}
+	}
+
+	allCVEs := vulns.LoadTargetCVEs(defaultCvePath, targetCVEs)
 	osvCVEs := generateOSVFromDebianTracker(debianData, debianReleaseMap, allCVEs)
 
 	vulnerabilities := make([]*osvschema.Vulnerability, 0, len(osvCVEs))

--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -818,6 +818,12 @@ func CheckQuality(text string) QualityCheck {
 
 // LoadAllCVEs loads the downloaded CVE's from the NVD database into memory.
 func LoadAllCVEs(cvePath string) map[models.CVEID]models.Vulnerability {
+	return LoadTargetCVEs(cvePath, nil)
+}
+
+// LoadTargetCVEs loads the downloaded CVE's from the NVD database into memory,
+// filtering by a set of target CVE IDs if provided.
+func LoadTargetCVEs(cvePath string, targetCVEs map[string]bool) map[models.CVEID]models.Vulnerability {
 	dir, err := os.ReadDir(cvePath)
 	if err != nil {
 		logger.Fatal("Failed to read dir", slog.String("path", cvePath), slog.Any("err", err))
@@ -849,7 +855,9 @@ func LoadAllCVEs(cvePath string) map[models.CVEID]models.Vulnerability {
 			}
 
 			for _, item := range nvdcve.Vulnerabilities {
-				vulnsChan <- item
+				if targetCVEs == nil || targetCVEs[string(item.CVE.ID)] {
+					vulnsChan <- item
+				}
 			}
 			logger.Info("Loaded "+filename, slog.String("cve", filename))
 		}(entry.Name())


### PR DESCRIPTION
I noticed that the Debian CVE converter was OOMing occasionally recently, and it was likely due to the following:

The `vulns.LoadAllCVEs` function previously loaded the entire NVD CVE dataset into memory by reading hundreds of thousands of CVE JSON files concurrently. This caused massive memory spikes and high garbage collection overhead during the Debian CVE conversion process.

This commit introduces a target-based filtering approach:
- Added `LoadTargetCVEs` which accepts a map of required CVE IDs.
- Modified the JSON parsing loop to only emit vulnerabilities that are present in the target list.
- Refactored `cmd/converters/debian/main.go` to extract the needed CVEs from the Debian Security Tracker data and pass them into `LoadTargetCVEs`.
- Preserved the existing `LoadAllCVEs` interface for backward compatibility. (Alpine still uses it, I believe - I should probably fix this too)