### PR TITLE
fix: duplicate GHSA reference extraction leading to 'related' entry

### DIFF
--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -612,7 +612,7 @@ func ExtractReferencedVulns(id models.CVEID, cveID models.CVEID, references []mo
 	}
 
 	var GHSAs []string
-	var SYNKs []string
+	var SNYKs []string
 	for _, reference := range references {
 		u, err := url.Parse(reference.URL)
 		if err == nil {
@@ -637,7 +637,7 @@ func ExtractReferencedVulns(id models.CVEID, cveID models.CVEID, references []mo
 					if pathParts[1] == "vuln" {
 						a := pathParts[len(pathParts)-1]
 						if string(id) != a && strings.HasPrefix(a, "SNYK-") {
-							SYNKs = append(SYNKs, a)
+							SNYKs = append(SNYKs, a)
 						}
 					}
 				}
@@ -648,15 +648,17 @@ func ExtractReferencedVulns(id models.CVEID, cveID models.CVEID, references []mo
 	// A CVE should have only one GHSA as an alias
 	// If multiple GHSAs are associated with a CVE,
 	// it can potentially cause one CVE to be aliased to other CVEs, which is most likely incorrect.
+	GHSAs = Unique(GHSAs)
 	if len(GHSAs) > 1 {
 		related = append(related, GHSAs...)
 	} else {
 		aliases = append(aliases, GHSAs...)
 	}
-	if len(SYNKs) > 1 {
-		related = append(related, SYNKs...)
+	SNYKs = Unique(SNYKs)
+	if len(SNYKs) > 1 {
+		related = append(related, SNYKs...)
 	} else {
-		aliases = append(aliases, SYNKs...)
+		aliases = append(aliases, SNYKs...)
 	}
 
 	// TODO(jesslowe): Check if references to other CVEs exist in the description and add to related


### PR DESCRIPTION
should fix #4866 

also fixed typos where Snyk was written as 'synk'