### PR TITLE
feat(go worker): copy over a bit more logic from python

### DIFF
--- a/go/cmd/importer/main.go
+++ b/go/cmd/importer/main.go
@@ -81,7 +81,9 @@ func main() {
 	}
 	config.SourceRepoStore = db.NewSourceRepositoryStore(datastoreClient)
 	// Needed for deletions only
-	config.VulnerabilityStore = db.NewVulnerabilityStore(datastoreClient, nil)
+	config.VulnerabilityStore = db.NewVulnerabilityStore(db.VulnStoreConfig{
+		Client: datastoreClient,
+	})
 
 	psClient, err := pubsub.NewClient(ctx, project)
 	if err != nil {

--- a/go/internal/database/datastore/import_findings.go
+++ b/go/internal/database/datastore/import_findings.go
@@ -1,0 +1,23 @@
+package datastore
+
+import (
+	"context"
+
+	"cloud.google.com/go/datastore"
+	"github.com/google/osv.dev/go/internal/models"
+)
+
+type ImportFindingsStore struct {
+	client *datastore.Client
+}
+
+var _ models.ImportFindingsStore = (*ImportFindingsStore)(nil)
+
+func NewImportFindingsStore(client *datastore.Client) *ImportFindingsStore {
+	return &ImportFindingsStore{client: client}
+}
+
+func (s *ImportFindingsStore) Clear(ctx context.Context, id string) error {
+	key := datastore.NameKey("ImportFinding", id, nil)
+	return s.client.Delete(ctx, key)
+}

--- a/go/internal/database/datastore/vulnerability.go
+++ b/go/internal/database/datastore/vulnerability.go
@@ -6,12 +6,15 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"log/slog"
 	"slices"
 	"strings"
 	"time"
 
 	"cloud.google.com/go/datastore"
+	"cloud.google.com/go/pubsub/v2"
 	"github.com/google/osv.dev/go/internal/models"
+	"github.com/google/osv.dev/go/logger"
 	"github.com/google/osv.dev/go/osv/clients"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
 	"google.golang.org/api/iterator"
@@ -19,14 +22,25 @@ import (
 )
 
 type VulnerabilityStore struct {
-	client   *datastore.Client
-	gcsStore clients.CloudStorage
+	client               *datastore.Client
+	gcsStore             clients.CloudStorage
+	failedWritePublisher clients.Publisher
 }
 
 var _ models.VulnerabilityStore = (*VulnerabilityStore)(nil)
 
-func NewVulnerabilityStore(client *datastore.Client, gcsStore clients.CloudStorage) *VulnerabilityStore {
-	return &VulnerabilityStore{client: client, gcsStore: gcsStore}
+type VulnStoreConfig struct {
+	Client               *datastore.Client
+	GCS                  clients.CloudStorage
+	FailedWritePublisher clients.Publisher
+}
+
+func NewVulnerabilityStore(cfg VulnStoreConfig) *VulnerabilityStore {
+	return &VulnerabilityStore{
+		client:               cfg.Client,
+		gcsStore:             cfg.GCS,
+		failedWritePublisher: cfg.FailedWritePublisher,
+	}
 }
 
 func (s *VulnerabilityStore) ListBySource(ctx context.Context, source string, skipWithdrawn bool) iter.Seq2[*models.VulnSourceRef, error] {
@@ -333,7 +347,22 @@ func (s *VulnerabilityStore) uploadToGCS(ctx context.Context, id string, enriche
 	}
 
 	if err := s.gcsStore.WriteObject(ctx, path, newData, opts); err != nil {
-		return fmt.Errorf("failed to write vulnerability object to GCS: %w", err)
+		if s.failedWritePublisher == nil {
+			// We don't have a recoverer, so we can't retry. Return the error.
+			return fmt.Errorf("failed to write vulnerability object to GCS: %w", err)
+		}
+		// Try sending to recoverer to retry
+		logger.ErrorContext(ctx, "failed to write vulnerability object to GCS, attempting to queue recovery task", slog.String("vuln_id", id), slog.Any("error", err))
+		res := s.failedWritePublisher.Publish(ctx, &pubsub.Message{
+			Data:       newData,
+			Attributes: map[string]string{"type": "gcs_retry"},
+		})
+		if _, err := res.Get(ctx); err != nil {
+			logger.ErrorContext(ctx, "failed to publish to failed write topic", slog.String("vuln_id", id), slog.Any("error", err))
+			// If we failed to even try recover, propagate the error up to let the caller deal with this.
+			return fmt.Errorf("failed to write vulnerability object to GCS: %w", err)
+		}
+		// Otherwise, sending to recoverer was successful, so we don't need to error anymore
 	}
 
 	return nil

--- a/go/internal/database/datastore/vulnerability_test.go
+++ b/go/internal/database/datastore/vulnerability_test.go
@@ -1,6 +1,7 @@
 package datastore
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"testing"
@@ -18,7 +19,10 @@ import (
 func TestVulnerabilityStore_ListBySource(t *testing.T) {
 	ctx := context.Background()
 	dsClient := testutils.MustNewDatastoreClientForTesting(t)
-	store := NewVulnerabilityStore(dsClient, testutils.NewMockStorage())
+	store := NewVulnerabilityStore(VulnStoreConfig{
+		Client: dsClient,
+		GCS:    testutils.NewMockStorage(),
+	})
 
 	vulns := []Vulnerability{
 		{
@@ -109,7 +113,10 @@ func TestVulnerabilityStore_Get(t *testing.T) {
 	ctx := context.Background()
 	dsClient := testutils.MustNewDatastoreClientForTesting(t)
 	gcsStore := testutils.NewMockStorage()
-	store := NewVulnerabilityStore(dsClient, gcsStore)
+	store := NewVulnerabilityStore(VulnStoreConfig{
+		Client: dsClient,
+		GCS:    gcsStore,
+	})
 
 	v := &osvschema.Vulnerability{
 		Id: "GHSA-xxxx-yyyy-zzzz",
@@ -137,7 +144,10 @@ func TestVulnerabilityStore_Get_NotFound(t *testing.T) {
 	ctx := context.Background()
 	dsClient := testutils.MustNewDatastoreClientForTesting(t)
 	gcsStore := testutils.NewMockStorage()
-	store := NewVulnerabilityStore(dsClient, gcsStore)
+	store := NewVulnerabilityStore(VulnStoreConfig{
+		Client: dsClient,
+		GCS:    gcsStore,
+	})
 
 	_, err := store.Get(ctx, "GHSA-not-exists")
 	if !errors.Is(err, models.ErrNotFound) {
@@ -149,7 +159,10 @@ func TestVulnerabilityStore_GetWithMetadata(t *testing.T) {
 	ctx := context.Background()
 	dsClient := testutils.MustNewDatastoreClientForTesting(t)
 	gcsStore := testutils.NewMockStorage()
-	store := NewVulnerabilityStore(dsClient, gcsStore)
+	store := NewVulnerabilityStore(VulnStoreConfig{
+		Client: dsClient,
+		GCS:    gcsStore,
+	})
 
 	v := &osvschema.Vulnerability{
 		Id: "GHSA-xxxx-yyyy-zzzz",
@@ -193,7 +206,10 @@ func TestVulnerabilityStore_GetWithMetadata_NotFound(t *testing.T) {
 	ctx := context.Background()
 	dsClient := testutils.MustNewDatastoreClientForTesting(t)
 	gcsStore := testutils.NewMockStorage()
-	store := NewVulnerabilityStore(dsClient, gcsStore)
+	store := NewVulnerabilityStore(VulnStoreConfig{
+		Client: dsClient,
+		GCS:    gcsStore,
+	})
 
 	_, _, err := store.GetWithMetadata(ctx, "GHSA-not-exists")
 	if !errors.Is(err, models.ErrNotFound) {
@@ -205,7 +221,10 @@ func TestVulnerabilityStore_Write(t *testing.T) {
 	ctx := context.Background()
 	dsClient := testutils.MustNewDatastoreClientForTesting(t)
 	gcsStore := testutils.NewMockStorage()
-	store := NewVulnerabilityStore(dsClient, gcsStore)
+	store := NewVulnerabilityStore(VulnStoreConfig{
+		Client: dsClient,
+		GCS:    gcsStore,
+	})
 
 	v := &osvschema.Vulnerability{
 		Id:        "TEST-WRITE-123",
@@ -297,5 +316,51 @@ func TestVulnerabilityStore_Write(t *testing.T) {
 	}
 	if gotV.GetId() != v.GetId() {
 		t.Errorf("GCS Vulnerability ID mismatch, got %s, want %s", gotV.GetId(), v.GetId())
+	}
+}
+
+func TestVulnerabilityStore_Write_GCSFailure_Retry(t *testing.T) {
+	ctx := context.Background()
+	dsClient := testutils.MustNewDatastoreClientForTesting(t)
+	gcsStore := testutils.NewMockStorage()
+	mockPublisher := &testutils.MockPublisher{}
+
+	store := NewVulnerabilityStore(VulnStoreConfig{
+		Client:               dsClient,
+		GCS:                  gcsStore,
+		FailedWritePublisher: mockPublisher,
+	})
+
+	// Make GCS write fail
+	gcsStore.WriteError = errors.New("GCS write failed")
+
+	v := &osvschema.Vulnerability{
+		Id: "TEST-WRITE-RETRY",
+	}
+
+	req := models.WriteRequest{
+		ID:       "TEST-WRITE-RETRY",
+		Source:   "test-source",
+		Path:     "TEST-WRITE-RETRY.json",
+		Enriched: v,
+	}
+
+	if err := store.Write(ctx, req); err != nil {
+		t.Fatalf("Write() failed: %v", err)
+	}
+
+	// Verify that it attempted to publish to the retry topic
+	if len(mockPublisher.Messages) != 1 {
+		t.Fatalf("Expected 1 message published, got %d", len(mockPublisher.Messages))
+	}
+
+	msg := mockPublisher.Messages[0]
+	if msg.Attributes["type"] != "gcs_retry" {
+		t.Errorf("Expected message type 'gcs_retry', got %q", msg.Attributes["type"])
+	}
+
+	expectedData, _ := proto.Marshal(v)
+	if !bytes.Equal(msg.Data, expectedData) {
+		t.Errorf("Message data mismatch")
 	}
 }

--- a/go/internal/models/import_findings.go
+++ b/go/internal/models/import_findings.go
@@ -1,0 +1,11 @@
+// Package models contains the domain types for the OSV database.
+package models
+
+import (
+	"context"
+)
+
+type ImportFindingsStore interface {
+	// Clear deletes all entries from the store for a given vulnerability.
+	Clear(ctx context.Context, id string) error
+}

--- a/go/internal/worker/engine.go
+++ b/go/internal/worker/engine.go
@@ -115,7 +115,13 @@ func (e *Engine) handleUpdate(ctx context.Context, task Task) error {
 		e.notifyPyPI(ctx, enriched, current)
 	}
 
-	// TODO: Remove ImportFindings for the record
+	// Remove ImportFindings
+	if e.Stores.ImportFindings != nil {
+		if err := e.Stores.ImportFindings.Clear(ctx, enriched.GetId()); err != nil {
+			// Don't really want to return an error here since we successfully wrote the vuln
+			logger.ErrorContext(ctx, "Failed to clear import findings", slog.String("vuln_id", enriched.GetId()), slog.Any("error", err))
+		}
+	}
 
 	return nil
 }

--- a/go/internal/worker/subscriber.go
+++ b/go/internal/worker/subscriber.go
@@ -87,6 +87,7 @@ func (s *Subscriber) handleMessage(ctx context.Context, m *pubsub.Message) {
 		logger.ErrorContext(taskCtx, "Failed to process task", append(logInfo, slog.Any("error", err))...)
 		m.Nack()
 	} else {
+		logTaskLatency(taskCtx, task)
 		m.Ack()
 	}
 }
@@ -121,4 +122,23 @@ func (s *Subscriber) timeFromUnixSeconds(tsString string) (*time.Time, error) {
 	ts := time.Unix(timestamp, 0)
 
 	return &ts, nil
+}
+
+func logTaskLatency(ctx context.Context, task Task) {
+	if task.ReceivedTime == nil {
+		return
+	}
+	now := time.Now()
+	latency := now.Sub(*task.ReceivedTime)
+	latencySeconds := int64(latency.Seconds())
+	logAttrs := []any{
+		slog.Int64("latency", latencySeconds),
+		slog.String("source", task.SourceID),
+		slog.String("path", task.PathInSource),
+	}
+	if task.SourceTime != nil {
+		srcLatency := now.Sub(*task.SourceTime)
+		logAttrs = append(logAttrs, slog.Int64("src_latency", int64(srcLatency.Seconds())))
+	}
+	logger.InfoContext(ctx, fmt.Sprintf("Task update (source_id=%s) latency %d", task.SourceID, latencySeconds), logAttrs...)
 }

--- a/go/internal/worker/worker.go
+++ b/go/internal/worker/worker.go
@@ -31,8 +31,9 @@ type Task struct {
 }
 
 type Stores struct {
-	SourceRepo    models.SourceRepositoryStore
-	Vulnerability models.VulnerabilityStore
-	Relations     models.RelationsStore
-	PyPIPublisher clients.Publisher
+	SourceRepo     models.SourceRepositoryStore
+	Vulnerability  models.VulnerabilityStore
+	Relations      models.RelationsStore
+	ImportFindings models.ImportFindingsStore
+	PyPIPublisher  clients.Publisher
 }


### PR DESCRIPTION
- Clear the ImportFindings in Datastore when import is successful
- send a `gcs_retry` pub/sub message on (what will be) the failed-tasks topic when writing to GCS fails after writing datastore entities
- log the task latency that we have a log-based metric set up for