### PR TITLE
fix(conv): repositories should be lowercase for deterministic behaviour

### DIFF
--- a/vulnfeeds/cmd/converters/cve/nvd-cve-osv/main.go
+++ b/vulnfeeds/cmd/converters/cve/nvd-cve-osv/main.go
@@ -217,12 +217,20 @@ func worker(wg *sync.WaitGroup, jobs <-chan models.NVDCVE, gcsHelper *gcs.Helper
 		totalConversionsCount.Add(1)
 		cveID := string(cve.ID)
 		if outcome == models.Error {
-			logger.Error("Error generating OSV record", slog.String("cve", cveID), slog.String("outcome", outcome.String()))
+			var notes []string
+			if metrics != nil {
+				notes = metrics.Notes
+			}
+			logger.Error("Error generating OSV record", slog.String("cve", cveID), slog.String("outcome", outcome.String()), slog.Any("notes", notes))
 			continue // Don't attempt to output files if there was an error
 		}
 
 		if outcome != models.Successful {
-			logger.Info("Failed to generate a successful OSV record", slog.String("cve", cveID), slog.String("outcome", outcome.String()))
+			var notes []string
+			if metrics != nil {
+				notes = metrics.Notes
+			}
+			logger.Info("Failed to generate a successful OSV record", slog.String("cve", cveID), slog.String("outcome", outcome.String()), slog.Any("notes", notes))
 			if *rejectFailed {
 				continue // Skip outputting OSV file
 			}

--- a/vulnfeeds/cmd/converters/cve/nvd-cve-osv/main.go
+++ b/vulnfeeds/cmd/converters/cve/nvd-cve-osv/main.go
@@ -222,6 +222,7 @@ func worker(wg *sync.WaitGroup, jobs <-chan models.NVDCVE, gcsHelper *gcs.Helper
 				notes = metrics.Notes
 			}
 			logger.Error("Error generating OSV record", slog.String("cve", cveID), slog.String("outcome", outcome.String()), slog.Any("notes", notes))
+
 			continue // Don't attempt to output files if there was an error
 		}
 

--- a/vulnfeeds/cmd/converters/cve/nvd-cve-osv/main.go
+++ b/vulnfeeds/cmd/converters/cve/nvd-cve-osv/main.go
@@ -226,11 +226,7 @@ func worker(wg *sync.WaitGroup, jobs <-chan models.NVDCVE, gcsHelper *gcs.Helper
 		}
 
 		if outcome != models.Successful {
-			var notes []string
-			if metrics != nil {
-				notes = metrics.Notes
-			}
-			logger.Info("Failed to generate a successful OSV record", slog.String("cve", cveID), slog.String("outcome", outcome.String()), slog.Any("notes", notes))
+			logger.Info("Failed to generate a successful OSV record", slog.String("cve", cveID), slog.String("outcome", outcome.String()))
 			if *rejectFailed {
 				continue // Skip outputting OSV file
 			}

--- a/vulnfeeds/conversion/testdata/TestReposFromReferences_A_CVE_with_a_repo_not_already_present_in_the_VendorRepo_cache_(that_happens_to_have_a_useful_commit_and_a_repo_that_has_no_tags).yaml
+++ b/vulnfeeds/conversion/testdata/TestReposFromReferences_A_CVE_with_a_repo_not_already_present_in_the_VendorRepo_cache_(that_happens_to_have_a_useful_commit_and_a_repo_that_has_no_tags).yaml
@@ -18,7 +18,7 @@ interactions:
                 - github.com
             User-Agent:
                 - go-git/5.x
-        url: https://github.com/saemorris/TheRadSystem/info/refs?service=git-upload-pack
+        url: https://github.com/saemorris/theradsystem/info/refs?service=git-upload-pack
         method: GET
       response:
         proto: HTTP/2.0

--- a/vulnfeeds/conversion/versions.go
+++ b/vulnfeeds/conversion/versions.go
@@ -135,6 +135,7 @@ func Repo(u string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return strings.ToLower(r), nil
 }
 

--- a/vulnfeeds/conversion/versions.go
+++ b/vulnfeeds/conversion/versions.go
@@ -131,6 +131,14 @@ func repoGitWeb(parsedURL *url.URL) (string, error) {
 
 // Returns the base repository URL for supported repository hosts.
 func Repo(u string) (string, error) {
+	r, err := repo(u)
+	if err != nil {
+		return "", err
+	}
+	return strings.ToLower(r), nil
+}
+
+func repo(u string) (string, error) {
 	var supportedHosts = []string{
 		"bitbucket.org",
 		"github.com",

--- a/vulnfeeds/conversion/versions.go
+++ b/vulnfeeds/conversion/versions.go
@@ -26,10 +26,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/knqyf263/go-cpe/naming"
-
 	"github.com/google/osv/vulnfeeds/git"
 	"github.com/google/osv/vulnfeeds/models"
+	"github.com/knqyf263/go-cpe/naming"
 )
 
 // References with these tags have been found to contain completely unrelated
@@ -135,8 +134,17 @@ func Repo(u string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	parsedURL, err := url.Parse(r)
+	if err == nil && isCaseInsensitiveHost(parsedURL.Hostname()) {
+		return strings.ToLower(r), nil
+	}
 
-	return strings.ToLower(r), nil
+	return r, nil
+}
+
+func isCaseInsensitiveHost(host string) bool {
+	host = strings.ToLower(host)
+	return host == "github.com" || host == "bitbucket.org" || strings.Contains(host, "gitlab")
 }
 
 func repo(u string) (string, error) {

--- a/vulnfeeds/conversion/versions_test.go
+++ b/vulnfeeds/conversion/versions_test.go
@@ -1298,7 +1298,7 @@ func TestReposFromReferences(t *testing.T) {
 				},
 				tagDenyList: RefTagDenyList,
 			},
-			wantRepos: []string{"https://github.com/saemorris/TheRadSystem"},
+			wantRepos: []string{"https://github.com/saemorris/theradsystem"},
 		},
 		{
 			name: "A CVE with a useless (vulnerability researcher) repo",

--- a/vulnfeeds/conversion/versions_test.go
+++ b/vulnfeeds/conversion/versions_test.go
@@ -214,13 +214,13 @@ func TestRepo(t *testing.T) {
 		{
 			description:     "Freedesktop cGit mirror",
 			inputLink:       "https://cgit.freedesktop.org/xorg/lib/libXRes/commit/?id=c05c6d918b0e2011d4bfa370c321482e34630b17",
-			expectedRepoURL: "https://gitlab.freedesktop.org/xorg/lib/libXRes",
+			expectedRepoURL: "https://gitlab.freedesktop.org/xorg/lib/libxres",
 			expectedOk:      true,
 		},
 		{
 			description:     "Exact Freedesktop cGit mirror",
 			inputLink:       "https://cgit.freedesktop.org/xorg/lib/libXRes",
-			expectedRepoURL: "https://gitlab.freedesktop.org/xorg/lib/libXRes",
+			expectedRepoURL: "https://gitlab.freedesktop.org/xorg/lib/libxres",
 			expectedOk:      true,
 		},
 		{


### PR DESCRIPTION
Noticed some records were flip flopping indeterminately. Root cause is that repos have sometimes uppercase letters version in references, but lower case letter version in CPEs, causing duplicate repos, and its picking the first one it comes across in the non-deterministicly ordered map. 

also put notes in the logs if the record errors