### PR TITLE
feat(vulnfeeds): Add persistent Redis caching layer for canonical repo links

### DIFF
--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/cve5-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/cve5-to-osv.yaml
@@ -16,3 +16,5 @@ spec:
                 value: oss-vdb-test 
               - name: NUM_WORKERS
                 value: "30"
+              - name: REDISHOST
+                value: "10.102.25.214"

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/nvd-cve-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/nvd-cve-osv.yaml
@@ -22,3 +22,5 @@ spec:
               value: "5"
             - name: GCS_WORKERS
               value: "100"
+            - name: REDISHOST
+              value: "10.102.25.214"

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/cve5-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/cve5-to-osv.yaml
@@ -18,3 +18,5 @@ spec:
                 value: "30"
               - name: OUTPUT_BUCKET
                 value: cve-osv-conversion
+              - name: REDISHOST
+                value: "10.102.25.213"

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/nvd-cve-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/nvd-cve-osv.yaml
@@ -22,3 +22,5 @@ spec:
               value: "5"
             - name: GCS_WORKERS
               value: "100"
+            - name: REDISHOST
+              value: "10.102.25.213"

--- a/vulnfeeds/cmd/converters/cve/nvd-cve-osv/main.go
+++ b/vulnfeeds/cmd/converters/cve/nvd-cve-osv/main.go
@@ -126,7 +126,7 @@ func main() {
 		logger.Info("VendorProductToRepoMap cache has entries preloaded")
 	}
 
-	repoTagsCache := &git.RepoTagsCache{}
+	repoTagsCache := git.NewRepoTagsCache()
 
 	var gcsHelper *gcs.Helper
 	ctx := context.Background()

--- a/vulnfeeds/cmd/converters/cve/nvd-cve-osv/main.go
+++ b/vulnfeeds/cmd/converters/cve/nvd-cve-osv/main.go
@@ -188,7 +188,7 @@ func main() {
 	}
 }
 
-func processCVE(cve models.NVDCVE, vpRepoCache *c.VPRepoCache, repoTagsCache *git.RepoTagsCache) (*vulns.Vulnerability, *models.ConversionMetrics, models.ConversionOutcome) {
+func processCVE(cve models.NVDCVE, vpRepoCache *c.VPRepoCache, repoTagsCache git.RepoTagsCache) (*vulns.Vulnerability, *models.ConversionMetrics, models.ConversionOutcome) {
 	metrics := &models.ConversionMetrics{
 		CVEID: cve.ID,
 		CNA:   "nvd",
@@ -210,7 +210,7 @@ func processCVE(cve models.NVDCVE, vpRepoCache *c.VPRepoCache, repoTagsCache *gi
 	return vuln, finalMetrics, outcome
 }
 
-func worker(wg *sync.WaitGroup, jobs <-chan models.NVDCVE, gcsHelper *gcs.Helper, outDir string, vpRepoCache *c.VPRepoCache, repoTagsCache *git.RepoTagsCache) {
+func worker(wg *sync.WaitGroup, jobs <-chan models.NVDCVE, gcsHelper *gcs.Helper, outDir string, vpRepoCache *c.VPRepoCache, repoTagsCache git.RepoTagsCache) {
 	defer wg.Done()
 	for cve := range jobs {
 		vuln, metrics, outcome := processCVE(cve, vpRepoCache, repoTagsCache)

--- a/vulnfeeds/conversion/common.go
+++ b/vulnfeeds/conversion/common.go
@@ -140,7 +140,7 @@ func ConductAnalysis(year string, dir string) {
 
 // GitVersionsToCommits examines repos and tries to convert versions to commits by treating them as Git tags.
 // Returns the resolved ranges, unresolved ranges, and successful repos involved.
-func GitVersionsToCommits(versionRanges []models.RangeWithMetadata, repos []string, metrics *models.ConversionMetrics, cache *git.RepoTagsCache) ([]models.RangeWithMetadata, []models.RangeWithMetadata, []string) {
+func GitVersionsToCommits(versionRanges []models.RangeWithMetadata, repos []string, metrics *models.ConversionMetrics, cache git.RepoTagsCache) ([]models.RangeWithMetadata, []models.RangeWithMetadata, []string) {
 	var newVersionRanges []models.RangeWithMetadata
 	unresolvedRanges := versionRanges
 	var successfulRepos []string
@@ -562,7 +562,7 @@ func AddFieldToDatabaseSpecific(ds *structpb.Struct, field string, value any) er
 }
 
 // ProcessRanges attempts to resolve the given ranges to commits and updates the metrics accordingly.
-func ProcessRanges(ranges []models.RangeWithMetadata, repos []string, metrics *models.ConversionMetrics, cache *git.RepoTagsCache, source models.VersionSource) ([]models.RangeWithMetadata, []models.RangeWithMetadata, []string) {
+func ProcessRanges(ranges []models.RangeWithMetadata, repos []string, metrics *models.ConversionMetrics, cache git.RepoTagsCache, source models.VersionSource) ([]models.RangeWithMetadata, []models.RangeWithMetadata, []string) {
 	if len(ranges) == 0 {
 		return nil, nil, nil
 	}

--- a/vulnfeeds/conversion/cve5/default_extractor.go
+++ b/vulnfeeds/conversion/cve5/default_extractor.go
@@ -34,7 +34,7 @@ func (d *DefaultVersionExtractor) handleAffected(affected []models.Affected, met
 func (d *DefaultVersionExtractor) ExtractVersions(cve models.CVE5, v *vulns.Vulnerability, metrics *models.ConversionMetrics, repos []string) {
 	gotVersions := false
 
-	repoTagsCache := &git.RepoTagsCache{}
+	repoTagsCache := git.NewRepoTagsCache()
 
 	ranges := d.handleAffected(cve.Containers.CNA.Affected, metrics)
 	successfulRepos := make(map[string]bool)

--- a/vulnfeeds/conversion/nvd/converter.go
+++ b/vulnfeeds/conversion/nvd/converter.go
@@ -27,7 +27,7 @@ var ErrNoRanges = errors.New("no ranges")
 var ErrUnresolvedFix = errors.New("fixes not resolved to commits")
 
 // CVEToOSV Takes an NVD CVE record and returns an OSV Vulnerability object, ConversionMetrics, and the outcome.
-func CVEToOSV(cve models.NVDCVE, repos []string, cache *git.RepoTagsCache, metrics *models.ConversionMetrics) (*vulns.Vulnerability, *models.ConversionMetrics, models.ConversionOutcome) {
+func CVEToOSV(cve models.NVDCVE, repos []string, cache git.RepoTagsCache, metrics *models.ConversionMetrics) (*vulns.Vulnerability, *models.ConversionMetrics, models.ConversionOutcome) {
 	CPEs := c.CPEs(cve)
 	metrics.CPEs = CPEs
 	refs := c.DeduplicateRefs(cve.References)
@@ -161,7 +161,7 @@ func CVEToOSV(cve models.NVDCVE, repos []string, cache *git.RepoTagsCache, metri
 }
 
 // CVEToPackageInfo takes an NVD CVE record and outputs a PackageInfo struct in a file in the specified directory.
-func CVEToPackageInfo(cve models.NVDCVE, repos []string, cache *git.RepoTagsCache, directory string, metrics *models.ConversionMetrics) models.ConversionOutcome {
+func CVEToPackageInfo(cve models.NVDCVE, repos []string, cache git.RepoTagsCache, directory string, metrics *models.ConversionMetrics) models.ConversionOutcome {
 	CPEs := c.CPEs(cve)
 	// The vendor name and product name are used to construct the output `vulnDir` below, so need to be set to *something* to keep the output tidy.
 	maybeVendorName := "ENOCPE"
@@ -269,7 +269,7 @@ func CVEToPackageInfo(cve models.NVDCVE, repos []string, cache *git.RepoTagsCach
 }
 
 // FindRepos attempts to find the source code repositories for a given CVE.
-func FindRepos(cve models.NVDCVE, vpRepoCache *c.VPRepoCache, repoTagsCache *git.RepoTagsCache, metrics *models.ConversionMetrics, httpClient *http.Client) []string {
+func FindRepos(cve models.NVDCVE, vpRepoCache *c.VPRepoCache, repoTagsCache git.RepoTagsCache, metrics *models.ConversionMetrics, httpClient *http.Client) []string {
 	// Find repos
 	refs := c.DeduplicateRefs(cve.References)
 	CPEs := c.CPEs(cve)

--- a/vulnfeeds/conversion/nvd/converter_test.go
+++ b/vulnfeeds/conversion/nvd/converter_test.go
@@ -65,7 +65,7 @@ func TestCVEToOSV_429(t *testing.T) {
 	}
 
 	metrics := &models.ConversionMetrics{}
-	cache := &git.RepoTagsCache{}
+	cache := &git.InMemoryRepoTagsCache{}
 	outDir := t.TempDir()
 
 	_, _, outcome := CVEToOSV(cve, []string{"https://github.com/foo/bar"}, cache, metrics)
@@ -109,7 +109,7 @@ func TestCVEToOSV_ReferencesDeterminism(t *testing.T) {
 
 	var firstResult []*osvschema.Reference
 	for i := range 10 {
-		cache := &git.RepoTagsCache{}
+		cache := &git.InMemoryRepoTagsCache{}
 		vuln, _, _ := CVEToOSV(cve, nil, cache, metrics)
 		if vuln == nil {
 			t.Fatalf("Iteration %d produced nil vulnerability", i)

--- a/vulnfeeds/conversion/versions.go
+++ b/vulnfeeds/conversion/versions.go
@@ -1071,7 +1071,7 @@ func (c *VPRepoCache) Initialize(vpMap VendorProductToRepoMap) {
 // Takes a CVE ID string (for logging), VersionInfo with AffectedVersions and
 // typically no AffectedCommits and attempts to add AffectedCommits (including Fixed commits) where there aren't any.
 // Refuses to add the same commit to AffectedCommits more than once.
-func VersionInfoToCommits(v *models.VersionInfo, repos []string, cache *git.RepoTagsCache, metrics *models.ConversionMetrics) {
+func VersionInfoToCommits(v *models.VersionInfo, repos []string, cache git.RepoTagsCache, metrics *models.ConversionMetrics) {
 	// versions is a VersionInfo with AffectedVersions and typically no AffectedCommits
 	// v is a VersionInfo with AffectedCommits (containing Fixed commits) included
 	for _, repo := range repos {
@@ -1163,7 +1163,7 @@ func VersionInfoToCommits(v *models.VersionInfo, repos []string, cache *git.Repo
 
 // Examines the CVE references for a CVE and derives repos for it, optionally caching it.
 // *** Does external calls to verify repos ***
-func ReposFromReferences(cache *VPRepoCache, vp *VendorProduct, refs []models.Reference, tagDenyList []string, repoTagsCache *git.RepoTagsCache, metrics *models.ConversionMetrics, httpClient *http.Client) (repos []string) {
+func ReposFromReferences(cache *VPRepoCache, vp *VendorProduct, refs []models.Reference, tagDenyList []string, repoTagsCache git.RepoTagsCache, metrics *models.ConversionMetrics, httpClient *http.Client) (repos []string) {
 	for _, ref := range refs {
 		// If any of the denylist tags are in the ref's tag set, it's out of consideration.
 		if !RefAcceptable(ref, tagDenyList) {

--- a/vulnfeeds/conversion/versions_test.go
+++ b/vulnfeeds/conversion/versions_test.go
@@ -1365,7 +1365,7 @@ func TestReposFromReferences(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			testutils.SetupGitVCR(t)
 			metrics := &models.ConversionMetrics{}
-			repoTagsCache := &git.RepoTagsCache{}
+			repoTagsCache := &git.InMemoryRepoTagsCache{}
 			if gotRepos := ReposFromReferences(tt.args.cache, tt.args.vp, tt.args.refs, tt.args.tagDenyList, repoTagsCache, metrics, http.DefaultClient); !reflect.DeepEqual(gotRepos, tt.wantRepos) {
 				t.Errorf("ReposFromReferences() = %#v, want %#v", gotRepos, tt.wantRepos)
 			}

--- a/vulnfeeds/git/repository.go
+++ b/vulnfeeds/git/repository.go
@@ -54,8 +54,8 @@ var ErrRateLimit = errors.New("rate limit exceeded")
 
 // A GitTag holds a Git tag and corresponding commit hash.
 type Tag struct {
-	Tag    string // Git tag
-	Commit string // Git commit hash
+	Tag    string `json:"tag"`    // Git tag
+	Commit string `json:"commit"` // Git commit hash
 }
 
 type Tags []Tag
@@ -66,51 +66,194 @@ func (t Tags) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
 
 // NormalizedTag holds a normalized (as by NormalizeRepoTags) tag and corresponding commit hash.
 type NormalizedTag struct {
-	OriginalTag        string
-	Commit             string
-	MatchesVersionText bool
+	OriginalTag        string `json:"original_tag"`
+	Commit             string `json:"commit"`
+	MatchesVersionText bool   `json:"matches_version_text"`
 }
 
 // RepoTagsMap holds all of the tags (naturally occurring and normalized) for a Git repo.
 type RepoTagsMap struct {
-	Tag           map[string]Tag           // The key is the original tag as seen on the repo.
-	NormalizedTag map[string]NormalizedTag // The key is the normalized (as by NormalizeRepoTags) original tag.
+	Tag           map[string]Tag           `json:"tag"`            // The key is the original tag as seen on the repo.
+	NormalizedTag map[string]NormalizedTag `json:"normalized_tag"` // The key is the normalized (as by NormalizeRepoTags) original tag.
 }
 
 // RepoTagsCache acts as a cache for RepoTags results, keyed on the repo's URL.
-type RepoTagsCache struct {
+type RepoTagsCache interface {
+	Get(repo string) (RepoTagsMap, bool)
+	Set(repo string, tags RepoTagsMap)
+	SetInvalid(repo string)
+	IsInvalid(repo string) bool
+	SetCanonicalLink(repo string, canonicalLink string)
+	GetCanonicalLink(repo string) (string, bool)
+}
+
+type InMemoryRepoTagsCache struct {
 	sync.RWMutex
 
 	m             map[string]RepoTagsMap
 	invalid       map[string]bool
 	canonicalLink map[string]string
-	redisClient   *redis.Client
 }
 
-func NewRepoTagsCache() *RepoTagsCache {
-	c := &RepoTagsCache{
+func (c *InMemoryRepoTagsCache) Get(repo string) (RepoTagsMap, bool) {
+	c.RLock()
+	defer c.RUnlock()
+	if c.m == nil {
+		return RepoTagsMap{}, false
+	}
+	tags, ok := c.m[repo]
+
+	return tags, ok
+}
+
+func (c *InMemoryRepoTagsCache) Set(repo string, tags RepoTagsMap) {
+	c.Lock()
+	defer c.Unlock()
+	if c.m == nil {
+		c.m = make(map[string]RepoTagsMap)
+	}
+	c.m[repo] = tags
+}
+
+func (c *InMemoryRepoTagsCache) SetInvalid(repo string) {
+	c.Lock()
+	defer c.Unlock()
+	if c.invalid == nil {
+		c.invalid = make(map[string]bool)
+	}
+	c.invalid[repo] = true
+}
+
+func (c *InMemoryRepoTagsCache) IsInvalid(repo string) bool {
+	c.RLock()
+	defer c.RUnlock()
+	if c.invalid == nil {
+		return false
+	}
+
+	return c.invalid[repo]
+}
+
+func (c *InMemoryRepoTagsCache) SetCanonicalLink(repo string, canonicalLink string) {
+	c.Lock()
+	defer c.Unlock()
+	if c.canonicalLink == nil {
+		c.canonicalLink = make(map[string]string)
+	}
+	c.canonicalLink[repo] = canonicalLink
+}
+
+func (c *InMemoryRepoTagsCache) GetCanonicalLink(repo string) (string, bool) {
+	c.RLock()
+	defer c.RUnlock()
+	if c.canonicalLink == nil {
+		return "", false
+	}
+	canonicalLink, ok := c.canonicalLink[repo]
+
+	return canonicalLink, ok
+}
+
+type RedisRepoTagsCache struct {
+	redisClient *redis.Client
+}
+
+func (c *RedisRepoTagsCache) Get(repo string) (RepoTagsMap, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	key := "repo_tags:" + repo
+	val, err := c.redisClient.Get(ctx, key).Result()
+	if err != nil {
+		return RepoTagsMap{}, false
+	}
+
+	var tags RepoTagsMap
+	if err := json.Unmarshal([]byte(val), &tags); err != nil {
+		return RepoTagsMap{}, false
+	}
+
+	return tags, true
+}
+
+func (c *RedisRepoTagsCache) Set(repo string, tags RepoTagsMap) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	key := "repo_tags:" + repo
+	val, err := json.Marshal(tags)
+	if err != nil {
+		return
+	}
+
+	ttl := randomTTL()
+	c.redisClient.Set(ctx, key, val, ttl)
+}
+
+func (c *RedisRepoTagsCache) SetInvalid(repo string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	key := "invalid_repo:" + repo
+	ttl := randomTTL()
+	c.redisClient.Set(ctx, key, "true", ttl)
+}
+
+func (c *RedisRepoTagsCache) IsInvalid(repo string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	key := "invalid_repo:" + repo
+	val, err := c.redisClient.Get(ctx, key).Result()
+	if err != nil {
+		return false
+	}
+
+	return val == "true"
+}
+
+func (c *RedisRepoTagsCache) SetCanonicalLink(repo string, canonicalLink string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	key := "canonical_link:" + repo
+	ttl := randomTTL()
+	c.redisClient.Set(ctx, key, canonicalLink, ttl)
+}
+
+func (c *RedisRepoTagsCache) GetCanonicalLink(repo string) (string, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	key := "canonical_link:" + repo
+	val, err := c.redisClient.Get(ctx, key).Result()
+	if err != nil {
+		return "", false
+	}
+
+	return val, true
+}
+
+func NewRepoTagsCache() RepoTagsCache {
+	redisHost := os.Getenv("REDISHOST")
+	if redisHost != "" {
+		redisPort := os.Getenv("REDISPORT")
+		if redisPort == "" {
+			redisPort = "6379"
+		}
+		client := redis.NewClient(&redis.Options{
+			Addr:     fmt.Sprintf("%s:%s", redisHost, redisPort),
+			Protocol: 2,
+		})
+
+		return &RedisRepoTagsCache{redisClient: client}
+	}
+
+	return &InMemoryRepoTagsCache{
 		m:             make(map[string]RepoTagsMap),
 		invalid:       make(map[string]bool),
 		canonicalLink: make(map[string]string),
 	}
-	c.InitRedis()
-
-	return c
-}
-
-func (c *RepoTagsCache) InitRedis() {
-	redisHost := os.Getenv("REDISHOST")
-	if redisHost == "" {
-		return
-	}
-	redisPort := os.Getenv("REDISPORT")
-	if redisPort == "" {
-		redisPort = "6379"
-	}
-	c.redisClient = redis.NewClient(&redis.Options{
-		Addr:     fmt.Sprintf("%s:%s", redisHost, redisPort),
-		Protocol: 2,
-	})
 }
 
 func randomTTL() time.Duration {
@@ -122,94 +265,6 @@ func randomTTL() time.Duration {
 	r := rand.Intn(maxHours - minHours + 1)
 
 	return time.Duration(minHours+r) * time.Hour
-}
-
-func (c *RepoTagsCache) Get(repo string) (RepoTagsMap, bool) {
-	c.RLock()
-	defer c.RUnlock()
-	if c.m == nil {
-		return RepoTagsMap{}, false
-	}
-	tags, ok := c.m[repo]
-
-	return tags, ok
-}
-
-func (c *RepoTagsCache) Set(repo string, tags RepoTagsMap) {
-	c.Lock()
-	defer c.Unlock()
-	if c.m == nil {
-		c.m = make(map[string]RepoTagsMap)
-	}
-	c.m[repo] = tags
-}
-
-func (c *RepoTagsCache) SetInvalid(repo string) {
-	c.Lock()
-	defer c.Unlock()
-	if c.invalid == nil {
-		c.invalid = make(map[string]bool)
-	}
-	c.invalid[repo] = true
-}
-
-func (c *RepoTagsCache) IsInvalid(repo string) bool {
-	c.RLock()
-	defer c.RUnlock()
-	if c.invalid == nil {
-		return false
-	}
-
-	return c.invalid[repo]
-}
-
-func (c *RepoTagsCache) SetCanonicalLink(repo string, canonicalLink string) {
-	c.Lock()
-	if c.canonicalLink == nil {
-		c.canonicalLink = make(map[string]string)
-	}
-	c.canonicalLink[repo] = canonicalLink
-	c.Unlock()
-
-	if c.redisClient != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-		defer cancel()
-
-		key := "canonical_link:" + repo
-		ttl := randomTTL()
-		c.redisClient.Set(ctx, key, canonicalLink, ttl)
-	}
-}
-
-func (c *RepoTagsCache) GetCanonicalLink(repo string) (string, bool) {
-	c.RLock()
-	if c.canonicalLink != nil {
-		if canonicalLink, ok := c.canonicalLink[repo]; ok {
-			c.RUnlock()
-			return canonicalLink, true
-		}
-	}
-	c.RUnlock()
-
-	if c.redisClient != nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-		defer cancel()
-
-		key := "canonical_link:" + repo
-		val, err := c.redisClient.Get(ctx, key).Result()
-		if err == nil {
-			c.Lock()
-			if c.canonicalLink == nil {
-				c.canonicalLink = make(map[string]string)
-			}
-			c.canonicalLink[repo] = val
-			c.Unlock()
-
-			return val, true
-		}
-	}
-
-	return "", false
 }
 
 type GitterRef struct {
@@ -355,7 +410,7 @@ func RepoName(repoURL string) (name string, e error) {
 // RepoTags returns an array of Tag being the (unpeeled, if annotated) tags and associated commits in repoURL.
 // An optional repoTagsCache can be supplied to reduce repeated remote connections to the same repo.
 // *** Does external calls to verify repos ***
-func RepoTags(repoURL string, repoTagsCache *RepoTagsCache) (tags Tags, e error) {
+func RepoTags(repoURL string, repoTagsCache RepoTagsCache) (tags Tags, e error) {
 	if repoTagsCache != nil {
 		tagsRepoMap, ok := repoTagsCache.Get(repoURL)
 		if ok {
@@ -448,7 +503,7 @@ func normalizeRepoTag(tag string, reponame string) (normalizedTag string, err er
 
 // NormalizeRepoTags returns a map of normalized tags mapping back to original tags and also commit hashes.
 // An optional repoTagsCache can be supplied to reduce repeated remote connections to the same repo.
-func NormalizeRepoTags(repoURL string, repoTagsCache *RepoTagsCache) (normalizedTags map[string]NormalizedTag, e error) {
+func NormalizeRepoTags(repoURL string, repoTagsCache RepoTagsCache) (normalizedTags map[string]NormalizedTag, e error) {
 	if repoTagsCache != nil {
 		tags, ok := repoTagsCache.Get(repoURL)
 		if ok && tags.NormalizedTag != nil {

--- a/vulnfeeds/git/repository.go
+++ b/vulnfeeds/git/repository.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"log/slog"
 	"maps"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
@@ -41,6 +42,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/google/osv/vulnfeeds/utility/logger"
+	"github.com/redis/go-redis/v9"
 	"github.com/sethvargo/go-retry"
 )
 
@@ -82,6 +84,44 @@ type RepoTagsCache struct {
 	m             map[string]RepoTagsMap
 	invalid       map[string]bool
 	canonicalLink map[string]string
+	redisClient   *redis.Client
+}
+
+func NewRepoTagsCache() *RepoTagsCache {
+	c := &RepoTagsCache{
+		m:             make(map[string]RepoTagsMap),
+		invalid:       make(map[string]bool),
+		canonicalLink: make(map[string]string),
+	}
+	c.InitRedis()
+
+	return c
+}
+
+func (c *RepoTagsCache) InitRedis() {
+	redisHost := os.Getenv("REDISHOST")
+	if redisHost == "" {
+		return
+	}
+	redisPort := os.Getenv("REDISPORT")
+	if redisPort == "" {
+		redisPort = "6379"
+	}
+	c.redisClient = redis.NewClient(&redis.Options{
+		Addr:     fmt.Sprintf("%s:%s", redisHost, redisPort),
+		Protocol: 2,
+	})
+}
+
+func randomTTL() time.Duration {
+	// 1 week = 7 days = 168 hours
+	// +- 1 day = +- 24 hours
+	minHours := 144
+	maxHours := 192
+	//nolint:gosec
+	r := rand.Intn(maxHours - minHours + 1)
+
+	return time.Duration(minHours+r) * time.Hour
 }
 
 func (c *RepoTagsCache) Get(repo string) (RepoTagsMap, bool) {
@@ -125,22 +165,51 @@ func (c *RepoTagsCache) IsInvalid(repo string) bool {
 
 func (c *RepoTagsCache) SetCanonicalLink(repo string, canonicalLink string) {
 	c.Lock()
-	defer c.Unlock()
 	if c.canonicalLink == nil {
 		c.canonicalLink = make(map[string]string)
 	}
 	c.canonicalLink[repo] = canonicalLink
+	c.Unlock()
+
+	if c.redisClient != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		key := "canonical_link:" + repo
+		ttl := randomTTL()
+		c.redisClient.Set(ctx, key, canonicalLink, ttl)
+	}
 }
 
 func (c *RepoTagsCache) GetCanonicalLink(repo string) (string, bool) {
 	c.RLock()
-	defer c.RUnlock()
-	if c.canonicalLink == nil {
-		return "", false
+	if c.canonicalLink != nil {
+		if canonicalLink, ok := c.canonicalLink[repo]; ok {
+			c.RUnlock()
+			return canonicalLink, true
+		}
 	}
-	canonicalLink, ok := c.canonicalLink[repo]
+	c.RUnlock()
 
-	return canonicalLink, ok
+	if c.redisClient != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		key := "canonical_link:" + repo
+		val, err := c.redisClient.Get(ctx, key).Result()
+		if err == nil {
+			c.Lock()
+			if c.canonicalLink == nil {
+				c.canonicalLink = make(map[string]string)
+			}
+			c.canonicalLink[repo] = val
+			c.Unlock()
+
+			return val, true
+		}
+	}
+
+	return "", false
 }
 
 type GitterRef struct {

--- a/vulnfeeds/git/repository_test.go
+++ b/vulnfeeds/git/repository_test.go
@@ -56,12 +56,12 @@ func TestRepoName(t *testing.T) {
 }
 
 func TestRepoTags(t *testing.T) {
-	cache := &RepoTagsCache{}
+	cache := &InMemoryRepoTagsCache{}
 
 	tests := []struct {
 		description       string
 		inputRepoURL      string
-		cache             *RepoTagsCache
+		cache             RepoTagsCache
 		expectedResult    Tags
 		expectedOk        bool
 		disableExpiryDate time.Time
@@ -186,9 +186,11 @@ func TestRepoTags(t *testing.T) {
 			}
 			var cacheBefore, cacheAfter int
 			if tc.cache != nil {
-				tc.cache.RLock()
-				cacheBefore = len(tc.cache.m) + len(tc.cache.invalid)
-				tc.cache.RUnlock()
+				if inMem, ok := tc.cache.(*InMemoryRepoTagsCache); ok {
+					inMem.RLock()
+					cacheBefore = len(inMem.m) + len(inMem.invalid)
+					inMem.RUnlock()
+				}
 			}
 			got, err := RepoTags(tc.inputRepoURL, tc.cache)
 			if err != nil && tc.expectedOk {
@@ -198,9 +200,11 @@ func TestRepoTags(t *testing.T) {
 				t.Errorf("test %q: RepoTags(%q) incorrect result: %s", tc.description, tc.inputRepoURL, diff)
 			}
 			if tc.cache != nil {
-				tc.cache.RLock()
-				cacheAfter = len(tc.cache.m) + len(tc.cache.invalid)
-				tc.cache.RUnlock()
+				if inMem, ok := tc.cache.(*InMemoryRepoTagsCache); ok {
+					inMem.RLock()
+					cacheAfter = len(inMem.m) + len(inMem.invalid)
+					inMem.RUnlock()
+				}
 			}
 			if tc.cache != nil && (cacheAfter <= cacheBefore) {
 				t.Errorf("test %q: RepoTags(%q) incorrect cache behaviour: size before: %d size after: %d cache: %#v", tc.description, tc.inputRepoURL, cacheBefore, cacheAfter, tc.cache)
@@ -303,7 +307,7 @@ func TestNormalizeRepoTags(t *testing.T) {
 			expectedOk:   false,
 		},
 	}
-	cache := &RepoTagsCache{}
+	cache := &InMemoryRepoTagsCache{}
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			testutils.SetupGitVCR(t)

--- a/vulnfeeds/git/versions.go
+++ b/vulnfeeds/git/versions.go
@@ -233,7 +233,7 @@ func ValidateAndCanonicalizeLink(link string, httpClient *http.Client) (canonica
 	return canonicalLink, nil
 }
 
-func FindCanonicalLink(link string, httpClient *http.Client, cache *RepoTagsCache) (canonicalLink string, err error) {
+func FindCanonicalLink(link string, httpClient *http.Client, cache RepoTagsCache) (canonicalLink string, err error) {
 	if canonicalLink, ok := cache.GetCanonicalLink(link); ok {
 		return canonicalLink, nil
 	}

--- a/vulnfeeds/git/versions_test.go
+++ b/vulnfeeds/git/versions_test.go
@@ -1,14 +1,10 @@
 package git
 
 import (
-	"fmt"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"reflect"
-	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -413,138 +409,5 @@ func TestValidateAndCanonicalizeLink_Retries(t *testing.T) {
 	}
 	if requests != 4 {
 		t.Errorf("ValidateAndCanonicalizeLink() expected 4 requests (1 initial + 3 retries), got %d", requests)
-	}
-}
-
-func TestRedisCanonicalLinkCache(t *testing.T) {
-	// 1. Spin up a local TCP server to mock Redis protocol
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("Failed to start mock Redis listener: %v", err)
-	}
-	defer ln.Close()
-
-	addr := ln.Addr().String()
-	host, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		t.Fatalf("Failed to parse host/port: %v", err)
-	}
-
-	// Simple map to store mock keys/values in memory
-	redisStore := make(map[string]string)
-	var storeMu sync.Mutex
-
-	// Flag to track if any requests were handled
-	var requestHandled bool
-	var requestMu sync.Mutex
-
-	go func() {
-		for {
-			conn, err := ln.Accept()
-			if err != nil {
-				return
-			}
-			go func(c net.Conn) {
-				defer c.Close()
-				buf := make([]byte, 1024)
-				for {
-					n, err := c.Read(buf)
-					if err != nil {
-						return
-					}
-					req := string(buf[:n])
-					t.Logf("Incoming mock Redis request: %q", req)
-					requestMu.Lock()
-					requestHandled = true
-					requestMu.Unlock()
-
-					// Split requests by '*' (RESP arrays)
-					commands := strings.Split(req, "*")
-					for _, cmd := range commands {
-						if cmd == "" {
-							continue
-						}
-						cmd = "*" + cmd
-						cmdUpper := strings.ToUpper(cmd)
-						if strings.Contains(cmdUpper, "HELLO") {
-							t.Log("Received HELLO, returning ERR to force fallback to RESP2")
-							_, _ = c.Write([]byte("-ERR unknown command 'HELLO'\r\n"))
-						} else if strings.Contains(cmdUpper, "GET") {
-							lines := strings.Split(cmd, "\r\n")
-							var key string
-							for i, line := range lines {
-								if strings.ToUpper(line) == "GET" && i+2 < len(lines) {
-									key = lines[i+2]
-									break
-								}
-							}
-							t.Logf("GET key: %q", key)
-							storeMu.Lock()
-							val, ok := redisStore[key]
-							storeMu.Unlock()
-							t.Logf("GET val found: %q (ok: %t)", val, ok)
-							if ok {
-								_, _ = fmt.Fprintf(c, "$%d\r\n%s\r\n", len(val), val)
-							} else {
-								_, _ = c.Write([]byte("$-1\r\n"))
-							}
-						} else if strings.Contains(cmdUpper, "SET") {
-							lines := strings.Split(cmd, "\r\n")
-							var key, val string
-							for i, line := range lines {
-								if strings.ToUpper(line) == "SET" && i+4 < len(lines) {
-									key = lines[i+2]
-									val = lines[i+4]
-
-									break
-								}
-							}
-							t.Logf("SET key: %q, val: %q", key, val)
-							storeMu.Lock()
-							redisStore[key] = val
-							storeMu.Unlock()
-							_, _ = c.Write([]byte("+OK\r\n"))
-						} else {
-							_, _ = c.Write([]byte("+OK\r\n"))
-						}
-					}
-				}
-			}(conn)
-		}
-	}()
-
-	t.Setenv("REDISHOST", host)
-	t.Setenv("REDISPORT", port)
-
-	cache := NewRepoTagsCache()
-	redisCache, ok := cache.(*RedisRepoTagsCache)
-	if !ok {
-		t.Fatalf("Expected NewRepoTagsCache() to return RedisRepoTagsCache when REDISHOST is set")
-	}
-	if redisCache.redisClient == nil {
-		t.Fatal("Expected redisClient to be initialized, but got nil")
-	}
-
-	repo := "https://github.com/foo/bar"
-	canonical := "https://github.com/canonical/bar"
-
-	got, ok := cache.GetCanonicalLink(repo)
-	if ok {
-		t.Errorf("GetCanonicalLink() expected false on empty cache, got %q", got)
-	}
-
-	cache.SetCanonicalLink(repo, canonical)
-
-	gotFromRedis, ok := cache.GetCanonicalLink(repo)
-	if !ok || gotFromRedis != canonical {
-		t.Errorf("GetCanonicalLink() failed to retrieve from Redis, got: %q, expected: %q", gotFromRedis, canonical)
-	}
-
-	requestMu.Lock()
-	handled := requestHandled
-	requestMu.Unlock()
-
-	if !handled {
-		t.Error("Mock Redis server did not handle any requests")
 	}
 }

--- a/vulnfeeds/git/versions_test.go
+++ b/vulnfeeds/git/versions_test.go
@@ -1,10 +1,14 @@
 package git
 
 import (
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"reflect"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -409,5 +413,143 @@ func TestValidateAndCanonicalizeLink_Retries(t *testing.T) {
 	}
 	if requests != 4 {
 		t.Errorf("ValidateAndCanonicalizeLink() expected 4 requests (1 initial + 3 retries), got %d", requests)
+	}
+}
+
+func TestRedisCanonicalLinkCache(t *testing.T) {
+	// 1. Spin up a local TCP server to mock Redis protocol
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Failed to start mock Redis listener: %v", err)
+	}
+	defer ln.Close()
+
+	addr := ln.Addr().String()
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("Failed to parse host/port: %v", err)
+	}
+
+	// Simple map to store mock keys/values in memory
+	redisStore := make(map[string]string)
+	var storeMu sync.Mutex
+
+	// Flag to track if any requests were handled
+	var requestHandled bool
+	var requestMu sync.Mutex
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				buf := make([]byte, 1024)
+				for {
+					n, err := c.Read(buf)
+					if err != nil {
+						return
+					}
+					req := string(buf[:n])
+					t.Logf("Incoming mock Redis request: %q", req)
+					requestMu.Lock()
+					requestHandled = true
+					requestMu.Unlock()
+
+					// Split requests by '*' (RESP arrays)
+					commands := strings.Split(req, "*")
+					for _, cmd := range commands {
+						if cmd == "" {
+							continue
+						}
+						cmd = "*" + cmd
+						cmdUpper := strings.ToUpper(cmd)
+						if strings.Contains(cmdUpper, "HELLO") {
+							t.Log("Received HELLO, returning ERR to force fallback to RESP2")
+							_, _ = c.Write([]byte("-ERR unknown command 'HELLO'\r\n"))
+						} else if strings.Contains(cmdUpper, "GET") {
+							lines := strings.Split(cmd, "\r\n")
+							var key string
+							for i, line := range lines {
+								if strings.ToUpper(line) == "GET" && i+2 < len(lines) {
+									key = lines[i+2]
+									break
+								}
+							}
+							t.Logf("GET key: %q", key)
+							storeMu.Lock()
+							val, ok := redisStore[key]
+							storeMu.Unlock()
+							t.Logf("GET val found: %q (ok: %t)", val, ok)
+							if ok {
+								_, _ = fmt.Fprintf(c, "$%d\r\n%s\r\n", len(val), val)
+							} else {
+								_, _ = c.Write([]byte("$-1\r\n"))
+							}
+						} else if strings.Contains(cmdUpper, "SET") {
+							lines := strings.Split(cmd, "\r\n")
+							var key, val string
+							for i, line := range lines {
+								if strings.ToUpper(line) == "SET" && i+4 < len(lines) {
+									key = lines[i+2]
+									val = lines[i+4]
+
+									break
+								}
+							}
+							t.Logf("SET key: %q, val: %q", key, val)
+							storeMu.Lock()
+							redisStore[key] = val
+							storeMu.Unlock()
+							_, _ = c.Write([]byte("+OK\r\n"))
+						} else {
+							_, _ = c.Write([]byte("+OK\r\n"))
+						}
+					}
+				}
+			}(conn)
+		}
+	}()
+
+	t.Setenv("REDISHOST", host)
+	t.Setenv("REDISPORT", port)
+
+	cache := NewRepoTagsCache()
+	if cache.redisClient == nil {
+		t.Fatal("Expected redisClient to be initialized, but got nil")
+	}
+
+	repo := "https://github.com/foo/bar"
+	canonical := "https://github.com/canonical/bar"
+
+	got, ok := cache.GetCanonicalLink(repo)
+	if ok {
+		t.Errorf("GetCanonicalLink() expected false on empty cache, got %q", got)
+	}
+
+	cache.SetCanonicalLink(repo, canonical)
+
+	gotInMemory, ok := cache.canonicalLink[repo]
+	if !ok || gotInMemory != canonical {
+		t.Errorf("SetCanonicalLink() failed to populate in-memory cache, got: %q, expected: %q", gotInMemory, canonical)
+	}
+
+	cache.Lock()
+	delete(cache.canonicalLink, repo)
+	cache.Unlock()
+
+	gotFromRedis, ok := cache.GetCanonicalLink(repo)
+	if !ok || gotFromRedis != canonical {
+		t.Errorf("GetCanonicalLink() failed to retrieve from Redis, got: %q, expected: %q", gotFromRedis, canonical)
+	}
+
+	requestMu.Lock()
+	handled := requestHandled
+	requestMu.Unlock()
+
+	if !handled {
+		t.Error("Mock Redis server did not handle any requests")
 	}
 }

--- a/vulnfeeds/git/versions_test.go
+++ b/vulnfeeds/git/versions_test.go
@@ -17,12 +17,12 @@ import (
 )
 
 func TestVersionToAffectedCommit(t *testing.T) {
-	cache := &RepoTagsCache{}
+	cache := &InMemoryRepoTagsCache{}
 
 	tests := []struct {
 		description       string
 		inputRepoURL      string
-		cache             *RepoTagsCache
+		cache             RepoTagsCache
 		inputVersion      string
 		expectedResult    string
 		expectedOk        bool
@@ -517,7 +517,11 @@ func TestRedisCanonicalLinkCache(t *testing.T) {
 	t.Setenv("REDISPORT", port)
 
 	cache := NewRepoTagsCache()
-	if cache.redisClient == nil {
+	redisCache, ok := cache.(*RedisRepoTagsCache)
+	if !ok {
+		t.Fatalf("Expected NewRepoTagsCache() to return RedisRepoTagsCache when REDISHOST is set")
+	}
+	if redisCache.redisClient == nil {
 		t.Fatal("Expected redisClient to be initialized, but got nil")
 	}
 
@@ -530,15 +534,6 @@ func TestRedisCanonicalLinkCache(t *testing.T) {
 	}
 
 	cache.SetCanonicalLink(repo, canonical)
-
-	gotInMemory, ok := cache.canonicalLink[repo]
-	if !ok || gotInMemory != canonical {
-		t.Errorf("SetCanonicalLink() failed to populate in-memory cache, got: %q, expected: %q", gotInMemory, canonical)
-	}
-
-	cache.Lock()
-	delete(cache.canonicalLink, repo)
-	cache.Unlock()
 
 	gotFromRedis, ok := cache.GetCanonicalLink(repo)
 	if !ok || gotFromRedis != canonical {

--- a/vulnfeeds/go.mod
+++ b/vulnfeeds/go.mod
@@ -17,11 +17,13 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/knqyf263/go-cpe v0.0.0-20230627041855-cb0794d06872
 	github.com/ossf/osv-schema/bindings/go v0.0.0-20260331231022-2a6a0b9b0ccd
+	github.com/redis/go-redis/v9 v9.19.0
 	github.com/sethvargo/go-retry v0.3.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.43.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.36.0
 	google.golang.org/api v0.276.0
 	google.golang.org/protobuf v1.36.11
@@ -106,12 +108,12 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.3 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/exp v0.0.0-20250819193227-8b4c13bb791b // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect

--- a/vulnfeeds/go.sum
+++ b/vulnfeeds/go.sum
@@ -59,6 +59,10 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/atombender/go-jsonschema v0.23.0 h1:1W586wlGS2Zup69szfgJpQ/NKZcjuMEocAtYvEcPyzw=
 github.com/atombender/go-jsonschema v0.23.0/go.mod h1:KAi1zDASp4e0FvlFM5QvLyU3k7+DsX+7hCq98G34gtg=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -232,6 +236,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/redis/go-redis/v9 v9.19.0 h1:XPVaaPSnG6RhYf7p+rmSa9zZfeVAnWsH5h3lxthOm/k=
+github.com/redis/go-redis/v9 v9.19.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
@@ -278,6 +284,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=
 github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
+github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
 go.einride.tech/aip v0.79.0 h1:19zdPlZzlUvxOA8syAFw4LkdJdXepzyTl6gt9XEeqdU=
 go.einride.tech/aip v0.79.0/go.mod h1:E8+wdTApA70odnpFzJgsGogHozC2JCIhFJBKPr8bVig=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
@@ -302,6 +310,8 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=


### PR DESCRIPTION
This PR adds a persistent Redis caching layer to `vulnfeeds` to cache the mappings of resolved canonical repository links. Caching these lookups helps avoid making redundant external HEAD requests, preventing us from regularly getting rate limited (HTTP 429) during CVE processing.

* **Protocol**: Configured `go-redis` to force `Protocol: 2` (RESP2) to ensure full compatibility with older Memorystore Redis instances.
* **TTL**: Keys are stored with a randomized expiration of 1 week ± 1 day to avoid cache stampedes.
* **Fallback**: If Redis isn't configured or goes down, the cache gracefully falls back to in-memory caching.
* **Deployments**: Configured `REDISHOST` in both the test and prod GKE CronJob manifests (`nvd-cve-osv.yaml`).

### Testing
Added a new unit test `TestRedisCanonicalLinkCache` in `git/versions_test.go` that uses a mock TCP Redis server to test connect, get, set, and pipelined RESP2 parsing. Ran all other tests in `vulnfeeds/` and verified they all pass.