### PR TITLE
fix(PyPi): nil pointer and index out-of-bounds panics in PyPI converter

### DIFF
--- a/vulnfeeds/cmd/pypi/main.go
+++ b/vulnfeeds/cmd/pypi/main.go
@@ -64,9 +64,6 @@ func loadExisting(vulnsDir string) (map[string]bool, error) {
 		}
 
 		for _, affected := range vuln.GetAffected() {
-			if affected.GetPackage() == nil {
-				continue
-			}
 			pkgName := affected.GetPackage().GetName()
 			if pkgName == "" {
 				continue

--- a/vulnfeeds/cmd/pypi/main.go
+++ b/vulnfeeds/cmd/pypi/main.go
@@ -63,9 +63,18 @@ func loadExisting(vulnsDir string) (map[string]bool, error) {
 			return fmt.Errorf("failed to parse %s: %w", path, err)
 		}
 
-		ids[vuln.GetId()+"/"+vuln.GetAffected()[0].GetPackage().GetName()] = true
-		for _, alias := range vuln.GetAliases() {
-			ids[alias+"/"+vuln.GetAffected()[0].GetPackage().GetName()] = true
+		for _, affected := range vuln.GetAffected() {
+			if affected.GetPackage() == nil {
+				continue
+			}
+			pkgName := affected.GetPackage().GetName()
+			if pkgName == "" {
+				continue
+			}
+			ids[vuln.GetId()+"/"+pkgName] = true
+			for _, alias := range vuln.GetAliases() {
+				ids[alias+"/"+pkgName] = true
+			}
 		}
 
 		return nil

--- a/vulnfeeds/cmd/pypi/main_test.go
+++ b/vulnfeeds/cmd/pypi/main_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadExisting(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// 1. Write a valid vulnerability YAML
+	validYaml := `
+vulnerability:
+  id: PYSEC-2021-123
+  affected:
+    - package:
+        name: foo-pkg
+        ecosystem: PyPI
+  aliases:
+    - CVE-2021-12345
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "valid.yaml"), []byte(validYaml), 0600); err != nil {
+		t.Fatalf("failed to write valid YAML: %v", err)
+	}
+
+	// 2. Write a vulnerability YAML with empty/missing affected block
+	missingAffectedYaml := `
+vulnerability:
+  id: PYSEC-2021-456
+  aliases:
+    - CVE-2021-67890
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "missing_affected.yaml"), []byte(missingAffectedYaml), 0600); err != nil {
+		t.Fatalf("failed to write YAML with missing affected: %v", err)
+	}
+
+	// 3. Write a vulnerability YAML with affected block but missing package
+	missingPackageYaml := `
+vulnerability:
+  id: PYSEC-2021-789
+  affected:
+    - {}
+`
+	if err := os.WriteFile(filepath.Join(tmpDir, "missing_package.yaml"), []byte(missingPackageYaml), 0600); err != nil {
+		t.Fatalf("failed to write YAML with missing package: %v", err)
+	}
+
+	// Run loadExisting
+	got, err := loadExisting(tmpDir)
+	if err != nil {
+		t.Fatalf("loadExisting failed: %v", err)
+	}
+
+	// Check expected IDs
+	expected := map[string]bool{
+		"PYSEC-2021-123/foo-pkg": true,
+		"CVE-2021-12345/foo-pkg": true,
+	}
+
+	if len(got) != len(expected) {
+		t.Errorf("loadExisting returned map of size %d, want %d", len(got), len(expected))
+	}
+
+	for k, v := range expected {
+		if !got[k] {
+			t.Errorf("Expected map to contain %s", k)
+		}
+		if got[k] != v {
+			t.Errorf("Expected map[%s] to be %t, got %t", k, v, got[k])
+		}
+	}
+
+	// Ensure invalid/skipped entries are NOT present
+	unexpectedKeys := []string{
+		"PYSEC-2021-456/foo-pkg",
+		"CVE-2021-67890/foo-pkg",
+		"PYSEC-2021-789/foo-pkg",
+	}
+	for _, k := range unexpectedKeys {
+		if got[k] {
+			t.Errorf("Map unexpectedly contains %s", k)
+		}
+	}
+}

--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -769,7 +769,7 @@ func GetCPEs(cpeApplicability []models.CPE, metrics *models.ConversionMetrics) [
 // FromYAML deserializes a Vulnerability from a YAML reader.
 func FromYAML(r io.Reader) (*Vulnerability, error) {
 	decoder := yaml.NewDecoder(r)
-	var vuln Vulnerability
+	vuln := Vulnerability{Vulnerability: &osvschema.Vulnerability{}}
 	err := decoder.Decode(&vuln)
 	if err != nil {
 		return nil, err
@@ -781,7 +781,7 @@ func FromYAML(r io.Reader) (*Vulnerability, error) {
 // FromJSON deserializes a Vulnerability from a JSON reader.
 func FromJSON(r io.Reader) (*Vulnerability, error) {
 	decoder := json.NewDecoder(r)
-	var vuln Vulnerability
+	vuln := Vulnerability{Vulnerability: &osvschema.Vulnerability{}}
 	err := decoder.Decode(&vuln)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fix #5142  

#### Core bug issue
The PyPI converter crashed with a panic when running `loadExisting` if:
1. The YAML/JSON unmarshaler tried to decode into a newly initialized `Vulnerability` struct, because its embedded `*osvschema.Vulnerability` pointer remained `nil`.
2. An existing YAML file possessed an empty `affected` block, causing `vuln.GetAffected()[0]` to raise an index out-of-range panic.
3. The first element in `affected` had no package information, triggering a nil pointer dereference when fetching the package name.

#### Fix
- **Initialize Embedded Struct Pointer:** Updated `FromYAML` and `FromJSON` in `vulnfeeds/vulns/vulns.go` to explicitly initialize the inner `*osvschema.Vulnerability` pointer before parsing.
- **Safe Iteration and Nil Checks:** Refactored the walker loop in `loadExisting` inside `vulnfeeds/cmd/pypi/main.go` to iterate over `vuln.GetAffected()` and safely check for `nil` package pointers and empty package names.
- **Added Regression Tests:** Created `vulnfeeds/cmd/pypi/main_test.go` to cover parsing files with valid, empty, or incomplete `affected` blocks.