### PR TITLE
feat(exporter): skip GCS upload when object CRC32C is unchanged

### DIFF
--- a/go/.golangci.yaml
+++ b/go/.golangci.yaml
@@ -122,6 +122,7 @@ linters:
       - path: _test\.go
         linters:
           - dupl
+          - unparam
       - path-except: _test\.go
         text: use `testutility.GetCurrentWorkingDirectory`
     paths:

--- a/go/.golangci.yaml
+++ b/go/.golangci.yaml
@@ -122,7 +122,6 @@ linters:
       - path: _test\.go
         linters:
           - dupl
-          - unparam
       - path-except: _test\.go
         text: use `testutility.GetCurrentWorkingDirectory`
     paths:

--- a/go/cmd/exporter/writer.go
+++ b/go/cmd/exporter/writer.go
@@ -81,10 +81,12 @@ func gcsContentUnchanged(ctx context.Context, client clients.CloudStorage, path 
 		if !errors.Is(err, clients.ErrNotFound) {
 			logger.WarnContext(ctx, "failed to read object attrs, proceeding with upload", slog.String("path", path), slog.Any("err", err))
 		}
+
 		return false
 	}
 	if attrs.CRC32C == crc32.Checksum(data, crc32cTable) {
 		logger.InfoContext(ctx, "skipping upload, content unchanged", slog.String("path", path))
+
 		return true
 	}
 	return false

--- a/go/cmd/exporter/writer.go
+++ b/go/cmd/exporter/writer.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"errors"
+	"hash/crc32"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -10,6 +12,9 @@ import (
 	"github.com/google/osv.dev/go/logger"
 	"github.com/google/osv.dev/go/osv/clients"
 )
+
+// crc32cTable uses the Castagnoli polynomial, matching GCS's own checksum algorithm.
+var crc32cTable = crc32.MakeTable(crc32.Castagnoli)
 
 // writeMsg holds the data for a file to be written.
 type writeMsg struct {
@@ -31,7 +36,10 @@ func writer(ctx context.Context, cancel context.CancelFunc, inCh <-chan writeMsg
 			}
 			path := filepath.Join(pathPrefix, msg.path)
 			if client != nil {
-				// Write to the bucket.
+				// Skip the upload if the object already has the same content.
+				if gcsContentUnchanged(ctx, client, path, msg.data) {
+					break
+				}
 				err := client.WriteObject(ctx, path, msg.data, &clients.WriteOptions{
 					ContentType: msg.mimeType,
 				})
@@ -61,4 +69,23 @@ func writer(ctx context.Context, cancel context.CancelFunc, inCh <-chan writeMsg
 			return
 		}
 	}
+}
+
+// gcsContentUnchanged returns true if the object at path already has the same
+// CRC32C checksum as data, meaning the upload would be a no-op. Any error
+// reading the object's attributes (other than ErrNotFound) is logged and
+// treated as "content changed" so the upload proceeds.
+func gcsContentUnchanged(ctx context.Context, client clients.CloudStorage, path string, data []byte) bool {
+	attrs, err := client.ReadObjectAttrs(ctx, path)
+	if err != nil {
+		if !errors.Is(err, clients.ErrNotFound) {
+			logger.WarnContext(ctx, "failed to read object attrs, proceeding with upload", slog.String("path", path), slog.Any("err", err))
+		}
+		return false
+	}
+	if attrs.CRC32C == crc32.Checksum(data, crc32cTable) {
+		logger.InfoContext(ctx, "skipping upload, content unchanged", slog.String("path", path))
+		return true
+	}
+	return false
 }

--- a/go/cmd/exporter/writer.go
+++ b/go/cmd/exporter/writer.go
@@ -89,5 +89,6 @@ func gcsContentUnchanged(ctx context.Context, client clients.CloudStorage, path 
 
 		return true
 	}
+
 	return false
 }

--- a/go/cmd/exporter/writer_test.go
+++ b/go/cmd/exporter/writer_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // runWriter sends msgs to a writer goroutine and waits for it to finish.
-func runWriter(t *testing.T, storage clients.CloudStorage, pathPrefix string, msgs []writeMsg) {
+func runWriter(t *testing.T, storage clients.CloudStorage, msgs []writeMsg) {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -24,7 +24,7 @@ func runWriter(t *testing.T, storage clients.CloudStorage, pathPrefix string, ms
 
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go writer(ctx, cancel, inCh, storage, pathPrefix, &wg)
+	go writer(ctx, cancel, inCh, storage, "out", &wg)
 	wg.Wait()
 }
 
@@ -39,7 +39,7 @@ func TestWriter_GCS_SkipsUnchangedContent(t *testing.T) {
 	}
 	attrsBefore, _ := storage.ReadObjectAttrs(t.Context(), objPath)
 
-	runWriter(t, storage, "out", []writeMsg{
+	runWriter(t, storage, []writeMsg{
 		{path: "OSV-1.json", mimeType: "application/json", data: data},
 	})
 
@@ -61,7 +61,7 @@ func TestWriter_GCS_UploadsChangedContent(t *testing.T) {
 	}
 	attrsBefore, _ := storage.ReadObjectAttrs(t.Context(), objPath)
 
-	runWriter(t, storage, "out", []writeMsg{
+	runWriter(t, storage, []writeMsg{
 		{path: "OSV-1.json", mimeType: "application/json", data: []byte(`{"id":"OSV-1","old":false}`)},
 	})
 
@@ -77,7 +77,7 @@ func TestWriter_GCS_UploadsChangedContent(t *testing.T) {
 func TestWriter_GCS_UploadsNewObject(t *testing.T) {
 	storage := testutils.NewMockStorage()
 
-	runWriter(t, storage, "out", []writeMsg{
+	runWriter(t, storage, []writeMsg{
 		{path: "OSV-1.json", mimeType: "application/json", data: []byte(`{"id":"OSV-1"}`)},
 	})
 
@@ -120,7 +120,7 @@ func TestWriter_GCS_SkipsMultipleUnchanged(t *testing.T) {
 	for i, e := range entries {
 		msgs[i] = writeMsg{path: e.msgPath, mimeType: "application/json", data: e.data}
 	}
-	runWriter(t, storage, "out", msgs)
+	runWriter(t, storage, msgs)
 
 	for _, e := range entries {
 		attrs, err := storage.ReadObjectAttrs(t.Context(), e.objPath)

--- a/go/cmd/exporter/writer_test.go
+++ b/go/cmd/exporter/writer_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/google/osv.dev/go/osv/clients"
+	"github.com/google/osv.dev/go/testutils"
+)
+
+// runWriter sends msgs to a writer goroutine and waits for it to finish.
+func runWriter(t *testing.T, storage clients.CloudStorage, pathPrefix string, msgs []writeMsg) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	inCh := make(chan writeMsg, len(msgs))
+	for _, m := range msgs {
+		inCh <- m
+	}
+	close(inCh)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go writer(ctx, cancel, inCh, storage, pathPrefix, &wg)
+	wg.Wait()
+}
+
+func TestWriter_GCS_SkipsUnchangedContent(t *testing.T) {
+	storage := testutils.NewMockStorage()
+	data := []byte(`{"id":"OSV-1"}`)
+
+	// Pre-populate using the same path the writer will compute.
+	objPath := filepath.Join("out", "OSV-1.json")
+	if err := storage.WriteObject(t.Context(), objPath, data, nil); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	attrsBefore, _ := storage.ReadObjectAttrs(t.Context(), objPath)
+
+	runWriter(t, storage, "out", []writeMsg{
+		{path: "OSV-1.json", mimeType: "application/json", data: data},
+	})
+
+	attrsAfter, err := storage.ReadObjectAttrs(t.Context(), objPath)
+	if err != nil {
+		t.Fatalf("ReadObjectAttrs: %v", err)
+	}
+	if attrsAfter.Generation != attrsBefore.Generation {
+		t.Errorf("expected generation %d (skipped), got %d", attrsBefore.Generation, attrsAfter.Generation)
+	}
+}
+
+func TestWriter_GCS_UploadsChangedContent(t *testing.T) {
+	storage := testutils.NewMockStorage()
+
+	objPath := filepath.Join("out", "OSV-1.json")
+	if err := storage.WriteObject(t.Context(), objPath, []byte(`{"id":"OSV-1","old":true}`), nil); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	attrsBefore, _ := storage.ReadObjectAttrs(t.Context(), objPath)
+
+	runWriter(t, storage, "out", []writeMsg{
+		{path: "OSV-1.json", mimeType: "application/json", data: []byte(`{"id":"OSV-1","old":false}`)},
+	})
+
+	attrsAfter, err := storage.ReadObjectAttrs(t.Context(), objPath)
+	if err != nil {
+		t.Fatalf("ReadObjectAttrs: %v", err)
+	}
+	if attrsAfter.Generation <= attrsBefore.Generation {
+		t.Errorf("expected generation > %d (uploaded), got %d", attrsBefore.Generation, attrsAfter.Generation)
+	}
+}
+
+func TestWriter_GCS_UploadsNewObject(t *testing.T) {
+	storage := testutils.NewMockStorage()
+
+	runWriter(t, storage, "out", []writeMsg{
+		{path: "OSV-1.json", mimeType: "application/json", data: []byte(`{"id":"OSV-1"}`)},
+	})
+
+	objPath := filepath.Join("out", "OSV-1.json")
+	attrs, err := storage.ReadObjectAttrs(t.Context(), objPath)
+	if err != nil {
+		t.Fatalf("expected object to exist after upload: %v", err)
+	}
+	if attrs.Generation != 1 {
+		t.Errorf("expected generation 1 for new object, got %d", attrs.Generation)
+	}
+}
+
+func TestWriter_GCS_SkipsMultipleUnchanged(t *testing.T) {
+	storage := testutils.NewMockStorage()
+
+	type entry struct {
+		msgPath string
+		objPath string
+		data    []byte
+	}
+	entries := []entry{
+		{"A.json", filepath.Join("out", "A.json"), []byte(`{"id":"A"}`)},
+		{"B.json", filepath.Join("out", "B.json"), []byte(`{"id":"B"}`)},
+		{"C.json", filepath.Join("out", "C.json"), []byte(`{"id":"C"}`)},
+	}
+	for _, e := range entries {
+		if err := storage.WriteObject(t.Context(), e.objPath, e.data, nil); err != nil {
+			t.Fatalf("setup %s: %v", e.objPath, err)
+		}
+	}
+
+	gensBefore := make(map[string]int64)
+	for _, e := range entries {
+		attrs, _ := storage.ReadObjectAttrs(t.Context(), e.objPath)
+		gensBefore[e.objPath] = attrs.Generation
+	}
+
+	msgs := make([]writeMsg, len(entries))
+	for i, e := range entries {
+		msgs[i] = writeMsg{path: e.msgPath, mimeType: "application/json", data: e.data}
+	}
+	runWriter(t, storage, "out", msgs)
+
+	for _, e := range entries {
+		attrs, err := storage.ReadObjectAttrs(t.Context(), e.objPath)
+		if err != nil {
+			t.Fatalf("ReadObjectAttrs(%s): %v", e.objPath, err)
+		}
+		if attrs.Generation != gensBefore[e.objPath] {
+			t.Errorf("%s: expected generation %d (skipped), got %d", e.objPath, gensBefore[e.objPath], attrs.Generation)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #3513.

Before this change, the exporter uploaded every output file on every run regardless of whether the content had changed. Since all.zip and other generated files became reproducible in #3491, unchanged runs would still create new object generations in the bucket -- making it harder for downstream consumers to detect real updates and generating unnecessary storage churn.

**Approach:** before each GCS write the writer now fetches the existing object's attributes via `ReadObjectAttrs` and computes the CRC32C checksum of the outgoing data using the Castagnoli polynomial (the same algorithm GCS itself uses). If the checksums match, the upload is skipped and an info log is emitted. Three edge cases fall through to the normal upload path:
- Object does not exist yet (`ErrNotFound`) -- upload always proceeds
- Any transient error reading attrs -- upload proceeds, a warning is logged
- Checksums differ -- upload proceeds as usual

The local-write path (used for dev/test via `-upload-to-gcs=false`) is unchanged, since writes there carry no network cost.

## Changes

- `go/cmd/exporter/writer.go`: add `gcsContentUnchanged` helper and call it before `WriteObject`
- `go/cmd/exporter/writer_test.go`: new test file covering skip-on-unchanged, upload-on-changed, upload-of-new-object, and multi-file skip

## Test plan

- [x] `TestWriter_GCS_SkipsUnchangedContent` -- same data, generation must not increment
- [x] `TestWriter_GCS_UploadsChangedContent` -- different data, generation must increment
- [x] `TestWriter_GCS_UploadsNewObject` -- no pre-existing object, must be created at generation 1
- [x] `TestWriter_GCS_SkipsMultipleUnchanged` -- three unchanged files, all generations stable