### PR TITLE
fix: bump osv-schema/bindings and ignore schema_version in comparisons

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/osv-scalibr v0.4.5
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/klauspost/compress v1.18.5
-	github.com/ossf/osv-schema/bindings/go v0.0.0-20260331231022-2a6a0b9b0ccd
+	github.com/ossf/osv-schema/bindings/go v0.0.0-20260424063704-83285ce2a866
 	github.com/package-url/packageurl-go v0.1.5
 	github.com/tidwall/gjson v1.18.0
 	github.com/xeipuuv/gojsonschema v1.2.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -186,6 +186,8 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/ossf/osv-schema/bindings/go v0.0.0-20260331231022-2a6a0b9b0ccd h1:7/pf+9KbVBdpinVh/CHgEOTv1KGoKswhluFcMeGQ3XM=
 github.com/ossf/osv-schema/bindings/go v0.0.0-20260331231022-2a6a0b9b0ccd/go.mod h1:IrUa4QzZUi03J3WXDzZYXVawYipHownNfqqZrqeGXfg=
+github.com/ossf/osv-schema/bindings/go v0.0.0-20260424063704-83285ce2a866 h1:Los+Hnv3nFlNkIES9bca+PrGSau8MDzC9pRC/WWMmfE=
+github.com/ossf/osv-schema/bindings/go v0.0.0-20260424063704-83285ce2a866/go.mod h1:IrUa4QzZUi03J3WXDzZYXVawYipHownNfqqZrqeGXfg=
 github.com/package-url/packageurl-go v0.1.5 h1:O4efRXja2XQ5CtiiYiCZ22k/m7i5ugLiAghgcC+eDgk=
 github.com/package-url/packageurl-go v0.1.5/go.mod h1:nKAWB8E6uk1MHqiS/lQb9pYBGH2+mdJ2PJc2s50dQY0=
 github.com/pjbgf/sha1cd v0.5.0 h1:a+UkboSi1znleCDUNT3M5YxjOnN1fz2FhN48FlwCxs0=

--- a/go/internal/worker/engine.go
+++ b/go/internal/worker/engine.go
@@ -129,7 +129,7 @@ func (e *Engine) handleUpdate(ctx context.Context, task Task) error {
 func (e *Engine) isSemanticallyDifferent(vuln1, vuln2 *osvschema.Vulnerability) bool {
 	return !cmp.Equal(vuln1, vuln2,
 		protocmp.Transform(),
-		protocmp.IgnoreFields(&osvschema.Vulnerability{}, "modified", "published"),
+		protocmp.IgnoreFields(&osvschema.Vulnerability{}, "modified", "published", "schema_version"),
 	)
 }
 


### PR DESCRIPTION
Not sure why the osv-schema go module here was out of date, but it had an old SchemaVersion that caused a lot of churn in the test instance.

Don't update the modified date of a vulnerability if the only change is the schema version.