### PR TITLE
chore(website): remove unused osv scanner ignore

### DIFF
--- a/gcp/website/frontend3/osv-scanner.toml
+++ b/gcp/website/frontend3/osv-scanner.toml
@@ -1,3 +1,0 @@
-[[IgnoredVulns]]
-id = "MAL-2025-1051"
-reason = "This record references the npm package - we are pinned to a specific git commit of a forked repository"


### PR DESCRIPTION
Website has migrated away from spicy-sections so this ignore should be no longer needed.