### PR TITLE
chore(worker): set up temporary big node pool to evaluate cpu usage

### DIFF
--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/workers.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/workers.yaml
@@ -5,6 +5,12 @@ metadata:
 spec:
   template:
     spec:
+      tolerations:
+      - key: workloadType
+        operator: Equal
+        value: worker-pool
+      nodeSelector:
+        workloadType: worker-pool
       containers:
       - name: worker-private
         env:
@@ -12,3 +18,10 @@ spec:
             value: oss-vdb-test
           - name: OSV_VULNERABILITIES_BUCKET
             value: osv-test-vulnerabilities
+        resources:
+          requests:
+            cpu: 14
+            memory: "10G"
+          limits:
+            cpu: 16
+            memory: "13G"

--- a/deployment/terraform/modules/osv/workers_gke.tf
+++ b/deployment/terraform/modules/osv/workers_gke.tf
@@ -159,6 +159,42 @@ resource "google_container_node_pool" "importer_pool" {
   }
 }
 
+resource "google_container_node_pool" "worker_pool_temp" {
+  count      = var.project_id == "oss-vdb-test" ? 1 : 0
+  project    = var.project_id
+  name       = "worker-pool-temp"
+  cluster    = google_container_cluster.workers.name
+  location   = google_container_cluster.workers.location
+  node_count = 1
+
+  lifecycle {
+    replace_triggered_by = [
+      google_container_cluster.workers.id,
+    ]
+  }
+
+  autoscaling {
+    min_node_count  = 0
+    max_node_count  = 250
+    location_policy = "BALANCED"
+  }
+
+  node_config {
+    machine_type = "n2-highcpu-16"
+
+    oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+
+    labels = {
+      workloadType = "worker-pool"
+    }
+    taint {
+      effect = "NO_EXECUTE"
+      key    = "workloadType"
+      value  = "worker-pool"
+    }
+  }
+}
+
 # Service account permissions
 data "google_compute_default_service_account" "default" {
   project = var.project_id


### PR DESCRIPTION
Setting up a temporary GKE pool on the test instance to evaluate how CPU-hungry the new go worker actually is. 
using `n2-highcpu-16`, which has 16 CPUs / 16GB memory.
Once we get an idea on how much CPU the worker actually demands, I can set up a more sensible pool & CPU & memory  requests.