### PR TITLE
fix: don't batch AffectedCommits puts

### DIFF
--- a/go/internal/database/datastore/vulnerability.go
+++ b/go/internal/database/datastore/vulnerability.go
@@ -8,6 +8,7 @@ import (
 	"iter"
 	"log/slog"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -309,22 +310,28 @@ func (s *VulnerabilityStore) updateAffectedCommits(ctx context.Context, id strin
 		numPages++
 	}
 
-	if len(toPut) > 0 {
-		if _, err := s.client.PutMulti(ctx, keys, toPut); err != nil {
+	// If there are too many, AffectedCommits is too big for a single batch put
+	// So just put them one-by-one
+	for i, ac := range toPut {
+		if _, err := s.client.Put(ctx, keys[i], ac); err != nil {
 			return fmt.Errorf("failed to write AffectedCommits: %w", err)
 		}
 	}
 
-	// Clear any previously written pages above our current page count.
-	q := datastore.NewQuery("AffectedCommits").FilterField("bug_id", "=", id)
-	var existing []AffectedCommits
-	keys, err := s.client.GetAll(ctx, q, &existing)
+	// Clear any previously written that we didn't just write.
+	q := datastore.NewQuery("AffectedCommits").FilterField("bug_id", "=", id).KeysOnly()
+	keys, err := s.client.GetAll(ctx, q, nil)
 	if err != nil {
 		return fmt.Errorf("failed to query AffectedCommits: %w", err)
 	}
 
-	for idx, k := range keys {
-		if existing[idx].Page >= numPages {
+	for _, k := range keys {
+		parts := strings.Split(k.Name, "-")
+		page, err := strconv.Atoi(parts[len(parts)-1])
+		if err != nil {
+			return fmt.Errorf("failed to parse page number from key: %w", err)
+		}
+		if page >= numPages {
 			if err := s.client.Delete(ctx, k); err != nil {
 				return fmt.Errorf("failed to delete AffectedCommits: %w", err)
 			}


### PR DESCRIPTION
AffectedCommits are (sometimes) too big to all be put together in one batch. Do them one-by-one.
Also, avoid querying the the entire AffectedCommits when determining which to delete - just grab the keys.