### PR TITLE
fix(go worker): populate AffectedVersions for GIT versions

### DIFF
--- a/go/internal/database/datastore/affected_versions.go
+++ b/go/internal/database/datastore/affected_versions.go
@@ -36,22 +36,21 @@ func computeAffectedVersions(vuln *osvschema.Vulnerability) []AffectedVersions {
 	var res []AffectedVersions
 
 	for _, affected := range vuln.GetAffected() {
+		var allPkgEcosystems []string
 		pkgEcosystem := affected.GetPackage().GetEcosystem()
-		if pkgEcosystem == "" {
-			continue
-		}
+		if pkgEcosystem != "" {
+			allPkgEcosystems = []string{pkgEcosystem}
+			normalized, _, _ := strings.Cut(pkgEcosystem, ":")
+			if normalized != pkgEcosystem {
+				allPkgEcosystems = append(allPkgEcosystems, normalized)
+			}
+			if v := removeVariants(pkgEcosystem); v != "" {
+				allPkgEcosystems = append(allPkgEcosystems, v)
+			}
 
-		allPkgEcosystems := []string{pkgEcosystem}
-		normalized, _, _ := strings.Cut(pkgEcosystem, ":")
-		if normalized != pkgEcosystem {
-			allPkgEcosystems = append(allPkgEcosystems, normalized)
+			slices.Sort(allPkgEcosystems)
+			allPkgEcosystems = slices.Compact(allPkgEcosystems)
 		}
-		if v := removeVariants(pkgEcosystem); v != "" {
-			allPkgEcosystems = append(allPkgEcosystems, v)
-		}
-
-		slices.Sort(allPkgEcosystems)
-		allPkgEcosystems = slices.Compact(allPkgEcosystems)
 
 		pkgName := affected.GetPackage().GetName()
 		eHelper, exists := ecosystem.DefaultProvider.Get(pkgEcosystem)

--- a/go/internal/database/datastore/affected_versions_test.go
+++ b/go/internal/database/datastore/affected_versions_test.go
@@ -191,3 +191,84 @@ func TestNormalizeRepo(t *testing.T) {
 		})
 	}
 }
+
+func TestComputeAffectedVersions_GitWithoutPackage(t *testing.T) {
+	vuln := &osvschema.Vulnerability{
+		Id: "CVE-2024-7264",
+		Affected: []*osvschema.Affected{
+			{
+				// Package intentionally omitted
+				Versions: []string{"curl-8_5_0", "curl-8_6_0"},
+				Ranges: []*osvschema.Range{
+					{
+						Type: osvschema.Range_GIT,
+						Repo: "https://github.com/curl/curl",
+						Events: []*osvschema.Event{
+							{Introduced: "0"},
+							{Fixed: "27959ecce75cdb2809c0bdb3286e60e08fadb519"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := computeAffectedVersions(vuln)
+
+	want := []AffectedVersions{
+		{
+			VulnID:    "CVE-2024-7264",
+			Ecosystem: "GIT",
+			Name:      "github.com/curl/curl",
+			Versions:  []string{"curl-8_5_0", "curl-8_6_0"},
+		},
+	}
+
+	if diff := gocmp.Diff(want, got, cmpopts.EquateEmpty()); diff != "" {
+		t.Errorf("computeAffectedVersions mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestComputeAffectedVersions_GitAndSemverWithoutPackage(t *testing.T) {
+	vuln := &osvschema.Vulnerability{
+		Id: "CVE-2024-7264-SEMVER",
+		Affected: []*osvschema.Affected{
+			{
+				// Package intentionally omitted
+				Versions: []string{"curl-8_5_0"},
+				Ranges: []*osvschema.Range{
+					{
+						Type: osvschema.Range_GIT,
+						Repo: "https://github.com/curl/curl",
+						Events: []*osvschema.Event{
+							{Introduced: "0"},
+							{Fixed: "27959ecce75cdb2809c0bdb3286e60e08fadb519"},
+						},
+					},
+					{
+						Type: osvschema.Range_SEMVER,
+						Events: []*osvschema.Event{
+							{Introduced: "0"},
+							{Fixed: "8.6.0"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := computeAffectedVersions(vuln)
+
+	want := []AffectedVersions{
+		{
+			VulnID:    "CVE-2024-7264-SEMVER",
+			Ecosystem: "GIT",
+			Name:      "github.com/curl/curl",
+			Versions:  []string{"curl-8_5_0"},
+		},
+	}
+
+	if diff := gocmp.Diff(want, got, cmpopts.EquateEmpty()); diff != "" {
+		t.Errorf("computeAffectedVersions mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
Early exiting this loop was causing affected git versions from being skipped when generating the AffectedVersions entities, which makes querying by git tag impossible.

Merging and reimporting on test (😭) should revert the diff seen in #5357