### PR TITLE
docs: hyphenate Go-based in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ An instance of OSV's web UI is deployed at <https://osv.dev>.
 
 ## Using the scanner
 
-We provide a Go based tool that will scan your dependencies, and check them against the OSV database for known vulnerabilities via the OSV API.
+We provide a Go-based tool that will scan your dependencies, and check them against the OSV database for known vulnerabilities via the OSV API.
 
 Currently it is able to scan various lockfiles, debian docker containers, SPDX and CycloneDB SBOMs, and git repositories.
 


### PR DESCRIPTION
Small README wording cleanup.