### PR TITLE
fix(vulnfeeds): use the cache for commits in refs too

### DIFF
--- a/vulnfeeds/cmd/pypi/main.go
+++ b/vulnfeeds/cmd/pypi/main.go
@@ -177,7 +177,7 @@ func main() {
 			}
 			v := vulns.FromNVDCVE(id, cve.CVE)
 			v.AddPkgInfo(pkgInfo)
-			versions := conversion.ExtractVersionInfo(cve.CVE, validVersions, http.DefaultClient, metrics)
+			versions := conversion.ExtractVersionInfo(cve.CVE, validVersions, http.DefaultClient, metrics, nil)
 
 			vulns.AttachExtractedVersionInfo(v, versions)
 			if len(v.Affected[0].GetRanges()) == 0 {

--- a/vulnfeeds/conversion/nvd/converter.go
+++ b/vulnfeeds/conversion/nvd/converter.go
@@ -93,9 +93,13 @@ func CVEToOSV(cve models.NVDCVE, repos []string, vpRepoCache *c.VPRepoCache, cac
 	}
 
 	// Extract Commits
-	commits, err := c.ExtractCommitsFromRefs(refs, http.DefaultClient)
+	commits, err := c.ExtractCommitsFromRefs(refs, http.DefaultClient, cache)
 	if err != nil {
 		metrics.AddNote("Failed to extract commits from refs: %#v", err)
+		if errors.Is(err, git.ErrRateLimit) || strings.Contains(err.Error(), "429") {
+			metrics.SetOutcome(models.Error)
+			return nil, metrics, models.Error
+		}
 	}
 	if len(commits) > 0 {
 		metrics.AddNote("Extracted commits from refs: %v", commits)
@@ -179,7 +183,10 @@ func CVEToPackageInfo(cve models.NVDCVE, repos []string, cache git.RepoTagsCache
 	}
 
 	// more often than not, this yields a VersionInfo with AffectedVersions and no AffectedCommits.
-	versions := c.ExtractVersionInfo(cve, nil, http.DefaultClient, metrics)
+	versions := c.ExtractVersionInfo(cve, nil, http.DefaultClient, metrics, cache)
+	if metrics.Outcome == models.Error {
+		return models.Error
+	}
 
 	if len(versions.AffectedVersions) != 0 {
 		// There are some AffectedVersions to try and resolve to AffectedCommits.

--- a/vulnfeeds/conversion/versions.go
+++ b/vulnfeeds/conversion/versions.go
@@ -571,12 +571,7 @@ func ExtractGitCommit(link string, httpClient *http.Client, depth int, cache git
 	commit = c
 
 	// If URL doesn't validate, treat it as linkrot.
-	var possiblyDifferentLink string
-	if cache != nil {
-		possiblyDifferentLink, err = git.FindCanonicalLink(link, httpClient, cache)
-	} else {
-		possiblyDifferentLink, err = git.ValidateAndCanonicalizeLink(link, httpClient)
-	}
+	possiblyDifferentLink, err := git.FindCanonicalLink(link, httpClient, cache)
 	if err != nil {
 		return "", "", err
 	}

--- a/vulnfeeds/conversion/versions.go
+++ b/vulnfeeds/conversion/versions.go
@@ -517,13 +517,16 @@ func resolveGitTag(parsedURL *url.URL, u string, gitSHA1Regex *regexp.Regexp) (s
 }
 
 // For URLs referencing commits in supported Git repository hosts, return a cloneable AffectedCommit.
-func ExtractCommitsFromRefs(references []models.Reference, httpClient *http.Client) ([]models.AffectedCommit, error) {
+func ExtractCommitsFromRefs(references []models.Reference, httpClient *http.Client, cache git.RepoTagsCache) ([]models.AffectedCommit, error) {
 	var commits []models.AffectedCommit //nolint:prealloc
 
 	for _, ref := range references {
 		// (Potentially faulty) Assumption: All viable Git commit reference links are fix commits.
-		ac, err := extractGitAffectedCommit(ref.URL, models.Fixed, httpClient)
+		ac, err := extractGitAffectedCommit(ref.URL, models.Fixed, httpClient, cache)
 		if err != nil {
+			if errors.Is(err, git.ErrRateLimit) || strings.Contains(err.Error(), "429") {
+				return nil, err
+			}
 			continue
 		}
 
@@ -534,9 +537,9 @@ func ExtractCommitsFromRefs(references []models.Reference, httpClient *http.Clie
 }
 
 // For URLs referencing commits in supported Git repository hosts, return a cloneable AffectedCommit.
-func extractGitAffectedCommit(link string, commitType models.CommitType, httpClient *http.Client) (models.AffectedCommit, error) {
+func extractGitAffectedCommit(link string, commitType models.CommitType, httpClient *http.Client, cache git.RepoTagsCache) (models.AffectedCommit, error) {
 	var ac models.AffectedCommit
-	c, r, err := ExtractGitCommit(link, httpClient, 0)
+	c, r, err := ExtractGitCommit(link, httpClient, 0, cache)
 	if err != nil {
 		return ac, err
 	}
@@ -548,7 +551,7 @@ func extractGitAffectedCommit(link string, commitType models.CommitType, httpCli
 	return ac, nil
 }
 
-func ExtractGitCommit(link string, httpClient *http.Client, depth int) (string, string, error) {
+func ExtractGitCommit(link string, httpClient *http.Client, depth int, cache git.RepoTagsCache) (string, string, error) {
 	if depth > 10 {
 		return "", "", fmt.Errorf("max recursion depth exceeded for %s", link)
 	}
@@ -567,7 +570,12 @@ func ExtractGitCommit(link string, httpClient *http.Client, depth int) (string, 
 	commit = c
 
 	// If URL doesn't validate, treat it as linkrot.
-	possiblyDifferentLink, err := git.ValidateAndCanonicalizeLink(link, httpClient)
+	var possiblyDifferentLink string
+	if cache != nil {
+		possiblyDifferentLink, err = git.FindCanonicalLink(link, httpClient, cache)
+	} else {
+		possiblyDifferentLink, err = git.ValidateAndCanonicalizeLink(link, httpClient)
+	}
 	if err != nil {
 		return "", "", err
 	}
@@ -576,7 +584,7 @@ func ExtractGitCommit(link string, httpClient *http.Client, depth int) (string, 
 	// redirect to a completely different host, instead of a redirect within
 	// GitHub)
 	if possiblyDifferentLink != link {
-		return ExtractGitCommit(possiblyDifferentLink, httpClient, depth+1)
+		return ExtractGitCommit(possiblyDifferentLink, httpClient, depth+1, cache)
 	}
 
 	return commit, r, nil
@@ -835,9 +843,12 @@ func ExtractVersionsFromCPEs(cve models.NVDCVE, validVersions []string, vpRepoCa
 
 // ExtractVersionInfo extracts version information from a CVE and saves to a VersionInfo struct.
 // This is mostly deprecated, but is still used by the Alpine, Debian, and PyPi converters.
-func ExtractVersionInfo(cve models.NVDCVE, validVersions []string, httpClient *http.Client, metrics *models.ConversionMetrics) (v models.VersionInfo) {
-	if commit, err := ExtractCommitsFromRefs(cve.References, httpClient); err == nil {
+func ExtractVersionInfo(cve models.NVDCVE, validVersions []string, httpClient *http.Client, metrics *models.ConversionMetrics, cache git.RepoTagsCache) (v models.VersionInfo) {
+	if commit, err := ExtractCommitsFromRefs(cve.References, httpClient, cache); err == nil {
 		v.AffectedCommits = append(v.AffectedCommits, commit...)
+	} else if errors.Is(err, git.ErrRateLimit) || strings.Contains(err.Error(), "429") {
+		metrics.Outcome = models.Error
+		return v
 	}
 
 	if v.AffectedCommits != nil {

--- a/vulnfeeds/conversion/versions.go
+++ b/vulnfeeds/conversion/versions.go
@@ -527,6 +527,7 @@ func ExtractCommitsFromRefs(references []models.Reference, httpClient *http.Clie
 			if errors.Is(err, git.ErrRateLimit) || strings.Contains(err.Error(), "429") {
 				return nil, err
 			}
+
 			continue
 		}
 

--- a/vulnfeeds/conversion/versions_test.go
+++ b/vulnfeeds/conversion/versions_test.go
@@ -692,7 +692,7 @@ func TestExtractGitCommit(t *testing.T) {
 			if !tc.disableExpiryDate.IsZero() && time.Now().After(tc.disableExpiryDate) {
 				t.Logf("test %q: extractGitAffectedCommit(%q, %v) has been enabled on %s.", tc.description, tc.inputLink, tc.inputCommitType, tc.disableExpiryDate)
 			}
-			got, err := extractGitAffectedCommit(tc.inputLink, tc.inputCommitType, client)
+			got, err := extractGitAffectedCommit(tc.inputLink, tc.inputCommitType, client, nil)
 			if err != nil && !tc.expectFailure {
 				t.Errorf("test %q: extractGitAffectedCommit for %q (%v) errored unexpectedly: %#v", tc.description, tc.inputLink, tc.inputCommitType, err)
 			}
@@ -927,7 +927,7 @@ func TestExtractVersionInfo(t *testing.T) {
 				t.Logf("test %q: VersionInfo for %#v has been enabled on %s.", tc.description, tc.inputCVEItem, tc.disableExpiryDate)
 			}
 			metrics := &models.ConversionMetrics{}
-			gotVersionInfo := ExtractVersionInfo(tc.inputCVEItem.CVE, tc.inputValidVersions, client, metrics)
+			gotVersionInfo := ExtractVersionInfo(tc.inputCVEItem.CVE, tc.inputValidVersions, client, metrics, nil)
 			if diff := cmp.Diff(tc.expectedVersionInfo, gotVersionInfo); diff != "" {
 				t.Errorf("test %q: VersionInfo for %#v was incorrect: %s", tc.description, tc.inputCVEItem, diff)
 			}
@@ -963,11 +963,14 @@ func TestExtractVersionInfo_429(t *testing.T) {
 	}
 
 	metrics := &models.ConversionMetrics{}
-	gotVersionInfo := ExtractVersionInfo(cve, nil, client, metrics)
+	gotVersionInfo := ExtractVersionInfo(cve, nil, client, metrics, nil)
 
 	// Since it's a 429 and we retry, it should eventually fail and return no affected commits.
 	if len(gotVersionInfo.AffectedCommits) != 0 {
 		t.Errorf("Expected 0 affected commits, got %d", len(gotVersionInfo.AffectedCommits))
+	}
+	if metrics.Outcome != models.Error {
+		t.Errorf("Expected outcome to be Error, got %v", metrics.Outcome)
 	}
 }
 

--- a/vulnfeeds/git/versions.go
+++ b/vulnfeeds/git/versions.go
@@ -234,14 +234,18 @@ func ValidateAndCanonicalizeLink(link string, httpClient *http.Client) (canonica
 }
 
 func FindCanonicalLink(link string, httpClient *http.Client, cache RepoTagsCache) (canonicalLink string, err error) {
-	if canonicalLink, ok := cache.GetCanonicalLink(link); ok {
-		return canonicalLink, nil
+	if cache != nil {
+		if canonicalLink, ok := cache.GetCanonicalLink(link); ok {
+			return canonicalLink, nil
+		}
 	}
 	canonicalLink, err = ValidateAndCanonicalizeLink(link, httpClient)
 	if err != nil {
 		return link, err
 	}
-	cache.SetCanonicalLink(link, canonicalLink)
+	if cache != nil {
+		cache.SetCanonicalLink(link, canonicalLink)
+	}
 
 	return canonicalLink, nil
 }


### PR DESCRIPTION
it seems extracting commits from the refs was not utilising the repo tags cache for looking up canonical links. 

Also, we were not errorring and exiting upon 429 responses