### PR TITLE
fix: Update 'failed to assign ID' error message to include path

### DIFF
--- a/vulnfeeds/cmd/ids/main.go
+++ b/vulnfeeds/cmd/ids/main.go
@@ -185,7 +185,7 @@ func assignIDs(prefix, dir string, format fileFormat) error {
 	logger.Info("Assigning IDs using detected maximums", slog.Any("counters", yearCounters))
 	for _, path := range unassigned {
 		if err := assignID(prefix, path, format, yearCounters, defaultYear); err != nil {
-			return fmt.Errorf("failed to assign ID: %w", err)
+			return fmt.Errorf("failed to assign ID for %s: %w", path, err)
 		}
 	}
 

--- a/vulnfeeds/cmd/ids/main_test.go
+++ b/vulnfeeds/cmd/ids/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -99,5 +100,23 @@ func TestAssignIDs(t *testing.T) {
 				t.Errorf("Expected .id-allocator to exist")
 			}
 		})
+	}
+}
+
+func TestAssignIDsError(t *testing.T) {
+	tmpDir := t.TempDir()
+	invalidFile := filepath.Join(tmpDir, "OSV-0000-invalid.yaml")
+	if err := os.WriteFile(invalidFile, []byte("invalid yaml content"), 0600); err != nil {
+		t.Fatalf("failed to setup invalid vuln: %v", err)
+	}
+
+	err := assignIDs("OSV", tmpDir, fileFormatYAML)
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
+
+	expectedErr := "failed to assign ID for " + invalidFile
+	if !strings.Contains(err.Error(), expectedErr) {
+		t.Errorf("Expected error message to contain %q, but got %q", expectedErr, err.Error())
 	}
 }


### PR DESCRIPTION
To help determine which advisories are failing to parse, which is currently omitted when this fails (example: https://github.com/pypa/advisory-database/actions/runs/26036795928/job/76537293443) 