### PR TITLE
feat(frontend): add collapsible fields to the json on the triage page

### DIFF
--- a/gcp/website/frontend3/package.json
+++ b/gcp/website/frontend3/package.json
@@ -16,6 +16,7 @@
     "@material/layout-grid": "14.0.0",
     "@material/theme": "14.0.0",
     "@material/web": "^2.0.0",
+    "json-formatter-js": "^2.5.23",
     "lit": "3.3.2"
   },
   "devDependencies": {

--- a/gcp/website/frontend3/pnpm-lock.yaml
+++ b/gcp/website/frontend3/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@material/web':
         specifier: ^2.0.0
         version: 2.4.1
+      json-formatter-js:
+        specifier: ^2.5.23
+        version: 2.5.23
       lit:
         specifier: 3.3.2
         version: 3.3.2
@@ -1220,6 +1223,9 @@ packages:
   jest-worker@27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
+
+  json-formatter-js@2.5.23:
+    resolution: {integrity: sha512-Cbm8wHXjo/C56aCePP1VuKvjxoMEmL7g7Ckss1oWFFlCsvOEEbye1kTeaNNaqba1Cl6YpIOYAnK65pUQ8mDIUQ==}
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -3346,6 +3352,8 @@ snapshots:
       '@types/node': 25.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
+
+  json-formatter-js@2.5.23: {}
 
   json-schema-traverse@0.4.1: {}
 

--- a/gcp/website/frontend3/src/triage.js
+++ b/gcp/website/frontend3/src/triage.js
@@ -2,6 +2,7 @@ import "./triage.scss";
 import "@material/web/textfield/filled-text-field.js";
 import "@material/web/button/filled-button.js";
 import "@material/web/progress/circular-progress.js";
+import JSONFormatter from "json-formatter-js";
 
 document.addEventListener("DOMContentLoaded", () => {
   const vulnIdInput = document.getElementById("vuln-id-input");
@@ -58,38 +59,7 @@ document.addEventListener("DOMContentLoaded", () => {
     },
   };
 
-  function escapeHtml(text) {
-    const div = document.createElement('div');
-    div.textContent = text;
-    return div.innerHTML;
-  }
 
-  function syntaxHighlight(json) { // credit to https://codepen.io/absolutedevelopment/pen/EpwVzN
-    if (typeof json !== 'string') {
-      json = JSON.stringify(json, undefined, 2);
-    }
-
-    const escapedJson = escapeHtml(json);
-
-    return escapedJson.replace(
-      /("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)/g,
-      function (match) {
-        let cls = 'json-number';
-        if (/^"/.test(match)) {
-          if (/:$/.test(match)) {
-            cls = 'json-key';
-          } else {
-            cls = 'json-string';
-          }
-        } else if (/true|false/.test(match)) {
-          cls = 'json-boolean';
-        } else if (/null/.test(match)) {
-          cls = 'json-null';
-        }
-        return `<span class="${cls}">${match}</span>`;
-      }
-    );
-  }
 
   async function fetchData(sourceKey, vulnId) {
     const config = sourceConfigMap[sourceKey];
@@ -132,10 +102,12 @@ document.addEventListener("DOMContentLoaded", () => {
     spinner.classList.remove("hidden");
     contentPre.textContent = "";
 
-    fetchData(sourceKey, vulnId)
-      .then((data) => {
-        contentPre.innerHTML = syntaxHighlight(data);
-      })
+      fetchData(sourceKey, vulnId)
+        .then((data) => {
+          contentPre.textContent = "";
+          const formatter = new JSONFormatter(data, Infinity, { theme: "dark" });
+          contentPre.appendChild(formatter.render());
+        })
       .catch((error) => {
         contentPre.textContent = error.message;
       })
@@ -144,13 +116,42 @@ document.addEventListener("DOMContentLoaded", () => {
       });
   }
 
+  function updateUrlParams() {
+    const url = new URL(window.location.href);
+    const vulnId = vulnIdInput.value.trim();
+    
+    if (vulnId) {
+      url.searchParams.set("id", vulnId.toUpperCase());
+      url.searchParams.delete("cve");
+    } else {
+      url.searchParams.delete("id");
+      url.searchParams.delete("cve");
+    }
+    
+    columns.forEach((col, idx) => {
+      const colNum = idx + 1;
+      const select = col.querySelector(".source-select");
+      if (select.value) {
+        url.searchParams.set(`s${colNum}`, select.value);
+      } else {
+        url.searchParams.delete(`s${colNum}`);
+      }
+      url.searchParams.delete(`col${colNum}`);
+      url.searchParams.delete(`source${colNum}`);
+    });
+    
+    window.history.replaceState(null, "", url.toString());
+  }
+
   loadBtn.addEventListener("click", () => {
+    updateUrlParams();
     columns.forEach((col) => updateColumn(col));
   });
 
   // Also handle Enter key on the input field
   vulnIdInput.addEventListener("keydown", (e) => {
       if (e.key === "Enter") {
+          updateUrlParams();
           columns.forEach((col) => updateColumn(col));
       }
   });
@@ -159,9 +160,38 @@ document.addEventListener("DOMContentLoaded", () => {
   columns.forEach((col) => {
     const select = col.querySelector(".source-select");
     select.addEventListener("change", () => {
+        updateUrlParams();
         if (vulnIdInput.value.trim()) {
             updateColumn(col);
         }
     });
   });
+
+  // Check if a CVE/vulnerability ID query param is specified in the URL
+  const urlParams = new URLSearchParams(window.location.search);
+  const urlId = urlParams.get("id") || urlParams.get("cve");
+  if (urlId) {
+    vulnIdInput.value = urlId.toUpperCase();
+    
+    columns.forEach((col, idx) => {
+      const colNum = idx + 1;
+      const select = col.querySelector(".source-select");
+      
+      // Check for column-specific source query param
+      const sourceParam = urlParams.get(`s${colNum}`) || 
+                          urlParams.get(`col${colNum}`) || 
+                          urlParams.get(`source${colNum}`);
+                          
+      if (sourceParam && sourceConfigMap[sourceParam]) {
+        select.value = sourceParam;
+      } else if (!select.value) {
+        // Pre-populate reasonable defaults if no selection is set
+        if (colNum === 1) select.value = "test-cve5";
+        else if (colNum === 2) select.value = "test-nvd";
+        else if (colNum === 3) select.value = "test-osv";
+      }
+      
+      updateColumn(col);
+    });
+  }
 });

--- a/gcp/website/frontend3/src/triage.scss
+++ b/gcp/website/frontend3/src/triage.scss
@@ -1,6 +1,6 @@
 .triage-container {
   // padding: 40px;
-    padding: 20px 40px;
+  padding: 20px 40px;
   width: 100%;
   box-sizing: border-box;
 
@@ -11,27 +11,28 @@
   --md-filled-button-container-color: #c5221f;
 
   .header-container {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      margin-bottom: 32px;
-    }
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 32px;
+  }
+
   h1 {
     margin: 0;
-    }
+  }
 
-    .input-section {
-      display: flex;
-      align-items: center;
+  .input-section {
+    display: flex;
+    align-items: center;
     gap: 16px;
 
 
     .standard-input {
-        flex: 1;
-        max-width: 400px;
-      }
+      flex: 1;
+      max-width: 400px;
     }
-    }
+  }
+}
 
 .triage-grid {
   display: grid;
@@ -77,7 +78,7 @@
 
 .content-display {
   flex-grow: 1;
-  padding: 16px;
+  padding: 8px 12px;
   overflow: auto;
   position: relative;
   background-color: #1e1e1e;
@@ -91,26 +92,70 @@
   overflow-wrap: anywhere;
   margin: 0;
   color: #d4d4d4;
+}
 
-  .json-key {
-      color: #9cdcfe;
-    }
-  
-    .json-string {
-      color: #ce9178;
-    }
-  
-    .json-number {
-      color: #b5cea8;
-    }
-  
-    .json-boolean {
-      color: #569cd6;
-    }
-  
-    .json-null {
-      color: #569cd6;
-    }
+// Hide top-level root collapsible elements & brackets
+.json-content>.json-formatter-row {
+  >a.json-formatter-toggler-link {
+    display: none !important;
+  }
+
+  >.json-formatter-children {
+    margin-left: 0 !important;
+  }
+}
+
+.json-formatter-row {
+  font-family: "Overpass Mono", monospace !important;
+  font-size: 13px !important;
+  line-height: 1.5 !important;
+
+  // Word wrapping to prevent horizontal scrolling
+  white-space: pre-wrap !important;
+  word-wrap: break-word !important;
+  overflow-wrap: anywhere !important;
+  word-break: break-all !important;
+
+  .json-formatter-row {
+    margin-left: 0.8rem !important;
+  }
+
+  .toggler:after {
+    color: #c5221f !important;
+  }
+
+  .json-formatter-constructor-name {
+    display: none !important;
+  }
+
+  // Custom color overrides matching OSV/VS Code scheme
+  .json-formatter-key {
+    color: #9cdcfe !important;
+  }
+
+  .json-formatter-string,
+  .json-formatter-stringifiable {
+    color: #ce9178 !important;
+    white-space: pre-wrap !important;
+    word-break: break-all !important;
+  }
+
+  .json-formatter-number {
+    color: #b5cea8 !important;
+  }
+
+  .json-formatter-boolean {
+    color: #569cd6 !important;
+  }
+
+  .json-formatter-null,
+  .json-formatter-undefined {
+    color: #569cd6 !important;
+  }
+
+  .json-formatter-bracket {
+    color: #d4d4d4 !important;
+  }
 }
 
 .loading-spinner {


### PR DESCRIPTION
uses the json-formatter-js dependency to add collapsible fields to the json (uncollapsed by default)

Built on top of the changes in #5387, so probably merge that first.

<img width="2539" height="942" alt="image" src="https://github.com/user-attachments/assets/3ae71237-cf16-4dc4-a11f-2f85c3075a10" />
