### PR TITLE
fix(PyPi): support flat and wrapped JSON formats

### DIFF
--- a/vulnfeeds/cmd/ids/main.go
+++ b/vulnfeeds/cmd/ids/main.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/google/osv/vulnfeeds/utility/logger"
+	"github.com/google/osv/vulnfeeds/vulns"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -133,7 +134,7 @@ func assignID(prefix, path string, format fileFormat, yearCounters map[int]int, 
 	}
 	defer writef.Close()
 
-	if err := writeVulnWithFormat(vuln, writef, format); err != nil {
+	if err := writeVulnWithFormat(vuln.Vulnerability, writef, format); err != nil {
 		return fmt.Errorf("failed to serialize: %w", err)
 	}
 
@@ -197,31 +198,15 @@ func assignIDs(prefix, dir string, format fileFormat) error {
 	return os.WriteFile(filepath.Join(dir, conflictFile), []byte(hex.EncodeToString(b)), 0600)
 }
 
-func readVulnWithFormat(r io.Reader, format fileFormat) (*osvschema.Vulnerability, error) {
-	data, err := io.ReadAll(r)
-	if err != nil {
-		return nil, err
-	}
-
-	var jsonBytes []byte
+func readVulnWithFormat(r io.Reader, format fileFormat) (*vulns.Vulnerability, error) {
 	switch format {
 	case fileFormatJSON:
-		jsonBytes = data
+		return vulns.FromJSON(r)
 	case fileFormatYAML:
-		jsonBytes, err = yaml.YAMLToJSON(data)
-		if err != nil {
-			return nil, err
-		}
+		return vulns.FromYAML(r)
 	default:
 		return nil, fmt.Errorf("unknown file format: %v", format)
 	}
-
-	var v osvschema.Vulnerability
-	if err := protojson.Unmarshal(jsonBytes, &v); err != nil {
-		return nil, err
-	}
-
-	return &v, nil
 }
 
 func writeVulnWithFormat(v *osvschema.Vulnerability, w io.Writer, format fileFormat) error {

--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -16,6 +16,7 @@
 package vulns
 
 import (
+	"bytes"
 	"cmp"
 	"encoding/json"
 	"errors"
@@ -29,6 +30,7 @@ import (
 	"strings"
 	"sync"
 
+	goccyyaml "github.com/goccy/go-yaml"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"gopkg.in/yaml.v2"
@@ -768,26 +770,49 @@ func GetCPEs(cpeApplicability []models.CPE, metrics *models.ConversionMetrics) [
 
 // FromYAML deserializes a Vulnerability from a YAML reader.
 func FromYAML(r io.Reader) (*Vulnerability, error) {
-	decoder := yaml.NewDecoder(r)
-	inner := &osvschema.Vulnerability{}
-	err := decoder.Decode(inner)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Vulnerability{Vulnerability: inner}, nil
+	jsonBytes, err := goccyyaml.YAMLToJSON(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return FromJSON(bytes.NewReader(jsonBytes))
 }
 
 // FromJSON deserializes a Vulnerability from a JSON reader.
 func FromJSON(r io.Reader) (*Vulnerability, error) {
-	decoder := json.NewDecoder(r)
-	inner := &osvschema.Vulnerability{}
-	err := decoder.Decode(inner)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
 
-	return &Vulnerability{Vulnerability: inner}, nil
+	// Check if wrapped with top-level "vulnerability" key
+	var wrapper map[string]json.RawMessage
+	if err := json.Unmarshal(data, &wrapper); err != nil {
+		return nil, err
+	}
+
+	var innerBytes []byte
+	if inner, ok := wrapper["vulnerability"]; ok {
+		innerBytes = inner
+	} else {
+		innerBytes = data
+	}
+
+	var inner osvschema.Vulnerability
+	opts := protojson.UnmarshalOptions{DiscardUnknown: true}
+	if err := opts.Unmarshal(innerBytes, &inner); err != nil {
+		// Fall back to standard json.Unmarshal for Go internal struct formats (seconds/nanos)
+		if err2 := json.Unmarshal(innerBytes, &inner); err2 != nil {
+			return nil, err
+		}
+	}
+
+	return &Vulnerability{Vulnerability: &inner}, nil
 }
 
 // CheckQuality will return true if field text is not a filler text or otherwise empty

--- a/vulnfeeds/vulns/vulns_test.go
+++ b/vulnfeeds/vulns/vulns_test.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
+	"time"
 
 	"slices"
 
@@ -511,5 +513,181 @@ func TestClassifyReferences_Determinism(t *testing.T) {
 		if diff := gocmp.Diff(firstResult, got, protocmp.Transform()); diff != "" {
 			t.Fatalf("Iteration %d produced different references result:\n%s", i, diff)
 		}
+	}
+}
+
+func TestUnmarshalVulnerability(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     string
+		isYAML   bool
+		wantID   string
+		wantType osvschema.Range_Type
+		wantTime string // UTC RFC3339 representation
+		verify   func(t *testing.T, v *Vulnerability)
+	}{
+		{
+			name: "Flat JSON Standard",
+			data: `{
+				"id": "CVE-2026-1234",
+				"published": "2026-01-02T00:00:00Z",
+				"affected": [{
+					"package": {"name": "foo", "ecosystem": "PyPI"},
+					"ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}]}]
+				}]
+			}`,
+			isYAML:   false,
+			wantID:   "CVE-2026-1234",
+			wantType: osvschema.Range_ECOSYSTEM,
+			wantTime: "2026-01-02T00:00:00Z",
+		},
+		{
+			name: "Wrapped JSON Standard",
+			data: `{
+				"vulnerability": {
+					"id": "CVE-2026-5678",
+					"published": "2026-05-19T01:46:00Z",
+					"affected": [{
+						"package": {"name": "bar", "ecosystem": "PyPI"},
+						"ranges": [{"type": "GIT", "events": [{"introduced": "0"}]}]
+					}]
+				}
+			}`,
+			isYAML:   false,
+			wantID:   "CVE-2026-5678",
+			wantType: osvschema.Range_GIT,
+			wantTime: "2026-05-19T01:46:00Z",
+		},
+		{
+			name: "Wrapped YAML with Structpb and Timestamppb Go Internal Format",
+			data: `
+vulnerability:
+  id: PYSEC-2022-36124
+  published:
+    seconds: 1660029307
+    nanos: 443000000
+  affected:
+  - package:
+      name: avro
+      ecosystem: PyPI
+    ranges:
+    - type: 1
+      events:
+      - introduced: "0"
+`,
+			isYAML:   true,
+			wantID:   "PYSEC-2022-36124",
+			wantType: osvschema.Range_GIT,
+			wantTime: "2022-08-09T07:15:07.443Z",
+		},
+		{
+			name: "Flat YAML with String Enums and Timestamps",
+			data: `
+id: PYSEC-2022-43066
+published: "2022-06-20T00:00:00Z"
+affected:
+  - package:
+      name: aamiles
+      ecosystem: PyPI
+    ranges:
+      - type: ECOSYSTEM
+        events:
+          - introduced: "0"
+`,
+			isYAML:   true,
+			wantID:   "PYSEC-2022-43066",
+			wantType: osvschema.Range_ECOSYSTEM,
+			wantTime: "2022-06-20T00:00:00Z",
+		},
+		{
+			name: "YAML with Comments (Notes) and Database Specifics",
+			data: `
+id: PYSEC-2022-9999
+published: "2022-06-20T00:00:00Z"
+affected:
+  - package:
+      name: custom-package
+      ecosystem: PyPI
+    ranges:
+      - type: ECOSYSTEM
+        events:
+          - introduced: "0"
+database_specific:
+  custom_field: custom_value
+  another_field: 42
+
+# <Vulnfeeds Notes>
+# This is a note comment at the end of the YAML file
+# that standard parsers must skip without failure.
+`,
+			isYAML:   true,
+			wantID:   "PYSEC-2022-9999",
+			wantType: osvschema.Range_ECOSYSTEM,
+			wantTime: "2022-06-20T00:00:00Z",
+			verify: func(t *testing.T, vuln *Vulnerability) {
+				t.Helper()
+				if vuln.GetDatabaseSpecific() == nil {
+					t.Errorf("expected database_specific to be unmarshaled")
+					return
+				}
+				fields := vuln.GetDatabaseSpecific().GetFields()
+				if val, ok := fields["custom_field"]; !ok || val.GetStringValue() != "custom_value" {
+					t.Errorf("expected custom_field in database_specific to be 'custom_value'")
+				}
+				if val, ok := fields["another_field"]; !ok || val.GetNumberValue() != 42 {
+					t.Errorf("expected another_field in database_specific to be 42")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var vuln *Vulnerability
+			var err error
+			if tt.isYAML {
+				vuln, err = FromYAML(strings.NewReader(tt.data))
+			} else {
+				vuln, err = FromJSON(strings.NewReader(tt.data))
+			}
+
+			if err != nil {
+				t.Fatalf("unmarshal failed: %v", err)
+			}
+
+			if vuln.GetId() != tt.wantID {
+				t.Errorf("expected ID %q, got %q", tt.wantID, vuln.GetId())
+			}
+
+			if len(vuln.GetAffected()) == 0 || len(vuln.GetAffected()[0].GetRanges()) == 0 {
+				t.Fatalf("no affected ranges unmarshaled")
+			}
+
+			gotType := vuln.GetAffected()[0].GetRanges()[0].GetType()
+			if gotType != tt.wantType {
+				t.Errorf("expected range type %v, got %v", tt.wantType, gotType)
+			}
+
+			if vuln.GetPublished() != nil {
+				gotTime := vuln.GetPublished().AsTime().Format(time.RFC3339Nano)
+				wantTime := tt.wantTime
+				// Compare parsed times
+				parsedGot, err1 := time.Parse(time.RFC3339Nano, gotTime)
+				parsedWant, err2 := time.Parse(time.RFC3339Nano, wantTime)
+				if err1 == nil && err2 == nil {
+					if !parsedGot.Equal(parsedWant) {
+						t.Errorf("expected published time %v, got %v", parsedWant, parsedGot)
+					}
+				} else {
+					if gotTime != wantTime {
+						t.Errorf("expected published time %q, got %q", wantTime, gotTime)
+					}
+				}
+			}
+
+			if tt.verify != nil {
+				tt.verify(t, vuln)
+			}
+		})
 	}
 }


### PR DESCRIPTION
When walking PyPI vulnerabilities, standard YAML decoders failed to load existing records with errors like `cannot unmarshal !!str ECOSYSTEM into osvschema.Range_Type` and `cannot unmarshal !!str 2024-11... into timestamppb.Timestamp`. 

Some records have been starting with `vulnerability`, and have the record nested, whereas some are the record directly. This has caused problems with parsing. 

These errors occurred because `vulns.FromYAML` and the `cmd/ids` allocator tool were decoding inputs directly into protobuf-backed `osvschema.Vulnerability` structures using standard decoders. Standard decoders do not natively support custom protobuf types (like enums and timestamps represented as string values in YAML).

## Solution
Implemented a robust and streamlined deserialization pipeline inside the core `vulns` package and updated the ID allocator to delegate format parsing to it:

1. **Normalized Deserialization**:
   - **`vulns.FromYAML`**: Converts the raw YAML payload directly to normalized JSON using `goccyyaml.YAMLToJSON`. This natively resolves key-type issues and converts string enums and RFC3339 timestamps cleanly.
   - **`vulns.FromJSON`**: Inspects the payload to transparently handle both wrapped legacy formats (possessing a top-level `"vulnerability"` key) and flat standard OSV records.
   - **Strict & Resilient Decodes**: Uses `protojson.UnmarshalOptions{DiscardUnknown: true}` for schema compliance (preventing crashes on newer schema fields) with a safe fallback to `json.Unmarshal` for raw Go internal time structs (e.g., `seconds`/`nanos`).
2. **Refactored ID Allocator (`cmd/ids`)**: Refactored `readVulnWithFormat` to delegate parsing to `vulns.FromJSON` / `FromYAML` instead of running raw decodes that fail on legacy fields.
3. **Robust Unit Tests**: Added table-driven unit tests covering all combinations:
   - Flat standard JSON/YAML OSV.
   - Wrapped standard JSON/YAML OSV.
   - YAML with human notes comments appended at the end.
   - Nested `database_specific` fields.