### PR TITLE
refactor: Add pool filter to worker pub/sub subscription

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/scaler.yaml
+++ b/deployment/clouddeploy/gke-workers/base/scaler.yaml
@@ -25,7 +25,7 @@ spec:
         name: pubsub.googleapis.com|subscription|num_undelivered_messages
         selector:
           matchLabels:
-            resource.labels.subscription_id: tasks
+            resource.labels.subscription_id: default-pool
       target:
         type: AverageValue
         averageValue: 10  # each worker can handle 10 tasks now

--- a/deployment/clouddeploy/gke-workers/base/workers.yaml
+++ b/deployment/clouddeploy/gke-workers/base/workers.yaml
@@ -34,7 +34,7 @@ spec:
           - name: GITTER_HOST
             value: http://gitter-service:8888
           - name: PUBSUB_SUBSCRIPTION
-            value: tasks
+            value: default-pool
           - name: DATASTORE_DATABASE_ID
             value: "" # default
           - name: FAILED_TASKS_TOPIC

--- a/deployment/terraform/modules/osv/pubsub_tasks.tf
+++ b/deployment/terraform/modules/osv/pubsub_tasks.tf
@@ -18,9 +18,9 @@ resource "google_pubsub_topic" "failed_tasks" {
   name    = "failed-tasks"
 }
 
-resource "google_pubsub_subscription" "tasks" {
+resource "google_pubsub_subscription" "default_work" {
   project                    = var.project_id
-  name                       = "tasks"
+  name                       = "default-pool"
   topic                      = google_pubsub_topic.tasks.id
   message_retention_duration = "604800s"
   ack_deadline_seconds       = 600
@@ -37,6 +37,8 @@ resource "google_pubsub_subscription" "tasks" {
   labels = {
     goog-dm = "pubsub"
   }
+
+  filter = "attributes.work_pool = \"default\""
 }
 
 resource "google_pubsub_topic" "pypi_bridge" {
@@ -51,9 +53,9 @@ resource "google_project_service_identity" "pubsub" {
   service  = "pubsub.googleapis.com"
 }
 
-resource "google_pubsub_subscription_iam_member" "tasks_service_subscriber" {
+resource "google_pubsub_subscription_iam_member" "default_work_service_subscriber" {
   project      = var.project_id
-  subscription = google_pubsub_subscription.tasks.name
+  subscription = google_pubsub_subscription.default_work.name
   role         = "roles/pubsub.subscriber"
   member       = "serviceAccount:${google_project_service_identity.pubsub.email}"
 }


### PR DESCRIPTION
Delete the old `tasks` subscription and replace it with a `default-pool` subscription that filters on the `work_pool` field.
In a follow-up PR, I'll add the reimport & CVE pools