### PR TITLE
fix(pypi): unify PyPI package and version range fields into a single Affected block

### DIFF
--- a/vulnfeeds/cmd/pypi/main.go
+++ b/vulnfeeds/cmd/pypi/main.go
@@ -165,22 +165,12 @@ func main() {
 			}
 			logger.Info("Got valid versions", slog.Any("versions", validVersions))
 
-			id := "PYSEC-0000-" + cve.CVE.ID // To be assigned later.
 			purl := ecosystem.PackageURL(pkg)
-			pkgInfo := vulns.PackageInfo{
-				PkgName:   pkg,
-				Ecosystem: "PyPI",
-				PURL:      purl,
-			}
 			metrics := &models.ConversionMetrics{
 				CVEID: cve.CVE.ID,
 			}
-			v := vulns.FromNVDCVE(id, cve.CVE)
-			v.AddPkgInfo(pkgInfo)
-			versions := conversion.ExtractVersionInfo(cve.CVE, validVersions, http.DefaultClient, metrics, nil)
-
-			vulns.AttachExtractedVersionInfo(v, versions)
-			if len(v.Affected[0].GetRanges()) == 0 {
+			v := generatePyPIAffected(cve.CVE, pkg, validVersions, purl, metrics)
+			if len(v.Affected) == 0 || len(v.Affected[0].GetRanges()) == 0 {
 				logger.Info("No affected versions detected")
 			}
 
@@ -226,4 +216,20 @@ func main() {
 			}
 		}
 	}
+}
+
+func generatePyPIAffected(cve models.NVDCVE, pkg string, validVersions []string, purl string, metrics *models.ConversionMetrics) *vulns.Vulnerability {
+	id := "PYSEC-0000-" + cve.ID
+	versions := conversion.ExtractVersionInfo(cve, validVersions, http.DefaultClient, metrics, nil)
+
+	pkgInfo := vulns.PackageInfo{
+		PkgName:     pkg,
+		Ecosystem:   "PyPI",
+		PURL:        purl,
+		VersionInfo: versions,
+	}
+	v := vulns.FromNVDCVE(id, cve)
+	v.AddPkgInfo(pkgInfo)
+
+	return v
 }

--- a/vulnfeeds/cmd/pypi/main_test.go
+++ b/vulnfeeds/cmd/pypi/main_test.go
@@ -18,6 +18,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/google/osv/vulnfeeds/models"
+	"github.com/ossf/osv-schema/bindings/go/osvschema"
 )
 
 func TestLoadExisting(t *testing.T) {
@@ -91,6 +94,115 @@ affected:
 	for _, k := range unexpectedKeys {
 		if got[k] {
 			t.Errorf("Map unexpectedly contains %s", k)
+		}
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func TestGeneratePyPIAffected(t *testing.T) {
+	cve := models.NVDCVE{
+		ID:      "CVE-2022-29194",
+		Metrics: &models.CVEItemMetrics{},
+		Configurations: []models.Config{
+			{
+				Nodes: []models.Node{
+					{
+						Operator: "OR",
+						CPEMatch: []models.CPEMatch{
+							{
+								Vulnerable:          true,
+								Criteria:            "cpe:2.3:a:google:tensorflow:*:*:*:*:*:*:*:*",
+								VersionEndExcluding: strPtr("2.6.4"),
+							},
+							{
+								Vulnerable:            true,
+								Criteria:              "cpe:2.3:a:google:tensorflow:*:*:*:*:*:*:*:*",
+								VersionStartIncluding: strPtr("2.7.0"),
+								VersionEndExcluding:   strPtr("2.7.2"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	validVersions := []string{
+		"2.5.0", "2.6.0", "2.6.1", "2.6.2", "2.6.3", "2.6.4",
+		"2.7.0", "2.7.1", "2.7.2",
+	}
+	pkg := "tensorflow"
+	purl := "pkg:pypi/tensorflow"
+	metrics := &models.ConversionMetrics{
+		CVEID: cve.ID,
+	}
+
+	v := generatePyPIAffected(cve, pkg, validVersions, purl, metrics)
+
+	// Verify ID
+	expectedID := "PYSEC-0000-CVE-2022-29194"
+	if v.Id != expectedID {
+		t.Errorf("expected ID %q, got %q", expectedID, v.Id)
+	}
+
+	// Verify Affected
+	if len(v.Affected) != 1 {
+		t.Fatalf("expected exactly 1 affected entry, got %d", len(v.Affected))
+	}
+
+	affected := v.Affected[0]
+
+	// Verify Package
+	if affected.GetPackage() == nil {
+		t.Fatal("expected non-nil affected.Package")
+	}
+	if affected.GetPackage().GetName() != pkg {
+		t.Errorf("expected package name %q, got %q", pkg, affected.GetPackage().GetName())
+	}
+	if affected.GetPackage().GetEcosystem() != "PyPI" {
+		t.Errorf("expected package ecosystem %q, got %q", "PyPI", affected.GetPackage().GetEcosystem())
+	}
+	if affected.GetPackage().GetPurl() != purl {
+		t.Errorf("expected package PURL %q, got %q", purl, affected.GetPackage().GetPurl())
+	}
+
+	// Verify Ranges
+	if len(affected.GetRanges()) != 1 {
+		t.Fatalf("expected exactly 1 range entry, got %d", len(affected.GetRanges()))
+	}
+
+	r := affected.GetRanges()[0]
+	if r.GetType() != osvschema.Range_ECOSYSTEM {
+		t.Errorf("expected range type %v, got %v", osvschema.Range_ECOSYSTEM, r.GetType())
+	}
+
+	// Log all generated events for debugging
+	for i, ev := range r.GetEvents() {
+		t.Logf("Generated Event[%d]: %+v", i, ev)
+	}
+
+	// Verify Events
+	expectedEvents := []*osvschema.Event{
+		{Introduced: "0"},
+		{Fixed: "2.6.4"},
+		{Introduced: "2.7.0"},
+		{Fixed: "2.7.2"},
+	}
+
+	if len(r.GetEvents()) != len(expectedEvents) {
+		t.Fatalf("expected %d events, got %d", len(expectedEvents), len(r.GetEvents()))
+	}
+
+	for i, ev := range r.GetEvents() {
+		expectedEv := expectedEvents[i]
+		if ev.GetIntroduced() != expectedEv.GetIntroduced() {
+			t.Errorf("event[%d]: expected introduced %q, got %q", i, expectedEv.GetIntroduced(), ev.GetIntroduced())
+		}
+		if ev.GetFixed() != expectedEv.GetFixed() {
+			t.Errorf("event[%d]: expected fixed %q, got %q", i, expectedEv.GetFixed(), ev.GetFixed())
 		}
 	}
 }

--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -291,32 +291,38 @@ func (v *Vulnerability) AddPkgInfo(pkgInfo PackageInfo) {
 			Type:   osvschema.Range_ECOSYSTEM,
 			Events: []*osvschema.Event{},
 		}
-		hasIntroduced := false
+		seenIntroduced := map[string]bool{}
+		seenFixed := map[string]bool{}
+		seenLastAffected := map[string]bool{}
+
 		for _, av := range pkgInfo.VersionInfo.AffectedVersions {
-			if av.Introduced != "" {
-				hasIntroduced = true
-				versionRange.Events = append(versionRange.Events, &osvschema.Event{
-					Introduced: av.Introduced,
-				})
+			var introduced string
+			if av.Introduced == "" {
+				introduced = "0"
+			} else {
+				introduced = av.Introduced
 			}
-			if av.Fixed != "" {
+
+			if _, seen := seenIntroduced[introduced]; !seen {
+				versionRange.Events = append(versionRange.Events, &osvschema.Event{
+					Introduced: introduced,
+				})
+				seenIntroduced[introduced] = true
+			}
+
+			if _, seen := seenFixed[av.Fixed]; av.Fixed != "" && !seen {
 				versionRange.Events = append(versionRange.Events, &osvschema.Event{
 					Fixed: av.Fixed,
 				})
+				seenFixed[av.Fixed] = true
 			}
-			if av.LastAffected != "" {
+
+			if _, seen := seenLastAffected[av.LastAffected]; av.LastAffected != "" && !seen {
 				versionRange.Events = append(versionRange.Events, &osvschema.Event{
 					LastAffected: av.LastAffected,
 				})
+				seenLastAffected[av.LastAffected] = true
 			}
-		}
-
-		if !hasIntroduced {
-			// If no introduced entry, add one with special value of 0 to indicate
-			// all versions before fixed is affected
-			versionRange.Events = append([]*osvschema.Event{{
-				Introduced: "0",
-			}}, versionRange.GetEvents()...)
 		}
 		affected.Ranges = append(affected.Ranges, versionRange)
 	}


### PR DESCRIPTION
Turns out the newly generating PyPi records are generating without version ranges, which isn't exactly ideal. 

This PR refactors the PyPI record generation flow and resolves a bug in the shared library's range generation logic that caused empty range blocks or detached `affected` fields under specific CPE configurations.

#### Key Changes:
1. **Ecosystem Converter Alignment**: Refactored `vulnfeeds/cmd/pypi/main.go` to extract vulnerability version details *before* compiling package metadata. This aligns the PyPI flow with standard converters (like Alpine and Debian) and enables both `ECOSYSTEM` and `GIT` ranges to be cleanly grouped into a single `affected` block.
2. **Extracted Helper Function**: Encapsulated the core generation logic inside a new `generatePyPIAffected` helper function in `cmd/pypi/main.go` to enhance testability.
3. **AddPkgInfo Bug Fix**: Fixed a bug in `vulns/vulns.go` (`AddPkgInfo`) where empty introduced version ranges were not correctly defaulted to `"0"` individually per range when multiple range blocks were present.
4. **Testing**: Added the unit test `TestGeneratePyPIAffected` inside `cmd/pypi/main_test.go` using strict proto getters to verify correct packaging, range limits, and sequence compliance under the OSV schema.