### PR TITLE
fix: importer-reconciler actually checkout branch

### DIFF
--- a/go/internal/importer/git.go
+++ b/go/internal/importer/git.go
@@ -285,20 +285,27 @@ func handleReconcileGit(ctx context.Context, ch chan<- WorkItem, config Config, 
 			return nil, err
 		}
 
-		if sourceRepo.Git.Branch != "" {
-			wt, err := repo.Worktree()
-			if err == nil {
-				_ = wt.Checkout(&git.CheckoutOptions{
-					Branch: plumbing.NewRemoteReferenceName("origin", sourceRepo.Git.Branch),
-					Force:  true,
-				})
-			}
+		var branch plumbing.ReferenceName
+		if sourceRepo.Git.Branch == "" {
+			branch = plumbing.NewRemoteHEADReferenceName("origin")
+		} else {
+			branch = plumbing.NewRemoteReferenceName("origin", sourceRepo.Git.Branch)
 		}
+
+		wt, err := repo.Worktree()
+		if err != nil {
+			return nil, err
+		}
+
+		err = wt.Checkout(&git.CheckoutOptions{
+			Branch: branch,
+			Force:  true,
+		})
 
 		return sharedRepo{
 			Repository: repo,
 			mu:         &sync.Mutex{},
-		}, nil
+		}, err
 	})
 	if err != nil {
 		if !errors.Is(err, context.Canceled) {

--- a/go/internal/importer/git_test.go
+++ b/go/internal/importer/git_test.go
@@ -178,7 +178,6 @@ func TestHandleImportGit(t *testing.T) {
 func TestHandleImportGit_Deletion(t *testing.T) {
 	// Setup a temporary git repo acting as the remote source
 	remoteDir := t.TempDir()
-
 	remoteRepo, err := git.PlainInit(remoteDir, false)
 	if err != nil {
 		t.Fatalf("Failed to init remote repo: %v", err)

--- a/go/internal/importer/main_test.go
+++ b/go/internal/importer/main_test.go
@@ -1,0 +1,25 @@
+package importer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// Create a temp dir to isolate HOME and XDG_CONFIG_HOME for all tests in this package.
+	// This prevents go-git from reading files like ~/.config/git/config, which might cause non-deterministic test runs.
+	dir, err := os.MkdirTemp("", "osv-importer-test-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create temp dir for TestMain: %v\n", err)
+		return
+	}
+
+	os.Setenv("HOME", filepath.Join(dir, "home"))
+	os.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
+
+	m.Run()
+
+	os.RemoveAll(dir)
+}


### PR DESCRIPTION
Actually checkout the main/master branch when there is no specific branch specified  in the reconciler.


Also fixing tests by:

Isolates `HOME` and `XDG_CONFIG_HOME` to a clean temporary directory package-wide for the `importer` package. This ensures host machine Git configurations (such as `commit.gpgSign`) don't interfere with tests, resolving failures in `TestGitSourceRecord_Open` and `TestHandleImportGit` on environments with those custom configs.