### PR TITLE
fix(vulnfeeds): Modify valid versions output logic in versions.go

### DIFF
--- a/vulnfeeds/conversion/versions.go
+++ b/vulnfeeds/conversion/versions.go
@@ -943,7 +943,8 @@ func ExtractVersionInfo(cve models.NVDCVE, validVersions []string, httpClient *h
 		metrics.AddNote("No versions detected.")
 	}
 
-	if len(validVersions) > 0 {
+	// Valid versions should only be output if there are errors generating the record
+	if len(metrics.Notes) > 0 && len(validVersions) > 0 {
 		metrics.AddNote("Valid versions:")
 		for _, version := range validVersions {
 			metrics.AddNote("  - %v", version)


### PR DESCRIPTION
Add condition to output valid versions only if there are errors.

otherwise this prevents the PyPi advisory database from producing records with successful ranges...