### PR TITLE
fix(vulnfeeds): ToYAML round-tripping

### DIFF
--- a/vulnfeeds/vulns/vulns.go
+++ b/vulnfeeds/vulns/vulns.go
@@ -33,7 +33,6 @@ import (
 	goccyyaml "github.com/goccy/go-yaml"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	"gopkg.in/yaml.v2"
 
 	"github.com/google/osv/vulnfeeds/models"
 	"github.com/google/osv/vulnfeeds/utility"
@@ -410,8 +409,23 @@ func (v *Vulnerability) ToJSON(w io.Writer) error {
 
 // ToYAML serializes the Vulnerability to YAML.
 func (v *Vulnerability) ToYAML(w io.Writer) error {
-	encoder := yaml.NewEncoder(w)
-	return encoder.Encode(v.Vulnerability)
+	// Go via protojson so the OSV schema's field names (e.g. last_affected),
+	// string enums and omitempty are honored. Encoding the protobuf-backed
+	// struct directly with a generic YAML encoder emits lowercased Go field
+	// names that FromYAML (which decodes via protojson) then silently drops.
+	jsonBytes, err := protojson.Marshal(v.Vulnerability)
+	if err != nil {
+		return err
+	}
+
+	yamlBytes, err := goccyyaml.JSONToYAML(jsonBytes)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(yamlBytes)
+
+	return err
 }
 
 // ClassifyReferenceLink infers the OSV schema's reference type for a given URL.

--- a/vulnfeeds/vulns/vulns_test.go
+++ b/vulnfeeds/vulns/vulns_test.go
@@ -691,3 +691,69 @@ database_specific:
 		})
 	}
 }
+
+// TestToYAMLFromYAMLRoundTripLastAffected is a regression test for empty `{}`
+// events being emitted for advisories whose only upper bound is a last_affected
+// version (e.g. a vulnerability with no released fix).
+//
+// ToYAML must emit the OSV schema's snake_case `last_affected` key. Encoding the
+// protobuf-backed struct with a generic YAML encoder instead emits the
+// lowercased Go field name `lastaffected`, which FromYAML (decoding via
+// protojson with DiscardUnknown) silently drops, leaving an all-empty event
+// that serializes to `{}` and violates the OSV schema.
+// See https://github.com/pypa/advisory-database/issues/284.
+func TestToYAMLFromYAMLRoundTripLastAffected(t *testing.T) {
+	vuln := &Vulnerability{
+		Vulnerability: &osvschema.Vulnerability{Id: "PYSEC-0000-TEST"},
+	}
+	vuln.AddPkgInfo(PackageInfo{
+		PkgName:   "pyjwt",
+		Ecosystem: "PyPI",
+		PURL:      "pkg:pypi/pyjwt",
+		VersionInfo: models.VersionInfo{
+			AffectedVersions: []models.AffectedVersion{
+				{LastAffected: "2.12.1"},
+			},
+		},
+	})
+
+	var buf strings.Builder
+	if err := vuln.ToYAML(&buf); err != nil {
+		t.Fatalf("ToYAML failed: %v", err)
+	}
+	yamlOut := buf.String()
+
+	// ToYAML must emit the OSV schema key, not the lowercased Go field name.
+	if strings.Contains(yamlOut, "lastaffected") {
+		t.Errorf("ToYAML emitted non-schema key 'lastaffected':\n%s", yamlOut)
+	}
+	if !strings.Contains(yamlOut, "last_affected") {
+		t.Errorf("ToYAML did not emit 'last_affected' key:\n%s", yamlOut)
+	}
+
+	roundTripped, err := FromYAML(strings.NewReader(yamlOut))
+	if err != nil {
+		t.Fatalf("FromYAML failed: %v", err)
+	}
+
+	if len(roundTripped.GetAffected()) == 0 || len(roundTripped.GetAffected()[0].GetRanges()) == 0 {
+		t.Fatalf("no affected ranges survived the round-trip")
+	}
+
+	events := roundTripped.GetAffected()[0].GetRanges()[0].GetEvents()
+	lastAffectedSeen := false
+	for i, ev := range events {
+		// Every OSV event must carry exactly one of introduced/fixed/
+		// last_affected/limit; an all-empty event serializes to `{}`.
+		if ev.GetIntroduced() == "" && ev.GetFixed() == "" &&
+			ev.GetLastAffected() == "" && ev.GetLimit() == "" {
+			t.Errorf("event[%d] is empty after round-trip; would serialize to '{}'", i)
+		}
+		if ev.GetLastAffected() == "2.12.1" {
+			lastAffectedSeen = true
+		}
+	}
+	if !lastAffectedSeen {
+		t.Errorf("last_affected '2.12.1' did not survive the YAML round-trip; events=%v", events)
+	}
+}


### PR DESCRIPTION
This is an attempt to fix some downstream breakage that we've been observing in `uv audit`. The underlying cause appears to be a regression in YAML roundtripping within `vulnfeeds`.

TL;DR: vulnfeeds generates OSV records as protobuf-backed `osvschema.Vulnerability` structs. Those structs only carry `protobuf` and `json` struct tags, not `yaml` tags. `vulns.ToYAML` was serializing them by handing the struct straight to a generic YAML encoder (`gopkg.in/yaml.v2`), which doesn't understand protobuf naming and just lowercases the Go field names. So an event field `LastAffected` got written as `lastaffected:` instead of the OSV schema's `last_affected:`, among other things.

That didn't cause problems until #5397 changed `vulns.FromYAML` to decode via `protojson` with `DiscardUnknown: true`. `protojson` expects the real schema name `last_affected` and silently throws away the unrecognized `lastaffected` key. So on the round trip that the PyPI pipeline does (`cmd/pypi` writes with `ToYAML`, `cmd/ids` reads with `FromYAML`), the `last_affected` value was dropped. An event whose only key was `last_affected` decoded into a completely empty `Event{}`, which then re-serialized to `{}`, violating the schema.

I've added a test that demonstrates the fixed behavior, and I had an LLM produce a reproducer [here](https://gist.github.com/woodruffw/2c4a62b2bff3df6cb09cd9b743e9e7a5).

Note: I'm not particularly experienced in Go, so this could use a sanity check for idioms (and correctness with respect to the larger codebase). It would also be ideal (IMO) to have a stronger regression backstop here; this breakage was pretty disruptive to a slice of the Python ecosystem that depends on `uv audit` and other OSV-aware auditing tools 🙂 

Refs:

- https://github.com/pypa/advisory-database/issues/284
- https://github.com/astral-sh/uv/issues/19492

CC @jess-lowe @another-rex 