### PR TITLE
fix(PyPi): don't error out on 429

### DIFF
--- a/vulnfeeds/conversion/versions.go
+++ b/vulnfeeds/conversion/versions.go
@@ -842,9 +842,6 @@ func ExtractVersionsFromCPEs(cve models.NVDCVE, validVersions []string, vpRepoCa
 func ExtractVersionInfo(cve models.NVDCVE, validVersions []string, httpClient *http.Client, metrics *models.ConversionMetrics, cache git.RepoTagsCache) (v models.VersionInfo) {
 	if commit, err := ExtractCommitsFromRefs(cve.References, httpClient, cache); err == nil {
 		v.AffectedCommits = append(v.AffectedCommits, commit...)
-	} else if errors.Is(err, git.ErrRateLimit) || strings.Contains(err.Error(), "429") {
-		metrics.Outcome = models.Error
-		return v
 	}
 
 	if v.AffectedCommits != nil {

--- a/vulnfeeds/conversion/versions_test.go
+++ b/vulnfeeds/conversion/versions_test.go
@@ -969,8 +969,8 @@ func TestExtractVersionInfo_429(t *testing.T) {
 	if len(gotVersionInfo.AffectedCommits) != 0 {
 		t.Errorf("Expected 0 affected commits, got %d", len(gotVersionInfo.AffectedCommits))
 	}
-	if metrics.Outcome != models.Error {
-		t.Errorf("Expected outcome to be Error, got %v", metrics.Outcome)
+	if metrics.Outcome == models.Error {
+		t.Errorf("Did not expected outcome to be Error, got %v", metrics.Outcome)
 	}
 }
 


### PR DESCRIPTION
While we want to error if we get 429ed in the NVD conversion, the PyPi conversion relies more heavily on CPE configs rather than commits from refs, and resolving repos isn't necessary for a successful conversion. This should prevent the record generation from ending early and returning an empty affected range only due to getting 429ed during the commit extraction phase.

ExtractVersionInfo is a mostly deprecated function that is only being called by PyPi and OSVToPackageInfo (the second of which is not used)