### PR TITLE
fix: add docker syntax to Dockerfiles

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/go/cmd/osv-linter-worker/Dockerfile
+++ b/go/cmd/osv-linter-worker/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Trying to fix these build issues one step at a time.
The gcloud docker seems to be quite old, and needs to be told to use the newer docker syntax