### PR TITLE
fix: add VSCode PURL conversion

### DIFF
--- a/osv/purl_helpers.py
+++ b/osv/purl_helpers.py
@@ -104,6 +104,8 @@ ECOSYSTEM_PURL_DATA = {
         EcosystemPURL('swift', None),
     'Ubuntu':
         EcosystemPURL('deb', 'ubuntu'),
+    'VSCode':
+        EcosystemPURL('vscode-extension', None),
     'Wolfi':
         EcosystemPURL('apk', 'wolfi'),
 }
@@ -195,7 +197,8 @@ def parse_purl(purl_str: str) -> ParsedPURL | None:
       package = purl.namespace + '/' + purl.name
       if purl.subpath:
         package = package + '/' + purl.subpath
-    elif purl.type in ('composer', 'hex', 'npm', 'swift'):
+    elif purl.type in ('composer', 'hex', 'npm', 'swift',
+                       'vscode-extension'):
       package = purl.namespace + '/' + purl.name
     elif purl.type in ('maven', 'gradle'):
       package = purl.namespace + ':' + purl.name

--- a/osv/purl_helpers_test.py
+++ b/osv/purl_helpers_test.py
@@ -178,6 +178,10 @@ class PurlHelpersTest(unittest.TestCase):
     self.assertEqual('pkg:deb/ubuntu/pygments',
                      purl_helpers.package_to_purl('Ubuntu', 'pygments'))
 
+    self.assertEqual(
+        'pkg:vscode-extension/ms-python/python',
+        purl_helpers.package_to_purl('VSCode', 'ms-python/python'))
+
     self.assertEqual('pkg:apk/wolfi/test-package',
                      purl_helpers.package_to_purl('Wolfi', 'test-package'))
 
@@ -333,6 +337,11 @@ class PurlHelpersTest(unittest.TestCase):
     self.assertEqual(('Ubuntu', 'pygments', '2.11.2+dfsg-2ubuntu0.1'),
                      purl_helpers.parse_purl(
                          'pkg:deb/ubuntu/pygments@2.11.2+dfsg-2ubuntu0.1'))
+
+    self.assertEqual(
+        ('VSCode', 'ms-python/python', '2023.25.10292213'),
+        purl_helpers.parse_purl(
+            'pkg:vscode-extension/ms-python/python@2023.25.10292213'))
 
     self.assertEqual(
         ('Wolfi', 'test-package', '1.2.3'),


### PR DESCRIPTION
## Summary
- Map the OSV `VSCode` ecosystem to the `vscode-extension` PURL type.
- Parse `pkg:vscode-extension/<publisher>/<name>` PURLs back to `VSCode` package names.
- Add package-to-PURL and parse-PURL test coverage.

Part of #2402

## Tests
- `/tmp/osvdev-purl-venv/bin/python -m unittest osv.purl_helpers_test`
- `git diff --check`