### PR TITLE
test(importer): update CleanUntracked test to cover complex subdir structures

### DIFF
--- a/go/internal/importer/git_test.go
+++ b/go/internal/importer/git_test.go
@@ -268,12 +268,21 @@ func TestHandleReconcileGit_CleanUntracked(t *testing.T) {
 		t.Fatalf("Failed to get remote worktree: %v", err)
 	}
 
-	// Initial commit: one tracked file
+	// Initial commit: tracked files in root and subdir
 	if err := os.WriteFile(filepath.Join(remoteDir, "CVE-A.json"), []byte("{}"), 0600); err != nil {
 		t.Fatalf("Failed to write file: %v", err)
 	}
+	if err := os.Mkdir(filepath.Join(remoteDir, "tracked_dir"), 0755); err != nil {
+		t.Fatalf("Failed to create tracked dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(remoteDir, "tracked_dir", "CVE-B.json"), []byte("{}"), 0600); err != nil {
+		t.Fatalf("Failed to write file in tracked dir: %v", err)
+	}
 	if _, err := remoteWt.Add("CVE-A.json"); err != nil {
 		t.Fatalf("Failed to add file: %v", err)
+	}
+	if _, err := remoteWt.Add("tracked_dir/CVE-B.json"); err != nil {
+		t.Fatalf("Failed to add file in tracked dir: %v", err)
 	}
 	_, err = remoteWt.Commit("Initial", &git.CommitOptions{
 		Author: &object.Signature{Name: "Test", Email: "test@example.com", When: time.Now()},
@@ -322,26 +331,47 @@ func TestHandleReconcileGit_CleanUntracked(t *testing.T) {
 	sha := sha256.Sum256([]byte(sourceRepo.Git.URL))
 	localCloneDir := filepath.Join(workDir, hex.EncodeToString(sha[:]))
 
-	// Verify the local clone exists and has the tracked file
-	trackedFilePath := filepath.Join(localCloneDir, "CVE-A.json")
-	if _, err := os.Stat(trackedFilePath); err != nil {
-		t.Fatalf("Expected tracked file to exist at %s, got error: %v", trackedFilePath, err)
+	// Verify the local clone exists and has the tracked files
+	trackedFilePathA := filepath.Join(localCloneDir, "CVE-A.json")
+	if _, err := os.Stat(trackedFilePathA); err != nil {
+		t.Fatalf("Expected tracked file A to exist at %s, got error: %v", trackedFilePathA, err)
+	}
+	trackedFilePathB := filepath.Join(localCloneDir, "tracked_dir", "CVE-B.json")
+	if _, err := os.Stat(trackedFilePathB); err != nil {
+		t.Fatalf("Expected tracked file B to exist at %s, got error: %v", trackedFilePathB, err)
 	}
 
-	// 2. Create an untracked file in the local clone
-	untrackedFilePath := filepath.Join(localCloneDir, "untracked.json")
-	if err := os.WriteFile(untrackedFilePath, []byte("untracked"), 0600); err != nil {
-		t.Fatalf("Failed to write untracked file: %v", err)
+	// 2. Create untracked files/dirs in the local clone
+	// 2a. Untracked file in root
+	untrackedRootFile := filepath.Join(localCloneDir, "untracked.json")
+	if err := os.WriteFile(untrackedRootFile, []byte("untracked"), 0600); err != nil {
+		t.Fatalf("Failed to write untracked file in root: %v", err)
 	}
 
-	// Create an untracked directory with a file
-	untrackedSubDir := filepath.Join(localCloneDir, "untracked_dir")
-	if err := os.Mkdir(untrackedSubDir, 0755); err != nil {
-		t.Fatalf("Failed to create untracked dir: %v", err)
+	// 2b. Untracked file in tracked subdir
+	untrackedInTrackedDir := filepath.Join(localCloneDir, "tracked_dir", "untracked_in_tracked.json")
+	if err := os.WriteFile(untrackedInTrackedDir, []byte("untracked"), 0600); err != nil {
+		t.Fatalf("Failed to write untracked file in tracked dir: %v", err)
 	}
-	untrackedFileInDir := filepath.Join(untrackedSubDir, "file.json")
-	if err := os.WriteFile(untrackedFileInDir, []byte("untracked"), 0600); err != nil {
-		t.Fatalf("Failed to write untracked file in dir: %v", err)
+
+	// 2c. Untracked subdir in tracked subdir (with a file)
+	untrackedDirInTrackedDir := filepath.Join(localCloneDir, "tracked_dir", "untracked_dir_in_tracked")
+	if err := os.Mkdir(untrackedDirInTrackedDir, 0755); err != nil {
+		t.Fatalf("Failed to create untracked dir in tracked dir: %v", err)
+	}
+	fileInUntrackedDirInTrackedDir := filepath.Join(untrackedDirInTrackedDir, "file.json")
+	if err := os.WriteFile(fileInUntrackedDirInTrackedDir, []byte("untracked"), 0600); err != nil {
+		t.Fatalf("Failed to write file in untracked dir in tracked dir: %v", err)
+	}
+
+	// 2d. Untracked subdir in root (with a file)
+	untrackedRootDir := filepath.Join(localCloneDir, "untracked_dir")
+	if err := os.Mkdir(untrackedRootDir, 0755); err != nil {
+		t.Fatalf("Failed to create untracked dir in root: %v", err)
+	}
+	fileInUntrackedRootDir := filepath.Join(untrackedRootDir, "file.json")
+	if err := os.WriteFile(fileInUntrackedRootDir, []byte("untracked"), 0600); err != nil {
+		t.Fatalf("Failed to write file in untracked root dir: %v", err)
 	}
 
 	// 3. Run reconcile again. It should clean up untracked files/dirs.
@@ -355,16 +385,25 @@ func TestHandleReconcileGit_CleanUntracked(t *testing.T) {
 		continue
 	}
 
-	// 4. Verify untracked file and dir are GONE
-	if _, err := os.Stat(untrackedFilePath); !os.IsNotExist(err) {
-		t.Errorf("Expected untracked file to be deleted, but it still exists (or got error: %v)", err)
+	// 4. Verify all untracked files and dirs are GONE
+	if _, err := os.Stat(untrackedRootFile); !os.IsNotExist(err) {
+		t.Errorf("Expected untracked root file to be deleted, but it still exists (or got error: %v)", err)
 	}
-	if _, err := os.Stat(untrackedSubDir); !os.IsNotExist(err) {
-		t.Errorf("Expected untracked directory to be deleted, but it still exists (or got error: %v)", err)
+	if _, err := os.Stat(untrackedInTrackedDir); !os.IsNotExist(err) {
+		t.Errorf("Expected untracked file in tracked dir to be deleted, but it still exists (or got error: %v)", err)
+	}
+	if _, err := os.Stat(untrackedDirInTrackedDir); !os.IsNotExist(err) {
+		t.Errorf("Expected untracked dir in tracked dir to be deleted, but it still exists (or got error: %v)", err)
+	}
+	if _, err := os.Stat(untrackedRootDir); !os.IsNotExist(err) {
+		t.Errorf("Expected untracked root dir to be deleted, but it still exists (or got error: %v)", err)
 	}
 
-	// Verify tracked file still exists
-	if _, err := os.Stat(trackedFilePath); err != nil {
-		t.Errorf("Expected tracked file to still exist, got error: %v", err)
+	// Verify tracked files still exist
+	if _, err := os.Stat(trackedFilePathA); err != nil {
+		t.Errorf("Expected tracked file A to still exist, got error: %v", err)
+	}
+	if _, err := os.Stat(trackedFilePathB); err != nil {
+		t.Errorf("Expected tracked file B to still exist, got error: %v", err)
 	}
 }


### PR DESCRIPTION
This PR updates the `CleanUntracked` test to cover complex subdirectory structures, ensuring that untracked files and directories inside both root and tracked/untracked subdirectories are correctly cleaned up.

This is a follow-up to #5440 to ensure thorough test coverage of the `go-git` `wt.Clean` implementation.

agy