### PR TITLE
fix(vulnfeeds): don't recognize GHSA links without repos bases as repos

### DIFF
--- a/vulnfeeds/conversion/versions.go
+++ b/vulnfeeds/conversion/versions.go
@@ -179,6 +179,13 @@ func repo(u string) (string, error) {
 		}
 	}
 
+	if strings.ToLower(parsedURL.Hostname()) == "github.com" {
+		pathParts := strings.Split(parsedURL.Path, "/")
+		if len(pathParts) >= 2 && strings.ToLower(pathParts[1]) == "advisories" {
+			return "", fmt.Errorf("%q is a GHSA reference link, not a repository", u)
+		}
+	}
+
 	// Were we handed a base repository URL from the get go?
 	if slices.Contains(supportedHosts, parsedURL.Hostname()) || slices.Contains(supportedHostPrefixes, strings.Split(parsedURL.Hostname(), ".")[0]) {
 		pathParts := strings.Split(parsedURL.Path, "/")

--- a/vulnfeeds/conversion/versions_test.go
+++ b/vulnfeeds/conversion/versions_test.go
@@ -469,6 +469,12 @@ func TestRepo(t *testing.T) {
 			expectedRepoURL: "https://git.savannah.gnu.org/git/wget.git",
 			expectedOk:      true,
 		},
+		{
+			description:     "GitHub advisory database URL (GHSA reference, not a repo)",
+			inputLink:       "https://github.com/advisories/GHSA-fv3m-xhqw-9m79",
+			expectedRepoURL: "",
+			expectedOk:      false,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
references that include links to GHSA advisories, but aren't based on a repo, are somewhat useless to us for generating the OSV CVE records. this filters those out from being recognized as repos.

example link: https://github.com/advisories/GHSA-fv3m-xhqw-9m79