### PR TITLE
feat(nvd): differentiate between CPE ranges and string sources

### DIFF
--- a/vulnfeeds/conversion/common.go
+++ b/vulnfeeds/conversion/common.go
@@ -654,7 +654,7 @@ func AddFieldToDatabaseSpecific(ds *structpb.Struct, field string, value any) er
 }
 
 // ProcessRanges attempts to resolve the given ranges to commits and updates the metrics accordingly.
-func ProcessRanges(ranges []models.RangeWithMetadata, repos []string, metrics *models.ConversionMetrics, cache git.RepoTagsCache, source models.VersionSource) ([]models.RangeWithMetadata, []models.RangeWithMetadata, []string) {
+func ProcessRanges(ranges []models.RangeWithMetadata, repos []string, metrics *models.ConversionMetrics, cache git.RepoTagsCache) ([]models.RangeWithMetadata, []models.RangeWithMetadata, []string) {
 	if len(ranges) == 0 {
 		return nil, nil, nil
 	}

--- a/vulnfeeds/conversion/common.go
+++ b/vulnfeeds/conversion/common.go
@@ -672,7 +672,24 @@ func ProcessRanges(ranges []models.RangeWithMetadata, repos []string, metrics *m
 		}
 	}
 
-	metrics.VersionSources = append(metrics.VersionSources, source)
+	// Dynamically record the precise sources from each processed range's metadata.
+	// This ensures that granular version sources (such as CPE-RANGE or CPE-STRING) are tracked in
+	// the final conversion metrics instead of a single generic fallback source.
+	for _, rng := range ranges {
+		if rng.Metadata.Source == "" {
+			continue
+		}
+		found := false
+		for _, s := range metrics.VersionSources {
+			if s == rng.Metadata.Source {
+				found = true
+				break
+			}
+		}
+		if !found {
+			metrics.VersionSources = append(metrics.VersionSources, rng.Metadata.Source)
+		}
+	}
 
 	return r, un, sR
 }

--- a/vulnfeeds/conversion/common.go
+++ b/vulnfeeds/conversion/common.go
@@ -673,21 +673,14 @@ func ProcessRanges(ranges []models.RangeWithMetadata, repos []string, metrics *m
 	}
 
 	// Dynamically record the precise sources from each processed range's metadata.
-	// This ensures that granular version sources (such as CPE-RANGE or CPE-STRING) are tracked in
+	// This ensures that granular version sources (such as CPE_RANGE or CPE_STRING) are tracked in
 	// the final conversion metrics instead of a single generic fallback source.
-	for _, rng := range ranges {
-		if rng.Metadata.Source == "" {
+	for _, ra := range ranges {
+		if ra.Metadata.Source == "" {
 			continue
 		}
-		found := false
-		for _, s := range metrics.VersionSources {
-			if s == rng.Metadata.Source {
-				found = true
-				break
-			}
-		}
-		if !found {
-			metrics.VersionSources = append(metrics.VersionSources, rng.Metadata.Source)
+		if !slices.Contains(metrics.VersionSources, ra.Metadata.Source) {
+			metrics.VersionSources = append(metrics.VersionSources, ra.Metadata.Source)
 		}
 	}
 

--- a/vulnfeeds/conversion/cve5/default_extractor.go
+++ b/vulnfeeds/conversion/cve5/default_extractor.go
@@ -42,7 +42,7 @@ func (d *DefaultVersionExtractor) ExtractVersions(cve models.CVE5, v *vulns.Vuln
 	var unresolvedRanges []models.RangeWithMetadata
 
 	processRanges := func(nr []models.RangeWithMetadata) bool {
-		r, un, sR := c.ProcessRanges(nr, repos, metrics, repoTagsCache, models.VersionSourceAffected)
+		r, un, sR := c.ProcessRanges(nr, repos, metrics, repoTagsCache)
 		resolvedRanges = append(resolvedRanges, r...)
 		unresolvedRanges = append(unresolvedRanges, un...)
 		for _, s := range sR {

--- a/vulnfeeds/conversion/nvd/__snapshots__/converter_test.snap
+++ b/vulnfeeds/conversion/nvd/__snapshots__/converter_test.snap
@@ -1767,7 +1767,7 @@
               }
             ],
             "source": [
-              "CPE_FIELD",
+              "CPE_RANGE",
               "REFERENCES"
             ]
           },
@@ -1853,7 +1853,7 @@
               }
             ],
             "source": [
-              "CPE_FIELD",
+              "CPE_RANGE",
               "REFERENCES"
             ]
           },
@@ -1997,7 +1997,7 @@
               }
             ],
             "source": [
-              "CPE_FIELD",
+              "CPE_RANGE",
               "REFERENCES"
             ]
           },
@@ -2066,7 +2066,7 @@
                 "fixed": "7.61.1"
               }
             ],
-            "source": "CPE_FIELD"
+            "source": "CPE_RANGE"
           },
           "events": [
             {
@@ -2105,7 +2105,7 @@
             "last_affected": "18.04"
           }
         ],
-        "source": "CPE_FIELD",
+        "source": "CPE_STRING",
         "vendor_product": "canonical:ubuntu_linux"
       },
       {
@@ -2117,7 +2117,7 @@
             "last_affected": "9.0"
           }
         ],
-        "source": "CPE_FIELD",
+        "source": "CPE_STRING",
         "vendor_product": "debian:debian_linux"
       },
       {
@@ -2145,7 +2145,7 @@
             "last_affected": "7.6"
           }
         ],
-        "source": "CPE_FIELD",
+        "source": "CPE_STRING",
         "vendor_product": "redhat:enterprise_linux"
       }
     ]
@@ -2230,7 +2230,7 @@
             "last_affected": "38"
           }
         ],
-        "source": "CPE_FIELD",
+        "source": "CPE_STRING",
         "vendor_product": "fedoraproject:fedora"
       },
       {
@@ -2254,7 +2254,7 @@
             "last_affected": "12.1"
           }
         ],
-        "source": "CPE_FIELD",
+        "source": "CPE_STRING",
         "vendor_product": "redhat:directory_server"
       }
     ]
@@ -2388,7 +2388,7 @@
               }
             ],
             "source": [
-              "CPE_FIELD",
+              "CPE_STRING",
               "REFERENCES"
             ]
           },
@@ -2424,7 +2424,7 @@
             "last_affected": "36"
           }
         ],
-        "source": "CPE_FIELD",
+        "source": "CPE_STRING",
         "vendor_product": "fedoraproject:fedora"
       }
     ]
@@ -2810,7 +2810,7 @@
                 "last_affected": "2.8.4"
               }
             ],
-            "source": "CPE_FIELD"
+            "source": "CPE_STRING"
           },
           "events": [
             {
@@ -3077,7 +3077,7 @@
             "last_affected": "12.04"
           }
         ],
-        "source": "CPE_FIELD",
+        "source": "CPE_STRING",
         "vendor_product": "canonical:ubuntu_linux"
       },
       {
@@ -3089,7 +3089,7 @@
             "last_affected": "42.1"
           }
         ],
-        "source": "CPE_FIELD",
+        "source": "CPE_STRING",
         "vendor_product": "opensuse:leap"
       }
     ]
@@ -3243,7 +3243,7 @@
                 "fixed": "0.9.2"
               }
             ],
-            "source": "CPE_FIELD"
+            "source": "CPE_RANGE"
           },
           "events": [
             {
@@ -3270,7 +3270,7 @@
             "last_affected": "40"
           }
         ],
-        "source": "CPE_FIELD",
+        "source": "CPE_STRING",
         "vendor_product": "fedoraproject:fedora"
       },
       {
@@ -3286,7 +3286,7 @@
             "last_affected": "8.0"
           }
         ],
-        "source": "CPE_FIELD",
+        "source": "CPE_STRING",
         "vendor_product": "redhat:enterprise_linux"
       }
     ]
@@ -3331,6 +3331,69 @@
     "unresolved_ranges": [
       {
         "cpes": [
+          "cpe:2.3:a:filezilla-project:filezilla_client:*:*:*:*:*:*:*:*"
+        ],
+        "extracted_events": [
+          {
+            "fixed": "3.67.0"
+          }
+        ],
+        "source": "CPE_RANGE",
+        "vendor_product": "filezilla-project:filezilla_client"
+      },
+      {
+        "cpes": [
+          "cpe:2.3:a:putty:putty:*:*:*:*:*:*:*:*"
+        ],
+        "extracted_events": [
+          {
+            "introduced": "0.68"
+          },
+          {
+            "fixed": "0.81"
+          }
+        ],
+        "source": "CPE_RANGE",
+        "vendor_product": "putty:putty"
+      },
+      {
+        "cpes": [
+          "cpe:2.3:a:tigris:tortoisesvn:*:*:*:*:*:*:*:*"
+        ],
+        "extracted_events": [
+          {
+            "fixed": "1.14.6"
+          }
+        ],
+        "source": "CPE_RANGE",
+        "vendor_product": "tigris:tortoisesvn"
+      },
+      {
+        "cpes": [
+          "cpe:2.3:a:tortoisegit:tortoisegit:*:*:*:*:*:*:*:*"
+        ],
+        "extracted_events": [
+          {
+            "fixed": "2.15.0.1"
+          }
+        ],
+        "source": "CPE_RANGE",
+        "vendor_product": "tortoisegit:tortoisegit"
+      },
+      {
+        "cpes": [
+          "cpe:2.3:a:winscp:winscp:*:*:*:*:*:*:*:*"
+        ],
+        "extracted_events": [
+          {
+            "fixed": "6.3.3"
+          }
+        ],
+        "source": "CPE_RANGE",
+        "vendor_product": "winscp:winscp"
+      },
+      {
+        "cpes": [
           "cpe:2.3:o:fedoraproject:fedora:38:*:*:*:*:*:*:*",
           "cpe:2.3:o:fedoraproject:fedora:39:*:*:*:*:*:*:*",
           "cpe:2.3:o:fedoraproject:fedora:40:*:*:*:*:*:*:*"
@@ -3346,71 +3409,8 @@
             "last_affected": "40"
           }
         ],
-        "source": "CPE_FIELD",
+        "source": "CPE_STRING",
         "vendor_product": "fedoraproject:fedora"
-      },
-      {
-        "cpes": [
-          "cpe:2.3:a:filezilla-project:filezilla_client:*:*:*:*:*:*:*:*"
-        ],
-        "extracted_events": [
-          {
-            "fixed": "3.67.0"
-          }
-        ],
-        "source": "CPE_FIELD",
-        "vendor_product": "filezilla-project:filezilla_client"
-      },
-      {
-        "cpes": [
-          "cpe:2.3:a:putty:putty:*:*:*:*:*:*:*:*"
-        ],
-        "extracted_events": [
-          {
-            "introduced": "0.68"
-          },
-          {
-            "fixed": "0.81"
-          }
-        ],
-        "source": "CPE_FIELD",
-        "vendor_product": "putty:putty"
-      },
-      {
-        "cpes": [
-          "cpe:2.3:a:tigris:tortoisesvn:*:*:*:*:*:*:*:*"
-        ],
-        "extracted_events": [
-          {
-            "fixed": "1.14.6"
-          }
-        ],
-        "source": "CPE_FIELD",
-        "vendor_product": "tigris:tortoisesvn"
-      },
-      {
-        "cpes": [
-          "cpe:2.3:a:tortoisegit:tortoisegit:*:*:*:*:*:*:*:*"
-        ],
-        "extracted_events": [
-          {
-            "fixed": "2.15.0.1"
-          }
-        ],
-        "source": "CPE_FIELD",
-        "vendor_product": "tortoisegit:tortoisegit"
-      },
-      {
-        "cpes": [
-          "cpe:2.3:a:winscp:winscp:*:*:*:*:*:*:*:*"
-        ],
-        "extracted_events": [
-          {
-            "fixed": "6.3.3"
-          }
-        ],
-        "source": "CPE_FIELD",
-        "vendor_product": "winscp:winscp"
       },
       {
         "extracted_events": [

--- a/vulnfeeds/conversion/nvd/converter.go
+++ b/vulnfeeds/conversion/nvd/converter.go
@@ -82,7 +82,7 @@ func CVEToOSV(cve models.NVDCVE, repos []string, vpRepoCache *c.VPRepoCache, cac
 	}
 
 	// If we have ranges, try to resolve them
-	r, un, sR := c.ProcessRanges(cpeRanges, repos, metrics, cache, models.VersionSourceCPE)
+	r, un, sR := c.ProcessRanges(cpeRanges, repos, metrics, cache)
 	if metrics.Outcome == models.Error {
 		return nil, metrics, models.Error
 	}
@@ -116,7 +116,7 @@ func CVEToOSV(cve models.NVDCVE, repos []string, vpRepoCache *c.VPRepoCache, cac
 		if len(textRanges) > 0 {
 			metrics.AddNote("Extracted versions from description: %v", textRanges)
 		}
-		r, un, sR := c.ProcessRanges(textRanges, repos, metrics, cache, models.VersionSourceDescription)
+		r, un, sR := c.ProcessRanges(textRanges, repos, metrics, cache)
 		if metrics.Outcome == models.Error {
 			return nil, metrics, models.Error
 		}

--- a/vulnfeeds/conversion/versions.go
+++ b/vulnfeeds/conversion/versions.go
@@ -729,6 +729,8 @@ func ExtractVersionsFromCPEs(cve models.NVDCVE, validVersions []string, vpRepoCa
 				introduced := ""
 				fixed := ""
 				lastaffected := ""
+				source := models.VersionSourceCPERange
+
 				if match.VersionStartIncluding != nil {
 					introduced = cleanVersion(*match.VersionStartIncluding)
 				} else if match.VersionStartExcluding != nil {
@@ -771,6 +773,7 @@ func ExtractVersionsFromCPEs(cve models.NVDCVE, validVersions []string, vpRepoCa
 					if CPE.Update != "ANY" {
 						lastaffected += "-" + CPE.Update
 					}
+					source = models.VersionSourceCPEString
 				}
 
 				if introduced == "" {
@@ -809,7 +812,7 @@ func ExtractVersionsFromCPEs(cve models.NVDCVE, validVersions []string, vpRepoCa
 								Range: vr,
 								Metadata: models.Metadata{
 									CPE:    match.Criteria,
-									Source: models.VersionSourceCPE,
+									Source: source,
 								},
 							},
 						)
@@ -821,7 +824,7 @@ func ExtractVersionsFromCPEs(cve models.NVDCVE, validVersions []string, vpRepoCa
 							Range: vr,
 							Metadata: models.Metadata{
 								CPE:    match.Criteria,
-								Source: models.VersionSourceCPE,
+								Source: source,
 							},
 						},
 					)

--- a/vulnfeeds/models/metrics.go
+++ b/vulnfeeds/models/metrics.go
@@ -110,6 +110,8 @@ const (
 	VersionSourceAffected    VersionSource = "AFFECTED_FIELD"
 	VersionSourceGit         VersionSource = "AFFECTED_FIELD_GIT"
 	VersionSourceCPE         VersionSource = "CPE_FIELD"
+	VersionSourceCPERange    VersionSource = "CPE_RANGE"
+	VersionSourceCPEString   VersionSource = "CPE_STRING"
 	VersionSourceDescription VersionSource = "DESCRIPTION"
 	VersionSourceText        VersionSource = "TEXT_EXTRACTION"
 	VersionSourceRefs        VersionSource = "REFERENCES"


### PR DESCRIPTION
Versions originating from CPE ranges vs the CPE match criteria string are of vastly different qualities. 

OSV favours ranges, whereas CPE strings usually represent a single affected version. Being able to differentiate between these two origins should help make better informed decisions in the combine-to-osv merging. 

New version sources constants: `CPE_RANGE` and `CPE_STRING` 
   - Version information extracted using NVD's explicit boundary fields (`VersionStartIncluding`, `VersionStartExcluding`, `VersionEndExcluding`, or `VersionEndIncluding`) is categorized under `CPE_RANGE`.
   - Versions extracted from the match criteria CPE string itself (`CPE.Version`) are categorized under `CPE_STRING`.

Refactored `ProcessRanges` in common.go now extracts and logs the actual, distinct sources of processed ranges dynamically rather than using the generic `"CPE_FIELD"` fallback parameter.