### PR TITLE
fix(?): more RAM, less CPU to build-and-stage

### DIFF
--- a/deployment/build-and-stage.yaml
+++ b/deployment/build-and-stage.yaml
@@ -490,7 +490,7 @@ timeout: 7200s
 serviceAccount: 'projects/oss-vdb/serviceAccounts/deployment@oss-vdb.iam.gserviceaccount.com'
 logsBucket: gs://oss-vdb-tf/apply-logs
 options:
-  machineType: E2_HIGHCPU_32
+  machineType: E2_STANDARD_16
 
 tags: ['build-and-stage']
 

--- a/deployment/build-and-stage.yaml
+++ b/deployment/build-and-stage.yaml
@@ -490,7 +490,8 @@ timeout: 7200s
 serviceAccount: 'projects/oss-vdb/serviceAccounts/deployment@oss-vdb.iam.gserviceaccount.com'
 logsBucket: gs://oss-vdb-tf/apply-logs
 options:
-  machineType: E2_STANDARD_16
+  pool:
+    name: 'projects/oss-vdb/locations/us-west1/workerPools/build-and-stage-pool'
 
 tags: ['build-and-stage']
 


### PR DESCRIPTION
`build-and-stage` has been flakily failing recently, for inscrutable reasons related to docker.
It might be because the machine is running out of memory, and killing the docker process.
Change the machine from e2-highcpu-32 (32 CPU, 32GB RAM) to e2-standard-16 (16 CPU, 64GB RAM) to see if it's less flaky this way.