### PR TITLE
fix: configure min replicas to 1 for new gke-workers

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/workers-cves.yaml
+++ b/deployment/clouddeploy/gke-workers/base/workers-cves.yaml
@@ -17,7 +17,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: pubsub-cves
 spec:
-  minReplicas: 0
+  minReplicas: 1
   maxReplicas: 100
   metrics:
   - external:
@@ -51,7 +51,7 @@ kind: Deployment
 metadata:
   name: workers-cves
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       name: workers-cves

--- a/deployment/clouddeploy/gke-workers/base/workers-reimport.yaml
+++ b/deployment/clouddeploy/gke-workers/base/workers-reimport.yaml
@@ -17,7 +17,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: pubsub-reimport
 spec:
-  minReplicas: 0
+  minReplicas: 1
   maxReplicas: 100
   metrics:
   - external:
@@ -51,7 +51,7 @@ kind: Deployment
 metadata:
   name: workers-reimport
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       name: workers-reimport


### PR DESCRIPTION
Update HorizontalPodAutoscaler minReplicas and Deployment replicas configurations from 0 to 1 for the new workers-cves and workers-reimport deployments. Because apparently it must be at least 1 :shrug: