### PR TITLE
fix(vulnfeeds): prevent false-positive HTTP 429 rate limit detections

### DIFF
--- a/vulnfeeds/conversion/common.go
+++ b/vulnfeeds/conversion/common.go
@@ -163,7 +163,7 @@ func GitVersionsToCommits(versionRanges []models.RangeWithMetadata, repos []stri
 		repo, err := git.FindCanonicalLink(repo, http.DefaultClient, cache)
 		if err != nil {
 			metrics.AddNote("Failed to find canonical link - %s %v", repo, err)
-			if errors.Is(err, git.ErrRateLimit) || strings.Contains(err.Error(), "429") {
+			if git.IsRateLimit(err) {
 				metrics.Outcome = models.Error
 				return nil, nil, nil
 			}
@@ -173,7 +173,7 @@ func GitVersionsToCommits(versionRanges []models.RangeWithMetadata, repos []stri
 
 		normalizedTags, err := git.NormalizeRepoTags(repo, cache)
 		if err != nil {
-			if errors.Is(err, git.ErrRateLimit) || strings.Contains(err.Error(), "429") {
+			if git.IsRateLimit(err) {
 				metrics.Outcome = models.Error
 				return nil, nil, nil
 			}

--- a/vulnfeeds/conversion/nvd/converter.go
+++ b/vulnfeeds/conversion/nvd/converter.go
@@ -96,7 +96,7 @@ func CVEToOSV(cve models.NVDCVE, repos []string, vpRepoCache *c.VPRepoCache, cac
 	commits, err := c.ExtractCommitsFromRefs(refs, http.DefaultClient, cache)
 	if err != nil {
 		metrics.AddNote("Failed to extract commits from refs: %v", err)
-		if errors.Is(err, git.ErrRateLimit) || strings.Contains(err.Error(), "429") {
+		if git.IsRateLimit(err) {
 			metrics.SetOutcome(models.Error)
 			return nil, metrics, models.Error
 		}

--- a/vulnfeeds/conversion/versions.go
+++ b/vulnfeeds/conversion/versions.go
@@ -532,7 +532,7 @@ func ExtractCommitsFromRefs(references []models.Reference, httpClient *http.Clie
 		// (Potentially faulty) Assumption: All viable Git commit reference links are fix commits.
 		ac, err := extractGitAffectedCommit(ref.URL, models.Fixed, httpClient, cache)
 		if err != nil {
-			if errors.Is(err, git.ErrRateLimit) || strings.Contains(err.Error(), "429") {
+			if git.IsRateLimit(err) {
 				return nil, err
 			}
 
@@ -1118,7 +1118,7 @@ func VersionInfoToCommits(v *models.VersionInfo, repos []string, cache git.RepoT
 	for _, repo := range repos {
 		normalizedTags, err := git.NormalizeRepoTags(repo, cache)
 		if err != nil {
-			if errors.Is(err, git.ErrRateLimit) || strings.Contains(err.Error(), "429") {
+			if git.IsRateLimit(err) {
 				metrics.Outcome = models.Error
 				return
 			}
@@ -1226,7 +1226,7 @@ func ReposFromReferences(cache *VPRepoCache, vp *VendorProduct, refs []models.Re
 		canonicalRepo, err := git.FindCanonicalLink(repo, httpClient, repoTagsCache)
 		if err == nil {
 			repo = canonicalRepo
-		} else if errors.Is(err, git.ErrRateLimit) || strings.Contains(err.Error(), "429") {
+		} else if git.IsRateLimit(err) {
 			metrics.Outcome = models.Error
 			return nil
 		}
@@ -1296,7 +1296,7 @@ func validateRepo(repo string, isCommit bool, cache git.RepoTagsCache) (bool, er
 		valid, err = git.ValidRepoAndHasUsableRefs(repo)
 	}
 	if !valid && cache != nil {
-		if err != nil && (errors.Is(err, git.ErrRateLimit) || strings.Contains(err.Error(), "429") || strings.Contains(err.Error(), "Too Many Requests")) {
+		if err != nil && git.IsRateLimit(err) {
 			cache.SetInvalidWithTTL(repo, 1*time.Hour)
 		} else {
 			cache.SetInvalid(repo)

--- a/vulnfeeds/git/repository.go
+++ b/vulnfeeds/git/repository.go
@@ -52,6 +52,21 @@ const (
 
 var ErrRateLimit = errors.New("rate limit exceeded")
 
+// IsRateLimit checks if the error represents an HTTP 429 Rate Limit / Too Many Requests error.
+func IsRateLimit(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrRateLimit) {
+		return true
+	}
+	errStr := err.Error()
+	return strings.Contains(errStr, "status code 429") ||
+		strings.Contains(errStr, "status 429") ||
+		strings.Contains(errStr, "Too Many Requests") ||
+		strings.Contains(errStr, "rate limit")
+}
+
 // A GitTag holds a Git tag and corresponding commit hash.
 type Tag struct {
 	Tag    string `json:"tag"`    // Git tag
@@ -380,7 +395,7 @@ func RemoteRepoRefsWithRetry(repoURL string, retries uint64) (refs []*plumbing.R
 			if errors.Is(err, context.DeadlineExceeded) {
 				return retry.RetryableError(err)
 			}
-			if strings.Contains(err.Error(), "429") || strings.Contains(err.Error(), "Too Many Requests") {
+			if strings.Contains(err.Error(), "status code 429") || strings.Contains(err.Error(), "status 429") || strings.Contains(err.Error(), "Too Many Requests") || strings.Contains(err.Error(), "rate limit") {
 				return ErrRateLimit
 			}
 
@@ -425,7 +440,7 @@ func RepoTags(repoURL string, repoTagsCache RepoTagsCache) (tags Tags, e error) 
 	refs, err := getRepoRefs(repoURL)
 	if err != nil {
 		if repoTagsCache != nil {
-			if errors.Is(err, ErrRateLimit) || strings.Contains(err.Error(), "429") || strings.Contains(err.Error(), "Too Many Requests") {
+			if IsRateLimit(err) {
 				repoTagsCache.SetInvalidWithTTL(repoURL, 1*time.Hour)
 			} else {
 				repoTagsCache.SetInvalid(repoURL)

--- a/vulnfeeds/git/repository.go
+++ b/vulnfeeds/git/repository.go
@@ -64,7 +64,12 @@ func IsRateLimit(err error) bool {
 	return strings.Contains(errStr, "status code 429") ||
 		strings.Contains(errStr, "status 429") ||
 		strings.Contains(errStr, "Too Many Requests") ||
-		strings.Contains(errStr, "rate limit")
+		strings.Contains(errStr, "rate limit") ||
+		strings.Contains(errStr, "response: 429") ||
+		strings.Contains(errStr, "code: 429") ||
+		strings.Contains(errStr, "status: 429") ||
+		strings.Contains(errStr, "HTTP 429") ||
+		strings.Contains(errStr, "http: 429")
 }
 
 // A GitTag holds a Git tag and corresponding commit hash.

--- a/vulnfeeds/git/repository.go
+++ b/vulnfeeds/git/repository.go
@@ -61,6 +61,7 @@ func IsRateLimit(err error) bool {
 		return true
 	}
 	errStr := err.Error()
+
 	return strings.Contains(errStr, "status code 429") ||
 		strings.Contains(errStr, "status 429") ||
 		strings.Contains(errStr, "Too Many Requests") ||


### PR DESCRIPTION
Fixes a false-positive rate limit bug where the conversion pipeline mistakenly treated normal errors as HTTP 429 (Too Many Requests) rate limits. 

The old code checked for a raw `"429"` substring inside error messages, which triggered false positives on unrelated commit hashes, issue IDs, or long URL lengths. We consolidated this into a robust `git.IsRateLimit` helper that specifically checks for HTTP status codes, headers, and rate-limit responses.
