### PR TITLE
Add source context to importer parse failures

### DIFF
--- a/gcp/workers/importer/importer.py
+++ b/gcp/workers/importer/importer.py
@@ -342,7 +342,8 @@ class Importer:
     vulns = osv.parse_vulnerabilities_from_data(
         blob_bytes,
         os.path.splitext(blob.name)[1],
-        strict=source_repo.strict_validation and self._strict_validation)
+        strict=source_repo.strict_validation and self._strict_validation,
+        source=blob.name)
     for vuln in vulns:
       vuln_ids.append(vuln.id)
     return vuln_ids
@@ -409,7 +410,8 @@ class Importer:
     vulns = osv.parse_vulnerabilities_from_data(
         blob_bytes,
         os.path.splitext(blob.name)[1],
-        strict=self._strict_validation)
+        strict=self._strict_validation,
+        source=blob.name)
 
     # TODO(andrewpollock): integrate with linter here.
 

--- a/gcp/workers/oss_fuzz_worker/worker.py
+++ b/gcp/workers/oss_fuzz_worker/worker.py
@@ -377,7 +377,8 @@ class TaskRunner:
         vulnerabilities = osv.parse_vulnerabilities_from_data(
             blob,
             extension=os.path.splitext(path)[1],
-            key_path=source_repo.key_path)
+            key_path=source_repo.key_path,
+            source=path)
       except Exception:
         logging.exception('Failed to parse vulnerability %s', path)
         return

--- a/gcp/workers/worker/worker.py
+++ b/gcp/workers/worker/worker.py
@@ -341,7 +341,8 @@ class TaskRunner:
         vulnerabilities = osv.parse_vulnerabilities_from_data(
             blob,
             extension=os.path.splitext(path)[1],
-            key_path=source_repo.key_path)
+            key_path=source_repo.key_path,
+            source=path)
       except Exception:
         logging.exception('Failed to parse vulnerability %s', path)
         return

--- a/osv/sources.py
+++ b/osv/sources.py
@@ -147,14 +147,31 @@ def parse_vulnerabilities_from_data(
     data_text: str | bytes,
     extension: str,
     key_path=None,
-    strict=False) -> list[vulnerability_pb2.Vulnerability]:
-  """Parse vulnerabilities from data."""
-  if extension in YAML_EXTENSIONS:
-    data = yaml.load(data_text, Loader=NoDatesSafeLoader)
-  elif extension in JSON_EXTENSIONS:
-    data = json.loads(data_text)
-  else:
-    raise RuntimeError('Unknown format ' + extension)
+    strict=False,
+    source: str | None = None) -> list[vulnerability_pb2.Vulnerability]:
+  """Parse vulnerabilities from data.
+
+  Args:
+    data_text: the raw record content to parse.
+    extension: the file extension, used to pick the parser.
+    key_path: optional nested key path to the vulnerability.
+    strict: whether to reraise schema validation errors.
+    source: optional identifier (e.g. the record's filename or source name)
+      used to add context to parse failures, so a malformed record can be
+      traced back to its origin.
+  """
+  try:
+    if extension in YAML_EXTENSIONS:
+      data = yaml.load(data_text, Loader=NoDatesSafeLoader)
+    elif extension in JSON_EXTENSIONS:
+      data = json.loads(data_text)
+    else:
+      raise RuntimeError('Unknown format ' + extension)
+  except Exception as e:
+    if source:
+      raise RuntimeError(
+          f'Failed to parse vulnerability data from {source}: {e}') from e
+    raise
 
   return _parse_vulnerabilities(data, key_path, strict)
 

--- a/osv/sources_test.py
+++ b/osv/sources_test.py
@@ -1,0 +1,61 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""sources tests."""
+
+import json
+import unittest
+
+from . import sources
+
+
+class ParseVulnerabilitiesFromDataTest(unittest.TestCase):
+  """Tests for parse_vulnerabilities_from_data."""
+
+  def test_malformed_json_includes_source_context(self):
+    """A malformed JSON record names its source in the raised error."""
+    source = 'gs://osv-test/CVE-2024-0001.json'
+    with self.assertRaises(RuntimeError) as ctx:
+      sources.parse_vulnerabilities_from_data(
+          b'this is not json', '.json', source=source)
+
+    # The raised error must identify which record failed.
+    self.assertIn(source, str(ctx.exception))
+    # The original decode error is preserved as the cause.
+    self.assertIsInstance(ctx.exception.__cause__, json.JSONDecodeError)
+
+  def test_malformed_yaml_includes_source_context(self):
+    """A malformed YAML record names its source in the raised error."""
+    source = 'gs://osv-test/CVE-2024-0002.yaml'
+    with self.assertRaises(RuntimeError) as ctx:
+      sources.parse_vulnerabilities_from_data(
+          b'id: [unterminated', '.yaml', source=source)
+
+    self.assertIn(source, str(ctx.exception))
+
+  def test_malformed_json_without_source_is_unchanged(self):
+    """Without a source the original parse error is raised unchanged."""
+    with self.assertRaises(json.JSONDecodeError):
+      sources.parse_vulnerabilities_from_data(b'this is not json', '.json')
+
+  def test_unknown_extension_with_source_includes_context(self):
+    """An unknown extension surfaces its source when one is provided."""
+    source = 'gs://osv-test/record.txt'
+    with self.assertRaises(RuntimeError) as ctx:
+      sources.parse_vulnerabilities_from_data(b'data', '.txt', source=source)
+
+    self.assertIn(source, str(ctx.exception))
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Fixes #3518

When the importer fails to parse a vulnerability record, the only thing
that surfaces is the underlying decode message with no indication of
which record was at fault. The example from the issue:

```
Expecting value: line 1 column 1 (char 0)
...
  File "/env/osv/sources.py", line 146, in parse_vulnerabilities_from_data
    data = json.loads(data_text)
...
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

There is no filename or source in that output, so a single bad record
is hard to trace back to its origin.

## Change

`parse_vulnerabilities_from_data()` (the function the traceback bottoms
out in) gets an optional `source` argument. The YAML/JSON parse is
wrapped so that, when a `source` is provided and parsing fails, the
error is re-raised as a `RuntimeError` naming the source, with the
original exception preserved as `__cause__`. The failure is still
fatal and surfaced, just better-contextualized. When no `source` is
passed the behaviour is unchanged, so existing callers are unaffected.

The Python importer and worker call sites pass the blob name / path as
the source:

- `gcp/workers/importer/importer.py` (the two real import paths)
- `gcp/workers/worker/worker.py`
- `gcp/workers/oss_fuzz_worker/worker.py`

The identifier-inference call site in `importer.py` that deliberately
swallows exceptions is left untouched.

Scope note: per the discussion on the earlier attempt (#4546), the
importer has largely moved to Go and only the Python worker / shared
`osv` library parts apply, which is what this change targets. It fixes
the central `osv/sources.py` parse path the issue points at rather than
every downstream caller.

## Before vs after

Before (no record context):

```
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

After (source named, original error preserved):

```
RuntimeError: Failed to parse vulnerability data from
gs://osv-test/CVE-2024-0001.json: Expecting value: line 1 column 1 (char 0)
```

## Tests

Added `osv/sources_test.py` covering:

- malformed JSON with `source` -> `RuntimeError` whose message contains
  the source and whose `__cause__` is the original `JSONDecodeError`
- malformed YAML with `source` -> message contains the source
- malformed JSON without `source` -> original `JSONDecodeError` raised
  unchanged (backwards compatibility)
- unknown extension with `source` -> source surfaced

```
$ python -m pytest osv/sources_test.py -q
....
4 passed
```

Regression-checked by reverting `osv/sources.py`: three of the four
tests fail without the fix, confirming they exercise it.
