### PR TITLE
fix(ui): improve light-theme component rendering

### DIFF
--- a/gcp/website/frontend3/src/styles.scss
+++ b/gcp/website/frontend3/src/styles.scss
@@ -5,6 +5,7 @@
 @use '@material/data-table/data-table-theme';
 
 :root {
+  color-scheme: dark;
   --osv-bg: #292929;
   --osv-text: #fff;
   --osv-grey-100: #f8f9fa;
@@ -30,6 +31,7 @@
 }
 
 :root[data-theme="light"] {
+  color-scheme: light;
   --osv-bg: #f5f3f4;
   --osv-text: #161A1D;
   --osv-grey-100: #202124;
@@ -156,6 +158,7 @@ body {
   height: 100%;
   scroll-behavior: smooth;
   font-size: 14px;
+  background: $osv-background;
 }
 
 ol,
@@ -179,7 +182,6 @@ table {
 /** Global styles */
 
 body {
-  background: $osv-background;
   color: $osv-text-color;
   font-family: $osv-body-font-family;
   --mdc-theme-primary: #{$osv-text-color};
@@ -309,7 +311,7 @@ pre {
 
   &.severity-invalid {
     background: $osv-grey-800;
-    color: white;
+    color: $osv-text-color;
   }
 }
 
@@ -775,7 +777,7 @@ md-icon-button.mdc-data-table__sort-icon-button {
 
   turbo-frame[busy] .next-page-indicator {
     display: block;
-    --md-circular-progress-active-indicator-color: white;
+    --md-circular-progress-active-indicator-color: #{$osv-text-color};
     --md-circular-progress-size: 36px;
   }
 


### PR DESCRIPTION
Fixes some light-theme specific quirks:

On chromium-based browsers, scrollbar always rendered in dark styling, because the `color-scheme` property was missing, additionally the `$osv-background` was not visible. 

Before/After:
<img width="1704" height="520" alt="home_before" src="https://github.com/user-attachments/assets/74bfeb1c-9dc9-44f6-9165-c98f1869fc30" />
<img width="1704" height="588" alt="home_after" src="https://github.com/user-attachments/assets/78cf61b2-b1e5-4f03-a8b3-370751d636ba" />

---

The "Load More" spinner on the list page had a white color making it invisible on light mode so that was fixed too by setting it to `$osv-text-color` instead:

<img width="1700" height="462" alt="spinner_light" src="https://github.com/user-attachments/assets/2383de41-b6ba-4771-a0dc-39858b3bc065" />
 
---

Finally, non-CVSS severity chips had poor contrast on light mode, showing white text on a very light gray background (osv-grey-800):
<img width="944" height="248" alt="ubuntu_before" src="https://github.com/user-attachments/assets/84c2f06c-fb15-4ecf-a803-adf50691786b" />

Fixed by updating the text color:
<img width="1274" height="318" alt="ubuntu_after" src="https://github.com/user-attachments/assets/92081939-ab03-4ede-9a41-6431f47949a6" />
