### PR TITLE
chore: tweak test instance worker gke pools

### DIFF
--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/workers.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/workers.yaml
@@ -20,8 +20,8 @@ spec:
             value: osv-test-vulnerabilities
         resources:
           requests:
-            cpu: 14
-            memory: "10G"
+            cpu: "0.9"
+            memory: "1.2Gi"
           limits:
-            cpu: 16
-            memory: "13G"
+            cpu: "1.5"
+            memory: "1.3Gi"

--- a/deployment/terraform/modules/osv/workers_gke.tf
+++ b/deployment/terraform/modules/osv/workers_gke.tf
@@ -180,7 +180,7 @@ resource "google_container_node_pool" "worker_pool_temp" {
   }
 
   node_config {
-    machine_type = "n2-highcpu-16"
+    machine_type = "n4-highcpu-2"
 
     oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
 

--- a/deployment/terraform/modules/osv/workers_gke.tf
+++ b/deployment/terraform/modules/osv/workers_gke.tf
@@ -165,7 +165,6 @@ resource "google_container_node_pool" "worker_pool_temp" {
   name       = "worker-pool-temp"
   cluster    = google_container_cluster.workers.name
   location   = google_container_cluster.workers.location
-  node_count = 1
 
   lifecycle {
     replace_triggered_by = [

--- a/deployment/terraform/modules/osv/workers_gke.tf
+++ b/deployment/terraform/modules/osv/workers_gke.tf
@@ -160,11 +160,11 @@ resource "google_container_node_pool" "importer_pool" {
 }
 
 resource "google_container_node_pool" "worker_pool_temp" {
-  count      = var.project_id == "oss-vdb-test" ? 1 : 0
-  project    = var.project_id
-  name       = "worker-pool-temp"
-  cluster    = google_container_cluster.workers.name
-  location   = google_container_cluster.workers.location
+  count    = var.project_id == "oss-vdb-test" ? 1 : 0
+  project  = var.project_id
+  name     = "worker-pool-temp"
+  cluster  = google_container_cluster.workers.name
+  location = google_container_cluster.workers.location
 
   lifecycle {
     replace_triggered_by = [


### PR DESCRIPTION
These are the request/limits I used on the CVE/reimport workers.
Two worker instances should be able to fit on one n4-highcpu-2, which is nice.
I'm not 100% sure if this is enough memory for every record. I might ~double it and use n4-standard-2 machines instead if there are problems.