### PR TITLE
refactor(go api): determine version, import findings, health checks

### DIFF
--- a/go/cmd/api-devserver/main.go
+++ b/go/cmd/api-devserver/main.go
@@ -202,12 +202,14 @@ func runBackend(ctx context.Context, port int) {
 	})
 	relationsStore := db.NewRelationsStore(dbClient)
 	importFindingsStore := db.NewImportFindingsStore(dbClient, nil, "", "")
+	repoIndexStore := db.NewRepoIndexStore(dbClient)
 	if err := api.RunServer(ctx, api.ServerOptions{
 		Port:                port,
 		VerboseLogs:         true,
 		VulnStore:           vulnStore,
 		RelationsStore:      relationsStore,
 		ImportFindingsStore: importFindingsStore,
+		RepoIndexStore:      repoIndexStore,
 	}); err != nil {
 		logger.ErrorContext(ctx, "Go API server exited", "error", err)
 	}

--- a/go/cmd/api-devserver/main.go
+++ b/go/cmd/api-devserver/main.go
@@ -201,11 +201,13 @@ func runBackend(ctx context.Context, port int) {
 		BatchMaxElements: batchMaxElements,
 	})
 	relationsStore := db.NewRelationsStore(dbClient)
+	importFindingsStore := db.NewImportFindingsStore(dbClient, nil, "", "")
 	if err := api.RunServer(ctx, api.ServerOptions{
-		Port:           port,
-		VerboseLogs:    true,
-		VulnStore:      vulnStore,
-		RelationsStore: relationsStore,
+		Port:                port,
+		VerboseLogs:         true,
+		VulnStore:           vulnStore,
+		RelationsStore:      relationsStore,
+		ImportFindingsStore: importFindingsStore,
 	}); err != nil {
 		logger.ErrorContext(ctx, "Go API server exited", "error", err)
 	}

--- a/go/cmd/api/main.go
+++ b/go/cmd/api/main.go
@@ -91,7 +91,7 @@ func run() error {
 		BatchMaxElements: batchMaxElements,
 	})
 	relationsStore := db.NewRelationsStore(dbClient)
-
+	importFindingsStore := db.NewImportFindingsStore(dbClient, nil, "", "") // The API does not need to talk to GCS, so we can ignore those fields.
 	verboseLogs := strings.EqualFold(os.Getenv("OSV_VERBOSE_LOGGING"), "true")
 
 	var recovererPublisher clients.Publisher
@@ -107,10 +107,11 @@ func run() error {
 	}
 
 	return api.RunServer(ctx, api.ServerOptions{
-		Port:               *port,
-		VerboseLogs:        verboseLogs,
-		VulnStore:          vulnStore,
-		RelationsStore:     relationsStore,
-		RecovererPublisher: recovererPublisher,
+		Port:                *port,
+		VerboseLogs:         verboseLogs,
+		VulnStore:           vulnStore,
+		RelationsStore:      relationsStore,
+		ImportFindingsStore: importFindingsStore,
+		RecovererPublisher:  recovererPublisher,
 	})
 }

--- a/go/cmd/api/main.go
+++ b/go/cmd/api/main.go
@@ -92,6 +92,7 @@ func run() error {
 	})
 	relationsStore := db.NewRelationsStore(dbClient)
 	importFindingsStore := db.NewImportFindingsStore(dbClient, nil, "", "") // The API does not need to talk to GCS, so we can ignore those fields.
+	repoIndexStore := db.NewRepoIndexStore(dbClient)
 	verboseLogs := strings.EqualFold(os.Getenv("OSV_VERBOSE_LOGGING"), "true")
 
 	var recovererPublisher clients.Publisher
@@ -112,6 +113,7 @@ func run() error {
 		VulnStore:           vulnStore,
 		RelationsStore:      relationsStore,
 		ImportFindingsStore: importFindingsStore,
+		RepoIndexStore:      repoIndexStore,
 		RecovererPublisher:  recovererPublisher,
 	})
 }

--- a/go/internal/api/determine_version.go
+++ b/go/internal/api/determine_version.go
@@ -1,0 +1,1 @@
+package api

--- a/go/internal/api/determine_version.go
+++ b/go/internal/api/determine_version.go
@@ -1,1 +1,344 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package api
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+
+	"crypto/md5" //nolint:gosec // indexer uses md5 to hash files
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"math"
+	"math/bits"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/google/osv.dev/go/internal/models"
+	"github.com/google/osv.dev/go/logger"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	pb "osv.dev/bindings/go/api"
+)
+
+const (
+	bucketSize                     = 512
+	minScoreCutoff                 = 0.05
+	maxDetermineVerResultsToReturn = 10
+	// maxCandidatesToFetch is the number of candidate RepoIndexes we fetch and score.
+	// Python limited this to 10, which caused it to arbitrarily discard good matches in
+	// tie cases (e.g. many repos with 1 match). We use 100 to resolve these ties and
+	// ensure accuracy while keeping Datastore read costs low.
+	maxCandidatesToFetch = 100
+	tagPrefix            = "refs/tags/"
+)
+
+var vendoredLibNames = map[string]struct{}{
+	"3rdparty":    {},
+	"dep":         {},
+	"deps":        {},
+	"thirdparty":  {},
+	"third-party": {},
+	"third_party": {},
+	"libs":        {},
+	"external":    {},
+	"externals":   {},
+	"vendor":      {},
+	"vendored":    {},
+}
+
+func shouldSkipBucket(path string) bool {
+	if path == "" {
+		return false
+	}
+	components := strings.Split(path, "/")
+	for _, c := range components {
+		if _, ok := vendoredLibNames[strings.ToLower(c)]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// processBuckets creates buckets in the same process as the indexer.
+func processBuckets(fileHashes []*pb.FileHash) ([]*models.RepoIndexBucket, error) {
+	buckets := make([][][]byte, bucketSize)
+
+	for _, fh := range fileHashes {
+		if len(fh.GetHash()) < 2 {
+			continue
+		}
+		if shouldSkipBucket(fh.GetFilePath()) {
+			continue
+		}
+
+		idx := binary.BigEndian.Uint16(fh.GetHash()[0:2]) % bucketSize
+		buckets[idx] = append(buckets[idx], fh.GetHash())
+	}
+
+	results := make([]*models.RepoIndexBucket, bucketSize)
+	for i := range bucketSize {
+		bucket := buckets[i]
+		// Sort hashes lexicographically to produce deterministic bucket hashes
+		slices.SortFunc(bucket, bytes.Compare)
+
+		hasher := md5.New() //nolint:gosec
+		for _, h := range bucket {
+			_, err := hasher.Write(h)
+			if err != nil {
+				return nil, fmt.Errorf("failed to write hash to hasher: %w", err)
+			}
+		}
+
+		results[i] = &models.RepoIndexBucket{
+			NodeHash:       hasher.Sum(nil),
+			FilesContained: len(bucket),
+		}
+	}
+
+	return results, nil
+}
+
+func estimateDiff(numBucketChange int, fileCountDiff int) int {
+	// Guard against potential out-of-bound values to prevent Log(<=0) or NaN
+	if numBucketChange < 0 {
+		numBucketChange = 0
+	}
+	if numBucketChange >= bucketSize {
+		numBucketChange = bucketSize - 1
+	}
+	estimate := float64(bucketSize) * math.Log(float64(bucketSize+1)/float64(bucketSize-numBucketChange+1))
+
+	// Use RoundToEven to match Python's round() behavior for 0.5,
+	// ensuring identical score calculations and preventing filtering discrepancies.
+	return fileCountDiff + int(math.RoundToEven(math.Max(estimate-float64(fileCountDiff), 0)/2))
+}
+
+var candidateRegex = regexp.MustCompile(`(?i:\d+|rc\d*|alpha\d*|beta\d*|preview\d*)`)
+var isWordChar = regexp.MustCompile(`(?i)^[a-z]$`)
+
+func normalizeTag(v string) string {
+	if strings.HasPrefix(v, ".") {
+		v = "0" + v
+	}
+	matches := candidateRegex.FindAllStringIndex(v, -1)
+	if len(matches) == 0 {
+		return v
+	}
+	components := make([]string, 0, len(matches))
+	for _, loc := range matches {
+		start, end := loc[0], loc[1]
+		matchStr := v[start:end]
+
+		firstChar := strings.ToLower(matchStr[:1])
+		if firstChar >= "a" && firstChar <= "z" {
+			if start > 0 {
+				prevChar := v[start-1 : start]
+				if isWordChar.MatchString(prevChar) {
+					continue
+				}
+			}
+		}
+		components = append(components, matchStr)
+	}
+	if len(components) == 0 {
+		return v
+	}
+
+	return strings.Join(components, "-")
+}
+
+func (s *server) DetermineVersion(ctx context.Context, req *pb.DetermineVersionParameters) (*pb.VersionMatchList, error) {
+	query := req.GetQuery()
+	if query == nil {
+		return &pb.VersionMatchList{}, nil
+	}
+
+	logger.InfoContext(ctx, "DetermineVersion called", "hashes_count", len(query.GetFileHashes()))
+
+	// Filter and prepare file hashes
+	var validHashes []*pb.FileHash
+	for _, fh := range query.GetFileHashes() {
+		if fh.Hash != nil && len(fh.GetHash()) <= 100 {
+			validHashes = append(validHashes, fh)
+		}
+	}
+
+	buckets, err := processBuckets(validHashes)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to process buckets", slog.Any("error", err))
+		return nil, status.Error(codes.Internal, "failed to process buckets")
+	}
+
+	nodeHashes := make([][]byte, 0, len(buckets))
+	nonEmtpyBucketIndices := make([]int, 0, len(buckets))
+	var emptyBucketBitmap [bucketSize / 8]byte // 64 bytes for 512 bits
+
+	for i, b := range buckets {
+		if b.FilesContained == 0 {
+			continue
+		}
+		nodeHashes = append(nodeHashes, b.NodeHash)
+		nonEmtpyBucketIndices = append(nonEmtpyBucketIndices, i)
+
+		// Set bit in emptyBucketBitmap (little-endian byte order bit allocation)
+		emptyBucketBitmap[i/8] |= 1 << (i % 8)
+	}
+
+	// Query Datastore via repository
+	matchedBucketsByHash, err := s.repoIndexStore.QueryBuckets(ctx, nodeHashes)
+	if err != nil {
+		logger.ErrorContext(ctx, "Failed to query RepoIndexBuckets", "error", err)
+		return nil, status.Error(codes.Internal, "failed to query repo index buckets")
+	}
+
+	fileMatchCount := make(map[string]int)
+	bucketMatchCount := make(map[string]int)
+	numSkippedBuckets := 0
+	skippedFiles := 0
+
+	// We need to keep track of which parent IDs we've seen
+	parentIDsSet := make(map[string]struct{})
+
+	for _, idx := range nonEmtpyBucketIndices {
+		b := buckets[idx]
+		hexHash := hex.EncodeToString(b.NodeHash)
+		matches := matchedBucketsByHash[hexHash]
+
+		if len(matches) == models.MaxMatchesToCare {
+			numSkippedBuckets++
+			skippedFiles += b.FilesContained
+
+			continue
+		}
+
+		for _, match := range matches {
+			if match.ParentID == "" {
+				continue
+			}
+			parentIDsSet[match.ParentID] = struct{}{}
+			fileMatchCount[match.ParentID] += match.FilesContained
+			bucketMatchCount[match.ParentID]++
+		}
+	}
+
+	// Add skipped files back to the match count of all seen parent IDs
+	for parentID := range parentIDsSet {
+		fileMatchCount[parentID] += skippedFiles
+	}
+
+	// Sort parent IDs by bucket match count descending, and limit to maxDetermineVerResultsToReturn
+	parentIDs := make([]string, 0, len(parentIDsSet))
+	for id := range parentIDsSet {
+		parentIDs = append(parentIDs, id)
+	}
+	slices.SortFunc(parentIDs, func(a, b string) int {
+		return -cmp.Compare(bucketMatchCount[a], bucketMatchCount[b])
+	})
+
+	if len(parentIDs) > maxCandidatesToFetch {
+		parentIDs = parentIDs[:maxCandidatesToFetch]
+	}
+
+	repoIndexes, err := s.repoIndexStore.GetRepoIndexes(ctx, parentIDs)
+	if err != nil {
+		logger.ErrorContext(ctx, "Failed to get RepoIndexes", "error", err)
+		return nil, status.Error(codes.Internal, "failed to get repo indexes")
+	}
+
+	matches := make([]*pb.VersionMatch, 0, len(repoIndexes))
+	queryFileCount := len(query.GetFileHashes())
+
+	// Inverted empty bucket bitmap of the query
+	// (bitwise NOT on the query bitmap, meaning 1 represents empty in query)
+	var invertedEmptyBucketBitmap [bucketSize / 8]byte
+	for i := range emptyBucketBitmap {
+		invertedEmptyBucketBitmap[i] = ^emptyBucketBitmap[i]
+	}
+
+	for _, idx := range repoIndexes {
+		if idx == nil || len(idx.EmptyBucketBitmap) < bucketSize/8 {
+			continue
+		}
+
+		// Calculate missed empty buckets
+		// We are looking to find cases where the bitmap generated by the user query
+		// gives a 0 (meaning empty in query, so 1 in invertedEmptyBucketBitmap),
+		// but the bitmap of the repo is a 1 (meaning non-empty in repo).
+		missedEmptyBuckets := 0
+		for i := range bucketSize / 8 {
+			// bitwise AND of inverted query bitmap and repo bitmap
+			missed := invertedEmptyBucketBitmap[i] & idx.EmptyBucketBitmap[i]
+			missedEmptyBuckets += bits.OnesCount8(missed)
+		}
+
+		// Count empty buckets in user query
+		emptyBucketCount := 0
+		for i := range bucketSize / 8 {
+			emptyBucketCount += bits.OnesCount8(invertedEmptyBucketBitmap[i])
+		}
+
+		numBucketChange := bucketSize - bucketMatchCount[idx.ID] - emptyBucketCount + missedEmptyBuckets - numSkippedBuckets
+		fileCountDiff := int(math.Abs(float64(idx.FileCount - queryFileCount)))
+
+		estimatedDiffFiles := estimateDiff(numBucketChange, fileCountDiff)
+		maxFiles := int(math.Max(float64(idx.FileCount), float64(queryFileCount)))
+		if maxFiles == 0 {
+			continue
+		}
+
+		score := float64(maxFiles-estimatedDiffFiles) / float64(maxFiles)
+		if score < minScoreCutoff {
+			continue
+		}
+
+		version := normalizeTag(strings.TrimPrefix(idx.Tag, tagPrefix))
+		version = strings.ReplaceAll(version, "-", ".")
+
+		if version == "" {
+			continue
+		}
+
+		matches = append(matches, &pb.VersionMatch{
+			Score:              score,
+			MinimumFileMatches: int64(fileMatchCount[idx.ID]),
+			EstimatedDiffFiles: int64(estimatedDiffFiles),
+			RepoInfo: &pb.VersionRepositoryInformation{
+				Type:    pb.VersionRepositoryInformation_GIT,
+				Address: idx.RepoAddr,
+				Commit:  hex.EncodeToString(idx.Commit),
+				Tag:     strings.TrimPrefix(idx.Tag, tagPrefix),
+				Version: version,
+			},
+		})
+	}
+
+	// Sort matches descending by score
+	slices.SortFunc(matches, func(a, b *pb.VersionMatch) int {
+		return -cmp.Compare(a.GetScore(), b.GetScore())
+	})
+
+	// Limit results
+	if len(matches) > maxDetermineVerResultsToReturn {
+		matches = matches[:maxDetermineVerResultsToReturn]
+	}
+
+	return &pb.VersionMatchList{Matches: matches}, nil
+}

--- a/go/internal/api/determine_version_test.go
+++ b/go/internal/api/determine_version_test.go
@@ -1,0 +1,215 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"crypto/md5" //nolint:gosec
+	"encoding/hex"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/osv.dev/go/internal/models"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	pb "osv.dev/bindings/go/api"
+)
+
+type mockRepoIndexStore struct {
+	buckets  map[string][]*models.RepoIndexBucket
+	indexes  map[string]*models.RepoIndex
+	queryErr error
+	getErr   error
+}
+
+func (m *mockRepoIndexStore) QueryBuckets(_ context.Context, nodeHashes [][]byte) (map[string][]*models.RepoIndexBucket, error) {
+	if m.queryErr != nil {
+		return nil, m.queryErr
+	}
+	res := make(map[string][]*models.RepoIndexBucket)
+	for _, hash := range nodeHashes {
+		hexHash := hex.EncodeToString(hash)
+		if buckets, ok := m.buckets[hexHash]; ok {
+			res[hexHash] = buckets
+		} else {
+			res[hexHash] = nil
+		}
+	}
+
+	return res, nil
+}
+
+func (m *mockRepoIndexStore) GetRepoIndexes(_ context.Context, ids []string) ([]*models.RepoIndex, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	var res []*models.RepoIndex
+	for _, id := range ids {
+		if idx, ok := m.indexes[id]; ok {
+			res = append(res, idx)
+		} else {
+			res = append(res, nil)
+		}
+	}
+
+	return res, nil
+}
+
+func TestDetermineVersion(t *testing.T) {
+	ctx := context.Background()
+
+	// Helper to calculate MD5 of a single hash (the bucket hash for single-item buckets)
+	hash1 := []byte{0, 1}
+	hash2 := []byte{0, 2}
+	md5_1 := md5.Sum(hash1) //nolint:gosec
+	md5_2 := md5.Sum(hash2) //nolint:gosec
+
+	// Perfect match bitmap: Bucket 1 and Bucket 2 are non-empty
+	// (bit 1 and bit 2 of byte 0 are set: 1<<1 | 1<<2 = 2 | 4 = 6)
+	perfectBitmap := make([]byte, 64)
+	perfectBitmap[0] = 6
+
+	tests := []struct {
+		name         string
+		query        *pb.VersionQuery
+		mockBuckets  map[string][]*models.RepoIndexBucket
+		mockIndexes  map[string]*models.RepoIndex
+		mockQueryErr error
+		mockGetErr   error
+		want         *pb.VersionMatchList
+		wantErr      bool
+	}{
+		{
+			name:  "Empty Query",
+			query: &pb.VersionQuery{},
+			want:  &pb.VersionMatchList{Matches: nil},
+		},
+		{
+			name: "Perfect Match",
+			query: &pb.VersionQuery{
+				Name: "test-lib",
+				FileHashes: []*pb.FileHash{
+					{FilePath: "file1.txt", Hash: hash1},
+					{FilePath: "file2.txt", Hash: hash2},
+				},
+			},
+			mockBuckets: map[string][]*models.RepoIndexBucket{
+				hex.EncodeToString(md5_1[:]): {
+					{ParentID: "test-repo-v1.0.0", NodeHash: md5_1[:], FilesContained: 1},
+				},
+				hex.EncodeToString(md5_2[:]): {
+					{ParentID: "test-repo-v1.0.0", NodeHash: md5_2[:], FilesContained: 1},
+				},
+			},
+			mockIndexes: map[string]*models.RepoIndex{
+				"test-repo-v1.0.0": {
+					ID:                "test-repo-v1.0.0",
+					Name:              "test-lib",
+					RepoAddr:          "https://github.com/test/lib",
+					Tag:               "refs/tags/v1.0.0",
+					Commit:            []byte{0xde, 0xad, 0xbe, 0xef},
+					FileCount:         2,
+					EmptyBucketBitmap: perfectBitmap,
+				},
+			},
+			want: &pb.VersionMatchList{
+				Matches: []*pb.VersionMatch{
+					{
+						Score:              1.0,
+						MinimumFileMatches: 2,
+						EstimatedDiffFiles: 0,
+						RepoInfo: &pb.VersionRepositoryInformation{
+							Type:    pb.VersionRepositoryInformation_GIT,
+							Address: "https://github.com/test/lib",
+							Commit:  "deadbeef",
+							Tag:     "v1.0.0",
+							Version: "1.0.0",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Partial Match (Missed File)",
+			query: &pb.VersionQuery{
+				Name: "test-lib",
+				FileHashes: []*pb.FileHash{
+					{FilePath: "file1.txt", Hash: hash1},
+				},
+			},
+			mockBuckets: map[string][]*models.RepoIndexBucket{
+				hex.EncodeToString(md5_1[:]): {
+					{ParentID: "test-repo-v1.0.0", NodeHash: md5_1[:], FilesContained: 1},
+				},
+			},
+			mockIndexes: map[string]*models.RepoIndex{
+				"test-repo-v1.0.0": {
+					ID:                "test-repo-v1.0.0",
+					Name:              "test-lib",
+					RepoAddr:          "https://github.com/test/lib",
+					Tag:               "refs/tags/v1.0.0",
+					Commit:            []byte{0xde, 0xad, 0xbe, 0xef},
+					FileCount:         2,
+					EmptyBucketBitmap: perfectBitmap,
+				},
+			},
+			// The query only has 1 file, but the repo has 2.
+			// Bitmap for query: only bucket 1 is non-empty (bitmap = [2, 0, ..., 0]).
+			// Missed empty buckets (repo non-empty but query empty): Bucket 2 is empty in query but non-empty in repo (missed = 1).
+			// Score will be lower than 1.0.
+			want: &pb.VersionMatchList{
+				Matches: []*pb.VersionMatch{
+					{
+						Score:              0.5, // 1 match out of 2 max files
+						MinimumFileMatches: 1,
+						EstimatedDiffFiles: 1,
+						RepoInfo: &pb.VersionRepositoryInformation{
+							Type:    pb.VersionRepositoryInformation_GIT,
+							Address: "https://github.com/test/lib",
+							Commit:  "deadbeef",
+							Tag:     "v1.0.0",
+							Version: "1.0.0",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &server{
+				repoIndexStore: &mockRepoIndexStore{
+					buckets:  tt.mockBuckets,
+					indexes:  tt.mockIndexes,
+					queryErr: tt.mockQueryErr,
+					getErr:   tt.mockGetErr,
+				},
+			}
+
+			got, err := s.DetermineVersion(ctx, &pb.DetermineVersionParameters{Query: tt.query})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("DetermineVersion() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tt.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("DetermineVersion() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/go/internal/api/import_finding.go
+++ b/go/internal/api/import_finding.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"math"
+
+	"github.com/google/osv.dev/go/logger"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	pb "osv.dev/bindings/go/api"
+)
+
+func (s *server) ImportFindings(ctx context.Context, params *pb.ImportFindingsParameters) (*pb.ImportFindingList, error) {
+	source := params.GetSource()
+	if source == "" {
+		return nil, status.Error(codes.InvalidArgument, "source is required")
+	}
+	if s.verboseLogs {
+		logger.InfoContext(ctx, "checking import findings", slog.String("source", source))
+	}
+	findings, err := s.importFindingsStore.ListAllFromSource(ctx, source)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to list import findings: %v", err)
+	}
+
+	result := new(pb.ImportFindingList)
+	result.InvalidRecords = make([]*pb.ImportFinding, 0, len(findings))
+	for _, finding := range findings {
+		protoRecord := &pb.ImportFinding{
+			BugId:       finding.BugID,
+			Source:      finding.Source,
+			FirstSeen:   timestamppb.New(finding.FirstSeen),
+			LastAttempt: timestamppb.New(finding.LastAttempt),
+			Findings:    make([]pb.ImportFindingType, len(finding.Findings)),
+		}
+		for i, f := range finding.Findings {
+			if f > math.MaxInt32 || f < math.MinInt32 {
+				f = -1
+			}
+			//nolint:gosec // G115: f is checked to be within int32 range above
+			protoRecord.Findings[i] = pb.ImportFindingType(f)
+		}
+		result.InvalidRecords = append(result.InvalidRecords, protoRecord)
+	}
+
+	return result, nil
+}

--- a/go/internal/api/server.go
+++ b/go/internal/api/server.go
@@ -11,6 +11,8 @@ import (
 	"github.com/google/osv.dev/go/logger"
 	"github.com/google/osv.dev/go/osv/clients"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 	pb "osv.dev/bindings/go/api"
 )
 
@@ -19,9 +21,11 @@ type server struct {
 
 	verboseLogs bool
 
-	vulnStore          models.VulnerabilityStore
-	relationsStore     models.RelationsStore
-	recovererPublisher clients.Publisher
+	vulnStore           models.VulnerabilityStore
+	relationsStore      models.RelationsStore
+	importFindingsStore models.ImportFindingsStore
+	recovererPublisher  clients.Publisher
+
 	singleQueryTimeout time.Duration
 	batchQueryTimeout  time.Duration
 	responseSizeLimit  int64
@@ -31,10 +35,11 @@ type ServerOptions struct {
 	Port int
 	// VerboseLogs controls whether to log verbose information,
 	// including per-request data.
-	VerboseLogs        bool
-	VulnStore          models.VulnerabilityStore
-	RelationsStore     models.RelationsStore
-	RecovererPublisher clients.Publisher
+	VerboseLogs         bool
+	VulnStore           models.VulnerabilityStore
+	RelationsStore      models.RelationsStore
+	ImportFindingsStore models.ImportFindingsStore
+	RecovererPublisher  clients.Publisher
 }
 
 // RunServer starts the gRPC server and handles graceful shutdown.
@@ -47,11 +52,15 @@ func RunServer(ctx context.Context, opts ServerOptions) error {
 
 	s := grpc.NewServer()
 	pb.RegisterOSVServer(s, &server{
-		vulnStore:          opts.VulnStore,
-		relationsStore:     opts.RelationsStore,
-		recovererPublisher: opts.RecovererPublisher,
-		verboseLogs:        opts.VerboseLogs,
+		vulnStore:           opts.VulnStore,
+		relationsStore:      opts.RelationsStore,
+		importFindingsStore: opts.ImportFindingsStore,
+		recovererPublisher:  opts.RecovererPublisher,
+		verboseLogs:         opts.VerboseLogs,
 	})
+
+	healthServer := health.NewServer()
+	healthgrpc.RegisterHealthServer(s, healthServer)
 
 	logger.InfoContext(ctx, "server listening", "port", opts.Port)
 
@@ -68,6 +77,7 @@ func RunServer(ctx context.Context, opts ServerOptions) error {
 		}
 	case <-ctx.Done():
 		logger.InfoContext(ctx, "received shutdown signal, shutting down server gracefully")
+		healthServer.Shutdown()
 		s.GracefulStop()
 		if err := <-serveErr; err != nil {
 			logger.ErrorContext(ctx, "server failed during shutdown", "error", err)

--- a/go/internal/api/server.go
+++ b/go/internal/api/server.go
@@ -24,6 +24,7 @@ type server struct {
 	vulnStore           models.VulnerabilityStore
 	relationsStore      models.RelationsStore
 	importFindingsStore models.ImportFindingsStore
+	repoIndexStore      models.RepoIndexStore
 	recovererPublisher  clients.Publisher
 
 	singleQueryTimeout time.Duration
@@ -39,6 +40,7 @@ type ServerOptions struct {
 	VulnStore           models.VulnerabilityStore
 	RelationsStore      models.RelationsStore
 	ImportFindingsStore models.ImportFindingsStore
+	RepoIndexStore      models.RepoIndexStore
 	RecovererPublisher  clients.Publisher
 }
 
@@ -55,6 +57,7 @@ func RunServer(ctx context.Context, opts ServerOptions) error {
 		vulnStore:           opts.VulnStore,
 		relationsStore:      opts.RelationsStore,
 		importFindingsStore: opts.ImportFindingsStore,
+		repoIndexStore:      opts.RepoIndexStore,
 		recovererPublisher:  opts.RecovererPublisher,
 		verboseLogs:         opts.VerboseLogs,
 	})

--- a/go/internal/database/datastore/import_finding.go
+++ b/go/internal/database/datastore/import_finding.go
@@ -164,6 +164,20 @@ func (s *ImportFindingsStore) DeleteResult(ctx context.Context, path string) err
 	return nil
 }
 
+func (s *ImportFindingsStore) ListAllFromSource(ctx context.Context, source string) ([]*models.ImportFinding, error) {
+	query := datastore.NewQuery("ImportFinding").FilterField("source", "=", source)
+	var entities []*ImportFinding
+	if _, err := s.dsClient.GetAll(ctx, query, &entities); err != nil {
+		return nil, fmt.Errorf("failed to fetch import findings: %w", err)
+	}
+	findings := make([]*models.ImportFinding, len(entities))
+	for i, entity := range entities {
+		findings[i] = entity.toModel()
+	}
+
+	return findings, nil
+}
+
 func (f *ImportFinding) toModel() *models.ImportFinding {
 	return &models.ImportFinding{
 		BugID:       f.BugID,

--- a/go/internal/database/datastore/internal/validate/validate.go
+++ b/go/internal/database/datastore/internal/validate/validate.go
@@ -108,6 +108,22 @@ func readRecords(ctx context.Context, client *datastore.Client) {
 		fmt.Printf("(Go) Failed getting AffectedVersions: %v\n", err)
 		os.Exit(1)
 	}
+
+	fmt.Println("(Go) Getting RepoIndex")
+	repoIdxKey := datastore.NameKey("RepoIndex", "https://github.com/test/repo-MD5-deadbeef", nil)
+	var repoIndex db.RepoIndex
+	if err := client.Get(ctx, repoIdxKey, &repoIndex); err != nil {
+		fmt.Printf("(Go) Failed getting RepoIndex: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println("(Go) Getting RepoIndexBucket")
+	bucketKey := datastore.NameKey("RepoIndexBucket", "d0e000-MD5-2", repoIdxKey)
+	var repoIndexBucket db.RepoIndexBucket
+	if err := client.Get(ctx, bucketKey, &repoIndexBucket); err != nil {
+		fmt.Printf("(Go) Failed getting RepoIndexBucket: %v\n", err)
+		os.Exit(1)
+	}
 }
 
 func writeRecords(ctx context.Context, client *datastore.Client) {
@@ -262,6 +278,39 @@ func writeRecords(ctx context.Context, client *datastore.Client) {
 	}
 	if _, err := client.Put(ctx, key, &affectedVersions); err != nil {
 		fmt.Printf("(Go) Failed writing AffectedVersions %v: %v\n", key, err)
+		os.Exit(1)
+	}
+
+	fmt.Println("(Go) Writing RepoIndex")
+	goRepoIdxKey := datastore.NameKey("RepoIndex", "https://github.com/go/repo-MD5-deadbeef", nil)
+	goRepoIndex := db.RepoIndex{
+		Name:              "go-repo",
+		BaseCPE:           "cpe:2.3:a:go:repo",
+		Commit:            []byte{0xde, 0xad, 0xbe, 0xef},
+		Tag:               "refs/tags/v2.0.0",
+		When:              time.Date(2025, time.December, 31, 23, 59, 59, 0, time.UTC),
+		RepoType:          "GIT",
+		RepoAddr:          "https://github.com/go/repo",
+		FileExts:          []string{".go", ".txt"},
+		FileHashType:      "MD5",
+		EmptyBucketBitmap: []byte{0x06, 0x00, 0x00, 0x00},
+		FileCount:         10,
+		DocumentVersion:   2,
+	}
+	if _, err := client.Put(ctx, goRepoIdxKey, &goRepoIndex); err != nil {
+		fmt.Printf("(Go) Failed writing RepoIndex %v: %v\n", goRepoIdxKey, err)
+		os.Exit(1)
+	}
+
+	fmt.Println("(Go) Writing RepoIndexBucket")
+	goBucketKey := datastore.NameKey("RepoIndexBucket", "d0e000-MD5-2", goRepoIdxKey)
+	goRepoIndexBucket := db.RepoIndexBucket{
+		NodeHash:        []byte{0xd0, 0xe0, 0x00},
+		FilesContained:  2,
+		DocumentVersion: 2,
+	}
+	if _, err := client.Put(ctx, goBucketKey, &goRepoIndexBucket); err != nil {
+		fmt.Printf("(Go) Failed writing RepoIndexBucket %v: %v\n", goBucketKey, err)
 		os.Exit(1)
 	}
 }

--- a/go/internal/database/datastore/internal/validate/validate.py
+++ b/go/internal/database/datastore/internal/validate/validate.py
@@ -22,7 +22,7 @@ import osv.tests
 from osv import Vulnerability, AliasGroup, AliasAllowListEntry, \
     AliasDenyListEntry, ListedVulnerability, Severity, UpstreamGroup, \
     RelatedGroup, SourceRepository, SourceRepositoryType, AffectedCommits, \
-    AffectedVersions, AffectedEvent
+    AffectedVersions, AffectedEvent, RepoIndex, RepoIndexBucket
 
 
 def main() -> int:
@@ -145,6 +145,30 @@ def main() -> int:
       work_pool='pool',
   ).put()
 
+  print('(Python) Putting RepoIndex')
+  repo_index = RepoIndex(
+      id='https://github.com/test/repo-MD5-deadbeef',
+      name='test-repo',
+      base_cpe='cpe:2.3:a:test:repo',
+      commit=b'\xde\xad\xbe\xef',
+      tag='refs/tags/v1.0.0',
+      repo_type='GIT',
+      repo_addr='https://github.com/test/repo',
+      file_exts=['.go', '.txt'],
+      file_hash_type='MD5',
+      empty_bucket_bitmap=b'\x06\x00\x00\x00',
+      file_count=10,
+  )
+  repo_index.put()
+
+  print('(Python) Putting RepoIndexBucket')
+  RepoIndexBucket(
+      id='d0e000-MD5-2',
+      parent=repo_index.key,
+      node_hash=b'\xd0\xe0\x00',
+      files_contained=2,
+  ).put()
+
   # Run Go program to read the Python-created entities in Go.
   # And write Go entities.
   result = subprocess.run(['go', 'run', './validate.go'], check=False, cwd='.')
@@ -178,6 +202,13 @@ def main() -> int:
     return 1
   print('(Python) Getting AffectedVersions')
   if AffectedVersions.get_by_id('2') is None:
+    return 1
+  print('(Python) Getting RepoIndex')
+  if RepoIndex.get_by_id('https://github.com/go/repo-MD5-deadbeef') is None:
+    return 1
+  print('(Python) Getting RepoIndexBucket')
+  go_repo_idx_key = ndb.Key(RepoIndex, 'https://github.com/go/repo-MD5-deadbeef')
+  if RepoIndexBucket.get_by_id('d0e000-MD5-2', parent=go_repo_idx_key) is None:
     return 1
 
   return 0

--- a/go/internal/database/datastore/internal/validate/validate.py
+++ b/go/internal/database/datastore/internal/validate/validate.py
@@ -207,7 +207,8 @@ def main() -> int:
   if RepoIndex.get_by_id('https://github.com/go/repo-MD5-deadbeef') is None:
     return 1
   print('(Python) Getting RepoIndexBucket')
-  go_repo_idx_key = ndb.Key(RepoIndex, 'https://github.com/go/repo-MD5-deadbeef')
+  go_repo_idx_key = ndb.Key(RepoIndex,
+                            'https://github.com/go/repo-MD5-deadbeef')
   if RepoIndexBucket.get_by_id('d0e000-MD5-2', parent=go_repo_idx_key) is None:
     return 1
 

--- a/go/internal/database/datastore/models.go
+++ b/go/internal/database/datastore/models.go
@@ -154,3 +154,26 @@ type SourceRepository struct {
 	StrictValidation        bool                        `datastore:"strict_validation"`
 	WorkPool                string                      `datastore:"work_pool"`
 }
+
+type RepoIndex struct {
+	Key               *datastore.Key `datastore:"__key__"`
+	Name              string         `datastore:"name"`
+	BaseCPE           string         `datastore:"base_cpe"`
+	Commit            []byte         `datastore:"commit"`
+	Tag               string         `datastore:"tag"`
+	When              time.Time      `datastore:"when,omitempty"`
+	RepoType          string         `datastore:"repo_type"`
+	RepoAddr          string         `datastore:"repo_addr"`
+	FileExts          []string       `datastore:"file_exts"`
+	FileHashType      string         `datastore:"file_hash_type"`
+	EmptyBucketBitmap []byte         `datastore:"empty_bucket_bitmap"`
+	FileCount         int            `datastore:"file_count"`
+	DocumentVersion   int            `datastore:"document_version"`
+}
+
+type RepoIndexBucket struct {
+	Key             *datastore.Key `datastore:"__key__"`
+	NodeHash        []byte         `datastore:"node_hash"`
+	FilesContained  int            `datastore:"files_contained,noindex"`
+	DocumentVersion int            `datastore:"document_version,noindex"`
+}

--- a/go/internal/database/datastore/repo_index.go
+++ b/go/internal/database/datastore/repo_index.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datastore
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sync"
+
+	"cloud.google.com/go/datastore"
+	"github.com/google/osv.dev/go/internal/models"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	// RepoIndexKind matches the Datastore kind for repository indexes.
+	RepoIndexKind = "RepoIndex"
+
+	// RepoIndexBucketKind matches the Datastore kind for repository index buckets.
+	RepoIndexBucketKind = "RepoIndexBucket"
+
+	// MaxConcurrentQueries limits the number of parallel Datastore queries we run.
+	MaxConcurrentQueries = 32
+)
+
+// RepoIndexStore implements models.RepoIndexStore using Google Cloud Datastore.
+type RepoIndexStore struct {
+	client *datastore.Client
+}
+
+var _ models.RepoIndexStore = (*RepoIndexStore)(nil)
+
+// NewRepoIndexStore creates a new RepoIndexStore.
+func NewRepoIndexStore(client *datastore.Client) *RepoIndexStore {
+	return &RepoIndexStore{client: client}
+}
+
+// QueryBuckets finds all RepoIndexBucket entities matching any of the given node hashes,
+// grouped by the hex-encoded string of the node hash.
+func (s *RepoIndexStore) QueryBuckets(ctx context.Context, nodeHashes [][]byte) (map[string][]*models.RepoIndexBucket, error) {
+	var mu sync.Mutex
+	results := make(map[string][]*models.RepoIndexBucket)
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(MaxConcurrentQueries)
+
+	for _, hash := range nodeHashes {
+		h := hash // capture loop variable
+		g.Go(func() error {
+			q := datastore.NewQuery(RepoIndexBucketKind).
+				FilterField("node_hash", "=", h).
+				Limit(models.MaxMatchesToCare)
+
+			var dbBuckets []*RepoIndexBucket
+			keys, err := s.client.GetAll(ctx, q, &dbBuckets)
+			if err != nil {
+				return fmt.Errorf("failed to fetch RepoIndexBucket for hash %x: %w", h, err)
+			}
+
+			var matched []*models.RepoIndexBucket
+			for i, k := range keys {
+				parentKey := k.Parent
+				var parentID string
+				if parentKey != nil {
+					parentID = parentKey.Name
+				}
+
+				matched = append(matched, &models.RepoIndexBucket{
+					ParentID:       parentID,
+					NodeHash:       dbBuckets[i].NodeHash,
+					FilesContained: dbBuckets[i].FilesContained,
+				})
+			}
+
+			hexHash := hex.EncodeToString(h)
+			mu.Lock()
+			results[hexHash] = matched
+			mu.Unlock()
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// GetRepoIndexes fetches the parent RepoIndex entities for the given IDs.
+func (s *RepoIndexStore) GetRepoIndexes(ctx context.Context, ids []string) ([]*models.RepoIndex, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	keys := make([]*datastore.Key, len(ids))
+	for i, id := range ids {
+		keys[i] = datastore.NameKey(RepoIndexKind, id, nil)
+	}
+
+	dbIndexes := make([]*RepoIndex, len(ids))
+	err := s.client.GetMulti(ctx, keys, dbIndexes)
+	if err != nil {
+		// If some entities are not found, GetMulti returns datastore.ErrMultiErr
+		var multiErr datastore.MultiError
+		if !errors.As(err, &multiErr) {
+			return nil, fmt.Errorf("failed to batch get RepoIndexes: %w", err)
+		}
+	}
+
+	results := make([]*models.RepoIndex, 0, len(dbIndexes))
+	for i, dbIdx := range dbIndexes {
+		if dbIdx == nil {
+			continue
+		}
+		results = append(results, &models.RepoIndex{
+			ID:                ids[i],
+			Name:              dbIdx.Name,
+			BaseCPE:           dbIdx.BaseCPE,
+			Commit:            dbIdx.Commit,
+			Tag:               dbIdx.Tag,
+			When:              dbIdx.When,
+			RepoType:          dbIdx.RepoType,
+			RepoAddr:          dbIdx.RepoAddr,
+			FileExts:          dbIdx.FileExts,
+			FileHashType:      dbIdx.FileHashType,
+			EmptyBucketBitmap: dbIdx.EmptyBucketBitmap,
+			FileCount:         dbIdx.FileCount,
+		})
+	}
+
+	return results, nil
+}

--- a/go/internal/models/import_finding.go
+++ b/go/internal/models/import_finding.go
@@ -58,4 +58,7 @@ type ImportFindingsStore interface {
 
 	// DeleteResult deletes the linter results for a given source in the GCS bucket.
 	DeleteResult(ctx context.Context, source string) error
+
+	// ListAllFromSource lists all import findings for a given source.
+	ListAllFromSource(ctx context.Context, source string) ([]*ImportFinding, error)
 }

--- a/go/internal/models/repo_index.go
+++ b/go/internal/models/repo_index.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	// MaxMatchesToCare matches the Python API's _MAX_MATCHES_TO_CARE.
+	// If a bucket has too many matches, it is ignored as a useful indicator.
+	MaxMatchesToCare = 100
+)
+
+// RepoIndex represents a single repository entry in the database.
+type RepoIndex struct {
+	ID                string
+	Name              string
+	BaseCPE           string
+	Commit            []byte
+	Tag               string
+	When              time.Time
+	RepoType          string
+	RepoAddr          string
+	FileExts          []string
+	FileHashType      string
+	EmptyBucketBitmap []byte
+	FileCount         int
+}
+
+// RepoIndexBucket represents a hashed bucket of files for a specific repository state.
+type RepoIndexBucket struct {
+	ParentID       string
+	NodeHash       []byte
+	FilesContained int
+}
+
+// RepoIndexStore defines the repository interface for querying repo index data.
+type RepoIndexStore interface {
+	// QueryBuckets finds all RepoIndexBucket entities matching any of the given node hashes,
+	// grouped by the hex-encoded string of the node hash.
+	QueryBuckets(ctx context.Context, nodeHashes [][]byte) (map[string][]*RepoIndexBucket, error)
+
+	// GetRepoIndexes fetches the parent RepoIndex entities for the given IDs.
+	GetRepoIndexes(ctx context.Context, ids []string) ([]*RepoIndex, error)
+}


### PR DESCRIPTION
Translate the final python API endpoints to go.
- health checks, which are automatically reporting healthy when the server is running. Querying the datastore/gcs for this seems unnecessary since I don't believe it maintains a persistent connection when not doing queries.
- import findings reading from datastore to give the import failures for a specific source. (I don't know if anyone actually uses this)
- determineversion for querying indexer results. For transparancy, I got Gemini to translate this from the python implementation (with reference to the indexer) for me. I don't see any issues with it, and the few repos I've tested it with give identical results, but I don't really understand the indexer enough to get what's going on.
I told it not to reuse the indexer code, since it would require moving it to the `go/` directory which is a bigger refactor than I want to do right now.