### PR TITLE
refactor: improve datastore repo index batch get error handling

### DIFF
--- a/go/internal/database/datastore/repo_index.go
+++ b/go/internal/database/datastore/repo_index.go
@@ -116,10 +116,17 @@ func (s *RepoIndexStore) GetRepoIndexes(ctx context.Context, ids []string) ([]*m
 	dbIndexes := make([]*RepoIndex, len(ids))
 	err := s.client.GetMulti(ctx, keys, dbIndexes)
 	if err != nil {
-		// If some entities are not found, GetMulti returns datastore.ErrMultiErr
 		var multiErr datastore.MultiError
-		if !errors.As(err, &multiErr) {
-			return nil, fmt.Errorf("failed to batch get RepoIndexes: %w", err)
+		if errors.As(err, &multiErr) {
+			for i, e := range multiErr {
+				if errors.Is(e, datastore.ErrNoSuchEntity) {
+					dbIndexes[i] = nil
+				} else if e != nil {
+					return nil, fmt.Errorf("failed to get multi: %w", err)
+				}
+			}
+		} else {
+			return nil, fmt.Errorf("failed to get multi: %w", err)
 		}
 	}
 


### PR DESCRIPTION
Improve error handling in GetRepoIndexes by checking individual errors in the MultiError returned by GetMulti. This ensures that we only ignore ErrNoSuchEntity (which is expected for missing entities) and correctly propagate other potential errors.

agy