### PR TITLE
fix: mismatching repository casings between nvd and cve5 records

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -639,7 +639,7 @@ func mergeDatabaseSpecifics(ds1, ds2 *structpb.Struct) *structpb.Struct {
 //     operation is limited to appending standalone commit events from advisory links, avoiding
 //     the corruption of paired version boundaries in complex ranges.
 func mergeRanges(base, other *osvschema.Range) (*osvschema.Range, error) {
-	if base.GetType() != other.GetType() || base.GetRepo() != other.GetRepo() {
+	if base.GetType() != other.GetType() || !conversion.IsSameRepo(base.GetRepo(), other.GetRepo()) {
 		return nil, fmt.Errorf("cannot merge ranges with mismatching Type/Repo: (%s, %s) and (%s, %s)",
 			base.GetType(), base.GetRepo(), other.GetType(), other.GetRepo())
 	}
@@ -707,7 +707,7 @@ func pickBestRange(cve5Range *osvschema.Range, nvdRange *osvschema.Range) *osvsc
 		return cve5Range
 	}
 
-	// 1. If one of the ranges is references-only, merge them instead of choosing one
+	// If one of the ranges is references-only, merge them instead of choosing one
 	if isReferencesOnly(nvdRange) {
 		merged, err := mergeRanges(cve5Range, nvdRange)
 		if err != nil {
@@ -729,7 +729,7 @@ func pickBestRange(cve5Range *osvschema.Range, nvdRange *osvschema.Range) *osvsc
 		return merged
 	}
 
-	// 2. Try to merge boundary versions first for simple 1-event/2-event ranges.
+	//  Try to merge boundary versions first for simple 1-event/2-event ranges.
 	var merged *osvschema.Range
 	if len(cve5Range.GetEvents()) <= 2 && len(nvdRange.GetEvents()) <= 2 {
 		c5Intro, c5Fixed := getRangeBoundaryVersions(cve5Range.GetEvents())
@@ -750,7 +750,7 @@ func pickBestRange(cve5Range *osvschema.Range, nvdRange *osvschema.Range) *osvsc
 	}
 
 	if merged == nil {
-		// 2. Prioritize range with fixed information over last_affected / open-ended ranges
+		// Prioritize range with fixed information over last_affected / open-ended ranges
 		c5HasFixed := hasFixedEvent(cve5Range)
 		nvdHasFixed := hasFixedEvent(nvdRange)
 
@@ -764,7 +764,7 @@ func pickBestRange(cve5Range *osvschema.Range, nvdRange *osvschema.Range) *osvsc
 	}
 
 	if merged == nil {
-		// 3. Prefer constrained ranges (no introduced "0")
+		// Prefer constrained ranges (no introduced "0")
 		c5HasIntroZero := hasIntroducedZero(cve5Range)
 		nvdHasIntroZero := hasIntroducedZero(nvdRange)
 
@@ -778,7 +778,7 @@ func pickBestRange(cve5Range *osvschema.Range, nvdRange *osvschema.Range) *osvsc
 	}
 
 	if merged == nil {
-		// 4. Prefer CPE_RANGE if it exists, otherwise fall back to preferred source (CVE5)
+		// Prefer CPE_RANGE if it exists, otherwise fall back to preferred source (CVE5)
 		c5IsCPERange := isCPERange(cve5Range)
 		nvdIsCPERange := isCPERange(nvdRange)
 
@@ -810,7 +810,7 @@ func pickBestRange(cve5Range *osvschema.Range, nvdRange *osvschema.Range) *osvsc
 		}
 	}
 
-	// 5. Remove last_affected events if a fixed commit exists
+	// Remove last_affected events if a fixed commit exists
 	cleanLastAffectedIfFixedExists(merged)
 
 	return merged

--- a/vulnfeeds/cmd/combine-to-osv/main_test.go
+++ b/vulnfeeds/cmd/combine-to-osv/main_test.go
@@ -791,6 +791,51 @@ func TestPickAffectedInformation(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Same repo with different casing (e.g. GitHub case-insensitivity)",
+			cve5Affected: []*osvschema.Affected{
+				{
+					Ranges: []*osvschema.Range{
+						{
+							Type: osvschema.Range_GIT,
+							Repo: "https://github.com/User/Repo",
+							Events: []*osvschema.Event{
+								{Introduced: "1.0.0"},
+								{Fixed: "1.0.1"},
+							},
+						},
+					},
+				},
+			},
+			nvdAffected: []*osvschema.Affected{
+				{
+					Ranges: []*osvschema.Range{
+						{
+							Type: osvschema.Range_GIT,
+							Repo: "https://github.com/user/repo",
+							Events: []*osvschema.Event{
+								{Introduced: "1.0.0"},
+								{Fixed: "1.0.2"},
+							},
+						},
+					},
+				},
+			},
+			wantAffected: []*osvschema.Affected{
+				{
+					Ranges: []*osvschema.Range{
+						{
+							Type: osvschema.Range_GIT,
+							Repo: "https://github.com/User/Repo", // Should preserve casing of cve5's repo
+							Events: []*osvschema.Event{
+								{Introduced: "1.0.0"},
+								{Fixed: "1.0.1"}, // Preferred CVE5 fixed version
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	// Sorter for comparing slices of Affected, ignoring order.

--- a/vulnfeeds/conversion/versions.go
+++ b/vulnfeeds/conversion/versions.go
@@ -129,6 +129,18 @@ func repoGitWeb(parsedURL *url.URL) (string, error) {
 	return "", fmt.Errorf("unsupported GitWeb URL: %s", parsedURL.String())
 }
 
+// IsSameRepo returns true if repo1 and repo2 are for the same repository.
+func IsSameRepo(repo1, repo2 string) bool {
+	u1, err1 := url.Parse(repo1)
+	if err1 != nil {
+		return false
+	}
+	if isCaseInsensitiveHost(u1.Hostname()) {
+		return strings.EqualFold(repo1, repo2)
+	}
+	return repo1 == repo2
+}
+
 // Returns the base repository URL for supported repository hosts.
 func Repo(u string) (string, error) {
 	r, err := repo(u)

--- a/vulnfeeds/conversion/versions.go
+++ b/vulnfeeds/conversion/versions.go
@@ -138,6 +138,7 @@ func IsSameRepo(repo1, repo2 string) bool {
 	if isCaseInsensitiveHost(u1.Hostname()) {
 		return strings.EqualFold(repo1, repo2)
 	}
+
 	return repo1 == repo2
 }
 


### PR DESCRIPTION
sometimes there are records where the case in the CVE5 OSV record and the NVD OSV record have the same repo, but different cases. if these are a non-case sensitive base (which is most cases - GitHub), this difference shouldnt matter. Currently, the record gets errored out instead.