### PR TITLE
fix(vulnfeeds): catch bad urls being parsed

### DIFF
--- a/vulnfeeds/git/testdata/TestValidateAndCanonicalizeLink_A_malformed_link_that_fails_url.Parse.yaml
+++ b/vulnfeeds/git/testdata/TestValidateAndCanonicalizeLink_A_malformed_link_that_fails_url.Parse.yaml
@@ -1,0 +1,3 @@
+---
+version: 2
+interactions: []

--- a/vulnfeeds/git/versions.go
+++ b/vulnfeeds/git/versions.go
@@ -187,6 +187,9 @@ func ParseVersionRange(versionRange string) (models.AffectedVersion, error) {
 // Detect linkrot and handle link decay in HTTP(S) links via HEAD request with exponential backoff.
 func ValidateAndCanonicalizeLink(link string, httpClient *http.Client) (canonicalLink string, err error) {
 	u, err := url.Parse(link)
+	if err != nil {
+		return link, err
+	}
 	if !slices.Contains([]string{"http", "https"}, u.Scheme) {
 		// Handle what's presumably a git:// URL.
 		return link, err

--- a/vulnfeeds/git/versions_test.go
+++ b/vulnfeeds/git/versions_test.go
@@ -355,6 +355,14 @@ func TestValidateAndCanonicalizeLink(t *testing.T) {
 			wantCanonicalLink: "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=ee1fee900537b5d9560e9f937402de5ddc8412f3",
 			wantErr:           false,
 		},
+		{
+			name: "A malformed link that fails url.Parse",
+			args: args{
+				link: "https://example.com/%",
+			},
+			wantCanonicalLink: "https://example.com/%",
+			wantErr:           true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Running the nvd-cve-osv conversion with a bad url that fails URL.Parse is causing a segfault and erroring. Let's catch that.