### PR TITLE
fix(build?): limit GOMAXPROCS for build-and-stage

### DIFF
--- a/deployment/build-and-stage.yaml
+++ b/deployment/build-and-stage.yaml
@@ -402,8 +402,6 @@ steps:
   args: ['buildx', 'build', '--build-arg', 'BUILDKIT_INLINE_CACHE=1',
          '-t', 'gcr.io/oss-vdb/osv-website:latest', '-t', 'gcr.io/oss-vdb/osv-website:$COMMIT_SHA',
          '-f', 'gcp/website/Dockerfile', '--cache-from', 'gcr.io/oss-vdb/osv-website:latest', '--pull', '.']
-  env:
-  - BUILDKIT_PROGRESS=plain
   id: 'build-website'
   waitFor: ['pull-website', 'build-first-package-finder']
 - name: 'gcr.io/cloud-builders/docker'
@@ -491,6 +489,9 @@ serviceAccount: 'projects/oss-vdb/serviceAccounts/deployment@oss-vdb.iam.gservic
 logsBucket: gs://oss-vdb-tf/apply-logs
 options:
   machineType: E2_HIGHCPU_32
+  env:
+  - BUILDKIT_PROGRESS=plain
+  - GOMAXPROCS=8
 
 tags: ['build-and-stage']
 


### PR DESCRIPTION
build-and-stage memory issues. Possibly due to too many parallel go builds.
Try limit GOMAXPROCS so that the builds aren't so hungry.
I'm not sure if this will fix - it's unclear how `go build` specifically treats the env var.