### PR TITLE
fix(vulnfeeds): prevent duplicate events in database_specific

### DIFF
--- a/vulnfeeds/conversion/common.go
+++ b/vulnfeeds/conversion/common.go
@@ -434,19 +434,37 @@ func MergeDatabaseSpecificValues(val1, val2 any) (any, error) {
 	}
 }
 
-// deduplicateList removes duplicate comparable elements (like strings) from a list.
+// deduplicateList removes duplicate elements from a list.
 func deduplicateList(list []any) []any {
 	var unique []any
-	seen := make(map[any]bool)
+	seenComparable := make(map[any]bool)
+	var seenUncomparable []any
 	for _, item := range list {
-		switch item.(type) {
-		case string, int, int32, int64, float32, float64, bool:
-			if !seen[item] {
-				seen[item] = true
+		if item == nil {
+			if !seenComparable[nil] {
+				seenComparable[nil] = true
 				unique = append(unique, item)
 			}
-		default:
-			unique = append(unique, item)
+			continue
+		}
+		typ := reflect.TypeOf(item)
+		if typ.Comparable() {
+			if !seenComparable[item] {
+				seenComparable[item] = true
+				unique = append(unique, item)
+			}
+		} else {
+			found := false
+			for _, seen := range seenUncomparable {
+				if reflect.DeepEqual(seen, item) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				seenUncomparable = append(seenUncomparable, item)
+				unique = append(unique, item)
+			}
 		}
 	}
 

--- a/vulnfeeds/conversion/common.go
+++ b/vulnfeeds/conversion/common.go
@@ -445,6 +445,7 @@ func deduplicateList(list []any) []any {
 				seenComparable[nil] = true
 				unique = append(unique, item)
 			}
+
 			continue
 		}
 		typ := reflect.TypeOf(item)

--- a/vulnfeeds/conversion/common_test.go
+++ b/vulnfeeds/conversion/common_test.go
@@ -307,6 +307,20 @@ func TestMergeDatabaseSpecificValues(t *testing.T) {
 			val2:    456.0,
 			wantErr: true,
 		},
+		{
+			name: "Merge lists of maps with duplicates",
+			val1: []any{
+				map[string]any{"introduced": "1.0"},
+			},
+			val2: []any{
+				map[string]any{"introduced": "1.0"},
+				map[string]any{"introduced": "2.0"},
+			},
+			want: []any{
+				map[string]any{"introduced": "1.0"},
+				map[string]any{"introduced": "2.0"},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
`combine-to-osv` merges database_specific fields using `MergeDatabaseSpecificValues` from the `conversion` package. However, the helper function `deduplicateList` only checked comparable basic types (strings, ints, floats, bools). Non-comparable types (like maps representing JSON objects) were always appended without deduplication.

I updated `deduplicateList` to check if a type is comparable. If it's not (e.g. a map or slice), it now checks for uniqueness against previously observed uncomparable elements using `reflect.DeepEqual`.