### PR TITLE
chore: Modify YAML dumping to disable key sorting

### DIFF
--- a/osv/sources.py
+++ b/osv/sources.py
@@ -234,7 +234,7 @@ def _write_vulnerability_dict(data: dict, output_path: str,
   with open(output_path, 'w') as f:
     ext = os.path.splitext(output_path)[1]
     if ext in YAML_EXTENSIONS:
-      yaml.dump(data, f, sort_keys=True, Dumper=YamlDumper)
+      yaml.dump(data, f, sort_keys=False, Dumper=YamlDumper)
     elif ext in JSON_EXTENSIONS:
       json.dump(data, f, indent=2, sort_keys=True)
     else:


### PR DESCRIPTION
Changed YAML dumping to not sort keys. Related https://github.com/pypa/advisory-database/pull/331