### PR TITLE
fix(vulnfeeds): only use the reference fixed value if only one other fixed value in the range

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -649,10 +649,33 @@ func mergeRanges(base, other *osvschema.Range) (*osvschema.Range, error) {
 			base.GetDatabaseSpecific(), other.GetDatabaseSpecific())
 	}
 
+	var baseFixed []*osvschema.Event
+	for _, e := range base.GetEvents() {
+		if e.GetFixed() != "" {
+			baseFixed = append(baseFixed, e)
+		}
+	}
+
+	var otherFixed []*osvschema.Event
+	for _, e := range other.GetEvents() {
+		if e.GetFixed() != "" {
+			otherFixed = append(otherFixed, e)
+		}
+	}
+
+	baseEvents := make([]*osvschema.Event, 0, len(base.GetEvents()))
+	replaceFixed := len(baseFixed) == 1 && len(otherFixed) >= 1
+	for _, e := range base.GetEvents() {
+		if replaceFixed && e.GetFixed() != "" {
+			continue
+		}
+		baseEvents = append(baseEvents, e)
+	}
+
 	merged := &osvschema.Range{
 		Type:             base.GetType(),
 		Repo:             base.GetRepo(),
-		Events:           append([]*osvschema.Event{}, base.GetEvents()...),
+		Events:           baseEvents,
 		DatabaseSpecific: mergeDatabaseSpecifics(base.GetDatabaseSpecific(), other.GetDatabaseSpecific()),
 	}
 	for _, e := range other.GetEvents() {

--- a/vulnfeeds/cmd/combine-to-osv/main_test.go
+++ b/vulnfeeds/cmd/combine-to-osv/main_test.go
@@ -694,6 +694,70 @@ func TestPickAffectedInformation(t *testing.T) {
 			},
 		},
 		{
+			name: "Merge references-only range (CVE-2016-15012): single fixed in base, references adds patch fixed, replace base fixed",
+			cve5Affected: []*osvschema.Affected{
+				{
+					Ranges: []*osvschema.Range{
+						{
+							Type: osvschema.Range_GIT,
+							Repo: "https://github.com/forcedotcom/salesforcemobilesdk-windows",
+							Events: []*osvschema.Event{
+								{Introduced: "0"},
+								{Fixed: "e4dd3fa3182d0fd382e229e0c25d1bfd8b77a711"},
+							},
+							DatabaseSpecific: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"source": structpb.NewStringValue("AFFECTED_FIELD"),
+								},
+							},
+						},
+					},
+				},
+			},
+			nvdAffected: []*osvschema.Affected{
+				{
+					Ranges: []*osvschema.Range{
+						{
+							Type: osvschema.Range_GIT,
+							Repo: "https://github.com/forcedotcom/salesforcemobilesdk-windows",
+							Events: []*osvschema.Event{
+								{Fixed: "83b3e91e0c1e84873a6d3ca3c5887eb5b4f5a3d8"},
+							},
+							DatabaseSpecific: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"source": structpb.NewStringValue("REFERENCES"),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantAffected: []*osvschema.Affected{
+				{
+					Ranges: []*osvschema.Range{
+						{
+							Type: osvschema.Range_GIT,
+							Repo: "https://github.com/forcedotcom/salesforcemobilesdk-windows",
+							Events: []*osvschema.Event{
+								{Introduced: "0"},
+								{Fixed: "83b3e91e0c1e84873a6d3ca3c5887eb5b4f5a3d8"},
+							},
+							DatabaseSpecific: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"source": structpb.NewListValue(&structpb.ListValue{
+										Values: []*structpb.Value{
+											structpb.NewStringValue("AFFECTED_FIELD"),
+											structpb.NewStringValue("REFERENCES"),
+										},
+									}),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "Multiple events, preferred source (CVE5) with more events is chosen",
 			cve5Affected: []*osvschema.Affected{
 				{


### PR DESCRIPTION
When there is only one other fixed value in a range, and the value was derived from tags mapping, it is safer to assume that a commit from the references is referencing the actual commit that fixed the issue - which is a lot more accurate than the release version. 

The cases in which this logic might not work are:
- multiple commits extracted from references and one is also a release tag. 