### PR TITLE
feat(vulnfeeds): treat ambiguious versions as enumerated by default

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -345,11 +345,13 @@ func pickAffectedInformation(cve5Affected []*osvschema.Affected, nvdAffected []*
 			return cmp.Compare(strings.ToLower(a.GetRepo()), strings.ToLower(b.GetRepo()))
 		})
 
-		// Find Package and EcosystemSpecific if any were present in the input ranges
+		// Find Package and EcosystemSpecific if any were present in the input ranges, and collect versions.
 		var pkg *osvschema.Package
 		var ecosystemSpecific *structpb.Struct
+		var versions []string
 		for _, aff := range cve5Affected {
 			if len(aff.GetRanges()) > 0 {
+				versions = append(versions, aff.GetVersions()...)
 				if aff.GetPackage() != nil {
 					pkg = aff.GetPackage()
 				}
@@ -358,23 +360,30 @@ func pickAffectedInformation(cve5Affected []*osvschema.Affected, nvdAffected []*
 				}
 			}
 		}
-		if pkg == nil || ecosystemSpecific == nil {
-			for _, aff := range nvdAffected {
-				if len(aff.GetRanges()) > 0 {
-					if pkg == nil && aff.GetPackage() != nil {
-						pkg = aff.GetPackage()
-					}
-					if ecosystemSpecific == nil && aff.GetEcosystemSpecific() != nil {
-						ecosystemSpecific = aff.GetEcosystemSpecific()
-					}
+		for _, aff := range nvdAffected {
+			if len(aff.GetRanges()) > 0 {
+				versions = append(versions, aff.GetVersions()...)
+				if pkg == nil && aff.GetPackage() != nil {
+					pkg = aff.GetPackage()
+				}
+				if ecosystemSpecific == nil && aff.GetEcosystemSpecific() != nil {
+					ecosystemSpecific = aff.GetEcosystemSpecific()
 				}
 			}
+		}
+
+		if len(versions) > 0 {
+			slices.Sort(versions)
+			versions = slices.Compact(versions)
+		} else {
+			versions = nil
 		}
 
 		combinedAffected = append(combinedAffected, &osvschema.Affected{
 			Ranges:            finalRanges,
 			Package:           pkg,
 			EcosystemSpecific: ecosystemSpecific,
+			Versions:          versions,
 		})
 	}
 

--- a/vulnfeeds/conversion/cve5/__snapshots__/converter_test.snap
+++ b/vulnfeeds/conversion/cve5/__snapshots__/converter_test.snap
@@ -577,727 +577,6 @@
           "database_specific": {
             "extracted_events": [
               {
-                "introduced": "0"
-              },
-              {
-                "last_affected": "4.x"
-              }
-            ],
-            "source": "AFFECTED_FIELD"
-          },
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "last_affected": "85c43e41805cde051a7a29aefcac2cd6aee8c69d"
-            }
-          ],
-          "repo": "https://github.com/forcedotcom/salesforcemobilesdk-windows",
-          "type": "GIT"
-        }
-      ]
-    }
-  ],
-  "database_specific": {
-    "cna_assigner": "VulDB",
-    "cwe_ids": [
-      "CWE-89"
-    ],
-    "osv_generated_from": "unknown"
-  },
-  "details": "** UNSUPPORTED WHEN ASSIGNED ** A vulnerability was found in forcedotcom SalesforceMobileSDK-Windows up to 4.x. It has been rated as critical. This issue affects the function ComputeCountSql of the file SalesforceSDK/SmartStore/Store/QuerySpec.cs. The manipulation leads to sql injection. Upgrading to version 5.0.0 is able to address this issue. The patch is named 83b3e91e0c1e84873a6d3ca3c5887eb5b4f5a3d8. It is recommended to upgrade the affected component. The associated identifier of this vulnerability is VDB-217619. NOTE: This vulnerability only affects products that are no longer supported by the maintainer.",
-  "id": "CVE-2016-15012",
-  "modified": "2025-04-08T20:30:50.208Z",
-  "published": "2023-01-07T12:59:27.772Z",
-  "references": [
-    {
-      "type": "FIX",
-      "url": "https://github.com/forcedotcom/SalesforceMobileSDK-Windows/commit/83b3e91e0c1e84873a6d3ca3c5887eb5b4f5a3d8"
-    },
-    {
-      "type": "FIX",
-      "url": "https://github.com/forcedotcom/SalesforceMobileSDK-Windows/releases/tag/v5.0.0"
-    },
-    {
-      "type": "ADVISORY",
-      "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-15012"
-    },
-    {
-      "type": "REPORT",
-      "url": "https://vuldb.com/?ctiid.217619"
-    },
-    {
-      "type": "ADVISORY",
-      "url": "https://vuldb.com/?id.217619"
-    }
-  ],
-  "schema_version": "1.7.5",
-  "severity": [
-    {
-      "score": "CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
-      "type": "CVSS_V3"
-    }
-  ],
-  "summary": "forcedotcom SalesforceMobileSDK-Windows QuerySpec.cs ComputeCountSql sql injection"
-}
-{
-  "affected": [
-    {
-      "ranges": [
-        {
-          "database_specific": {
-            "extracted_events": [
-              {
-                "introduced": "0"
-              },
-              {
-                "last_affected": "8.9.0"
-              },
-              {
-                "last_affected": "8.8.0"
-              },
-              {
-                "last_affected": "8.7.1"
-              },
-              {
-                "last_affected": "8.7.0"
-              },
-              {
-                "last_affected": "8.6.0"
-              },
-              {
-                "last_affected": "8.5.0"
-              },
-              {
-                "last_affected": "8.4.0"
-              },
-              {
-                "last_affected": "8.3.0"
-              },
-              {
-                "last_affected": "8.2.1"
-              },
-              {
-                "last_affected": "8.2.0"
-              },
-              {
-                "last_affected": "8.1.2"
-              },
-              {
-                "last_affected": "8.1.1"
-              },
-              {
-                "last_affected": "8.1.0"
-              },
-              {
-                "last_affected": "8.0.1"
-              },
-              {
-                "last_affected": "8.0.0"
-              },
-              {
-                "last_affected": "7.88.1"
-              },
-              {
-                "last_affected": "7.88.0"
-              },
-              {
-                "last_affected": "7.87.0"
-              },
-              {
-                "last_affected": "7.86.0"
-              },
-              {
-                "last_affected": "7.85.0"
-              },
-              {
-                "last_affected": "7.84.0"
-              },
-              {
-                "last_affected": "7.83.1"
-              },
-              {
-                "last_affected": "7.83.0"
-              },
-              {
-                "last_affected": "7.82.0"
-              },
-              {
-                "last_affected": "7.81.0"
-              },
-              {
-                "last_affected": "7.80.0"
-              },
-              {
-                "last_affected": "7.79.1"
-              },
-              {
-                "last_affected": "7.79.0"
-              },
-              {
-                "last_affected": "7.78.0"
-              },
-              {
-                "last_affected": "7.77.0"
-              },
-              {
-                "last_affected": "7.76.1"
-              },
-              {
-                "last_affected": "7.76.0"
-              },
-              {
-                "last_affected": "7.75.0"
-              },
-              {
-                "last_affected": "7.74.0"
-              },
-              {
-                "last_affected": "7.73.0"
-              },
-              {
-                "last_affected": "7.72.0"
-              },
-              {
-                "last_affected": "7.71.1"
-              },
-              {
-                "last_affected": "7.71.0"
-              },
-              {
-                "last_affected": "7.70.0"
-              },
-              {
-                "last_affected": "7.69.1"
-              },
-              {
-                "last_affected": "7.69.0"
-              },
-              {
-                "last_affected": "7.68.0"
-              },
-              {
-                "last_affected": "7.67.0"
-              },
-              {
-                "last_affected": "7.66.0"
-              },
-              {
-                "last_affected": "7.65.3"
-              },
-              {
-                "last_affected": "7.65.2"
-              },
-              {
-                "last_affected": "7.65.1"
-              },
-              {
-                "last_affected": "7.65.0"
-              },
-              {
-                "last_affected": "7.64.1"
-              },
-              {
-                "last_affected": "7.64.0"
-              },
-              {
-                "last_affected": "7.63.0"
-              },
-              {
-                "last_affected": "7.62.0"
-              },
-              {
-                "last_affected": "7.61.1"
-              },
-              {
-                "last_affected": "7.61.0"
-              },
-              {
-                "last_affected": "7.60.0"
-              },
-              {
-                "last_affected": "7.59.0"
-              },
-              {
-                "last_affected": "7.58.0"
-              },
-              {
-                "last_affected": "7.57.0"
-              },
-              {
-                "last_affected": "7.56.1"
-              },
-              {
-                "last_affected": "7.56.0"
-              },
-              {
-                "last_affected": "7.55.1"
-              },
-              {
-                "last_affected": "7.55.0"
-              },
-              {
-                "last_affected": "7.54.1"
-              },
-              {
-                "last_affected": "7.54.0"
-              },
-              {
-                "last_affected": "7.53.1"
-              },
-              {
-                "last_affected": "7.53.0"
-              },
-              {
-                "last_affected": "7.52.1"
-              },
-              {
-                "last_affected": "7.52.0"
-              },
-              {
-                "last_affected": "7.51.0"
-              },
-              {
-                "last_affected": "7.50.3"
-              },
-              {
-                "last_affected": "7.50.2"
-              },
-              {
-                "last_affected": "7.50.1"
-              },
-              {
-                "last_affected": "7.50.0"
-              },
-              {
-                "last_affected": "7.49.1"
-              },
-              {
-                "last_affected": "7.49.0"
-              },
-              {
-                "last_affected": "7.48.0"
-              },
-              {
-                "last_affected": "7.47.1"
-              },
-              {
-                "last_affected": "7.47.0"
-              },
-              {
-                "last_affected": "7.46.0"
-              },
-              {
-                "last_affected": "7.45.0"
-              },
-              {
-                "last_affected": "7.44.0"
-              },
-              {
-                "last_affected": "7.43.0"
-              },
-              {
-                "last_affected": "7.42.1"
-              },
-              {
-                "last_affected": "7.42.0"
-              },
-              {
-                "last_affected": "7.41.0"
-              },
-              {
-                "last_affected": "7.40.0"
-              },
-              {
-                "last_affected": "7.39.0"
-              },
-              {
-                "last_affected": "7.38.0"
-              },
-              {
-                "last_affected": "7.37.1"
-              },
-              {
-                "last_affected": "7.37.0"
-              },
-              {
-                "last_affected": "7.36.0"
-              },
-              {
-                "last_affected": "7.35.0"
-              },
-              {
-                "last_affected": "7.34.0"
-              },
-              {
-                "last_affected": "7.33.0"
-              },
-              {
-                "last_affected": "7.32.0"
-              }
-            ],
-            "source": "AFFECTED_FIELD"
-          },
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "last_affected": "5040f7e94cd01decbe7ba8fdacbf489182d503dc"
-            },
-            {
-              "last_affected": "fd567d4f06857f4fc8e2f64ea727b1318f76ad33"
-            },
-            {
-              "last_affected": "de7b3e89218467159a7af72d58cea8425946e97d"
-            },
-            {
-              "last_affected": "72cf468d459d29e5366e416c014faaaf281dfa2d"
-            },
-            {
-              "last_affected": "5ce164e0e9290c96eb7d502173426c0a135ec008"
-            },
-            {
-              "last_affected": "7161cb17c01dcff1dc5bf89a18437d9d729f1ecd"
-            },
-            {
-              "last_affected": "172e54cda18412da73fd8eb4e444e8a5b371ca59"
-            },
-            {
-              "last_affected": "6fa1d817e5b1a00d7d0c8168091877476b499317"
-            },
-            {
-              "last_affected": "50490c0679fcd0e50bb3a8fbf2d9244845652cf0"
-            },
-            {
-              "last_affected": "98044e81705dc24a56daaf3544f30c13f0fc3a31"
-            },
-            {
-              "last_affected": "7ab9d43720bc34d9aa351c7ca683c1668ebf8335"
-            },
-            {
-              "last_affected": "1561d0675208854b39066877b140780a965702fa"
-            },
-            {
-              "last_affected": "a9f8fe28481fef7c28d85b4a12a3a35521408eaf"
-            },
-            {
-              "last_affected": "b16d1fa8ee567b52c09a0f89940b07d8491b881d"
-            },
-            {
-              "last_affected": "47ccaa4218c408e70671a2fa9caaa3caf8c1a877"
-            },
-            {
-              "last_affected": "046209e561b7e9b5aab1aef7daebf29ee6e6e8c7"
-            },
-            {
-              "last_affected": "3027611ca6d4cc5510d2d0fccc3e5a074e09a2fb"
-            },
-            {
-              "last_affected": "c12fb3ddaf48e709a7a4deaa55ec485e4df163ee"
-            },
-            {
-              "last_affected": "cd95ee9f771361acf241629d2fe5507e308082a2"
-            },
-            {
-              "last_affected": "93d092867f0f2c78571983040ef75e078ee1a4c4"
-            },
-            {
-              "last_affected": "45ac4d019475df03562fe0ac54eb67e1d1de0ca7"
-            },
-            {
-              "last_affected": "462196e6b4a47f924293a0e26b8e9c23d37ac26f"
-            },
-            {
-              "last_affected": "1669b17d3a1a1fd824308544ca0ec02a2a4f50ea"
-            },
-            {
-              "last_affected": "64db5c575d9c5536bd273a890f50777ad1ca7c13"
-            },
-            {
-              "last_affected": "801bd5138ce31aa0d906fa4e2eabfc599d74e793"
-            },
-            {
-              "last_affected": "9e560d11aad028de74addc0d1edfefa5667884f4"
-            },
-            {
-              "last_affected": "c7aef0a945f9b6fb6d3f91716a21dfe2f4ea635f"
-            },
-            {
-              "last_affected": "8e82f2a04a238c54ba91e553e9a8452e6d405965"
-            },
-            {
-              "last_affected": "bfbde883af33397943df68a3ae01847a634d33bf"
-            },
-            {
-              "last_affected": "6b951a6928811507d493303b2878e848c077b471"
-            },
-            {
-              "last_affected": "566b74a0e19b9aa610f4931e5bfd339bcf8e9147"
-            },
-            {
-              "last_affected": "3266b35bbe21c68dea0dc7ccd991eb028e6d360c"
-            },
-            {
-              "last_affected": "2f33be817cbce6ad7a36f27dd7ada9219f13584c"
-            },
-            {
-              "last_affected": "e052859759b34d0e05ce0f17244873e5cd7b457b"
-            },
-            {
-              "last_affected": "315ee3fe75dade912b48a21ceec9ccda0230d937"
-            },
-            {
-              "last_affected": "0c9211798fc80d5c9cc9bcdc8e11eb485c9c1c5b"
-            },
-            {
-              "last_affected": "5a1fc8d33808d7b22f57bdf9403cda7ff07b0670"
-            },
-            {
-              "last_affected": "e9db32a09af03f27e86d1251a9e68e9b7486d371"
-            },
-            {
-              "last_affected": "53cdc2c963e33bc0cc1a51ad2df79396202e07f8"
-            },
-            {
-              "last_affected": "b81e0b07784dc4c1e8d0a86194b9d28776d071c0"
-            },
-            {
-              "last_affected": "b8d1366852fd0034374c5de1e4968c7a224f77cc"
-            },
-            {
-              "last_affected": "2cfac302fbeec68f1727cba3d1705e16f02220ad"
-            },
-            {
-              "last_affected": "2e9b725f67d49a9d7a1f053fe52dd4920c9ab1ad"
-            },
-            {
-              "last_affected": "9cd755e1d768bbf228e7c9faf223b7459f7e0105"
-            },
-            {
-              "last_affected": "aa73eb47bc8583070734696b25b34ad54c2c1f5e"
-            },
-            {
-              "last_affected": "72c2cac8f0ac3a89c21d00b6c6e36fe6c6a8e62b"
-            },
-            {
-              "last_affected": "69248b58f649e35b09a126c12781353e3471f5c6"
-            },
-            {
-              "last_affected": "885ce31401b6789c959131754b1e5ae518964072"
-            },
-            {
-              "last_affected": "521bbbe29928f9bc1c61306df612e856d45cbe5a"
-            },
-            {
-              "last_affected": "f3294d9d86e6a7915a967efff2842089b8b0d071"
-            },
-            {
-              "last_affected": "4258dc02d86e7e4de9f795a1af3a0bc6732d4ab5"
-            },
-            {
-              "last_affected": "196677150f711a96c38ed123e621f1d4e995b2e5"
-            },
-            {
-              "last_affected": "432eb5f5c254ee8383b2522ce597c9219877923e"
-            },
-            {
-              "last_affected": "eb8138405a3f747f2c236464932f72e918946f68"
-            },
-            {
-              "last_affected": "cb013830383f1ccc9757aba36bc32df5ec281c02"
-            },
-            {
-              "last_affected": "4d6bd91ab33328c6d27eddc32e064defc02dc4fd"
-            },
-            {
-              "last_affected": "d6c21c8eec597a925d2b647cff3d58ac69de01a0"
-            },
-            {
-              "last_affected": "62c07b5743490ce373910f469abc8cdc759bec2b"
-            },
-            {
-              "last_affected": "c514af5a4f5ac3ce724065cc6a8e009373436f78"
-            },
-            {
-              "last_affected": "3ea76790571c1f7cf1bed34fabffd3cc20ad3dd3"
-            },
-            {
-              "last_affected": "8839c05fba1f8415eec17eff8ac60cc3a50eb51e"
-            },
-            {
-              "last_affected": "2679562dc7685674998f2841811d361400ae0d19"
-            },
-            {
-              "last_affected": "54b636f14546d3fde9f9c67c3b32701d78563161"
-            },
-            {
-              "last_affected": "d957e2189fdc73cef0ff3d1fb58043d354754449"
-            },
-            {
-              "last_affected": "25df50aa3392ecdbf2b8256b93b30558e8b3a810"
-            },
-            {
-              "last_affected": "a7135ac3c3d825ec9f4919ee0212434e01e76b4c"
-            },
-            {
-              "last_affected": "44b9b4d4f56d6f6de92c89636994c03984e9cd01"
-            },
-            {
-              "last_affected": "95c717bbd9c327c38b4efcc37d5cda29b8ee2a36"
-            },
-            {
-              "last_affected": "3c561c657c2f0e553b19115a506592a8bbd744bc"
-            },
-            {
-              "last_affected": "8986c86e1ef297e95518ae4695339f2d64d913cf"
-            },
-            {
-              "last_affected": "9ce6d0d52821c6e33506cb173f0e27c68014e60e"
-            },
-            {
-              "last_affected": "f2cb3a01192d36395d16acec6cdb93446ca6fd45"
-            },
-            {
-              "last_affected": "79e63a53bb9598af863b0afe49ad662795faeef4"
-            },
-            {
-              "last_affected": "cf93a7b364a70b56150cf6ea77492b799ec02a45"
-            },
-            {
-              "last_affected": "67fe54d918a3b42a24cb7f5db81514c10e239735"
-            },
-            {
-              "last_affected": "9819cec61b00cc872136ea5faf469627b3b87e69"
-            },
-            {
-              "last_affected": "8f995e2e0022292374fc99a2277069b08ad98b5c"
-            },
-            {
-              "last_affected": "06bf874bbca0a5c600b210b5db920eff9f95f0d0"
-            },
-            {
-              "last_affected": "e2ae32ff5f3ab6f0819590f61f248f17df12987f"
-            },
-            {
-              "last_affected": "2c000d91f3c423cee0af44e8afc79b9d25a9e714"
-            },
-            {
-              "last_affected": "1a7f66a3de2625d10f65415e6eb3e56067dc0555"
-            },
-            {
-              "last_affected": "38e07886ed2792988217a2ffa482ce3a69ca92c2"
-            },
-            {
-              "last_affected": "4feb6e6d035d5d66984957c8ca22bc9a05df527f"
-            },
-            {
-              "last_affected": "22691f849ac959ffaa821a3ca7f746ee54bd5e52"
-            },
-            {
-              "last_affected": "ff837422ee4ec7d6aea7750a40e30cba29db93e8"
-            },
-            {
-              "last_affected": "9ce2d7001939b795b45a8ce7700d1a3dcde0475d"
-            },
-            {
-              "last_affected": "303bfc1024d948a5ba134ccfc106f82c0b4fd675"
-            },
-            {
-              "last_affected": "202aa9f7758636730299b86715d924f54468a908"
-            },
-            {
-              "last_affected": "df5169fa35f31ebe10893f2a3416ec8e8d8faa20"
-            },
-            {
-              "last_affected": "3fed9acaef45ac8b99ceecc38afbed3494e2d3ef"
-            },
-            {
-              "last_affected": "4f041c9d6e61829310eb0715d8edb2a232478123"
-            },
-            {
-              "last_affected": "2bf90d071016e279796e789f0ac223d635671a41"
-            },
-            {
-              "last_affected": "0966b324d911423c81351fb12e9219f71cd63be8"
-            },
-            {
-              "last_affected": "f77e89c5d20db09eaebf378ec036a7e796932810"
-            },
-            {
-              "last_affected": "70812c2f32fc5734bcbbe572b9f61c380433ad6a"
-            }
-          ],
-          "repo": "https://github.com/curl/curl",
-          "type": "GIT"
-        }
-      ]
-    }
-  ],
-  "database_specific": {
-    "cna_assigner": "curl",
-    "osv_generated_from": "unknown"
-  },
-  "details": "libcurl's ASN1 parser code has the `GTime2str()` function, used for parsing an\nASN.1 Generalized Time field. If given an syntactically incorrect field, the\nparser might end up using -1 for the length of the *time fraction*, leading to\na `strlen()` getting performed on a pointer to a heap buffer area that is not\n(purposely) null terminated.\n\nThis flaw most likely leads to a crash, but can also lead to heap contents\ngetting returned to the application when\n[CURLINFO_CERTINFO](https://curl.se/libcurl/c/CURLINFO_CERTINFO.html) is used.",
-  "id": "CVE-2024-7264",
-  "modified": "2025-11-03T22:32:51.400Z",
-  "published": "2024-07-31T08:08:14.585Z",
-  "references": [
-    {
-      "type": "WEB",
-      "url": "http://www.openwall.com/lists/oss-security/2024/07/31/1"
-    },
-    {
-      "type": "WEB",
-      "url": "https://curl.se/docs/CVE-2024-7264.html"
-    },
-    {
-      "type": "WEB",
-      "url": "https://curl.se/docs/CVE-2024-7264.json"
-    },
-    {
-      "type": "FIX",
-      "url": "https://github.com/curl/curl/commit/27959ecce75cdb2809c0bdb3286e60e08fadb519"
-    },
-    {
-      "type": "WEB",
-      "url": "https://hackerone.com/reports/2629968"
-    },
-    {
-      "type": "ADVISORY",
-      "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-7264"
-    },
-    {
-      "type": "ADVISORY",
-      "url": "https://security.netapp.com/advisory/ntap-20240828-0008/"
-    },
-    {
-      "type": "ADVISORY",
-      "url": "https://security.netapp.com/advisory/ntap-20241025-0006/"
-    },
-    {
-      "type": "ADVISORY",
-      "url": "https://security.netapp.com/advisory/ntap-20241025-0010/"
-    }
-  ],
-  "schema_version": "1.7.5",
-  "severity": [
-    {
-      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
-      "type": "CVSS_V3"
-    }
-  ],
-  "summary": "ASN.1 date parser overread"
-}
-{
-  "affected": [
-    {
-      "ranges": [
-        {
-          "database_specific": {
-            "extracted_events": [
-              {
                 "introduced": "1.7.0"
               },
               {
@@ -1485,6 +764,1128 @@
   "summary": "Request body not stripped after redirect in urllib3"
 }
 {
+  "affected": [
+    {
+      "ranges": [
+        {
+          "database_specific": {
+            "extracted_events": [
+              {
+                "introduced": "4.x"
+              },
+              {
+                "last_affected": "4.x"
+              }
+            ],
+            "source": "AFFECTED_FIELD"
+          },
+          "events": [
+            {
+              "introduced": "85c43e41805cde051a7a29aefcac2cd6aee8c69d"
+            },
+            {
+              "last_affected": "85c43e41805cde051a7a29aefcac2cd6aee8c69d"
+            }
+          ],
+          "repo": "https://github.com/forcedotcom/salesforcemobilesdk-windows",
+          "type": "GIT"
+        }
+      ],
+      "versions": [
+        "4.x"
+      ]
+    }
+  ],
+  "database_specific": {
+    "cna_assigner": "VulDB",
+    "cwe_ids": [
+      "CWE-89"
+    ],
+    "osv_generated_from": "unknown"
+  },
+  "details": "** UNSUPPORTED WHEN ASSIGNED ** A vulnerability was found in forcedotcom SalesforceMobileSDK-Windows up to 4.x. It has been rated as critical. This issue affects the function ComputeCountSql of the file SalesforceSDK/SmartStore/Store/QuerySpec.cs. The manipulation leads to sql injection. Upgrading to version 5.0.0 is able to address this issue. The patch is named 83b3e91e0c1e84873a6d3ca3c5887eb5b4f5a3d8. It is recommended to upgrade the affected component. The associated identifier of this vulnerability is VDB-217619. NOTE: This vulnerability only affects products that are no longer supported by the maintainer.",
+  "id": "CVE-2016-15012",
+  "modified": "2025-04-08T20:30:50.208Z",
+  "published": "2023-01-07T12:59:27.772Z",
+  "references": [
+    {
+      "type": "FIX",
+      "url": "https://github.com/forcedotcom/SalesforceMobileSDK-Windows/commit/83b3e91e0c1e84873a6d3ca3c5887eb5b4f5a3d8"
+    },
+    {
+      "type": "FIX",
+      "url": "https://github.com/forcedotcom/SalesforceMobileSDK-Windows/releases/tag/v5.0.0"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-15012"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://vuldb.com/?ctiid.217619"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://vuldb.com/?id.217619"
+    }
+  ],
+  "schema_version": "1.7.5",
+  "severity": [
+    {
+      "score": "CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+      "type": "CVSS_V3"
+    }
+  ],
+  "summary": "forcedotcom SalesforceMobileSDK-Windows QuerySpec.cs ComputeCountSql sql injection"
+}
+{
+  "affected": [
+    {
+      "ranges": [
+        {
+          "database_specific": {
+            "extracted_events": [
+              {
+                "introduced": "5.6.0"
+              },
+              {
+                "last_affected": "5.6.0"
+              },
+              {
+                "introduced": "5.6.1"
+              },
+              {
+                "last_affected": "5.6.1"
+              }
+            ],
+            "source": "AFFECTED_FIELD"
+          },
+          "events": [
+            {
+              "introduced": "2d7d862e3ffa8cec4fd3fdffcd84e984a17aa429"
+            },
+            {
+              "last_affected": "fd1b975b7851e081ed6e5cf63df946cd5cbdbb94"
+            }
+          ],
+          "repo": "https://github.com/tukaani-project/xz",
+          "type": "GIT"
+        }
+      ],
+      "versions": [
+        "5.6.0",
+        "5.6.1"
+      ]
+    }
+  ],
+  "aliases": [
+    "GHSA-rxwq-x6h5-x525"
+  ],
+  "database_specific": {
+    "cna_assigner": "redhat",
+    "cwe_ids": [
+      "CWE-506"
+    ],
+    "osv_generated_from": "unknown"
+  },
+  "details": "Malicious code was discovered in the upstream tarballs of xz, starting with version 5.6.0. \r\nThrough a series of complex obfuscations, the liblzma build process extracts a prebuilt object file from a disguised test file existing in the source code, which is then used to modify specific functions in the liblzma code. This results in a modified liblzma library that can be used by any software linked against this library, intercepting and modifying the data interaction with this library.",
+  "id": "CVE-2024-3094",
+  "modified": "2025-11-20T07:17:48.594Z",
+  "published": "2024-03-29T16:51:12.588Z",
+  "references": [
+    {
+      "type": "WEB",
+      "url": "http://www.openwall.com/lists/oss-security/2024/03/29/10"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.openwall.com/lists/oss-security/2024/03/29/12"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.openwall.com/lists/oss-security/2024/03/29/4"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.openwall.com/lists/oss-security/2024/03/29/5"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.openwall.com/lists/oss-security/2024/03/29/8"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.openwall.com/lists/oss-security/2024/03/30/12"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.openwall.com/lists/oss-security/2024/03/30/27"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.openwall.com/lists/oss-security/2024/03/30/36"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.openwall.com/lists/oss-security/2024/03/30/5"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.openwall.com/lists/oss-security/2024/04/16/5"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/downloads/content/package-browser/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://access.redhat.com/security/cve/CVE-2024-3094"
+    },
+    {
+      "type": "WEB",
+      "url": "https://ariadne.space/2024/04/02/the-xz-utils-backdoor-is-a-symptom-of-a-larger-problem/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://arstechnica.com/security/2024/03/backdoor-found-in-widely-used-linux-utility-breaks-encrypted-ssh-connections/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://aws.amazon.com/security/security-bulletins/AWS-2024-002/"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://blog.netbsd.org/tnf/entry/statement_on_backdoor_in_xz"
+    },
+    {
+      "type": "WEB",
+      "url": "https://boehs.org/node/everything-i-know-about-the-xz-backdoor"
+    },
+    {
+      "type": "WEB",
+      "url": "https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1068024"
+    },
+    {
+      "type": "WEB",
+      "url": "https://bugs.gentoo.org/928134"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2272210"
+    },
+    {
+      "type": "REPORT",
+      "url": "https://bugzilla.suse.com/show_bug.cgi?id=1222124"
+    },
+    {
+      "type": "WEB",
+      "url": "https://discourse.nixos.org/t/cve-2024-3094-malicious-code-in-xz-5-6-0-and-5-6-1-tarballs/42405"
+    },
+    {
+      "type": "WEB",
+      "url": "https://gist.github.com/thesamesam/223949d5a074ebc3dce9ee78baad9e27"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-rxwq-x6h5-x525"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/amlweems/xzbot"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/karcherm/xz-malware"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/tukaani-project/xz"
+    },
+    {
+      "type": "WEB",
+      "url": "https://gynvael.coldwind.pl/?lang=en\u0026id=782"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-security-announce/2024/msg00057.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.freebsd.org/archives/freebsd-security/2024-March/000248.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lwn.net/Articles/967180/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://news.ycombinator.com/item?id=39865810"
+    },
+    {
+      "type": "WEB",
+      "url": "https://news.ycombinator.com/item?id=39877267"
+    },
+    {
+      "type": "WEB",
+      "url": "https://news.ycombinator.com/item?id=39895344"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-3094"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://openssf.org/blog/2024/03/30/xz-backdoor-cve-2024-3094/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://research.swtch.com/xz-script"
+    },
+    {
+      "type": "WEB",
+      "url": "https://research.swtch.com/xz-timeline"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security-tracker.debian.org/tracker/CVE-2024-3094"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.alpinelinux.org/vuln/CVE-2024-3094"
+    },
+    {
+      "type": "WEB",
+      "url": "https://security.archlinux.org/CVE-2024-3094"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://security.netapp.com/advisory/ntap-20240402-0001/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://tukaani.org/xz-backdoor/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://twitter.com/LetsDefendIO/status/1774804387417751958"
+    },
+    {
+      "type": "WEB",
+      "url": "https://twitter.com/debian/status/1774219194638409898"
+    },
+    {
+      "type": "WEB",
+      "url": "https://twitter.com/infosecb/status/1774595540233167206"
+    },
+    {
+      "type": "WEB",
+      "url": "https://twitter.com/infosecb/status/1774597228864139400"
+    },
+    {
+      "type": "WEB",
+      "url": "https://ubuntu.com/security/CVE-2024-3094"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://www.binarly.io/blog/persistent-risk-xz-utils-backdoor-still-lurking-in-docker-images"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.cisa.gov/news-events/alerts/2024/03/29/reported-supply-chain-compromise-affecting-xz-utils-data-compression-library-cve-2024-3094"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.darkreading.com/vulnerabilities-threats/are-you-affected-by-the-backdoor-in-xz-utils"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://www.kali.org/blog/about-the-xz-backdoor/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.openwall.com/lists/oss-security/2024/03/29/4"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://www.redhat.com/en/blog/urgent-security-alert-fedora-41-and-rawhide-users"
+    },
+    {
+      "type": "ARTICLE",
+      "url": "https://www.tenable.com/blog/frequently-asked-questions-cve-2024-3094-supply-chain-backdoor-in-xz-utils"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.theregister.com/2024/03/29/malicious_backdoor_xz/"
+    },
+    {
+      "type": "WEB",
+      "url": "https://www.vicarius.io/vsociety/vulnerabilities/cve-2024-3094"
+    },
+    {
+      "type": "WEB",
+      "url": "https://xeiaso.net/notes/2024/xz-vuln/"
+    }
+  ],
+  "schema_version": "1.7.5",
+  "severity": [
+    {
+      "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+      "type": "CVSS_V3"
+    }
+  ],
+  "summary": "Xz: malicious code in distributed source"
+}
+{
+  "affected": [
+    {
+      "ranges": [
+        {
+          "database_specific": {
+            "extracted_events": [
+              {
+                "introduced": "8.9.0"
+              },
+              {
+                "last_affected": "8.9.0"
+              },
+              {
+                "introduced": "8.8.0"
+              },
+              {
+                "last_affected": "8.8.0"
+              },
+              {
+                "introduced": "8.7.1"
+              },
+              {
+                "last_affected": "8.7.1"
+              },
+              {
+                "introduced": "8.7.0"
+              },
+              {
+                "last_affected": "8.7.0"
+              },
+              {
+                "introduced": "8.6.0"
+              },
+              {
+                "last_affected": "8.6.0"
+              },
+              {
+                "introduced": "8.5.0"
+              },
+              {
+                "last_affected": "8.5.0"
+              },
+              {
+                "introduced": "8.4.0"
+              },
+              {
+                "last_affected": "8.4.0"
+              },
+              {
+                "introduced": "8.3.0"
+              },
+              {
+                "last_affected": "8.3.0"
+              },
+              {
+                "introduced": "8.2.1"
+              },
+              {
+                "last_affected": "8.2.1"
+              },
+              {
+                "introduced": "8.2.0"
+              },
+              {
+                "last_affected": "8.2.0"
+              },
+              {
+                "introduced": "8.1.2"
+              },
+              {
+                "last_affected": "8.1.2"
+              },
+              {
+                "introduced": "8.1.1"
+              },
+              {
+                "last_affected": "8.1.1"
+              },
+              {
+                "introduced": "8.1.0"
+              },
+              {
+                "last_affected": "8.1.0"
+              },
+              {
+                "introduced": "8.0.1"
+              },
+              {
+                "last_affected": "8.0.1"
+              },
+              {
+                "introduced": "8.0.0"
+              },
+              {
+                "last_affected": "8.0.0"
+              },
+              {
+                "introduced": "7.88.1"
+              },
+              {
+                "last_affected": "7.88.1"
+              },
+              {
+                "introduced": "7.88.0"
+              },
+              {
+                "last_affected": "7.88.0"
+              },
+              {
+                "introduced": "7.87.0"
+              },
+              {
+                "last_affected": "7.87.0"
+              },
+              {
+                "introduced": "7.86.0"
+              },
+              {
+                "last_affected": "7.86.0"
+              },
+              {
+                "introduced": "7.85.0"
+              },
+              {
+                "last_affected": "7.85.0"
+              },
+              {
+                "introduced": "7.84.0"
+              },
+              {
+                "last_affected": "7.84.0"
+              },
+              {
+                "introduced": "7.83.1"
+              },
+              {
+                "last_affected": "7.83.1"
+              },
+              {
+                "introduced": "7.83.0"
+              },
+              {
+                "last_affected": "7.83.0"
+              },
+              {
+                "introduced": "7.82.0"
+              },
+              {
+                "last_affected": "7.82.0"
+              },
+              {
+                "introduced": "7.81.0"
+              },
+              {
+                "last_affected": "7.81.0"
+              },
+              {
+                "introduced": "7.80.0"
+              },
+              {
+                "last_affected": "7.80.0"
+              },
+              {
+                "introduced": "7.79.1"
+              },
+              {
+                "last_affected": "7.79.1"
+              },
+              {
+                "introduced": "7.79.0"
+              },
+              {
+                "last_affected": "7.79.0"
+              },
+              {
+                "introduced": "7.78.0"
+              },
+              {
+                "last_affected": "7.78.0"
+              },
+              {
+                "introduced": "7.77.0"
+              },
+              {
+                "last_affected": "7.77.0"
+              },
+              {
+                "introduced": "7.76.1"
+              },
+              {
+                "last_affected": "7.76.1"
+              },
+              {
+                "introduced": "7.76.0"
+              },
+              {
+                "last_affected": "7.76.0"
+              },
+              {
+                "introduced": "7.75.0"
+              },
+              {
+                "last_affected": "7.75.0"
+              },
+              {
+                "introduced": "7.74.0"
+              },
+              {
+                "last_affected": "7.74.0"
+              },
+              {
+                "introduced": "7.73.0"
+              },
+              {
+                "last_affected": "7.73.0"
+              },
+              {
+                "introduced": "7.72.0"
+              },
+              {
+                "last_affected": "7.72.0"
+              },
+              {
+                "introduced": "7.71.1"
+              },
+              {
+                "last_affected": "7.71.1"
+              },
+              {
+                "introduced": "7.71.0"
+              },
+              {
+                "last_affected": "7.71.0"
+              },
+              {
+                "introduced": "7.70.0"
+              },
+              {
+                "last_affected": "7.70.0"
+              },
+              {
+                "introduced": "7.69.1"
+              },
+              {
+                "last_affected": "7.69.1"
+              },
+              {
+                "introduced": "7.69.0"
+              },
+              {
+                "last_affected": "7.69.0"
+              },
+              {
+                "introduced": "7.68.0"
+              },
+              {
+                "last_affected": "7.68.0"
+              },
+              {
+                "introduced": "7.67.0"
+              },
+              {
+                "last_affected": "7.67.0"
+              },
+              {
+                "introduced": "7.66.0"
+              },
+              {
+                "last_affected": "7.66.0"
+              },
+              {
+                "introduced": "7.65.3"
+              },
+              {
+                "last_affected": "7.65.3"
+              },
+              {
+                "introduced": "7.65.2"
+              },
+              {
+                "last_affected": "7.65.2"
+              },
+              {
+                "introduced": "7.65.1"
+              },
+              {
+                "last_affected": "7.65.1"
+              },
+              {
+                "introduced": "7.65.0"
+              },
+              {
+                "last_affected": "7.65.0"
+              },
+              {
+                "introduced": "7.64.1"
+              },
+              {
+                "last_affected": "7.64.1"
+              },
+              {
+                "introduced": "7.64.0"
+              },
+              {
+                "last_affected": "7.64.0"
+              },
+              {
+                "introduced": "7.63.0"
+              },
+              {
+                "last_affected": "7.63.0"
+              },
+              {
+                "introduced": "7.62.0"
+              },
+              {
+                "last_affected": "7.62.0"
+              },
+              {
+                "introduced": "7.61.1"
+              },
+              {
+                "last_affected": "7.61.1"
+              },
+              {
+                "introduced": "7.61.0"
+              },
+              {
+                "last_affected": "7.61.0"
+              },
+              {
+                "introduced": "7.60.0"
+              },
+              {
+                "last_affected": "7.60.0"
+              },
+              {
+                "introduced": "7.59.0"
+              },
+              {
+                "last_affected": "7.59.0"
+              },
+              {
+                "introduced": "7.58.0"
+              },
+              {
+                "last_affected": "7.58.0"
+              },
+              {
+                "introduced": "7.57.0"
+              },
+              {
+                "last_affected": "7.57.0"
+              },
+              {
+                "introduced": "7.56.1"
+              },
+              {
+                "last_affected": "7.56.1"
+              },
+              {
+                "introduced": "7.56.0"
+              },
+              {
+                "last_affected": "7.56.0"
+              },
+              {
+                "introduced": "7.55.1"
+              },
+              {
+                "last_affected": "7.55.1"
+              },
+              {
+                "introduced": "7.55.0"
+              },
+              {
+                "last_affected": "7.55.0"
+              },
+              {
+                "introduced": "7.54.1"
+              },
+              {
+                "last_affected": "7.54.1"
+              },
+              {
+                "introduced": "7.54.0"
+              },
+              {
+                "last_affected": "7.54.0"
+              },
+              {
+                "introduced": "7.53.1"
+              },
+              {
+                "last_affected": "7.53.1"
+              },
+              {
+                "introduced": "7.53.0"
+              },
+              {
+                "last_affected": "7.53.0"
+              },
+              {
+                "introduced": "7.52.1"
+              },
+              {
+                "last_affected": "7.52.1"
+              },
+              {
+                "introduced": "7.52.0"
+              },
+              {
+                "last_affected": "7.52.0"
+              },
+              {
+                "introduced": "7.51.0"
+              },
+              {
+                "last_affected": "7.51.0"
+              },
+              {
+                "introduced": "7.50.3"
+              },
+              {
+                "last_affected": "7.50.3"
+              },
+              {
+                "introduced": "7.50.2"
+              },
+              {
+                "last_affected": "7.50.2"
+              },
+              {
+                "introduced": "7.50.1"
+              },
+              {
+                "last_affected": "7.50.1"
+              },
+              {
+                "introduced": "7.50.0"
+              },
+              {
+                "last_affected": "7.50.0"
+              },
+              {
+                "introduced": "7.49.1"
+              },
+              {
+                "last_affected": "7.49.1"
+              },
+              {
+                "introduced": "7.49.0"
+              },
+              {
+                "last_affected": "7.49.0"
+              },
+              {
+                "introduced": "7.48.0"
+              },
+              {
+                "last_affected": "7.48.0"
+              },
+              {
+                "introduced": "7.47.1"
+              },
+              {
+                "last_affected": "7.47.1"
+              },
+              {
+                "introduced": "7.47.0"
+              },
+              {
+                "last_affected": "7.47.0"
+              },
+              {
+                "introduced": "7.46.0"
+              },
+              {
+                "last_affected": "7.46.0"
+              },
+              {
+                "introduced": "7.45.0"
+              },
+              {
+                "last_affected": "7.45.0"
+              },
+              {
+                "introduced": "7.44.0"
+              },
+              {
+                "last_affected": "7.44.0"
+              },
+              {
+                "introduced": "7.43.0"
+              },
+              {
+                "last_affected": "7.43.0"
+              },
+              {
+                "introduced": "7.42.1"
+              },
+              {
+                "last_affected": "7.42.1"
+              },
+              {
+                "introduced": "7.42.0"
+              },
+              {
+                "last_affected": "7.42.0"
+              },
+              {
+                "introduced": "7.41.0"
+              },
+              {
+                "last_affected": "7.41.0"
+              },
+              {
+                "introduced": "7.40.0"
+              },
+              {
+                "last_affected": "7.40.0"
+              },
+              {
+                "introduced": "7.39.0"
+              },
+              {
+                "last_affected": "7.39.0"
+              },
+              {
+                "introduced": "7.38.0"
+              },
+              {
+                "last_affected": "7.38.0"
+              },
+              {
+                "introduced": "7.37.1"
+              },
+              {
+                "last_affected": "7.37.1"
+              },
+              {
+                "introduced": "7.37.0"
+              },
+              {
+                "last_affected": "7.37.0"
+              },
+              {
+                "introduced": "7.36.0"
+              },
+              {
+                "last_affected": "7.36.0"
+              },
+              {
+                "introduced": "7.35.0"
+              },
+              {
+                "last_affected": "7.35.0"
+              },
+              {
+                "introduced": "7.34.0"
+              },
+              {
+                "last_affected": "7.34.0"
+              },
+              {
+                "introduced": "7.33.0"
+              },
+              {
+                "last_affected": "7.33.0"
+              },
+              {
+                "introduced": "7.32.0"
+              },
+              {
+                "last_affected": "7.32.0"
+              }
+            ],
+            "source": "AFFECTED_FIELD"
+          },
+          "events": [
+            {
+              "introduced": "5040f7e94cd01decbe7ba8fdacbf489182d503dc"
+            },
+            {
+              "last_affected": "70812c2f32fc5734bcbbe572b9f61c380433ad6a"
+            }
+          ],
+          "repo": "https://github.com/curl/curl",
+          "type": "GIT"
+        }
+      ],
+      "versions": [
+        "7.32.0",
+        "7.33.0",
+        "7.34.0",
+        "7.35.0",
+        "7.36.0",
+        "7.37.0",
+        "7.37.1",
+        "7.38.0",
+        "7.39.0",
+        "7.40.0",
+        "7.41.0",
+        "7.42.0",
+        "7.42.1",
+        "7.43.0",
+        "7.44.0",
+        "7.45.0",
+        "7.46.0",
+        "7.47.0",
+        "7.47.1",
+        "7.48.0",
+        "7.49.0",
+        "7.49.1",
+        "7.50.0",
+        "7.50.1",
+        "7.50.2",
+        "7.50.3",
+        "7.51.0",
+        "7.52.0",
+        "7.52.1",
+        "7.53.0",
+        "7.53.1",
+        "7.54.0",
+        "7.54.1",
+        "7.55.0",
+        "7.55.1",
+        "7.56.0",
+        "7.56.1",
+        "7.57.0",
+        "7.58.0",
+        "7.59.0",
+        "7.60.0",
+        "7.61.0",
+        "7.61.1",
+        "7.62.0",
+        "7.63.0",
+        "7.64.0",
+        "7.64.1",
+        "7.65.0",
+        "7.65.1",
+        "7.65.2",
+        "7.65.3",
+        "7.66.0",
+        "7.67.0",
+        "7.68.0",
+        "7.69.0",
+        "7.69.1",
+        "7.70.0",
+        "7.71.0",
+        "7.71.1",
+        "7.72.0",
+        "7.73.0",
+        "7.74.0",
+        "7.75.0",
+        "7.76.0",
+        "7.76.1",
+        "7.77.0",
+        "7.78.0",
+        "7.79.0",
+        "7.79.1",
+        "7.80.0",
+        "7.81.0",
+        "7.82.0",
+        "7.83.0",
+        "7.83.1",
+        "7.84.0",
+        "7.85.0",
+        "7.86.0",
+        "7.87.0",
+        "7.88.0",
+        "7.88.1",
+        "8.0.0",
+        "8.0.1",
+        "8.1.0",
+        "8.1.1",
+        "8.1.2",
+        "8.2.0",
+        "8.2.1",
+        "8.3.0",
+        "8.4.0",
+        "8.5.0",
+        "8.6.0",
+        "8.7.0",
+        "8.7.1",
+        "8.8.0",
+        "8.9.0"
+      ]
+    }
+  ],
+  "database_specific": {
+    "cna_assigner": "curl",
+    "osv_generated_from": "unknown"
+  },
+  "details": "libcurl's ASN1 parser code has the `GTime2str()` function, used for parsing an\nASN.1 Generalized Time field. If given an syntactically incorrect field, the\nparser might end up using -1 for the length of the *time fraction*, leading to\na `strlen()` getting performed on a pointer to a heap buffer area that is not\n(purposely) null terminated.\n\nThis flaw most likely leads to a crash, but can also lead to heap contents\ngetting returned to the application when\n[CURLINFO_CERTINFO](https://curl.se/libcurl/c/CURLINFO_CERTINFO.html) is used.",
+  "id": "CVE-2024-7264",
+  "modified": "2025-11-03T22:32:51.400Z",
+  "published": "2024-07-31T08:08:14.585Z",
+  "references": [
+    {
+      "type": "WEB",
+      "url": "http://www.openwall.com/lists/oss-security/2024/07/31/1"
+    },
+    {
+      "type": "WEB",
+      "url": "https://curl.se/docs/CVE-2024-7264.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://curl.se/docs/CVE-2024-7264.json"
+    },
+    {
+      "type": "FIX",
+      "url": "https://github.com/curl/curl/commit/27959ecce75cdb2809c0bdb3286e60e08fadb519"
+    },
+    {
+      "type": "WEB",
+      "url": "https://hackerone.com/reports/2629968"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-7264"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://security.netapp.com/advisory/ntap-20240828-0008/"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://security.netapp.com/advisory/ntap-20241025-0006/"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://security.netapp.com/advisory/ntap-20241025-0010/"
+    }
+  ],
+  "schema_version": "1.7.5",
+  "severity": [
+    {
+      "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
+      "type": "CVSS_V3"
+    }
+  ],
+  "summary": "ASN.1 date parser overread"
+}
+{
   "database_specific": {
     "cna_assigner": "mitre",
     "osv_generated_from": "unknown"
@@ -1602,6 +2003,9 @@
       {
         "extracted_events": [
           {
+            "introduced": "7.61.1"
+          },
+          {
             "last_affected": "7.61.1"
           }
         ],
@@ -1690,6 +2094,9 @@
       {
         "extracted_events": [
           {
+            "introduced": "11 and 12"
+          },
+          {
             "last_affected": "11 and 12"
           }
         ],
@@ -1727,6 +2134,9 @@
     "unresolved_ranges": [
       {
         "extracted_events": [
+          {
+            "introduced": "0.1.0"
+          },
           {
             "last_affected": "0.1.0"
           }

--- a/vulnfeeds/conversion/cve5/default_extractor.go
+++ b/vulnfeeds/conversion/cve5/default_extractor.go
@@ -142,11 +142,15 @@ func (d *DefaultVersionExtractor) FindNormalAffectedRanges(affected models.Affec
 			continue
 		}
 
-		// As a fallback, assume a single version means it's the last affected version.
+		// As a fallback, treat a single version as a standalone version.
 		if vulns.CheckQuality(vers.Version).AtLeast(acceptableQuality) {
-			vr := []*osvschema.Range{c.BuildVersionRange("0", vers.Version, "")}
-			versionRanges = append(versionRanges, c.ToRangeWithMetadata(vr, models.VersionSourceAffected)...)
-			metrics.AddNote("Single version found %v - Assuming introduced = 0 and last affected = %v", vers.Version, vers.Version)
+			vr := []*osvschema.Range{c.BuildVersionRange(vers.Version, vers.Version, "")}
+			rwms := c.ToRangeWithMetadata(vr, models.VersionSourceAffected)
+			for i := range rwms {
+				rwms[i].Metadata.Versions = []string{vers.Version}
+			}
+			versionRanges = append(versionRanges, rwms...)
+			metrics.AddNote("Single version found %v - Treating as standalone version", vers.Version)
 		}
 	}
 

--- a/vulnfeeds/conversion/cve5/version_extraction_test.go
+++ b/vulnfeeds/conversion/cve5/version_extraction_test.go
@@ -74,7 +74,7 @@ func TestFindNormalAffectedRanges(t *testing.T) {
 				},
 			},
 			wantRanges: []*osvschema.Range{
-				conversion.BuildVersionRange("0", "2.0", ""),
+				conversion.BuildVersionRange("2.0", "2.0", ""),
 			},
 			wantRangeType: VersionRangeTypeSemver,
 		},
@@ -105,7 +105,7 @@ func TestFindNormalAffectedRanges(t *testing.T) {
 				},
 			},
 			wantRanges: []*osvschema.Range{
-				conversion.BuildVersionRange("", "deadbeef", ""),
+				conversion.BuildVersionRange("deadbeef", "deadbeef", ""),
 			},
 			wantRangeType: VersionRangeTypeGit,
 		},

--- a/vulnfeeds/conversion/grouping.go
+++ b/vulnfeeds/conversion/grouping.go
@@ -302,6 +302,11 @@ func MergeRangesAndCreateAffected(
 				}
 			}
 
+			// Standalone ranges (where introduced == lastAffected) are assumed to represent a
+			// sequence of enumerated ranges. If there are multiple, we attempt to combine
+			// them into a single range spanning from the first introduced commit to the last
+			// affected commit. If both endpoints cannot be determined, we fall back to keeping
+			// them as separate standalone ranges.
 			if len(standaloneRanges) > 0 {
 				var standaloneVersions []string
 				for _, vrwm := range standaloneRanges {

--- a/vulnfeeds/conversion/grouping.go
+++ b/vulnfeeds/conversion/grouping.go
@@ -289,18 +289,70 @@ func MergeRangesAndCreateAffected(
 		slices.Sort(successfulRepos)
 		successfulRepos = slices.Compact(successfulRepos)
 		for _, repo := range successfulRepos {
-			var mergedRange *osvschema.Range
+			var standaloneRanges []models.RangeWithMetadata
+			var otherRanges []models.RangeWithMetadata
 			for _, vrwm := range resolvedRanges {
+				if vrwm.Range.GetRepo() != repo {
+					continue
+				}
+				if isStandaloneRange(vrwm) {
+					standaloneRanges = append(standaloneRanges, vrwm)
+				} else {
+					otherRanges = append(otherRanges, vrwm)
+				}
+			}
+
+			if len(standaloneRanges) > 0 {
+				var standaloneVersions []string
+				for _, vrwm := range standaloneRanges {
+					standaloneVersions = append(standaloneVersions, vrwm.Metadata.Versions...)
+				}
+
+				var firstCommit, lastCommit string
+				// Standalone ranges preserve first appearance order from the record,
+				// so first range represents the earliest version, last range represents the latest version.
+				for _, e := range standaloneRanges[0].Range.GetEvents() {
+					if e.GetIntroduced() != "" {
+						firstCommit = e.GetIntroduced()
+					}
+				}
+				for _, e := range standaloneRanges[len(standaloneRanges)-1].Range.GetEvents() {
+					if e.GetLastAffected() != "" {
+						lastCommit = e.GetLastAffected()
+					}
+				}
+
+				if firstCommit != "" && lastCommit != "" {
+					combinedRange := BuildGitVersionRange(firstCommit, lastCommit, "", repo)
+					for _, vrwm := range standaloneRanges {
+						mergeDatabaseSpecific(combinedRange, vrwm.Range.GetDatabaseSpecific())
+					}
+					combinedRangeWM := models.RangeWithMetadata{
+						Range: combinedRange,
+						Metadata: models.Metadata{
+							CPE:      standaloneRanges[0].Metadata.CPE,
+							Source:   standaloneRanges[0].Metadata.Source,
+							Versions: standaloneVersions,
+						},
+					}
+					otherRanges = append(otherRanges, combinedRangeWM)
+				} else {
+					otherRanges = append(otherRanges, standaloneRanges...)
+				}
+			}
+
+			var mergedRange *osvschema.Range
+			var versions []string
+			for _, vrwm := range otherRanges {
 				vr := vrwm.Range
-				if vr.GetRepo() == repo {
-					if mergedRange == nil {
-						mergedRange = vr
-					} else {
-						var err error
-						mergedRange, err = MergeTwoRanges(mergedRange, vr)
-						if err != nil {
-							metrics.AddNote("Failed to merge ranges: %v", err)
-						}
+				versions = append(versions, vrwm.Metadata.Versions...)
+				if mergedRange == nil {
+					mergedRange = vr
+				} else {
+					var err error
+					mergedRange, err = MergeTwoRanges(mergedRange, vr)
+					if err != nil {
+						metrics.AddNote("Failed to merge ranges: %v", err)
 					}
 				}
 			}
@@ -330,8 +382,11 @@ func MergeRangesAndCreateAffected(
 				}
 			}
 			if mergedRange != nil {
+				slices.Sort(versions)
+				versions = slices.Compact(versions)
 				newAffected = append(newAffected, &osvschema.Affected{
-					Ranges: []*osvschema.Range{mergedRange},
+					Ranges:   []*osvschema.Range{mergedRange},
+					Versions: versions,
 				})
 			}
 		}
@@ -424,4 +479,21 @@ func convertCommitToEvent(commit models.AffectedCommit) *osvschema.Event {
 	}
 
 	return nil
+}
+
+func isStandaloneRange(vrwm models.RangeWithMetadata) bool {
+	if len(vrwm.Metadata.Versions) != 1 {
+		return false
+	}
+	var introduced, lastAffected string
+	for _, e := range vrwm.Range.GetEvents() {
+		if e.GetIntroduced() != "" {
+			introduced = e.GetIntroduced()
+		}
+		if e.GetLastAffected() != "" {
+			lastAffected = e.GetLastAffected()
+		}
+	}
+
+	return introduced != "" && introduced == lastAffected
 }

--- a/vulnfeeds/conversion/nvd/__snapshots__/converter_test.snap
+++ b/vulnfeeds/conversion/nvd/__snapshots__/converter_test.snap
@@ -2093,13 +2093,25 @@
         ],
         "extracted_events": [
           {
+            "introduced": "12.04"
+          },
+          {
             "last_affected": "12.04"
+          },
+          {
+            "introduced": "14.04"
           },
           {
             "last_affected": "14.04"
           },
           {
+            "introduced": "16.04"
+          },
+          {
             "last_affected": "16.04"
+          },
+          {
+            "introduced": "18.04"
           },
           {
             "last_affected": "18.04"
@@ -2113,6 +2125,9 @@
           "cpe:2.3:o:debian:debian_linux:9.0:*:*:*:*:*:*:*"
         ],
         "extracted_events": [
+          {
+            "introduced": "9.0"
+          },
           {
             "last_affected": "9.0"
           }
@@ -2130,16 +2145,31 @@
         ],
         "extracted_events": [
           {
+            "introduced": "6.0"
+          },
+          {
             "last_affected": "6.0"
+          },
+          {
+            "introduced": "7.0"
           },
           {
             "last_affected": "7.0"
           },
           {
+            "introduced": "7.4"
+          },
+          {
             "last_affected": "7.4"
           },
           {
+            "introduced": "7.5"
+          },
+          {
             "last_affected": "7.5"
+          },
+          {
+            "introduced": "7.6"
           },
           {
             "last_affected": "7.6"
@@ -2221,10 +2251,19 @@
         ],
         "extracted_events": [
           {
+            "introduced": "36"
+          },
+          {
             "last_affected": "36"
           },
           {
+            "introduced": "37"
+          },
+          {
             "last_affected": "37"
+          },
+          {
+            "introduced": "38"
           },
           {
             "last_affected": "38"
@@ -2242,13 +2281,25 @@
         ],
         "extracted_events": [
           {
+            "introduced": "11.5"
+          },
+          {
             "last_affected": "11.5"
+          },
+          {
+            "introduced": "11.6"
           },
           {
             "last_affected": "11.6"
           },
           {
+            "introduced": "12.0"
+          },
+          {
             "last_affected": "12.0"
+          },
+          {
+            "introduced": "12.1"
           },
           {
             "last_affected": "12.1"
@@ -2381,7 +2432,7 @@
             "cpe": "cpe:2.3:a:harfbuzz_project:harfbuzz:4.3.0:*:*:*:*:*:*:*",
             "extracted_events": [
               {
-                "introduced": "0"
+                "introduced": "4.3.0"
               },
               {
                 "last_affected": "4.3.0"
@@ -2394,7 +2445,7 @@
           },
           "events": [
             {
-              "introduced": "0"
+              "introduced": "aee123fc83388b8f5acfb301d87bd92eccc5b843"
             },
             {
               "last_affected": "aee123fc83388b8f5acfb301d87bd92eccc5b843"
@@ -2406,6 +2457,9 @@
           "repo": "https://github.com/harfbuzz/harfbuzz",
           "type": "GIT"
         }
+      ],
+      "versions": [
+        "4.3.0"
       ]
     }
   ],
@@ -2418,7 +2472,13 @@
         ],
         "extracted_events": [
           {
+            "introduced": "35"
+          },
+          {
             "last_affected": "35"
+          },
+          {
+            "introduced": "36"
           },
           {
             "last_affected": "36"
@@ -2561,250 +2621,493 @@
             ],
             "extracted_events": [
               {
-                "introduced": "0"
+                "introduced": "2.0"
               },
               {
                 "last_affected": "2.0"
               },
               {
+                "introduced": "2.0.1"
+              },
+              {
                 "last_affected": "2.0.1"
+              },
+              {
+                "introduced": "2.0.2"
               },
               {
                 "last_affected": "2.0.2"
               },
               {
+                "introduced": "2.0.3"
+              },
+              {
                 "last_affected": "2.0.3"
+              },
+              {
+                "introduced": "2.0.4"
               },
               {
                 "last_affected": "2.0.4"
               },
               {
+                "introduced": "2.0.5"
+              },
+              {
                 "last_affected": "2.0.5"
+              },
+              {
+                "introduced": "2.0.6"
               },
               {
                 "last_affected": "2.0.6"
               },
               {
+                "introduced": "2.0.7"
+              },
+              {
                 "last_affected": "2.0.7"
+              },
+              {
+                "introduced": "2.1"
               },
               {
                 "last_affected": "2.1"
               },
               {
+                "introduced": "2.1.1"
+              },
+              {
                 "last_affected": "2.1.1"
+              },
+              {
+                "introduced": "2.1.2"
               },
               {
                 "last_affected": "2.1.2"
               },
               {
+                "introduced": "2.1.3"
+              },
+              {
                 "last_affected": "2.1.3"
+              },
+              {
+                "introduced": "2.1.4"
               },
               {
                 "last_affected": "2.1.4"
               },
               {
+                "introduced": "2.1.5"
+              },
+              {
                 "last_affected": "2.1.5"
+              },
+              {
+                "introduced": "2.1.6"
               },
               {
                 "last_affected": "2.1.6"
               },
               {
+                "introduced": "2.1.7"
+              },
+              {
                 "last_affected": "2.1.7"
+              },
+              {
+                "introduced": "2.1.8"
               },
               {
                 "last_affected": "2.1.8"
               },
               {
+                "introduced": "2.2"
+              },
+              {
                 "last_affected": "2.2"
+              },
+              {
+                "introduced": "2.2.1"
               },
               {
                 "last_affected": "2.2.1"
               },
               {
+                "introduced": "2.2.2"
+              },
+              {
                 "last_affected": "2.2.2"
+              },
+              {
+                "introduced": "2.2.3"
               },
               {
                 "last_affected": "2.2.3"
               },
               {
+                "introduced": "2.2.4"
+              },
+              {
                 "last_affected": "2.2.4"
+              },
+              {
+                "introduced": "2.2.5"
               },
               {
                 "last_affected": "2.2.5"
               },
               {
+                "introduced": "2.2.6"
+              },
+              {
                 "last_affected": "2.2.6"
+              },
+              {
+                "introduced": "2.2.7"
               },
               {
                 "last_affected": "2.2.7"
               },
               {
+                "introduced": "2.2.8"
+              },
+              {
                 "last_affected": "2.2.8"
+              },
+              {
+                "introduced": "2.2.9"
               },
               {
                 "last_affected": "2.2.9"
               },
               {
+                "introduced": "2.2.10"
+              },
+              {
                 "last_affected": "2.2.10"
+              },
+              {
+                "introduced": "2.2.11"
               },
               {
                 "last_affected": "2.2.11"
               },
               {
+                "introduced": "2.2.12"
+              },
+              {
                 "last_affected": "2.2.12"
+              },
+              {
+                "introduced": "2.2.13"
               },
               {
                 "last_affected": "2.2.13"
               },
               {
+                "introduced": "2.2.14"
+              },
+              {
                 "last_affected": "2.2.14"
+              },
+              {
+                "introduced": "2.2.15"
               },
               {
                 "last_affected": "2.2.15"
               },
               {
+                "introduced": "2.2.16"
+              },
+              {
                 "last_affected": "2.2.16"
+              },
+              {
+                "introduced": "2.3"
               },
               {
                 "last_affected": "2.3"
               },
               {
+                "introduced": "2.3.1"
+              },
+              {
                 "last_affected": "2.3.1"
+              },
+              {
+                "introduced": "2.3.2"
               },
               {
                 "last_affected": "2.3.2"
               },
               {
+                "introduced": "2.3.3"
+              },
+              {
                 "last_affected": "2.3.3"
+              },
+              {
+                "introduced": "2.3.4"
               },
               {
                 "last_affected": "2.3.4"
               },
               {
+                "introduced": "2.3.5"
+              },
+              {
                 "last_affected": "2.3.5"
+              },
+              {
+                "introduced": "2.3.6"
               },
               {
                 "last_affected": "2.3.6"
               },
               {
+                "introduced": "2.4"
+              },
+              {
                 "last_affected": "2.4"
+              },
+              {
+                "introduced": "2.4.1"
               },
               {
                 "last_affected": "2.4.1"
               },
               {
+                "introduced": "2.4.2"
+              },
+              {
                 "last_affected": "2.4.2"
+              },
+              {
+                "introduced": "2.4.3"
               },
               {
                 "last_affected": "2.4.3"
               },
               {
+                "introduced": "2.4.4"
+              },
+              {
                 "last_affected": "2.4.4"
+              },
+              {
+                "introduced": "2.4.5"
               },
               {
                 "last_affected": "2.4.5"
               },
               {
+                "introduced": "2.4.6"
+              },
+              {
                 "last_affected": "2.4.6"
+              },
+              {
+                "introduced": "2.4.7"
               },
               {
                 "last_affected": "2.4.7"
               },
               {
+                "introduced": "2.4.8"
+              },
+              {
                 "last_affected": "2.4.8"
+              },
+              {
+                "introduced": "2.4.9"
               },
               {
                 "last_affected": "2.4.9"
               },
               {
+                "introduced": "2.4.10"
+              },
+              {
                 "last_affected": "2.4.10"
+              },
+              {
+                "introduced": "2.4.11"
               },
               {
                 "last_affected": "2.4.11"
               },
               {
+                "introduced": "2.4.12"
+              },
+              {
                 "last_affected": "2.4.12"
+              },
+              {
+                "introduced": "2.5"
               },
               {
                 "last_affected": "2.5"
               },
               {
+                "introduced": "2.5.1"
+              },
+              {
                 "last_affected": "2.5.1"
+              },
+              {
+                "introduced": "2.5.2"
               },
               {
                 "last_affected": "2.5.2"
               },
               {
+                "introduced": "2.5.3"
+              },
+              {
                 "last_affected": "2.5.3"
+              },
+              {
+                "introduced": "2.5.4"
               },
               {
                 "last_affected": "2.5.4"
               },
               {
+                "introduced": "2.5.5"
+              },
+              {
                 "last_affected": "2.5.5"
+              },
+              {
+                "introduced": "2.5.6"
               },
               {
                 "last_affected": "2.5.6"
               },
               {
+                "introduced": "2.5.7"
+              },
+              {
                 "last_affected": "2.5.7"
+              },
+              {
+                "introduced": "2.5.8"
               },
               {
                 "last_affected": "2.5.8"
               },
               {
+                "introduced": "2.5.9"
+              },
+              {
                 "last_affected": "2.5.9"
+              },
+              {
+                "introduced": "2.6"
               },
               {
                 "last_affected": "2.6"
               },
               {
+                "introduced": "2.6.1"
+              },
+              {
                 "last_affected": "2.6.1"
+              },
+              {
+                "introduced": "2.6.2"
               },
               {
                 "last_affected": "2.6.2"
               },
               {
+                "introduced": "2.6.3"
+              },
+              {
                 "last_affected": "2.6.3"
+              },
+              {
+                "introduced": "2.6.4"
               },
               {
                 "last_affected": "2.6.4"
               },
               {
+                "introduced": "2.6.5"
+              },
+              {
                 "last_affected": "2.6.5"
+              },
+              {
+                "introduced": "2.6.6"
               },
               {
                 "last_affected": "2.6.6"
               },
               {
+                "introduced": "2.7"
+              },
+              {
                 "last_affected": "2.7"
+              },
+              {
+                "introduced": "2.7.1"
               },
               {
                 "last_affected": "2.7.1"
               },
               {
+                "introduced": "2.7.2"
+              },
+              {
                 "last_affected": "2.7.2"
+              },
+              {
+                "introduced": "2.7.3"
               },
               {
                 "last_affected": "2.7.3"
               },
               {
+                "introduced": "2.7.4"
+              },
+              {
                 "last_affected": "2.7.4"
+              },
+              {
+                "introduced": "2.8"
               },
               {
                 "last_affected": "2.8"
               },
               {
+                "introduced": "2.8-dev"
+              },
+              {
                 "last_affected": "2.8-dev"
+              },
+              {
+                "introduced": "2.8.1"
               },
               {
                 "last_affected": "2.8.1"
               },
               {
+                "introduced": "2.8.2"
+              },
+              {
                 "last_affected": "2.8.2"
               },
               {
+                "introduced": "2.8.3"
+              },
+              {
                 "last_affected": "2.8.3"
+              },
+              {
+                "introduced": "2.8.4"
               },
               {
                 "last_affected": "2.8.4"
@@ -2814,247 +3117,7 @@
           },
           "events": [
             {
-              "introduced": "0"
-            },
-            {
-              "last_affected": "2b8b2ba19fe0ca6594cb09439b9ead2c328a79d8"
-            },
-            {
-              "last_affected": "acf511de34e0b79fff0183e06ed37f1aa8dc3d94"
-            },
-            {
-              "last_affected": "9d0bb7fc3991b030603acfe899e6f001e530c89a"
-            },
-            {
-              "last_affected": "b4552cc9b8c37410f754af5d34d24e7b8a9b4b0e"
-            },
-            {
-              "last_affected": "7de7bd4f563a1431bdac59dae5d8e930e71405e6"
-            },
-            {
-              "last_affected": "205e2264c3d5b1a16a4493b9281b9167d09c3505"
-            },
-            {
-              "last_affected": "3d91569c5e39f4062393fdb40b038e31df38473a"
-            },
-            {
-              "last_affected": "0caff57c42cac0f80152187473b1ee753aca8257"
-            },
-            {
-              "last_affected": "a37e42b3ee4226a4d2c69cd4eebf9c81e6df8ea5"
-            },
-            {
-              "last_affected": "9422cd85a081f6e084731e87eda3e8e4df9f6827"
-            },
-            {
-              "last_affected": "29353dd3f8159089ecf2fa0886f94f4cf32e75f2"
-            },
-            {
-              "last_affected": "eda6effcabcf9c238e4635eb058d72371336e09b"
-            },
-            {
-              "last_affected": "d3139c9733f1994fb86825e0d1fd2a5abf3be7b5"
-            },
-            {
-              "last_affected": "e7873dfccad595e9d8fc65217ebffcf3686e1d34"
-            },
-            {
-              "last_affected": "27172a5ca360e61a07ff16bf22f2ec91208f4e00"
-            },
-            {
-              "last_affected": "41802887eb647bee21238e0a575a7c4bbf954b86"
-            },
-            {
-              "last_affected": "68f89b8264d46d5812e710ca0f903d4d323ec899"
-            },
-            {
-              "last_affected": "6baf9c4406bcdf1015c9ec8bd6b8c4aef77624ac"
-            },
-            {
-              "last_affected": "e72c0a04664a9aab449b63135fe16ade51a99bb6"
-            },
-            {
-              "last_affected": "c2eb668617555cb8b8bcfb9796241ada9471ac65"
-            },
-            {
-              "last_affected": "f406bf3fa933be089bd76a95f75ea57b0942f8c5"
-            },
-            {
-              "last_affected": "e0a03d1f9cb18139ede8c3d0263a21828494c951"
-            },
-            {
-              "last_affected": "0edc79962641dd853cda187ee13b617701346061"
-            },
-            {
-              "last_affected": "1b99667005156cadc8d3ae0099ef5d244e598ac5"
-            },
-            {
-              "last_affected": "49fa398858df1a1e425740672de5fb4819b4d947"
-            },
-            {
-              "last_affected": "5df02760dd2f050b996f931fa7cdf8871bfa5d96"
-            },
-            {
-              "last_affected": "b05d3550407418aea53f2672463a8ebc8f75654e"
-            },
-            {
-              "last_affected": "969aee07e68c5930782bc46f2ac2391db55b8d1b"
-            },
-            {
-              "last_affected": "9f09bfe681259cfed7414f207c88f84c09d5b501"
-            },
-            {
-              "last_affected": "86a01362c0e46d155fbfc1ef19f5ba17af3ee69d"
-            },
-            {
-              "last_affected": "36cfee3adc70c6a78a07df4bb16349c4b0893ef4"
-            },
-            {
-              "last_affected": "bf0d2ee92c33d802907e829f99c26a46578ed679"
-            },
-            {
-              "last_affected": "1c14b09caf903f2e776dcd661085db49511bf531"
-            },
-            {
-              "last_affected": "051cd7dc5f42542753f809109d00ec3cf19eb337"
-            },
-            {
-              "last_affected": "3ec3f70ddb1b97fd6174ab3ca8617d8a1a6516ab"
-            },
-            {
-              "last_affected": "7c2d152f562ab089ecf8262438e2f8e9cb9c546f"
-            },
-            {
-              "last_affected": "b88de7b31a4a5c35d10b1392d2d86d93fc942b4c"
-            },
-            {
-              "last_affected": "bc259185cb69c6532232be4b2ad57a70ef7ed946"
-            },
-            {
-              "last_affected": "d005e2ecce5c8104679b39f2050a9d83e417d275"
-            },
-            {
-              "last_affected": "b44506c393b176dc396502ad262ac18bec52a110"
-            },
-            {
-              "last_affected": "db27f50e0658e91758e8a17fdcf390e6bc93c1d2"
-            },
-            {
-              "last_affected": "13a72d9b08c914c3d3c99be1053e9d5cda8baa88"
-            },
-            {
-              "last_affected": "e1ce4f805f31aecec83fc7c7ecaab623f3b6327f"
-            },
-            {
-              "last_affected": "d61454e7c1de48f6a9059ca98f55e6beb52a618c"
-            },
-            {
-              "last_affected": "043f32606046b1470218511ded151edfa7a126ee"
-            },
-            {
-              "last_affected": "dd2394754d8cee3717b3e198c83cc382674cf126"
-            },
-            {
-              "last_affected": "4afe2684d8f50b28ce6743c7ee999f3157c9857f"
-            },
-            {
-              "last_affected": "1fd7fb9036fcfb1620068014d8a52112067d2d59"
-            },
-            {
-              "last_affected": "3c63503792147a996997023694a3b45f27ab3f78"
-            },
-            {
-              "last_affected": "2c8c55195da97ee45fb0daf6d68c22b942e14ade"
-            },
-            {
-              "last_affected": "de7b74d2544d2cb5ff85db20a9853116ea72ed47"
-            },
-            {
-              "last_affected": "1047c286fa20c79dde8ddd7577a3b87cc1effdb7"
-            },
-            {
-              "last_affected": "0045969e411bcf946b2393e7bcb42032cb71a9a1"
-            },
-            {
-              "last_affected": "5e4ec87720a64cd969120af60e82cbd55454ab8e"
-            },
-            {
-              "last_affected": "da2186be81b5cb2d24da5671e25affbb8f09920d"
-            },
-            {
-              "last_affected": "2c01dd2ea5e39238261945185d2b30e11979cf4b"
-            },
-            {
-              "last_affected": "959ab06c68f8c74a0f31bcaf2692cbbdaf5702f6"
-            },
-            {
-              "last_affected": "07d508e4f55f6045b83df3346448b149faab5d7d"
-            },
-            {
-              "last_affected": "3429714f3d046f4e2235848a60b6f63bd084e01f"
-            },
-            {
-              "last_affected": "d0599a3516c5da31c7009af7574abbff360b9ce6"
-            },
-            {
-              "last_affected": "faac8e43315dae5818816bcebe52d11777b064b2"
-            },
-            {
-              "last_affected": "21d0ae829f72ec327aff31b0cb1af1261b56596c"
-            },
-            {
-              "last_affected": "1eb646ec9f87ed488f52561867e107eaee89e20c"
-            },
-            {
-              "last_affected": "d52b5f85f2837b0de9bdefe2a650d8d1b0e02ec1"
-            },
-            {
-              "last_affected": "f478bdabf2afcd5f709789347f8a3becc4ff17bc"
-            },
-            {
-              "last_affected": "b2c9cd36d34c4157af10342ad3476dd9260bbefe"
-            },
-            {
-              "last_affected": "04fd0250e1fd3fddcd7bc96c8ac95455f910637e"
-            },
-            {
-              "last_affected": "af5917698bd44f136fd0ff00a9e5f8b5f92f2d58"
-            },
-            {
-              "last_affected": "b17cec526214dff9d6ac1d97b70167d15a4e14d7"
-            },
-            {
-              "last_affected": "48d388b03336d01e0db9b729f9f82cbadf3af7bd"
-            },
-            {
-              "last_affected": "d6ce1cb14077891f3f6ac86cfd243835c92eb374"
-            },
-            {
-              "last_affected": "0bcb6ac150690d1b799982efabc11cab3420f3e3"
-            },
-            {
-              "last_affected": "620197d1ffea20e9168372c354438f1c1e926ecd"
-            },
-            {
-              "last_affected": "15466db69e60f486c44e4c3e680d27c951f125d7"
-            },
-            {
-              "last_affected": "93f3752b970cc7c9e1a360037fff1ddb9dcbb86e"
-            },
-            {
-              "last_affected": "26241af6f8b291eed42c597ffa2b32802331f813"
-            },
-            {
-              "last_affected": "58142a27ea96bf9246586a91a82db85e37646933"
-            },
-            {
-              "last_affected": "40934e0e9b632fa6c6ec22ac03b530625a027c79"
-            },
-            {
-              "last_affected": "c9b3451da3cf632424c07c35759c9ffbd537fa9e"
-            },
-            {
-              "last_affected": "644296e736ee219cd02f7b7d7b7b4c7c5a464217"
+              "introduced": "2b8b2ba19fe0ca6594cb09439b9ead2c328a79d8"
             },
             {
               "last_affected": "644179e0d4155ae8f5ddd5c3f6bd003e2e13cf94"
@@ -3063,6 +3126,89 @@
           "repo": "https://github.com/ffmpeg/ffmpeg",
           "type": "GIT"
         }
+      ],
+      "versions": [
+        "2.0",
+        "2.0.1",
+        "2.0.2",
+        "2.0.3",
+        "2.0.4",
+        "2.0.5",
+        "2.0.6",
+        "2.0.7",
+        "2.1",
+        "2.1.1",
+        "2.1.2",
+        "2.1.3",
+        "2.1.4",
+        "2.1.5",
+        "2.1.6",
+        "2.1.7",
+        "2.1.8",
+        "2.2",
+        "2.2.1",
+        "2.2.10",
+        "2.2.11",
+        "2.2.12",
+        "2.2.13",
+        "2.2.14",
+        "2.2.15",
+        "2.2.16",
+        "2.2.2",
+        "2.2.3",
+        "2.2.4",
+        "2.2.5",
+        "2.2.6",
+        "2.2.7",
+        "2.2.8",
+        "2.2.9",
+        "2.3",
+        "2.3.1",
+        "2.3.2",
+        "2.3.3",
+        "2.3.4",
+        "2.3.5",
+        "2.3.6",
+        "2.4",
+        "2.4.1",
+        "2.4.10",
+        "2.4.11",
+        "2.4.12",
+        "2.4.2",
+        "2.4.3",
+        "2.4.4",
+        "2.4.5",
+        "2.4.6",
+        "2.4.7",
+        "2.4.8",
+        "2.4.9",
+        "2.5",
+        "2.5.1",
+        "2.5.2",
+        "2.5.3",
+        "2.5.4",
+        "2.5.5",
+        "2.5.6",
+        "2.5.7",
+        "2.5.8",
+        "2.5.9",
+        "2.6",
+        "2.6.1",
+        "2.6.2",
+        "2.6.3",
+        "2.6.4",
+        "2.6.5",
+        "2.6.6",
+        "2.7",
+        "2.7.1",
+        "2.7.2",
+        "2.7.3",
+        "2.7.4",
+        "2.8",
+        "2.8.1",
+        "2.8.2",
+        "2.8.3",
+        "2.8.4"
       ]
     }
   ],
@@ -3073,6 +3219,9 @@
           "cpe:2.3:o:canonical:ubuntu_linux:12.04:*:*:*:lts:*:*:*"
         ],
         "extracted_events": [
+          {
+            "introduced": "12.04"
+          },
           {
             "last_affected": "12.04"
           }
@@ -3085,6 +3234,9 @@
           "cpe:2.3:o:opensuse:leap:42.1:*:*:*:*:*:*:*"
         ],
         "extracted_events": [
+          {
+            "introduced": "42.1"
+          },
           {
             "last_affected": "42.1"
           }
@@ -3267,6 +3419,9 @@
         ],
         "extracted_events": [
           {
+            "introduced": "40"
+          },
+          {
             "last_affected": "40"
           }
         ],
@@ -3280,7 +3435,13 @@
         ],
         "extracted_events": [
           {
+            "introduced": "7.0"
+          },
+          {
             "last_affected": "7.0"
+          },
+          {
+            "introduced": "8.0"
           },
           {
             "last_affected": "8.0"
@@ -3400,10 +3561,19 @@
         ],
         "extracted_events": [
           {
+            "introduced": "38"
+          },
+          {
             "last_affected": "38"
           },
           {
+            "introduced": "39"
+          },
+          {
             "last_affected": "39"
+          },
+          {
+            "introduced": "40"
           },
           {
             "last_affected": "40"

--- a/vulnfeeds/conversion/versions.go
+++ b/vulnfeeds/conversion/versions.go
@@ -779,6 +779,7 @@ func ExtractVersionsFromCPEs(cve models.NVDCVE, validVersions []string, vpRepoCa
 				if err != nil {
 					continue
 				}
+				var metadataVersions []string
 				if introduced == "" && fixed == "" && lastaffected == "" {
 					// See if a last affected version is inferable from the CPE string.
 					// In this situation there is no known introduced version.
@@ -795,6 +796,8 @@ func ExtractVersionsFromCPEs(cve models.NVDCVE, validVersions []string, vpRepoCa
 						lastaffected += "-" + CPE.Update
 					}
 					source = models.VersionSourceCPEString
+					introduced = lastaffected
+					metadataVersions = []string{lastaffected}
 				}
 
 				if introduced == "" {
@@ -832,8 +835,9 @@ func ExtractVersionsFromCPEs(cve models.NVDCVE, validVersions []string, vpRepoCa
 							models.RangeWithMetadata{
 								Range: vr,
 								Metadata: models.Metadata{
-									CPE:    match.Criteria,
-									Source: source,
+									CPE:      match.Criteria,
+									Source:   source,
+									Versions: metadataVersions,
 								},
 							},
 						)
@@ -844,8 +848,9 @@ func ExtractVersionsFromCPEs(cve models.NVDCVE, validVersions []string, vpRepoCa
 						models.RangeWithMetadata{
 							Range: vr,
 							Metadata: models.Metadata{
-								CPE:    match.Criteria,
-								Source: source,
+								CPE:      match.Criteria,
+								Source:   source,
+								Versions: metadataVersions,
 							},
 						},
 					)

--- a/vulnfeeds/conversion/versions.go
+++ b/vulnfeeds/conversion/versions.go
@@ -796,6 +796,9 @@ func ExtractVersionsFromCPEs(cve models.NVDCVE, validVersions []string, vpRepoCa
 						lastaffected += "-" + CPE.Update
 					}
 					source = models.VersionSourceCPEString
+					// Set introduced to lastaffected to represent a single standalone version.
+					// Otherwise, an empty introduced would default to "0" and mark all historical
+					// versions as affected.
 					introduced = lastaffected
 					metadataVersions = []string{lastaffected}
 				}

--- a/vulnfeeds/models/types.go
+++ b/vulnfeeds/models/types.go
@@ -37,8 +37,9 @@ type RangeWithMetadata struct {
 }
 
 type Metadata struct {
-	CPE    string
-	Source VersionSource
+	CPE      string
+	Source   VersionSource
+	Versions []string
 }
 
 func (ac *AffectedCommit) SetRepo(repo string) {

--- a/vulnfeeds/test_data/cve5/CVE-2024-3094.json
+++ b/vulnfeeds/test_data/cve5/CVE-2024-3094.json
@@ -1,0 +1,568 @@
+{
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.2",
+    "cveMetadata": {
+        "cveId": "CVE-2024-3094",
+        "assignerOrgId": "53f830b8-0a3f-465b-8143-3b8a9948e749",
+        "state": "PUBLISHED",
+        "assignerShortName": "redhat",
+        "dateReserved": "2024-03-29T15:38:13.249Z",
+        "datePublished": "2024-03-29T16:51:12.588Z",
+        "dateUpdated": "2025-11-20T07:17:48.594Z"
+    },
+    "containers": {
+        "cna": {
+            "title": "Xz: malicious code in distributed source",
+            "metrics": [
+                {
+                    "other": {
+                        "content": {
+                            "value": "Critical",
+                            "namespace": "https://access.redhat.com/security/updates/classification/"
+                        },
+                        "type": "Red Hat severity rating"
+                    }
+                },
+                {
+                    "cvssV3_1": {
+                        "attackComplexity": "LOW",
+                        "attackVector": "NETWORK",
+                        "availabilityImpact": "HIGH",
+                        "baseScore": 10,
+                        "baseSeverity": "CRITICAL",
+                        "confidentialityImpact": "HIGH",
+                        "integrityImpact": "HIGH",
+                        "privilegesRequired": "NONE",
+                        "scope": "CHANGED",
+                        "userInteraction": "NONE",
+                        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+                        "version": "3.1"
+                    },
+                    "format": "CVSS"
+                }
+            ],
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "Malicious code was discovered in the upstream tarballs of xz, starting with version 5.6.0. \r\nThrough a series of complex obfuscations, the liblzma build process extracts a prebuilt object file from a disguised test file existing in the source code, which is then used to modify specific functions in the liblzma code. This results in a modified liblzma library that can be used by any software linked against this library, intercepting and modifying the data interaction with this library."
+                }
+            ],
+            "affected": [
+                {
+                    "versions": [
+                        {
+                            "status": "affected",
+                            "version": "5.6.0"
+                        },
+                        {
+                            "status": "affected",
+                            "version": "5.6.1"
+                        }
+                    ],
+                    "packageName": "xz",
+                    "collectionURL": "https://github.com/tukaani-project/xz",
+                    "defaultStatus": "unaffected"
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Enterprise Linux 10",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "xz",
+                    "defaultStatus": "unaffected",
+                    "cpes": [
+                        "cpe:/o:redhat:enterprise_linux:10"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Enterprise Linux 6",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "xz",
+                    "defaultStatus": "unaffected",
+                    "cpes": [
+                        "cpe:/o:redhat:enterprise_linux:6"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Enterprise Linux 7",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "xz",
+                    "defaultStatus": "unaffected",
+                    "cpes": [
+                        "cpe:/o:redhat:enterprise_linux:7"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Enterprise Linux 8",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "xz",
+                    "defaultStatus": "unaffected",
+                    "cpes": [
+                        "cpe:/o:redhat:enterprise_linux:8"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat Enterprise Linux 9",
+                    "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                    "packageName": "xz",
+                    "defaultStatus": "unaffected",
+                    "cpes": [
+                        "cpe:/o:redhat:enterprise_linux:9"
+                    ]
+                },
+                {
+                    "vendor": "Red Hat",
+                    "product": "Red Hat JBoss Enterprise Application Platform 8",
+                    "collectionURL": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html",
+                    "packageName": "xz",
+                    "defaultStatus": "unaffected",
+                    "cpes": [
+                        "cpe:/a:redhat:jboss_enterprise_application_platform:8"
+                    ]
+                }
+            ],
+            "references": [
+                {
+                    "url": "https://access.redhat.com/security/cve/CVE-2024-3094",
+                    "tags": [
+                        "vdb-entry",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2272210",
+                    "name": "RHBZ#2272210",
+                    "tags": [
+                        "issue-tracking",
+                        "x_refsource_REDHAT"
+                    ]
+                },
+                {
+                    "url": "https://www.openwall.com/lists/oss-security/2024/03/29/4"
+                },
+                {
+                    "url": "https://www.redhat.com/en/blog/urgent-security-alert-fedora-41-and-rawhide-users"
+                }
+            ],
+            "datePublic": "2024-03-29T00:00:00.000Z",
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "cweId": "CWE-506",
+                            "description": "Embedded Malicious Code",
+                            "lang": "en",
+                            "type": "CWE"
+                        }
+                    ]
+                }
+            ],
+            "x_redhatCweChain": "CWE-506: Embedded Malicious Code",
+            "timeline": [
+                {
+                    "lang": "en",
+                    "time": "2024-03-27T00:00:00.000Z",
+                    "value": "Reported to Red Hat."
+                },
+                {
+                    "lang": "en",
+                    "time": "2024-03-29T00:00:00.000Z",
+                    "value": "Made public."
+                }
+            ],
+            "credits": [
+                {
+                    "lang": "en",
+                    "value": "Red Hat would like to thank Andres Freund for reporting this issue."
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "53f830b8-0a3f-465b-8143-3b8a9948e749",
+                "shortName": "redhat",
+                "dateUpdated": "2025-11-20T07:17:48.594Z"
+            }
+        },
+        "adp": [
+            {
+                "metrics": [
+                    {
+                        "other": {
+                            "type": "ssvc",
+                            "content": {
+                                "timestamp": "2024-04-02T04:00:23.138684Z",
+                                "id": "CVE-2024-3094",
+                                "options": [
+                                    {
+                                        "Exploitation": "none"
+                                    },
+                                    {
+                                        "Automatable": "yes"
+                                    },
+                                    {
+                                        "Technical Impact": "total"
+                                    }
+                                ],
+                                "role": "CISA Coordinator",
+                                "version": "2.0.3"
+                            }
+                        }
+                    }
+                ],
+                "title": "CISA ADP Vulnrichment",
+                "providerMetadata": {
+                    "orgId": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+                    "shortName": "CISA-ADP",
+                    "dateUpdated": "2024-07-30T15:37:17.662Z"
+                }
+            },
+            {
+                "providerMetadata": {
+                    "orgId": "af854a3a-2127-422b-91ae-364da2661108",
+                    "shortName": "CVE",
+                    "dateUpdated": "2025-08-19T00:24:09.962Z"
+                },
+                "references": [
+                    {
+                        "url": "https://www.binarly.io/blog/persistent-risk-xz-utils-backdoor-still-lurking-in-docker-images"
+                    },
+                    {
+                        "tags": [
+                            "vdb-entry",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ],
+                        "url": "https://access.redhat.com/security/cve/CVE-2024-3094"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://ariadne.space/2024/04/02/the-xz-utils-backdoor-is-a-symptom-of-a-larger-problem/"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://arstechnica.com/security/2024/03/backdoor-found-in-widely-used-linux-utility-breaks-encrypted-ssh-connections/"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://aws.amazon.com/security/security-bulletins/AWS-2024-002/"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://blog.netbsd.org/tnf/entry/statement_on_backdoor_in_xz"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://boehs.org/node/everything-i-know-about-the-xz-backdoor"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1068024"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://bugs.gentoo.org/928134"
+                    },
+                    {
+                        "name": "RHBZ#2272210",
+                        "tags": [
+                            "issue-tracking",
+                            "x_refsource_REDHAT",
+                            "x_transferred"
+                        ],
+                        "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2272210"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://bugzilla.suse.com/show_bug.cgi?id=1222124"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://discourse.nixos.org/t/cve-2024-3094-malicious-code-in-xz-5-6-0-and-5-6-1-tarballs/42405"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://gist.github.com/thesamesam/223949d5a074ebc3dce9ee78baad9e27"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://github.com/advisories/GHSA-rxwq-x6h5-x525"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://github.com/amlweems/xzbot"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://github.com/karcherm/xz-malware"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://gynvael.coldwind.pl/?lang=en&id=782"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.debian.org/debian-security-announce/2024/msg00057.html"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://lists.freebsd.org/archives/freebsd-security/2024-March/000248.html"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://lwn.net/Articles/967180/"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://news.ycombinator.com/item?id=39865810"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://news.ycombinator.com/item?id=39877267"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://news.ycombinator.com/item?id=39895344"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://openssf.org/blog/2024/03/30/xz-backdoor-cve-2024-3094/"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://research.swtch.com/xz-script"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://research.swtch.com/xz-timeline"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://security-tracker.debian.org/tracker/CVE-2024-3094"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://security.alpinelinux.org/vuln/CVE-2024-3094"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://security.archlinux.org/CVE-2024-3094"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://security.netapp.com/advisory/ntap-20240402-0001/"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://tukaani.org/xz-backdoor/"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://twitter.com/LetsDefendIO/status/1774804387417751958"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://twitter.com/debian/status/1774219194638409898"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://twitter.com/infosecb/status/1774595540233167206"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://twitter.com/infosecb/status/1774597228864139400"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://ubuntu.com/security/CVE-2024-3094"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://www.cisa.gov/news-events/alerts/2024/03/29/reported-supply-chain-compromise-affecting-xz-utils-data-compression-library-cve-2024-3094"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://www.darkreading.com/vulnerabilities-threats/are-you-affected-by-the-backdoor-in-xz-utils"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://www.kali.org/blog/about-the-xz-backdoor/"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://www.openwall.com/lists/oss-security/2024/03/29/4"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://www.redhat.com/en/blog/urgent-security-alert-fedora-41-and-rawhide-users"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://www.tenable.com/blog/frequently-asked-questions-cve-2024-3094-supply-chain-backdoor-in-xz-utils"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://www.theregister.com/2024/03/29/malicious_backdoor_xz/"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://www.vicarius.io/vsociety/vulnerabilities/cve-2024-3094"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "https://xeiaso.net/notes/2024/xz-vuln/"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "http://www.openwall.com/lists/oss-security/2024/03/30/12"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "http://www.openwall.com/lists/oss-security/2024/03/30/27"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "http://www.openwall.com/lists/oss-security/2024/03/29/12"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "http://www.openwall.com/lists/oss-security/2024/03/29/10"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "http://www.openwall.com/lists/oss-security/2024/03/30/36"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "http://www.openwall.com/lists/oss-security/2024/04/16/5"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "http://www.openwall.com/lists/oss-security/2024/03/29/8"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "http://www.openwall.com/lists/oss-security/2024/03/30/5"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "http://www.openwall.com/lists/oss-security/2024/03/29/5"
+                    },
+                    {
+                        "tags": [
+                            "x_transferred"
+                        ],
+                        "url": "http://www.openwall.com/lists/oss-security/2024/03/29/4"
+                    }
+                ],
+                "title": "CVE Program Container",
+                "x_generator": {
+                    "engine": "ADPogram 0.0.1"
+                }
+            }
+        ]
+    }
+}

--- a/vulnfeeds/test_data/cvelistV5/cves/2024/3xxx/CVE-2024-3094.json
+++ b/vulnfeeds/test_data/cvelistV5/cves/2024/3xxx/CVE-2024-3094.json
@@ -1,0 +1,568 @@
+{
+  "dataType": "CVE_RECORD",
+  "dataVersion": "5.2",
+  "cveMetadata": {
+    "cveId": "CVE-2024-3094",
+    "assignerOrgId": "53f830b8-0a3f-465b-8143-3b8a9948e749",
+    "state": "PUBLISHED",
+    "assignerShortName": "redhat",
+    "dateReserved": "2024-03-29T15:38:13.249Z",
+    "datePublished": "2024-03-29T16:51:12.588Z",
+    "dateUpdated": "2025-11-20T07:17:48.594Z"
+  },
+  "containers": {
+    "cna": {
+      "title": "Xz: malicious code in distributed source",
+      "metrics": [
+        {
+          "other": {
+            "content": {
+              "value": "Critical",
+              "namespace": "https://access.redhat.com/security/updates/classification/"
+            },
+            "type": "Red Hat severity rating"
+          }
+        },
+        {
+          "cvssV3_1": {
+            "attackComplexity": "LOW",
+            "attackVector": "NETWORK",
+            "availabilityImpact": "HIGH",
+            "baseScore": 10,
+            "baseSeverity": "CRITICAL",
+            "confidentialityImpact": "HIGH",
+            "integrityImpact": "HIGH",
+            "privilegesRequired": "NONE",
+            "scope": "CHANGED",
+            "userInteraction": "NONE",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+            "version": "3.1"
+          },
+          "format": "CVSS"
+        }
+      ],
+      "descriptions": [
+        {
+          "lang": "en",
+          "value": "Malicious code was discovered in the upstream tarballs of xz, starting with version 5.6.0. \r\nThrough a series of complex obfuscations, the liblzma build process extracts a prebuilt object file from a disguised test file existing in the source code, which is then used to modify specific functions in the liblzma code. This results in a modified liblzma library that can be used by any software linked against this library, intercepting and modifying the data interaction with this library."
+        }
+      ],
+      "affected": [
+        {
+          "versions": [
+            {
+              "status": "affected",
+              "version": "5.6.0"
+            },
+            {
+              "status": "affected",
+              "version": "5.6.1"
+            }
+          ],
+          "packageName": "xz",
+          "collectionURL": "https://github.com/tukaani-project/xz",
+          "defaultStatus": "unaffected"
+        },
+        {
+          "vendor": "Red Hat",
+          "product": "Red Hat Enterprise Linux 10",
+          "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+          "packageName": "xz",
+          "defaultStatus": "unaffected",
+          "cpes": [
+            "cpe:/o:redhat:enterprise_linux:10"
+          ]
+        },
+        {
+          "vendor": "Red Hat",
+          "product": "Red Hat Enterprise Linux 6",
+          "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+          "packageName": "xz",
+          "defaultStatus": "unaffected",
+          "cpes": [
+            "cpe:/o:redhat:enterprise_linux:6"
+          ]
+        },
+        {
+          "vendor": "Red Hat",
+          "product": "Red Hat Enterprise Linux 7",
+          "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+          "packageName": "xz",
+          "defaultStatus": "unaffected",
+          "cpes": [
+            "cpe:/o:redhat:enterprise_linux:7"
+          ]
+        },
+        {
+          "vendor": "Red Hat",
+          "product": "Red Hat Enterprise Linux 8",
+          "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+          "packageName": "xz",
+          "defaultStatus": "unaffected",
+          "cpes": [
+            "cpe:/o:redhat:enterprise_linux:8"
+          ]
+        },
+        {
+          "vendor": "Red Hat",
+          "product": "Red Hat Enterprise Linux 9",
+          "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+          "packageName": "xz",
+          "defaultStatus": "unaffected",
+          "cpes": [
+            "cpe:/o:redhat:enterprise_linux:9"
+          ]
+        },
+        {
+          "vendor": "Red Hat",
+          "product": "Red Hat JBoss Enterprise Application Platform 8",
+          "collectionURL": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html",
+          "packageName": "xz",
+          "defaultStatus": "unaffected",
+          "cpes": [
+            "cpe:/a:redhat:jboss_enterprise_application_platform:8"
+          ]
+        }
+      ],
+      "references": [
+        {
+          "url": "https://access.redhat.com/security/cve/CVE-2024-3094",
+          "tags": [
+            "vdb-entry",
+            "x_refsource_REDHAT"
+          ]
+        },
+        {
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2272210",
+          "name": "RHBZ#2272210",
+          "tags": [
+            "issue-tracking",
+            "x_refsource_REDHAT"
+          ]
+        },
+        {
+          "url": "https://www.openwall.com/lists/oss-security/2024/03/29/4"
+        },
+        {
+          "url": "https://www.redhat.com/en/blog/urgent-security-alert-fedora-41-and-rawhide-users"
+        }
+      ],
+      "datePublic": "2024-03-29T00:00:00.000Z",
+      "problemTypes": [
+        {
+          "descriptions": [
+            {
+              "cweId": "CWE-506",
+              "description": "Embedded Malicious Code",
+              "lang": "en",
+              "type": "CWE"
+            }
+          ]
+        }
+      ],
+      "x_redhatCweChain": "CWE-506: Embedded Malicious Code",
+      "timeline": [
+        {
+          "lang": "en",
+          "time": "2024-03-27T00:00:00.000Z",
+          "value": "Reported to Red Hat."
+        },
+        {
+          "lang": "en",
+          "time": "2024-03-29T00:00:00.000Z",
+          "value": "Made public."
+        }
+      ],
+      "credits": [
+        {
+          "lang": "en",
+          "value": "Red Hat would like to thank Andres Freund for reporting this issue."
+        }
+      ],
+      "providerMetadata": {
+        "orgId": "53f830b8-0a3f-465b-8143-3b8a9948e749",
+        "shortName": "redhat",
+        "dateUpdated": "2025-11-20T07:17:48.594Z"
+      }
+    },
+    "adp": [
+      {
+        "metrics": [
+          {
+            "other": {
+              "type": "ssvc",
+              "content": {
+                "timestamp": "2024-04-02T04:00:23.138684Z",
+                "id": "CVE-2024-3094",
+                "options": [
+                  {
+                    "Exploitation": "none"
+                  },
+                  {
+                    "Automatable": "yes"
+                  },
+                  {
+                    "Technical Impact": "total"
+                  }
+                ],
+                "role": "CISA Coordinator",
+                "version": "2.0.3"
+              }
+            }
+          }
+        ],
+        "title": "CISA ADP Vulnrichment",
+        "providerMetadata": {
+          "orgId": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+          "shortName": "CISA-ADP",
+          "dateUpdated": "2024-07-30T15:37:17.662Z"
+        }
+      },
+      {
+        "providerMetadata": {
+          "orgId": "af854a3a-2127-422b-91ae-364da2661108",
+          "shortName": "CVE",
+          "dateUpdated": "2025-08-19T00:24:09.962Z"
+        },
+        "references": [
+          {
+            "url": "https://www.binarly.io/blog/persistent-risk-xz-utils-backdoor-still-lurking-in-docker-images"
+          },
+          {
+            "tags": [
+              "vdb-entry",
+              "x_refsource_REDHAT",
+              "x_transferred"
+            ],
+            "url": "https://access.redhat.com/security/cve/CVE-2024-3094"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://ariadne.space/2024/04/02/the-xz-utils-backdoor-is-a-symptom-of-a-larger-problem/"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://arstechnica.com/security/2024/03/backdoor-found-in-widely-used-linux-utility-breaks-encrypted-ssh-connections/"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://aws.amazon.com/security/security-bulletins/AWS-2024-002/"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://blog.netbsd.org/tnf/entry/statement_on_backdoor_in_xz"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://boehs.org/node/everything-i-know-about-the-xz-backdoor"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1068024"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://bugs.gentoo.org/928134"
+          },
+          {
+            "name": "RHBZ#2272210",
+            "tags": [
+              "issue-tracking",
+              "x_refsource_REDHAT",
+              "x_transferred"
+            ],
+            "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2272210"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://bugzilla.suse.com/show_bug.cgi?id=1222124"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://discourse.nixos.org/t/cve-2024-3094-malicious-code-in-xz-5-6-0-and-5-6-1-tarballs/42405"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://gist.github.com/thesamesam/223949d5a074ebc3dce9ee78baad9e27"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://github.com/advisories/GHSA-rxwq-x6h5-x525"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://github.com/amlweems/xzbot"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://github.com/karcherm/xz-malware"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://gynvael.coldwind.pl/?lang=en&id=782"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://lists.debian.org/debian-security-announce/2024/msg00057.html"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://lists.freebsd.org/archives/freebsd-security/2024-March/000248.html"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://lwn.net/Articles/967180/"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://news.ycombinator.com/item?id=39865810"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://news.ycombinator.com/item?id=39877267"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://news.ycombinator.com/item?id=39895344"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://openssf.org/blog/2024/03/30/xz-backdoor-cve-2024-3094/"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://research.swtch.com/xz-script"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://research.swtch.com/xz-timeline"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://security-tracker.debian.org/tracker/CVE-2024-3094"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://security.alpinelinux.org/vuln/CVE-2024-3094"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://security.archlinux.org/CVE-2024-3094"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://security.netapp.com/advisory/ntap-20240402-0001/"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://tukaani.org/xz-backdoor/"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://twitter.com/LetsDefendIO/status/1774804387417751958"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://twitter.com/debian/status/1774219194638409898"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://twitter.com/infosecb/status/1774595540233167206"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://twitter.com/infosecb/status/1774597228864139400"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://ubuntu.com/security/CVE-2024-3094"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://www.cisa.gov/news-events/alerts/2024/03/29/reported-supply-chain-compromise-affecting-xz-utils-data-compression-library-cve-2024-3094"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://www.darkreading.com/vulnerabilities-threats/are-you-affected-by-the-backdoor-in-xz-utils"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://www.kali.org/blog/about-the-xz-backdoor/"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://www.openwall.com/lists/oss-security/2024/03/29/4"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://www.redhat.com/en/blog/urgent-security-alert-fedora-41-and-rawhide-users"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://www.tenable.com/blog/frequently-asked-questions-cve-2024-3094-supply-chain-backdoor-in-xz-utils"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://www.theregister.com/2024/03/29/malicious_backdoor_xz/"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://www.vicarius.io/vsociety/vulnerabilities/cve-2024-3094"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "https://xeiaso.net/notes/2024/xz-vuln/"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "http://www.openwall.com/lists/oss-security/2024/03/30/12"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "http://www.openwall.com/lists/oss-security/2024/03/30/27"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "http://www.openwall.com/lists/oss-security/2024/03/29/12"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "http://www.openwall.com/lists/oss-security/2024/03/29/10"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "http://www.openwall.com/lists/oss-security/2024/03/30/36"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "http://www.openwall.com/lists/oss-security/2024/04/16/5"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "http://www.openwall.com/lists/oss-security/2024/03/29/8"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "http://www.openwall.com/lists/oss-security/2024/03/30/5"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "http://www.openwall.com/lists/oss-security/2024/03/29/5"
+          },
+          {
+            "tags": [
+              "x_transferred"
+            ],
+            "url": "http://www.openwall.com/lists/oss-security/2024/03/29/4"
+          }
+        ],
+        "title": "CVE Program Container",
+        "x_generator": {
+          "engine": "ADPogram 0.0.1"
+        }
+      }
+    ]
+  }
+}

--- a/vulnfeeds/test_data/nvdcve-2.0/CVE-2024-3094.json
+++ b/vulnfeeds/test_data/nvdcve-2.0/CVE-2024-3094.json
@@ -1,0 +1,578 @@
+{
+  "resultsPerPage": 1,
+  "startIndex": 0,
+  "totalResults": 1,
+  "format": "NVD_CVE",
+  "version": "2.0",
+  "timestamp": "2026-07-07T03:28:20.959",
+  "vulnerabilities": [
+    {
+      "cve": {
+        "id": "CVE-2024-3094",
+        "sourceIdentifier": "secalert@redhat.com",
+        "published": "2024-03-29T17:15:21.150",
+        "lastModified": "2026-06-17T07:43:17.830",
+        "vulnStatus": "Modified",
+        "cveTags": [],
+        "descriptions": [
+          {
+            "lang": "en",
+            "value": "Malicious code was discovered in the upstream tarballs of xz, starting with version 5.6.0. \r\nThrough a series of complex obfuscations, the liblzma build process extracts a prebuilt object file from a disguised test file existing in the source code, which is then used to modify specific functions in the liblzma code. This results in a modified liblzma library that can be used by any software linked against this library, intercepting and modifying the data interaction with this library."
+          },
+          {
+            "lang": "es",
+            "value": "Se descubrió código malicioso en los archivos tar ascendentes de xz, a partir de la versión 5.6.0. A través de una serie de ofuscaciones complejas, el proceso de compilación de liblzma extrae un archivo objeto premanipulado de un archivo de prueba disfrazado existente en el código fuente, que luego se utiliza para modificar funciones específicas en el código de liblzma. Esto da como resultado una librería liblzma modificada que puede ser utilizada por cualquier software vinculado a esta librería, interceptando y modificando la interacción de datos con esta librería."
+          }
+        ],
+        "affected": [
+          {
+            "source": "secalert@redhat.com",
+            "affectedData": [
+              {
+                "defaultStatus": "unaffected",
+                "collectionURL": "https://github.com/tukaani-project/xz",
+                "packageName": "xz",
+                "versions": [
+                  {
+                    "version": "5.6.0",
+                    "status": "affected"
+                  },
+                  {
+                    "version": "5.6.1",
+                    "status": "affected"
+                  }
+                ]
+              },
+              {
+                "vendor": "Red Hat",
+                "product": "Red Hat Enterprise Linux 10",
+                "defaultStatus": "unaffected",
+                "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                "packageName": "xz",
+                "cpes": [
+                  "cpe:/o:redhat:enterprise_linux:10"
+                ]
+              },
+              {
+                "vendor": "Red Hat",
+                "product": "Red Hat Enterprise Linux 6",
+                "defaultStatus": "unaffected",
+                "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                "packageName": "xz",
+                "cpes": [
+                  "cpe:/o:redhat:enterprise_linux:6"
+                ]
+              },
+              {
+                "vendor": "Red Hat",
+                "product": "Red Hat Enterprise Linux 7",
+                "defaultStatus": "unaffected",
+                "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                "packageName": "xz",
+                "cpes": [
+                  "cpe:/o:redhat:enterprise_linux:7"
+                ]
+              },
+              {
+                "vendor": "Red Hat",
+                "product": "Red Hat Enterprise Linux 8",
+                "defaultStatus": "unaffected",
+                "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                "packageName": "xz",
+                "cpes": [
+                  "cpe:/o:redhat:enterprise_linux:8"
+                ]
+              },
+              {
+                "vendor": "Red Hat",
+                "product": "Red Hat Enterprise Linux 9",
+                "defaultStatus": "unaffected",
+                "collectionURL": "https://access.redhat.com/downloads/content/package-browser/",
+                "packageName": "xz",
+                "cpes": [
+                  "cpe:/o:redhat:enterprise_linux:9"
+                ]
+              },
+              {
+                "vendor": "Red Hat",
+                "product": "Red Hat JBoss Enterprise Application Platform 8",
+                "defaultStatus": "unaffected",
+                "collectionURL": "https://access.redhat.com/jbossnetwork/restricted/listSoftware.html",
+                "packageName": "xz",
+                "cpes": [
+                  "cpe:/a:redhat:jboss_enterprise_application_platform:8"
+                ]
+              }
+            ]
+          }
+        ],
+        "metrics": {
+          "cvssMetricV31": [
+            {
+              "source": "secalert@redhat.com",
+              "type": "Secondary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+                "baseScore": 10,
+                "baseSeverity": "CRITICAL",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "CHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 6
+            },
+            {
+              "source": "nvd@nist.gov",
+              "type": "Primary",
+              "cvssData": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+                "baseScore": 10,
+                "baseSeverity": "CRITICAL",
+                "attackVector": "NETWORK",
+                "attackComplexity": "LOW",
+                "privilegesRequired": "NONE",
+                "userInteraction": "NONE",
+                "scope": "CHANGED",
+                "confidentialityImpact": "HIGH",
+                "integrityImpact": "HIGH",
+                "availabilityImpact": "HIGH"
+              },
+              "exploitabilityScore": 3.9,
+              "impactScore": 6
+            }
+          ],
+          "ssvcV203": [
+            {
+              "source": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+              "ssvcData": {
+                "timestamp": "2024-04-02T04:00:23.138684Z",
+                "id": "CVE-2024-3094",
+                "options": [
+                  {
+                    "exploitation": "none"
+                  },
+                  {
+                    "automatable": "yes"
+                  },
+                  {
+                    "technicalImpact": "total"
+                  }
+                ],
+                "role": "CISA Coordinator",
+                "version": "2.0.3"
+              }
+            }
+          ]
+        },
+        "weaknesses": [
+          {
+            "source": "secalert@redhat.com",
+            "type": "Secondary",
+            "description": [
+              {
+                "lang": "en",
+                "value": "CWE-506"
+              }
+            ]
+          }
+        ],
+        "configurations": [
+          {
+            "nodes": [
+              {
+                "operator": "OR",
+                "negate": false,
+                "cpeMatch": [
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:tukaani:xz:5.6.0:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "73F1DAD7-F362-4C5B-B980-2E5313C369DA"
+                  },
+                  {
+                    "vulnerable": true,
+                    "criteria": "cpe:2.3:a:tukaani:xz:5.6.1:*:*:*:*:*:*:*",
+                    "matchCriteriaId": "55782A0B-B9C5-4536-A885-84CAB7029C09"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "references": [
+          {
+            "url": "https://access.redhat.com/security/cve/CVE-2024-3094",
+            "source": "secalert@redhat.com",
+            "tags": [
+              "Vendor Advisory"
+            ]
+          },
+          {
+            "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2272210",
+            "source": "secalert@redhat.com",
+            "tags": [
+              "Issue Tracking",
+              "Vendor Advisory"
+            ]
+          },
+          {
+            "url": "https://www.openwall.com/lists/oss-security/2024/03/29/4",
+            "source": "secalert@redhat.com",
+            "tags": [
+              "Mailing List"
+            ]
+          },
+          {
+            "url": "https://www.redhat.com/en/blog/urgent-security-alert-fedora-41-and-rawhide-users",
+            "source": "secalert@redhat.com",
+            "tags": [
+              "Vendor Advisory"
+            ]
+          },
+          {
+            "url": "http://www.openwall.com/lists/oss-security/2024/03/29/10",
+            "source": "af854a3a-2127-422b-91ae-364da2661108"
+          },
+          {
+            "url": "http://www.openwall.com/lists/oss-security/2024/03/29/12",
+            "source": "af854a3a-2127-422b-91ae-364da2661108"
+          },
+          {
+            "url": "http://www.openwall.com/lists/oss-security/2024/03/29/4",
+            "source": "af854a3a-2127-422b-91ae-364da2661108"
+          },
+          {
+            "url": "http://www.openwall.com/lists/oss-security/2024/03/29/5",
+            "source": "af854a3a-2127-422b-91ae-364da2661108"
+          },
+          {
+            "url": "http://www.openwall.com/lists/oss-security/2024/03/29/8",
+            "source": "af854a3a-2127-422b-91ae-364da2661108"
+          },
+          {
+            "url": "http://www.openwall.com/lists/oss-security/2024/03/30/12",
+            "source": "af854a3a-2127-422b-91ae-364da2661108"
+          },
+          {
+            "url": "http://www.openwall.com/lists/oss-security/2024/03/30/27",
+            "source": "af854a3a-2127-422b-91ae-364da2661108"
+          },
+          {
+            "url": "http://www.openwall.com/lists/oss-security/2024/03/30/36",
+            "source": "af854a3a-2127-422b-91ae-364da2661108"
+          },
+          {
+            "url": "http://www.openwall.com/lists/oss-security/2024/03/30/5",
+            "source": "af854a3a-2127-422b-91ae-364da2661108"
+          },
+          {
+            "url": "http://www.openwall.com/lists/oss-security/2024/04/16/5",
+            "source": "af854a3a-2127-422b-91ae-364da2661108"
+          },
+          {
+            "url": "https://access.redhat.com/security/cve/CVE-2024-3094",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Vendor Advisory"
+            ]
+          },
+          {
+            "url": "https://ariadne.space/2024/04/02/the-xz-utils-backdoor-is-a-symptom-of-a-larger-problem/",
+            "source": "af854a3a-2127-422b-91ae-364da2661108"
+          },
+          {
+            "url": "https://arstechnica.com/security/2024/03/backdoor-found-in-widely-used-linux-utility-breaks-encrypted-ssh-connections/",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://aws.amazon.com/security/security-bulletins/AWS-2024-002/",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://blog.netbsd.org/tnf/entry/statement_on_backdoor_in_xz",
+            "source": "af854a3a-2127-422b-91ae-364da2661108"
+          },
+          {
+            "url": "https://boehs.org/node/everything-i-know-about-the-xz-backdoor",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1068024",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Mailing List",
+              "Vendor Advisory"
+            ]
+          },
+          {
+            "url": "https://bugs.gentoo.org/928134",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Issue Tracking",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://bugzilla.redhat.com/show_bug.cgi?id=2272210",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Issue Tracking",
+              "Vendor Advisory"
+            ]
+          },
+          {
+            "url": "https://bugzilla.suse.com/show_bug.cgi?id=1222124",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Issue Tracking",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://discourse.nixos.org/t/cve-2024-3094-malicious-code-in-xz-5-6-0-and-5-6-1-tarballs/42405",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://gist.github.com/thesamesam/223949d5a074ebc3dce9ee78baad9e27",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://github.com/advisories/GHSA-rxwq-x6h5-x525",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://github.com/amlweems/xzbot",
+            "source": "af854a3a-2127-422b-91ae-364da2661108"
+          },
+          {
+            "url": "https://github.com/karcherm/xz-malware",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://gynvael.coldwind.pl/?lang=en&id=782",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Technical Description",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://lists.debian.org/debian-security-announce/2024/msg00057.html",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Mailing List",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://lists.freebsd.org/archives/freebsd-security/2024-March/000248.html",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://lwn.net/Articles/967180/",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Issue Tracking",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://news.ycombinator.com/item?id=39865810",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Issue Tracking",
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://news.ycombinator.com/item?id=39877267",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Issue Tracking"
+            ]
+          },
+          {
+            "url": "https://news.ycombinator.com/item?id=39895344",
+            "source": "af854a3a-2127-422b-91ae-364da2661108"
+          },
+          {
+            "url": "https://openssf.org/blog/2024/03/30/xz-backdoor-cve-2024-3094/",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://research.swtch.com/xz-script",
+            "source": "af854a3a-2127-422b-91ae-364da2661108"
+          },
+          {
+            "url": "https://research.swtch.com/xz-timeline",
+            "source": "af854a3a-2127-422b-91ae-364da2661108"
+          },
+          {
+            "url": "https://security-tracker.debian.org/tracker/CVE-2024-3094",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://security.alpinelinux.org/vuln/CVE-2024-3094",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://security.archlinux.org/CVE-2024-3094",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://security.netapp.com/advisory/ntap-20240402-0001/",
+            "source": "af854a3a-2127-422b-91ae-364da2661108"
+          },
+          {
+            "url": "https://tukaani.org/xz-backdoor/",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Issue Tracking",
+              "Vendor Advisory"
+            ]
+          },
+          {
+            "url": "https://twitter.com/LetsDefendIO/status/1774804387417751958",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://twitter.com/debian/status/1774219194638409898",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Press/Media Coverage"
+            ]
+          },
+          {
+            "url": "https://twitter.com/infosecb/status/1774595540233167206",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Press/Media Coverage"
+            ]
+          },
+          {
+            "url": "https://twitter.com/infosecb/status/1774597228864139400",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Press/Media Coverage"
+            ]
+          },
+          {
+            "url": "https://ubuntu.com/security/CVE-2024-3094",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://www.binarly.io/blog/persistent-risk-xz-utils-backdoor-still-lurking-in-docker-images",
+            "source": "af854a3a-2127-422b-91ae-364da2661108"
+          },
+          {
+            "url": "https://www.cisa.gov/news-events/alerts/2024/03/29/reported-supply-chain-compromise-affecting-xz-utils-data-compression-library-cve-2024-3094",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Third Party Advisory",
+              "US Government Resource"
+            ]
+          },
+          {
+            "url": "https://www.darkreading.com/vulnerabilities-threats/are-you-affected-by-the-backdoor-in-xz-utils",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://www.kali.org/blog/about-the-xz-backdoor/",
+            "source": "af854a3a-2127-422b-91ae-364da2661108"
+          },
+          {
+            "url": "https://www.openwall.com/lists/oss-security/2024/03/29/4",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Mailing List"
+            ]
+          },
+          {
+            "url": "https://www.redhat.com/en/blog/urgent-security-alert-fedora-41-and-rawhide-users",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Vendor Advisory"
+            ]
+          },
+          {
+            "url": "https://www.tenable.com/blog/frequently-asked-questions-cve-2024-3094-supply-chain-backdoor-in-xz-utils",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          },
+          {
+            "url": "https://www.theregister.com/2024/03/29/malicious_backdoor_xz/",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Press/Media Coverage"
+            ]
+          },
+          {
+            "url": "https://www.vicarius.io/vsociety/vulnerabilities/cve-2024-3094",
+            "source": "af854a3a-2127-422b-91ae-364da2661108"
+          },
+          {
+            "url": "https://xeiaso.net/notes/2024/xz-vuln/",
+            "source": "af854a3a-2127-422b-91ae-364da2661108",
+            "tags": [
+              "Third Party Advisory"
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This pull request changes how "standalone" (unbounded/ambiguous) version information from CPE match criteria and CVE5 records is converted to OSV version ranges. 

Previously, when a single version string was extracted (e.g., `cpe:2.3:a:vendor:product:1.2.3` or `version: "1.2.3"` in CVE5 `affected` with no `lessThan`/`lessThanOrEqual` boundaries), the converter defaulted to assuming a range starting from `"0"` up to that version (`introduced: "0"`, `last_affected: "1.2.3"`).

With these changes, we treat these standalone/ambiguous versions as **enumerated** versions. They are converted to single-commit GIT ranges (e.g. `introduced: <commit of 1.2.3>`, `last_affected: <commit of 1.2.3>`) rather than starting from `"0"`. All enumerated version strings are added to the flat `"versions"` array in the OSV record.

### Standalone Range Simplification (Combining)
To avoid cluttering the OSV record's `Ranges` list with dozens of disjoint single-commit intervals when a CVE lists many standalone versions (e.g., FFmpeg in `CVE-2016-1897`), the combiner groups all standalone versions for a repository and represents them as a single continuous range from the earliest version commit to the latest version commit (`[earliest_commit, latest_commit]`) in first-appearance record order, while listing all intermediate version strings in the flat `"versions"` array.

---

## Tradeoffs

### Pros (Improved Cleanliness & Matching)
* **Precision**: Eliminates incorrect `"introduced": "0"` range assumptions. This avoids falsely matching versions prior to the actual earliest defined vulnerable version.
* **Schema Cleanliness**: OSV JSON files remain clean and highly readable. Instead of containing dozens of `introduced`/`last_affected` pairs, a single consolidated range is created for the entire span of enumerated versions.
* **Version Matching**: Querying by version string (via package managers) remains fully accurate, as all intermediate versions are preserved inside the flat `"versions"` array.

### Cons (Git Commit Matching Granularity)
* **Range Approximation**: By simplifying the multiple single-version commits into a single `[earliest_commit, latest_commit]` range, we assume that all commits/versions between the earliest and latest versions are vulnerable. In some rare cases, this might lead to false positives if intermediate versions were not vulnerable (e.g., if a patch was backported to a version within that range). However, this matches the standard OSV range convention and is significantly cleaner than representing disjoint commits.

* **Matching only release commits**: Only release commits will be available in the enumerated affected commits dataset in some cases (especially when it's only one version affected), but we accept this, as most people would be using release tag version commits rather than something in between. 

* **Database Specific is still noisy**: all of the CPEs and versions used in the making of the final version will still be in the database_specific data, which can get a little noisy for cases with a lot of enumerated versions.