### PR TITLE
fix(vulnfeeds): prevent last_affected versions from being dropped in combine-to-osv

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -764,19 +764,22 @@ func pickBestRange(cve5Range *osvschema.Range, nvdRange *osvschema.Range) *osvsc
 	//  Try to merge boundary versions first for simple 1-event/2-event ranges.
 	var merged *osvschema.Range
 	if len(cve5Range.GetEvents()) <= 2 && len(nvdRange.GetEvents()) <= 2 {
-		c5Intro, c5Fixed := getRangeBoundaryVersions(cve5Range.GetEvents())
-		nvdIntro, nvdFixed := getRangeBoundaryVersions(nvdRange.GetEvents())
+		c5Intro, c5LastAffected, c5Fixed := getRangeBoundaryVersions(cve5Range.GetEvents())
+		nvdIntro, nvdLastAffected, nvdFixed := getRangeBoundaryVersions(nvdRange.GetEvents())
 
 		// Prefer cve5 bounds, but use nvd if cve5 is missing them
 		if c5Intro == "" {
 			c5Intro = nvdIntro
 		}
+		if c5LastAffected == "" {
+			c5LastAffected = nvdLastAffected
+		}
 		if c5Fixed == "" {
 			c5Fixed = nvdFixed
 		}
 
-		if c5Intro != "" || c5Fixed != "" {
-			merged = conversion.BuildGitVersionRange(c5Intro, "", c5Fixed, cve5Range.GetRepo())
+		if c5Intro != "" || c5LastAffected != "" || c5Fixed != "" {
+			merged = conversion.BuildGitVersionRange(c5Intro, c5LastAffected, c5Fixed, cve5Range.GetRepo())
 			merged.DatabaseSpecific = mergeDatabaseSpecifics(cve5Range.GetDatabaseSpecific(), nvdRange.GetDatabaseSpecific())
 		}
 	}
@@ -858,17 +861,20 @@ func hasRanges(affected []*osvschema.Affected) bool {
 	return false
 }
 
-// getRangeBoundaryVersions extracts the introduced and fixed versions from a slice of OSV events.
-// It iterates through the events and returns the last non-empty "introduced" and "fixed" versions found.
-func getRangeBoundaryVersions(events []*osvschema.Event) (introduced, fixed string) {
+// getRangeBoundaryVersions extracts the introduced, last_affected and fixed versions from a slice of OSV events.
+// It iterates through the events and returns the last non-empty "introduced", "last_affected" and "fixed" versions found.
+func getRangeBoundaryVersions(events []*osvschema.Event) (introduced, lastAffected, fixed string) {
 	for _, e := range events {
 		if e.GetIntroduced() != "0" && e.GetIntroduced() != "" {
 			introduced = e.GetIntroduced()
+		}
+		if e.GetLastAffected() != "" {
+			lastAffected = e.GetLastAffected()
 		}
 		if e.GetFixed() != "" {
 			fixed = e.GetFixed()
 		}
 	}
 
-	return introduced, fixed
+	return introduced, lastAffected, fixed
 }

--- a/vulnfeeds/cmd/combine-to-osv/main_test.go
+++ b/vulnfeeds/cmd/combine-to-osv/main_test.go
@@ -900,6 +900,51 @@ func TestPickAffectedInformation(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Introduced and LastAffected (no fixed) should preserve LastAffected",
+			cve5Affected: []*osvschema.Affected{
+				{
+					Ranges: []*osvschema.Range{
+						{
+							Type: osvschema.Range_GIT,
+							Repo: repoA,
+							Events: []*osvschema.Event{
+								{Introduced: "1.0.0"},
+								{LastAffected: "1.0.1"},
+							},
+						},
+					},
+				},
+			},
+			nvdAffected: []*osvschema.Affected{
+				{
+					Ranges: []*osvschema.Range{
+						{
+							Type: osvschema.Range_GIT,
+							Repo: repoA,
+							Events: []*osvschema.Event{
+								{Introduced: "1.0.0"},
+								{LastAffected: "1.0.1"},
+							},
+						},
+					},
+				},
+			},
+			wantAffected: []*osvschema.Affected{
+				{
+					Ranges: []*osvschema.Range{
+						{
+							Type: osvschema.Range_GIT,
+							Repo: repoA,
+							Events: []*osvschema.Event{
+								{Introduced: "1.0.0"},
+								{LastAffected: "1.0.1"},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	// Sorter for comparing slices of Affected, ignoring order.


### PR DESCRIPTION
In vulnfeeds/cmd/combine-to-osv/main.go, the function pickBestRange attempts to merge simple 1-event or 2-event ranges (for instance, when a CVE has an introduced and fixed/last_affected version). To do this, it extracts boundary versions using the helper getRangeBoundaryVersions, which only returned introduced and fixed versions, entirely ignoring last_affected versions. Subsequently, when pickBestRange called conversion.BuildGitVersionRange(c5Intro, "", c5Fixed, cve5Range.GetRepo()) to rebuild the range, it passed "" for the last_affected argument. This resulted in dropping the last_affected version completely if there was no fixed event in the range.