### PR TITLE
fix(vulnfeeds): discard imprecise introduced "0" from references-only ranges when merging

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -653,9 +653,28 @@ func mergeRanges(base, other *osvschema.Range) (*osvschema.Range, error) {
 			base.GetType(), base.GetRepo(), other.GetType(), other.GetRepo())
 	}
 
-	if !isReferencesOnly(base) && !isReferencesOnly(other) {
+	isBaseRefsOnly := isReferencesOnly(base)
+	isOtherRefsOnly := isReferencesOnly(other)
+
+	if !isBaseRefsOnly && !isOtherRefsOnly {
 		return nil, fmt.Errorf("invariance violation: mergeRanges can only be called when at least one range is references-only. Base: %v, Other: %v",
 			base.GetDatabaseSpecific(), other.GetDatabaseSpecific())
+	}
+
+	hasNonZeroIntroduced := false
+	for _, e := range base.GetEvents() {
+		if e.GetIntroduced() != "" && e.GetIntroduced() != "0" {
+			hasNonZeroIntroduced = true
+			break
+		}
+	}
+	if !hasNonZeroIntroduced {
+		for _, e := range other.GetEvents() {
+			if e.GetIntroduced() != "" && e.GetIntroduced() != "0" {
+				hasNonZeroIntroduced = true
+				break
+			}
+		}
 	}
 
 	var baseFixed []*osvschema.Event
@@ -678,6 +697,9 @@ func mergeRanges(base, other *osvschema.Range) (*osvschema.Range, error) {
 		if replaceFixed && e.GetFixed() != "" {
 			continue
 		}
+		if hasNonZeroIntroduced && isBaseRefsOnly && e.GetIntroduced() == "0" {
+			continue
+		}
 		baseEvents = append(baseEvents, e)
 	}
 
@@ -688,6 +710,9 @@ func mergeRanges(base, other *osvschema.Range) (*osvschema.Range, error) {
 		DatabaseSpecific: mergeDatabaseSpecifics(base.GetDatabaseSpecific(), other.GetDatabaseSpecific()),
 	}
 	for _, e := range other.GetEvents() {
+		if hasNonZeroIntroduced && isOtherRefsOnly && e.GetIntroduced() == "0" {
+			continue
+		}
 		found := false
 		for _, existing := range merged.GetEvents() {
 			if e.GetIntroduced() != "" && e.GetIntroduced() == existing.GetIntroduced() {

--- a/vulnfeeds/cmd/combine-to-osv/main_test.go
+++ b/vulnfeeds/cmd/combine-to-osv/main_test.go
@@ -674,7 +674,6 @@ func TestPickAffectedInformation(t *testing.T) {
 							Type: osvschema.Range_GIT,
 							Repo: repoA,
 							Events: []*osvschema.Event{
-								{Introduced: "0"},
 								{Introduced: "1.0.0"},
 								{Fixed: "2c1762b85acb"},
 							},


### PR DESCRIPTION
When merging OSV records in combine-to-osv, if one of the records is "references-only" (i.e., its source is strictly REFERENCES), its events are merged into the base record. However, if the references-only record contains introduced: "0" (a placeholder), and the base record already has a more precise, non-zero introduced event (like a specific git commit or version), the 0 was being retained, causing noisy and redundant range data (e.g., in CVE-2026-55646).

This PR updates mergeRanges to discard introduced: "0" from references-only ranges if a better (non-zero) introduced event exists in the merged set, resulting in cleaner and more precise OSV output.