### PR TITLE
chore(dev): update contribution guidelines, update dependencies for corp machines and update makefile to handle go version differences

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,11 +61,14 @@ You must install:
 1.  [Yapf](https://github.com/google/yapf)
 1.  [Make](https://www.gnu.org/software/make/)
 1.  [Poetry](https://python-poetry.org/) >= 2.3.3
-2.  [Google Cloud SDK](https://cloud.google.com/sdk)
-3.  [Hugo](https://gohugo.io/installation/)
-4.  [Node JS](https://nodejs.org/) >= 18.17.x
-5.  [pnpm](https://pnpm.io/installation) (install via `npm install -g pnpm --prefix ~/.local` or `corepack enable pnpm`)
-6.  [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.5 (for infrastructure changes)
+1.  [Google Cloud SDK](https://cloud.google.com/sdk)
+1.  [Hugo](https://gohugo.io/installation/)
+1.  [Node JS](https://nodejs.org/) >= 18.17.x
+1.  [pnpm](https://pnpm.io/installation) (install via `npm install -g pnpm --prefix ~/.local` or `corepack enable pnpm`)
+1.  [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.5 (for infrastructure changes)
+1.  [Go](https://go.dev/doc/install) >= 1.26
+1.  `protobuf-compiler` (e.g. `protoc` command, install via `sudo apt install protobuf-compiler` on Debian/Ubuntu)
+1.  `protoc-gen-go` and `protoc-gen-go-grpc` (Go proto plugins, install via `go install google.golang.org/protobuf/cmd/protoc-gen-go@latest` and `go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest`. Ensure your Go bin directory, e.g. `~/go/bin`, is in your `PATH`)
 
 Then you can set up the development environment by cloning the OSV repo and
 installing the Poetry dependencies.
@@ -93,6 +96,8 @@ gcloud auth login
 gcloud auth application-default login
 gcloud components install cloud-firestore-emulator
 ```
+
+> If your `gcloud` installation has the component manager disabled (common for package manager installs like `apt` or `dnf` on Linux), you may need to install the emulator via your package manager (e.g., `sudo apt install google-cloud-cli-firestore-emulator` if available) or use a [user-space installation of the gcloud CLI](https://cloud.google.com/sdk/docs/install) to manage components.
 
 To run tests:
 ```shell

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ update-api-snapshots:
 	cd gcp/api && UPDATE_SNAPS=true ./run_tests_e2e.sh $(HOME)/.config/gcloud/application_default_credentials.json
 
 lint:
-	GOTOOLCHAIN=go1.26.3 $(run-cmd) tools/lint_and_format.sh
+	GOTOOLCHAIN=auto $(run-cmd) tools/lint_and_format.sh
 
 build-osv-protos:
 	cd osv && $(run-cmd) python -m grpc_tools.protoc --python_out=. --mypy_out=. --proto_path=. --proto_path=osv-schema/proto vulnerability.proto importfinding.proto

--- a/gcp/website/poetry.lock
+++ b/gcp/website/poetry.lock
@@ -1698,6 +1698,25 @@ files = [
 ]
 
 [[package]]
+name = "pyopenssl"
+version = "26.3.0"
+description = "Python wrapper module around the OpenSSL library"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pyopenssl-26.3.0-py3-none-any.whl", hash = "sha256:46367f8f66b92271e6d218da9c87607e1ef5a0bc5c8dea5bb3db82f395c385a3"},
+    {file = "pyopenssl-26.3.0.tar.gz", hash = "sha256:589de7fae1c9ea670d18422ed00fc04da787bbde8e1454aea872aa57b49ad341"},
+]
+
+[package.dependencies]
+cryptography = ">=49.0.0,<50"
+
+[package.extras]
+docs = ["sphinx (!=5.2.0,!=5.2.0.post0,!=7.2.5)", "sphinx_rtd_theme"]
+test = ["pretend", "pytest (>=3.0.1)", "pytest-rerunfailures"]
+
+[[package]]
 name = "pytz"
 version = "2026.2"
 description = "World timezone definitions, modern and historical"
@@ -2092,4 +2111,4 @@ platformdirs = ">=3.5.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0"
-content-hash = "f094f32fbf67e134ec7c62b8204555350cb60f8ed09f5188c682ea9c1aeb8175"
+content-hash = "ff6462e3994399283bd5f9dd58dd6ad9bcdf4eccb0fcdf0b66e20ebe15526f09"

--- a/gcp/website/pyproject.toml
+++ b/gcp/website/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "whitenoise==6.12.0",
     "cvss==3.6",
     "osv",
+    "pyopenssl (>=26.3.0,<27.0.0)",
 ]
 
 [tool.poetry]


### PR DESCRIPTION
- Add pyopenssl to gcp/website dependencies to resolve mTLS 'No module named OpenSSL' errors on corp machines.                                                            
- Update CONTRIBUTING.md with local setup prerequisites and a workaround for installing firestore emulator when gcloud component manager is disabled.  
- Fix Makefile to use GOTOOLCHAIN=auto to prevent local Go version mismatch errors.