### PR TITLE
fix(vulnfeeds): don't assume enumeration on mitre when only one version

### DIFF
--- a/vulnfeeds/conversion/cve5/default_extractor.go
+++ b/vulnfeeds/conversion/cve5/default_extractor.go
@@ -3,6 +3,7 @@ package cve5
 import (
 	"maps"
 	"slices"
+	"strings"
 
 	c "github.com/google/osv/vulnfeeds/conversion"
 	"github.com/google/osv/vulnfeeds/git"
@@ -144,13 +145,19 @@ func (d *DefaultVersionExtractor) FindNormalAffectedRanges(affected models.Affec
 
 		// As a fallback, treat a single version as a standalone version.
 		if vulns.CheckQuality(vers.Version).AtLeast(acceptableQuality) {
-			vr := []*osvschema.Range{c.BuildVersionRange(vers.Version, vers.Version, "")}
+			var vr []*osvschema.Range
+			if strings.EqualFold(metrics.CNA, "mitre") && len(affected.Versions) == 1 {
+				vr = []*osvschema.Range{c.BuildVersionRange("", vers.Version, "")}
+				metrics.AddNote("Single version found %v for MITRE - Setting only last_affected", vers.Version)
+			} else {
+				vr = []*osvschema.Range{c.BuildVersionRange(vers.Version, vers.Version, "")}
+				metrics.AddNote("Single version found %v - Treating as standalone version", vers.Version)
+			}
 			rwms := c.ToRangeWithMetadata(vr, models.VersionSourceAffected)
 			for i := range rwms {
 				rwms[i].Metadata.Versions = []string{vers.Version}
 			}
 			versionRanges = append(versionRanges, rwms...)
-			metrics.AddNote("Single version found %v - Treating as standalone version", vers.Version)
 		}
 	}
 

--- a/vulnfeeds/conversion/cve5/version_extraction_test.go
+++ b/vulnfeeds/conversion/cve5/version_extraction_test.go
@@ -79,6 +79,46 @@ func TestFindNormalAffectedRanges(t *testing.T) {
 			wantRangeType: VersionRangeTypeSemver,
 		},
 		{
+			name: "mitre single version fallback",
+			affected: models.Affected{
+				Versions: []models.Versions{
+					{
+						Status:      "affected",
+						Version:     "3.0",
+						VersionType: "semver",
+					},
+				},
+			},
+			cnaAssigner: "mitre",
+			wantRanges: []*osvschema.Range{
+				conversion.BuildVersionRange("", "3.0", ""),
+			},
+			wantRangeType: VersionRangeTypeSemver,
+		},
+		{
+			name: "mitre multiple versions fallback",
+			affected: models.Affected{
+				Versions: []models.Versions{
+					{
+						Status:      "affected",
+						Version:     "3.0",
+						VersionType: "semver",
+					},
+					{
+						Status:      "affected",
+						Version:     "3.1",
+						VersionType: "semver",
+					},
+				},
+			},
+			cnaAssigner: "mitre",
+			wantRanges: []*osvschema.Range{
+				conversion.BuildVersionRange("3.0", "3.0", ""),
+				conversion.BuildVersionRange("3.1", "3.1", ""),
+			},
+			wantRangeType: VersionRangeTypeSemver,
+		},
+		{
 			name: "github range",
 			affected: models.Affected{
 				Versions: []models.Versions{
@@ -114,7 +154,7 @@ func TestFindNormalAffectedRanges(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			versionExtractor := &DefaultVersionExtractor{}
-			gotRangesWithMeta, gotRangeType := versionExtractor.FindNormalAffectedRanges(tt.affected, &models.ConversionMetrics{})
+			gotRangesWithMeta, gotRangeType := versionExtractor.FindNormalAffectedRanges(tt.affected, &models.ConversionMetrics{CNA: tt.cnaAssigner})
 			var gotRanges []*osvschema.Range
 			for _, r := range gotRangesWithMeta {
 				gotRanges = append(gotRanges, r.Range)


### PR DESCRIPTION
mitre records kinda mid ngl.