### PR TITLE
fix(api): tracing, grpc timeout issue

### DIFF
--- a/go/internal/api/determine_version.go
+++ b/go/internal/api/determine_version.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 
 	"github.com/google/osv.dev/go/internal/models"
+	"github.com/google/osv.dev/go/internal/osvutil"
 	"github.com/google/osv.dev/go/logger"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -205,7 +206,7 @@ func (s *server) DetermineVersion(ctx context.Context, req *pb.DetermineVersionP
 	// Query Datastore via repository
 	matchedBucketsByHash, err := s.repoIndexStore.QueryBuckets(ctx, nodeHashes)
 	if err != nil {
-		if !logger.IsContextError(err) {
+		if !osvutil.IsContextError(err) {
 			logger.ErrorContext(ctx, "Failed to query RepoIndexBuckets", "error", err)
 		}
 
@@ -262,7 +263,7 @@ func (s *server) DetermineVersion(ctx context.Context, req *pb.DetermineVersionP
 
 	repoIndexes, err := s.repoIndexStore.GetRepoIndexes(ctx, parentIDs)
 	if err != nil {
-		if !logger.IsContextError(err) {
+		if !osvutil.IsContextError(err) {
 			logger.ErrorContext(ctx, "Failed to get RepoIndexes", "error", err)
 		}
 

--- a/go/internal/api/get_vuln_by_id.go
+++ b/go/internal/api/get_vuln_by_id.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/google/osv.dev/go/internal/models"
+	"github.com/google/osv.dev/go/internal/osvutil"
 	"github.com/google/osv.dev/go/logger"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
 	"google.golang.org/grpc/codes"
@@ -30,7 +31,7 @@ func (s *server) GetVulnById(ctx context.Context, params *pb.GetVulnByIdParamete
 		return vulnerability, nil
 	}
 	if !errors.Is(err, models.ErrNotFound) {
-		if !logger.IsContextError(err) {
+		if !osvutil.IsContextError(err) {
 			logger.ErrorContext(ctx, "failed to get vulnerability from store",
 				slog.String("id", id),
 				slog.Any("error", err),
@@ -47,7 +48,7 @@ func (s *server) GetVulnById(ctx context.Context, params *pb.GetVulnByIdParamete
 			return nil, status.Error(codes.NotFound, "Vulnerability not found")
 		}
 
-		if !logger.IsContextError(err) {
+		if !osvutil.IsContextError(err) {
 			logger.ErrorContext(ctx, "failed to check aliases for vulnerability",
 				slog.String("id", id),
 				slog.Any("error", err),

--- a/go/internal/api/query_affected.go
+++ b/go/internal/api/query_affected.go
@@ -14,6 +14,7 @@ import (
 
 	"cloud.google.com/go/pubsub/v2"
 	"github.com/google/osv.dev/go/internal/models"
+	"github.com/google/osv.dev/go/internal/osvutil"
 	"github.com/google/osv.dev/go/internal/osvutil/safe"
 	"github.com/google/osv.dev/go/internal/osvutil/schema"
 	"github.com/google/osv.dev/go/logger"
@@ -539,7 +540,7 @@ func (s *server) runMatcher(
 			idx := 0
 			for match, err := range matcher {
 				if err != nil {
-					if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+					if osvutil.IsContextError(err) {
 						// If we timed out or been cancelled, we just return what we have.
 						return
 					}
@@ -652,7 +653,7 @@ func (s *server) collectAndSort(ctx context.Context,
 			}
 			// This is a real error, fail the whole query.
 			cancel(res.err)
-			if s.verboseLogs && !logger.IsContextError(res.err) {
+			if s.verboseLogs && !osvutil.IsContextError(res.err) {
 				logger.ErrorContext(ctx, "failed to hydrate", slog.String("id", res.id), slog.String("error", res.err.Error()))
 			}
 			// continue to drain the channel
@@ -672,7 +673,7 @@ func (s *server) collectAndSort(ctx context.Context,
 	// If we got a real error, fail the whole query.
 	if err := context.Cause(ctx); err != nil {
 		if s.verboseLogs {
-			if logger.IsContextError(err) {
+			if osvutil.IsContextError(err) {
 				logger.InfoContext(ctx, "query cancelled or timed out", slog.Any("error", err))
 			} else {
 				logger.ErrorContext(ctx, "failed to query and hydrate", slog.Any("error", err))

--- a/go/internal/api/server.go
+++ b/go/internal/api/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/osv.dev/go/internal/models"
 	"github.com/google/osv.dev/go/logger"
 	"github.com/google/osv.dev/go/osv/clients"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
@@ -58,7 +59,9 @@ func RunServer(ctx context.Context, opts ServerOptions) error {
 		return err
 	}
 
-	s := grpc.NewServer()
+	s := grpc.NewServer(
+		grpc.StatsHandler(otelgrpc.NewServerHandler()),
+	)
 	pb.RegisterOSVServer(s, &server{
 		vulnStore:           opts.VulnStore,
 		relationsStore:      opts.RelationsStore,

--- a/go/internal/osvutil/errors.go
+++ b/go/internal/osvutil/errors.go
@@ -1,0 +1,22 @@
+package osvutil
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// IsContextError returns true if the error is due to context cancellation or deadline expiration
+// (either standard Go context errors or gRPC status errors).
+func IsContextError(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	// Context cancellation during a gRPC call returns a gRPC status error rather than a standard context error.
+	// Check the gRPC status code directly (returns codes.Unknown if err is not a gRPC status error).
+	code := status.Code(err)
+
+	return code == codes.Canceled || code == codes.DeadlineExceeded
+}

--- a/go/logger/logger.go
+++ b/go/logger/logger.go
@@ -3,16 +3,14 @@ package logger
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"runtime"
 	"time"
 
+	"github.com/google/osv.dev/go/internal/osvutil"
 	"go.opentelemetry.io/otel/trace"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func log(ctx context.Context, level slog.Level, msg string, a []any) {
@@ -42,18 +40,6 @@ func log(ctx context.Context, level slog.Level, msg string, a []any) {
 	}
 }
 
-// IsContextError returns true if the error is due to context cancellation or deadline expiration.
-func IsContextError(err error) bool {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return true
-	}
-	// Context cancellation during a gRPC call returns a gRPC status error rather than a standard context error.
-	// Check the gRPC status code directly (returns codes.Unknown if err is not a gRPC status error).
-	code := status.Code(err)
-
-	return code == codes.Canceled || code == codes.DeadlineExceeded
-}
-
 func ignoreError(r slog.Record) bool {
 	ignore := false
 	r.Attrs(func(a slog.Attr) bool {
@@ -61,7 +47,7 @@ func ignoreError(r slog.Record) bool {
 			if err, ok := a.Value.Any().(error); ok {
 				// We want to ignore context cancelled/deadline errors, since they're usually caused by something else
 				// and we don't want to be alerted about them.
-				if IsContextError(err) {
+				if osvutil.IsContextError(err) {
 					ignore = true
 
 					return false


### PR DESCRIPTION
- Attempt to propagate traces from the endpoints/ESP stuff to the logs of the API
- Deal with a subtle issue of the query timeout being hit during a datastore gRPC call propagating first and not being interpreted as a timeout cancel, causing a 500 instead of pagination.
  - (moved `IsContextError` into `osvutil` for this)