### PR TITLE
fix: prevent batcher from exceeding maxSize

### DIFF
--- a/go/internal/osvutil/batcher/batcher.go
+++ b/go/internal/osvutil/batcher/batcher.go
@@ -180,8 +180,14 @@ func (b *Batcher[K, R]) runBatchLoop() {
 			b.mu.Lock()
 			// If we panicked before stealing the pending slice, steal it now
 			if len(batch) == 0 && len(b.pending) > 0 {
-				batch = b.pending
-				b.pending = nil
+				if len(b.pending) > b.maxSize {
+					batch = b.pending[:b.maxSize]
+					b.pending = b.pending[b.maxSize:]
+					go b.runBatchLoop()
+				} else {
+					batch = b.pending
+					b.pending = nil
+				}
 			}
 			b.mu.Unlock()
 
@@ -201,12 +207,26 @@ func (b *Batcher[K, R]) runBatchLoop() {
 	}
 
 	b.mu.Lock()
-	batch = b.pending
-	b.pending = nil // Reset pending so the next request starts a new batch.
-	// Drain triggerChan to avoid stale triggers for the next batch.
-	select {
-	case <-b.triggerChan:
-	default:
+	if len(b.pending) > b.maxSize {
+		batch = b.pending[:b.maxSize]
+		b.pending = b.pending[b.maxSize:]
+		// Spawn a worker for the remaining pending items.
+		go b.runBatchLoop()
+		// Ensure triggerChan is set if leftover items reach or exceed maxSize.
+		if len(b.pending) >= b.maxSize {
+			select {
+			case b.triggerChan <- struct{}{}:
+			default:
+			}
+		}
+	} else {
+		batch = b.pending
+		b.pending = nil // Reset pending so the next request starts a new batch.
+		// Drain triggerChan to avoid stale triggers for the next batch.
+		select {
+		case <-b.triggerChan:
+		default:
+		}
 	}
 	b.mu.Unlock()
 

--- a/go/internal/osvutil/batcher/batcher_test.go
+++ b/go/internal/osvutil/batcher/batcher_test.go
@@ -252,3 +252,58 @@ func TestBatcher_PanicPropagation(t *testing.T) {
 		t.Logf("Caller %d successfully received propagated PanicError: %v", i+1, panicErr)
 	}
 }
+
+func TestBatcher_MaxSizeEnforced(t *testing.T) {
+	ctx := context.Background()
+	maxSize := 10
+
+	var maxObservedBatchSize int
+	var mu sync.Mutex
+
+	batchFunc := func(_ context.Context, keys []int) []Result[int] {
+		mu.Lock()
+		if len(keys) > maxObservedBatchSize {
+			maxObservedBatchSize = len(keys)
+		}
+		mu.Unlock()
+
+		results := make([]Result[int], len(keys))
+		for i, key := range keys {
+			results[i] = Result[int]{Val: key * 2}
+		}
+
+		return results
+	}
+
+	b := New(50*time.Millisecond, maxSize, batchFunc)
+
+	const totalRequests = 100
+	results := make([]int, totalRequests)
+	errs := make([]error, totalRequests)
+
+	var wg sync.WaitGroup
+	for i := range totalRequests {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			res, err := b.Get(ctx, idx)
+			results[idx] = res
+			errs[idx] = err
+		}(i)
+	}
+
+	wg.Wait()
+
+	if maxObservedBatchSize > maxSize {
+		t.Errorf("Batch size %d exceeded maxSize %d", maxObservedBatchSize, maxSize)
+	}
+
+	for i := range totalRequests {
+		if errs[i] != nil {
+			t.Errorf("Request %d failed: %v", i, errs[i])
+		}
+		if results[i] != i*2 {
+			t.Errorf("Request %d got wrong result: %d, expected %d", i, results[i], i*2)
+		}
+	}
+}


### PR DESCRIPTION
The request batcher was using maxSize as a trigger to override the timeout, but wasn't capping the number of requests to that size (if a very large spike in requests happen at that exact moment).
This was causing the BatchQuery to attempt a GetMulti with over 1000 keys, which is an error in datastore.

If the pending slice is over maxSize, spawn a new batch loop to consume the remaining entities.