### PR TITLE
fix(vulnfeeds): descriptions using 'en-US' instead of 'en' weren't parsing

### DIFF
--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -217,10 +217,10 @@ func combineIntoOSV(cve5osv map[models.CVEID]*osvschema.Vulnerability, nvdosv ma
 func combineTwoOSVRecords(cve5 *osvschema.Vulnerability, nvd *osvschema.Vulnerability) *osvschema.Vulnerability {
 	baseOSV := cve5
 	if baseOSV.GetDetails() == "" && nvd.GetDetails() != "" {
-		baseOSV.Details = nvd.Details
+		baseOSV.Details = nvd.GetDetails()
 	}
 	if baseOSV.GetSummary() == "" && nvd.GetSummary() != "" {
-		baseOSV.Summary = nvd.Summary
+		baseOSV.Summary = nvd.GetSummary()
 	}
 	combinedAffected := pickAffectedInformation(cve5.GetAffected(), nvd.GetAffected())
 

--- a/vulnfeeds/cmd/combine-to-osv/main.go
+++ b/vulnfeeds/cmd/combine-to-osv/main.go
@@ -216,6 +216,12 @@ func combineIntoOSV(cve5osv map[models.CVEID]*osvschema.Vulnerability, nvdosv ma
 // combineTwoOSVRecords takes two osv records and combines them into one
 func combineTwoOSVRecords(cve5 *osvschema.Vulnerability, nvd *osvschema.Vulnerability) *osvschema.Vulnerability {
 	baseOSV := cve5
+	if baseOSV.GetDetails() == "" && nvd.GetDetails() != "" {
+		baseOSV.Details = nvd.Details
+	}
+	if baseOSV.GetSummary() == "" && nvd.GetSummary() != "" {
+		baseOSV.Summary = nvd.Summary
+	}
 	combinedAffected := pickAffectedInformation(cve5.GetAffected(), nvd.GetAffected())
 
 	baseOSV.Affected = combinedAffected

--- a/vulnfeeds/models/cve.go
+++ b/vulnfeeds/models/cve.go
@@ -146,7 +146,7 @@ type CVE5 struct {
 
 func EnglishDescription(descriptions []LangString) string {
 	for _, desc := range descriptions {
-		if desc.Lang == "en" {
+		if desc.Lang == "en" || strings.HasPrefix(desc.Lang, "en-") {
 			return desc.Value
 		}
 	}


### PR DESCRIPTION
fixes #5613 

If one of the records does have the correct information and the other one doesn't, grab the one that does have it. 