### PR TITLE
fix(alpine): set fixed version to introduced when Alpine reports "0"

### DIFF
--- a/vulnfeeds/cmd/converters/alpine/main.go
+++ b/vulnfeeds/cmd/converters/alpine/main.go
@@ -197,10 +197,14 @@ func generateAlpineOSV(allAlpineSecDb map[string][]VersionAndPkg, allCVEs map[mo
 
 		for _, verPkg := range verPkgs {
 			introduced := findIntroducedVersion(cve.CVE, verPkg.Pkg)
+			fixed := verPkg.Ver
+			if fixed == "0" {
+				fixed = introduced
+			}
 			pkgInfo := vulns.PackageInfo{
 				PkgName: verPkg.Pkg,
 				VersionInfo: models.VersionInfo{
-					AffectedVersions: []models.AffectedVersion{{Introduced: introduced, Fixed: verPkg.Ver}},
+					AffectedVersions: []models.AffectedVersion{{Introduced: introduced, Fixed: fixed}},
 				},
 				Ecosystem: "Alpine:" + verPkg.AlpineVer,
 				PURL:      "pkg:apk/alpine/" + verPkg.Pkg + "?arch=source",


### PR DESCRIPTION
In some cases, the Alpine SecDB records a security fix with a version of "0". When this is combined with a valid introduced version derived from NVD CPE data (e.g., "1.0"), it results in an invalid version range where fixed is chronologically before introduced ([1.0, 0)).

Solution: Update the Alpine converter logic to check if the fixed version reported by Alpine is "0". If so, set it to equal the introduced version, ensuring valid range semantics.