### PR TITLE
fix: change router nat config for manual ips

### DIFF
--- a/deployment/terraform/modules/osv/workers_network.tf
+++ b/deployment/terraform/modules/osv/workers_network.tf
@@ -28,10 +28,15 @@ resource "google_compute_router_nat" "nat_config" {
   project                             = var.project_id
   name                                = "nat-config"
   router                              = google_compute_router.router.name
-  source_subnetwork_ip_ranges_to_nat  = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+  source_subnetwork_ip_ranges_to_nat  = "LIST_OF_SUBNETWORKS"
   nat_ip_allocate_option              = "AUTO_ONLY"
   region                              = google_compute_router.router.region
   enable_endpoint_independent_mapping = false
+
+  subnetwork {
+    name                    = google_compute_subnetwork.my_subnet_0.id
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
 
   log_config {
     enable = false


### PR DESCRIPTION
I cannot apply the terraform changes in #5536 because the existing NAT router applies to all IPs:
```
Error: Error creating RouterNat: googleapi: Error 400: Invalid value for field 'resource.nats[0].sourceSubnetworkIpRangesToNat': 'ALL_SUBNETWORKS_ALL_IP_RANGES'. Can not create new Nats since a Nat with option ALL_SUBNETWORKS_ALL_IP_RANGES exists., invalid
```

I think changing this to just the specific subnetwork is okay (it at least doesn't trigger a deletion), but I may revert this before release if something on the test instance breaks.