### PR TITLE
chore: suppress reconciliation warnings for minimos source

### DIFF
--- a/go/internal/importer/importer.go
+++ b/go/internal/importer/importer.go
@@ -179,6 +179,15 @@ var reconcileSkipSources = []string{
 	"cve-osv",
 }
 
+// reconcileWarningAsInfoSources is a list of source names to log as INFO instead of WARNING during reconciliation.
+var reconcileWarningAsInfoSources = []string{
+	"minimos",
+}
+
+func reconcileWarningsAsInfo(source string) bool {
+	return slices.Contains(reconcileWarningAsInfoSources, source)
+}
+
 // ReconcileLeniencyDuration specifies how long of a time difference before it would be considered an outdated record
 // This needs to be some time as importer detecting the change to worker importing it is not instant.
 const ReconcileLeniencyDuration = time.Hour * 6
@@ -325,9 +334,15 @@ func checkReconcile(
 
 	dbMod, exists := dbRecords[path]
 	if !exists {
-		logger.WarnContext(ctx, "Found missing vulnerability in database during reconcile",
-			slog.String("source", recordTemplate.SourceRepository),
-			slog.String("path", path))
+		if reconcileWarningsAsInfo(recordTemplate.SourceRepository) {
+			logger.InfoContext(ctx, "Found missing vulnerability in database during reconcile",
+				slog.String("source", recordTemplate.SourceRepository),
+				slog.String("path", path))
+		} else {
+			logger.WarnContext(ctx, "Found missing vulnerability in database during reconcile",
+				slog.String("source", recordTemplate.SourceRepository),
+				slog.String("path", path))
+		}
 		// Trigger a standard import
 		recordTemplate.Action = ActionImport
 		select {
@@ -351,11 +366,19 @@ func checkReconcile(
 		}
 
 		if modified.After(dbMod.Add(ReconcileLeniencyDuration)) {
-			logger.WarnContext(ctx, "Found outdated vulnerability in database during reconcile",
-				slog.String("source", recordTemplate.SourceRepository),
-				slog.String("path", path),
-				slog.Time("database_modified", dbMod),
-				slog.Time("upstream_modified", modified))
+			if reconcileWarningsAsInfo(recordTemplate.SourceRepository) {
+				logger.InfoContext(ctx, "Found outdated vulnerability in database during reconcile",
+					slog.String("source", recordTemplate.SourceRepository),
+					slog.String("path", path),
+					slog.Time("database_modified", dbMod),
+					slog.Time("upstream_modified", modified))
+			} else {
+				logger.WarnContext(ctx, "Found outdated vulnerability in database during reconcile",
+					slog.String("source", recordTemplate.SourceRepository),
+					slog.String("path", path),
+					slog.Time("database_modified", dbMod),
+					slog.Time("upstream_modified", modified))
+			}
 
 			// We found that it is outdated, trigger a standard import
 			recordTemplate.Action = ActionImport
@@ -600,11 +623,19 @@ func processUpdate(ctx context.Context, config Config, item WorkItem) {
 					return
 				}
 
-				logger.WarnContext(ctx, "Found outdated vulnerability in database during reconcile",
-					slog.String("source", sourceRepoName),
-					slog.String("path", sourcePath),
-					slog.Time("database_modified", dbModified),
-					slog.Time("upstream_modified", modified))
+				if reconcileWarningsAsInfo(sourceRepoName) {
+					logger.InfoContext(ctx, "Found outdated vulnerability in database during reconcile",
+						slog.String("source", sourceRepoName),
+						slog.String("path", sourcePath),
+						slog.Time("database_modified", dbModified),
+						slog.Time("upstream_modified", modified))
+				} else {
+					logger.WarnContext(ctx, "Found outdated vulnerability in database during reconcile",
+						slog.String("source", sourceRepoName),
+						slog.String("path", sourcePath),
+						slog.Time("database_modified", dbModified),
+						slog.Time("upstream_modified", modified))
+				}
 			default:
 			}
 		}

--- a/go/internal/importer/importer_test.go
+++ b/go/internal/importer/importer_test.go
@@ -268,3 +268,23 @@ func TestImporterWorker(t *testing.T) {
 		t.Errorf("Expected path 4.json, got %s", mockPublisher.Messages[3].Attributes["path"])
 	}
 }
+
+func TestReconcileWarningsAsInfo(t *testing.T) {
+	tests := []struct {
+		source string
+		want   bool
+	}{
+		{"minimos", true},
+		{"git", false},
+		{"cve-osv", false},
+		{"random", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.source, func(t *testing.T) {
+			if got := reconcileWarningsAsInfo(tt.source); got != tt.want {
+				t.Errorf("reconcileWarningsAsInfo(%q) = %v, want %v", tt.source, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Suppress warnings about missing or outdated vulnerabilities during reconciliation for the minimos source. MinimOS tend to update their all.json before populating the actual vulnerabilities, causing a very common case of the default importer path failing to import from 404 errors.