### PR TITLE
fix: ignore field mismatch on datastore queries in API

### DIFF
--- a/go/cmd/api/main.go
+++ b/go/cmd/api/main.go
@@ -60,7 +60,7 @@ func run() error {
 		}
 	}
 	datastoreID := os.Getenv("DATASTORE_DATABASE_ID") // empty string is the (default) database
-	dbClient, err := datastore.NewClientWithDatabase(ctx, project, datastoreID)
+	dbClient, err := datastore.NewClientWithDatabase(ctx, project, datastoreID, datastore.WithIgnoreFieldMismatch())
 	if err != nil {
 		logger.ErrorContext(ctx, "Failed to create datastore client", slog.Any("error", err))
 		return err


### PR DESCRIPTION
The DetermineVersions database entities include some historic fields that are no longer reflected in the `models.py`, but are causing problems with the go Datastore's strict resolution.
Don't be strict on the API (which is fine, since it's not writing anything)