### PR TITLE
fix: missing config from terraform

### DIFF
--- a/deployment/terraform/modules/osv/workers_gke.tf
+++ b/deployment/terraform/modules/osv/workers_gke.tf
@@ -179,7 +179,7 @@ resource "google_container_node_pool" "worker_pool_temp" {
   }
 
   node_config {
-    machine_type = "n4-highcpu-2"
+    machine_type = "n4-highcpu-8"
     disk_type    = "hyperdisk-balanced"
 
     oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]

--- a/deployment/terraform/modules/osv_pipeline/gke.tf
+++ b/deployment/terraform/modules/osv_pipeline/gke.tf
@@ -158,43 +158,43 @@ resource "google_container_node_pool" "importer_pool" {
   }
 }
 
-# Will deal with this properly when we unify test and prod.
-# resource "google_container_node_pool" "worker_pool_temp" {
-#   count    = var.project_id == "oss-vdb-test" ? 1 : 0
-#   project  = var.project_id
-#   name     = "worker-pool-temp"
-#   cluster  = google_container_cluster.workers.name
-#   location = google_container_cluster.workers.location
-# 
-#   lifecycle {
-#     replace_triggered_by = [
-#       google_container_cluster.workers.id,
-#     ]
-#   }
-# 
-#   autoscaling {
-#     min_node_count  = 0
-#     max_node_count  = 250
-#     location_policy = "BALANCED"
-#   }
-# 
-#   node_config {
-#     service_account = google_service_account.worker_sa.email
-#     machine_type    = "n4-highcpu-2"
-#     disk_type       = "hyperdisk-balanced"
-# 
-#     oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
-# 
-#     labels = {
-#       workloadType = "worker-pool"
-#     }
-#     taint {
-#       effect = "NO_EXECUTE"
-#       key    = "workloadType"
-#       value  = "worker-pool"
-#     }
-#   }
-# }
+resource "google_container_node_pool" "worker_pool" {
+  project  = var.project_id
+  name     = "worker-pool"
+  cluster  = google_container_cluster.workers.name
+  location = google_container_cluster.workers.location
+
+  lifecycle {
+    replace_triggered_by = [
+      google_container_cluster.workers.id,
+    ]
+  }
+
+  autoscaling {
+    min_node_count  = 0
+    max_node_count  = 250
+    location_policy = "BALANCED"
+  }
+
+  node_config {
+    service_account = google_service_account.worker_sa.email
+    machine_type    = "n4-highcpu-8"
+    disk_type       = "hyperdisk-balanced"
+
+    oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+
+    labels = {
+      workloadType = "worker-pool"
+    }
+    taint {
+      effect = "NO_EXECUTE"
+      key    = "workloadType"
+      value  = "worker-pool"
+    }
+  }
+}
+
+
 
 # 6TiB SSD disk used by the gitter caching service
 resource "google_compute_disk" "gitter_disk" {

--- a/deployment/terraform/modules/osv_pipeline/iam.tf
+++ b/deployment/terraform/modules/osv_pipeline/iam.tf
@@ -30,7 +30,8 @@ resource "google_project_iam_member" "worker_node_roles" {
   for_each = toset([
     "roles/container.defaultNodeServiceAccount",
     "roles/monitoring.metricWriter",
-    "roles/monitoring.viewer"
+    "roles/monitoring.viewer",
+    "roles/cloudtrace.agent"
   ])
 
   project = var.project_id

--- a/deployment/terraform/modules/osv_pipeline/iam.tf
+++ b/deployment/terraform/modules/osv_pipeline/iam.tf
@@ -50,6 +50,21 @@ resource "google_storage_bucket_iam_member" "worker_backup_bucket" {
   member = "serviceAccount:${google_service_account.worker_sa.email}"
 }
 
+# Topic-level Pub/Sub publisher access for task creation and retry
+resource "google_pubsub_topic_iam_member" "worker_tasks_publisher" {
+  project = var.project_id
+  topic   = google_pubsub_topic.tasks.name
+  role    = "roles/pubsub.publisher"
+  member  = "serviceAccount:${google_service_account.worker_sa.email}"
+}
+
+resource "google_pubsub_topic_iam_member" "worker_failed_tasks_publisher" {
+  project = var.project_id
+  topic   = google_pubsub_topic.failed_tasks.name
+  role    = "roles/pubsub.publisher"
+  member  = "serviceAccount:${google_service_account.worker_sa.email}"
+}
+
 # Subscription-level Pub/Sub access to prevent queue cross-talk/task-stealing
 resource "google_pubsub_subscription_iam_member" "worker_subscriber" {
   project      = var.project_id
@@ -62,6 +77,13 @@ resource "google_pubsub_subscription_iam_member" "worker_extra_subscribers" {
   for_each     = toset(var.extra_work_pools)
   project      = var.project_id
   subscription = google_pubsub_subscription.work_pools[each.value].name
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:${google_service_account.worker_sa.email}"
+}
+
+resource "google_pubsub_subscription_iam_member" "worker_recovery_subscriber" {
+  project      = var.project_id
+  subscription = google_pubsub_subscription.recovery.name
   role         = "roles/pubsub.subscriber"
   member       = "serviceAccount:${google_service_account.worker_sa.email}"
 }

--- a/deployment/terraform/modules/osv_pipeline/iam.tf
+++ b/deployment/terraform/modules/osv_pipeline/iam.tf
@@ -25,9 +25,10 @@ resource "google_project_iam_member" "worker_datastore_roles" {
   }
 }
 
-# Cloud Monitoring roles at the project level
-resource "google_project_iam_member" "worker_monitoring_roles" {
+# GKE Node Service Account and Monitoring roles at the project level
+resource "google_project_iam_member" "worker_node_roles" {
   for_each = toset([
+    "roles/container.defaultNodeServiceAccount",
     "roles/monitoring.metricWriter",
     "roles/monitoring.viewer"
   ])
@@ -36,6 +37,7 @@ resource "google_project_iam_member" "worker_monitoring_roles" {
   role    = each.value
   member  = "serviceAccount:${google_service_account.worker_sa.email}"
 }
+
 
 # Bucket-level GCS access to secure vulnerability exports and backups
 resource "google_storage_bucket_iam_member" "worker_export_bucket" {


### PR DESCRIPTION
Added a few missing terraform configs for the private instance
- Pub/Sub permissions for the recovery topic
- Permissions to write traces
- Maybe `Grant roles/container.defaultNodeServiceAccount role to Node service account to allow for non-degraded operations.` but the error is still showing up in the GUI so idk.
- Actually gave it a worker pool, because the workers have the taint.

Also, adjusted the machine type for the worker pool to `n4-highcpu-8`, because `n4-highcpu-2` could only actually have one worker on it (with, like space for 0.8 of a worker remaining).
With 8 CPUs, we should have space for 6 or 7 (🤷) workers on a single machine.