### PR TITLE
fix(vulnfeeds): gcs logging

### DIFF
--- a/vulnfeeds/conversion/writer/writer.go
+++ b/vulnfeeds/conversion/writer/writer.go
@@ -91,7 +91,6 @@ func uploadIfChanged(ctx context.Context, v *osvschema.Vulnerability, hexHash st
 	if err == nil {
 		// Object exists, check hash.
 		if attrs.Metadata != nil && attrs.Metadata[hashMetadataKey] == hexHash {
-			logger.Info("Skipping GCS upload, hash matches", slog.String("id", vulnID), slog.String("object", objName))
 			return ErrUploadSkipped
 		}
 	} else if !errors.Is(err, storage.ErrObjectNotExist) {
@@ -217,14 +216,26 @@ func VulnWorker(ctx context.Context, vulnChan <-chan *osvschema.Vulnerability, o
 		}
 
 		if writeErr == nil {
-			logger.Info("Uploaded successfully", slog.String("id", vulnID))
+			if outBkt == nil && gcsHelper == nil {
+				logger.Info("Wrote to disk successfully", slog.String("id", vulnID))
+			} else if gcsHelper != nil {
+				logger.Info("Queued for upload successfully", slog.String("id", vulnID))
+			} else {
+				logger.Info("Uploaded to GCS successfully", slog.String("id", vulnID))
+			}
 			if counter != nil {
 				counter.Add(1)
 			}
 		} else if errors.Is(writeErr, ErrUploadSkipped) {
-			logger.Info("Skipping upload, hash matches", slog.String("id", vulnID))
+			logger.Info("Skipping GCS upload, hash matches", slog.String("id", vulnID))
 		} else {
-			logger.Error("Failed to upload/write", slog.String("id", vulnID), slog.Any("err", writeErr))
+			if outBkt == nil && gcsHelper == nil {
+				logger.Error("Failed to write to disk", slog.String("id", vulnID), slog.Any("err", writeErr))
+			} else if gcsHelper != nil {
+				logger.Error("Failed to queue for upload", slog.String("id", vulnID), slog.Any("err", writeErr))
+			} else {
+				logger.Error("Failed to upload to GCS", slog.String("id", vulnID), slog.Any("err", writeErr))
+			}
 		}
 	}
 }

--- a/vulnfeeds/gcs-tools/gcs.go
+++ b/vulnfeeds/gcs-tools/gcs.go
@@ -85,7 +85,8 @@ func bucketWorker(ctx context.Context, gcsHelper *Helper) {
 				metadata = map[string]string{hashMetadataKey: msg.hash}
 			}
 			if err := UploadToGCS(ctx, gcsHelper.bkt, msg.objectName, msg.data, msg.contentType, metadata); err != nil {
-				logger.Info("Failed to upload object", slog.String("object", msg.objectName), slog.String("error", err.Error()))
+				logger.Error("Failed to upload object", slog.String("object", msg.objectName), slog.String("error", err.Error()))
+				return
 			}
 
 			logger.Info("Uploaded GCS object", slog.String("object", msg.objectName))


### PR DESCRIPTION
*   **Context-Aware Worker Logging:** Clarified log messages in `VulnWorker` (used by `combine-to-osv` and others) to explicitly state whether a record was **written to disk**, **queued for async upload**, or **uploaded to GCS synchronously**, replacing generic "Uploaded" messages that were confusing in local or async modes.
*   **Fixed Success-on-Failure Bug:** Fixed a misleading bug in the async GCS uploader (`gcs.go`) where `"Uploaded GCS object"` was logged immediately after a failure message. It now returns early on error and logs failures at `Error` level instead of `Info`.
*   **Eliminated Duplicate "Skipped" Logs:** Removed redundant `"Skipping GCS upload"` log in the synchronous path (`writer.go`), leaving the logging responsibility solely to the calling worker for cleaner output.