### PR TITLE
feat: enable HTTP/2 on the API

### DIFF
--- a/deployment/clouddeploy/osv-api/run-prod.yaml
+++ b/deployment/clouddeploy/osv-api/run-prod.yaml
@@ -10,6 +10,9 @@ spec:
     spec:
       containers:
       - image: osv-server
+        ports:
+        - name: h2c
+          containerPort: 8080
         env:
         - name: GOOGLE_CLOUD_PROJECT
           value: oss-vdb

--- a/deployment/clouddeploy/osv-api/run-staging.yaml
+++ b/deployment/clouddeploy/osv-api/run-staging.yaml
@@ -10,6 +10,9 @@ spec:
     spec:
       containers:
       - image: osv-server
+        ports:
+        - name: h2c
+          containerPort: 8080
         env:
         - name: GOOGLE_CLOUD_PROJECT
           value: oss-vdb-test

--- a/deployment/terraform/modules/osv/osv_api.tf
+++ b/deployment/terraform/modules/osv/osv_api.tf
@@ -132,7 +132,7 @@ resource "google_cloud_run_service" "api" {
       containers {
         image = data.google_container_registry_image.api.image_url
         ports {
-          name = "h2c"
+          name           = "h2c"
           container_port = 8080
         }
         env {

--- a/deployment/terraform/modules/osv/osv_api.tf
+++ b/deployment/terraform/modules/osv/osv_api.tf
@@ -131,6 +131,10 @@ resource "google_cloud_run_service" "api" {
     spec {
       containers {
         image = data.google_container_registry_image.api.image_url
+        ports {
+          name = "h2c"
+          container_port = 8080
+        }
         env {
           name  = "ESPv2_ARGS"
           value = "^++^--transcoding_preserve_proto_field_names++--envoy_connection_buffer_limit_bytes=104857600++--underscores_in_headers++--cors_preset=basic++--cors_allow_methods=GET,POST,OPTIONS"


### PR DESCRIPTION
some people seem to be mysteriously managing to overcome the 32MB HTTP/1 limit in Cloud Run.
HTTP/2 doesn't appear to have a response size limit, so let's enable that.