### PR TITLE
chore: add python directories to code-worksapce file

### DIFF
--- a/osv.dev.code-workspace
+++ b/osv.dev.code-workspace
@@ -11,7 +11,16 @@
 		},
 		{
 			"path": "go/cmd/tools/reimport-tui"
-		}
+		},
+	    {
+	      "path": "gcp/api"
+	    },
+	    {
+	      "path": "gcp/website"
+	    },
+	    {
+	      "path": "gcp/workers"
+	    }
 	],
 	"settings": {}
 }


### PR DESCRIPTION
Unifying my personal workspace file with these.
Having these workspaces makes VSCode understand the different poetry environments better (even though we want to delete them soon)