### PR TITLE
feat: Exporter 12x faster hopefully

### DIFF
--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/exporter.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/exporter.yaml
@@ -18,4 +18,6 @@ spec:
               - "--workers=3000"
               - "--bucket=osv-test-vulnerabilities"
               - "--osv-vulns-bucket=osv-test-vulnerabilities"
+              - "--breakdown-prefixes=ALSA-,BIT-,CGA-0,CGA-a,CGA-m,CVE-,DLA-,DSA-,GHSA-,GO-,MAL-,MGASA-,OSV-,PYSEC-,RLSA-,RUSTSEC-,SUSE-,UBUNTU-"
+
 

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/exporter.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/exporter.yaml
@@ -15,7 +15,7 @@ spec:
             args:
               # TODO(michaelkedar): single source of truth w/ terraform config
               - "--upload-to-gcs=true"
-              - "--workers=600"
+              - "--workers=3000"
               - "--bucket=osv-test-vulnerabilities"
               - "--osv-vulns-bucket=osv-test-vulnerabilities"
 

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/exporter.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/exporter.yaml
@@ -14,7 +14,7 @@ spec:
               value: oss-vdb
             args:
               - "--upload-to-gcs=true"
-              - "--workers=600"
+              - "--workers=3000"
               - "--bucket=osv-vulnerabilities"
               - "--osv-vulns-bucket=osv-vulnerabilities"
 

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb/exporter.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb/exporter.yaml
@@ -17,4 +17,6 @@ spec:
               - "--workers=3000"
               - "--bucket=osv-vulnerabilities"
               - "--osv-vulns-bucket=osv-vulnerabilities"
+              - "--breakdown-prefixes=ALSA-,BIT-,CGA-0,CGA-a,CGA-m,CVE-,DLA-,DSA-,GHSA-,GO-,MAL-,MGASA-,OSV-,PYSEC-,RLSA-,RUSTSEC-,SUSE-,UBUNTU-"
+
 

--- a/deployment/clouddeploy/gke-workers/environments/private/exporter.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/private/exporter.yaml
@@ -14,7 +14,7 @@ spec:
               value: oss-vdb-test
             args:
               - "--upload-to-gcs=true"
-              - "--workers=600"
+              - "--workers=3000"
               - "--bucket=osv-test-vulnerabilities-private"
               - "--osv-vulns-bucket=osv-test-vulnerabilities-private"
 

--- a/go/cmd/exporter/README.md
+++ b/go/cmd/exporter/README.md
@@ -17,7 +17,7 @@ To run the exporter locally, run the exporter from within the `go/cmd/exporter` 
 
 ```sh
 # Example
-go run . -osv_vulns_bucket osv-test-vulnerabilities -uploadToGCS=false -bucket /tmp/osv-export
+go run . -osv-vulns-bucket osv-test-vulnerabilities -upload-to-gcs=false -bucket /tmp/osv-export
 ```
 
 This will write the exported files to the `/tmp/osv-export` directory.

--- a/go/cmd/exporter/downloader.go
+++ b/go/cmd/exporter/downloader.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 	"sync"
 
+	"github.com/google/osv.dev/go/internal/osvutil"
 	"github.com/google/osv.dev/go/logger"
 	"github.com/google/osv.dev/go/osv/clients"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
@@ -21,7 +21,7 @@ func downloader(ctx context.Context, client clients.CloudStorage, inCh <-chan st
 		// Process object.
 		data, err := client.ReadObject(ctx, path)
 		if err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			if osvutil.IsContextError(err) {
 				return
 			}
 			logger.ErrorContext(ctx, "failed to read vulnerability", slog.String("obj", path), slog.Any("err", err))
@@ -30,7 +30,7 @@ func downloader(ctx context.Context, client clients.CloudStorage, inCh <-chan st
 		}
 		vuln := &osvschema.Vulnerability{}
 		if err := proto.Unmarshal(data, vuln); err != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			if osvutil.IsContextError(err) {
 				return
 			}
 			logger.ErrorContext(ctx, "failed to unmarshal vulnerability", slog.String("obj", path), slog.Any("err", err))

--- a/go/cmd/exporter/downloader.go
+++ b/go/cmd/exporter/downloader.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sync"
 
@@ -16,29 +17,22 @@ import (
 // result to outCh.
 func downloader(ctx context.Context, client clients.CloudStorage, inCh <-chan string, outCh chan<- *osvschema.Vulnerability, wg *sync.WaitGroup) {
 	defer wg.Done()
-	for {
-		var path string
-		var ok bool
-
-		// Wait to receive an object path, or be cancelled.
-		select {
-		case path, ok = <-inCh:
-			if !ok {
-				return // Channel closed.
-			}
-		case <-ctx.Done():
-			return
-		}
-
+	for path := range inCh {
 		// Process object.
 		data, err := client.ReadObject(ctx, path)
 		if err != nil {
-			logger.Error("failed to read vulnerability", slog.String("obj", path), slog.Any("err", err))
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return
+			}
+			logger.ErrorContext(ctx, "failed to read vulnerability", slog.String("obj", path), slog.Any("err", err))
 			continue
 		}
 		vuln := &osvschema.Vulnerability{}
 		if err := proto.Unmarshal(data, vuln); err != nil {
-			logger.Error("failed to unmarshal vulnerability", slog.String("obj", path), slog.Any("err", err))
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return
+			}
+			logger.ErrorContext(ctx, "failed to unmarshal vulnerability", slog.String("obj", path), slog.Any("err", err))
 			continue
 		}
 

--- a/go/cmd/exporter/downloader.go
+++ b/go/cmd/exporter/downloader.go
@@ -25,6 +25,7 @@ func downloader(ctx context.Context, client clients.CloudStorage, inCh <-chan st
 				return
 			}
 			logger.ErrorContext(ctx, "failed to read vulnerability", slog.String("obj", path), slog.Any("err", err))
+
 			continue
 		}
 		vuln := &osvschema.Vulnerability{}
@@ -33,6 +34,7 @@ func downloader(ctx context.Context, client clients.CloudStorage, inCh <-chan st
 				return
 			}
 			logger.ErrorContext(ctx, "failed to unmarshal vulnerability", slog.String("obj", path), slog.Any("err", err))
+
 			continue
 		}
 

--- a/go/cmd/exporter/exporter.go
+++ b/go/cmd/exporter/exporter.go
@@ -37,7 +37,7 @@ func main() {
 	outBucketName := flag.String("bucket", "osv-test-vulnerabilities", "Output bucket or directory name. If -local is true, this is a local path; otherwise, it's a GCS bucket name.")
 	vulnBucketName := flag.String("osv-vulns-bucket", os.Getenv("OSV_VULNERABILITIES_BUCKET"), "GCS bucket to read vulnerability protobufs from. Can also be set with the OSV_VULNERABILITIES_BUCKET environment variable.")
 	uploadToGCS := flag.Bool("upload-to-gcs", false, "If false, writes the output to a local directory specified by -bucket instead of a GCS bucket.")
-	numWorkers := flag.Int("workers", 200, "The total number of concurrent workers to use for downloading from GCS and writing the output.")
+	numWorkers := flag.Int("workers", 1000, "The total number of concurrent workers to use for downloading from GCS and writing the output.")
 
 	flag.Parse()
 

--- a/go/cmd/exporter/exporter.go
+++ b/go/cmd/exporter/exporter.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/google/osv.dev/go/logger"
@@ -90,23 +89,28 @@ func main() {
 	downloaderToRouterCh := make(chan *osvschema.Vulnerability, 100)
 	routerToWriteCh := make(chan writeMsg, 100)
 
-	statsDone := make(chan struct{})
-	go func() {
-		ticker := time.NewTicker(2 * time.Second)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-statsDone:
-				return
-			case <-ticker.C:
-				logger.InfoContext(ctx, "exporter channel stats",
-					slog.Int("gcsPathToDownloaderCh", len(gcsPathToDownloaderCh)),
-					slog.Int("downloaderToRouterCh", len(downloaderToRouterCh)),
-					slog.Int("routerToWriteCh", len(routerToWriteCh)))
-			}
-		}
-	}()
-	defer close(statsDone)
+	// statsDone := make(chan struct{})
+	// go func() {
+	// 	ticker := time.NewTicker(2 * time.Second)
+	// 	defer ticker.Stop()
+	// 	for {
+	// 		select {
+	// 		case <-statsDone:
+	// 			return
+	// 		case <-ticker.C:
+	// 			logger.InfoContext(ctx, "exporter channel stats",
+	// 				slog.Int("gcsPathToDownloaderCh", len(gcsPathToDownloaderCh)),
+	// 				slog.Int("downloaderToRouterCh", len(downloaderToRouterCh)),
+	// 				slog.Int("routerToWriteCh", len(routerToWriteCh)))
+	// 		}
+	// 	}
+	// }()
+	// defer close(statsDone)
+
+	breakdownPrefixes := []string{
+		"ALSA-", "BIT-", "CGA-0", "CGA-a", "CGA-m", "CVE-", "DLA-", "DSA-", "GHSA-", "GO-",
+		"MAL-", "MGASA-", "OSV-", "PYSEC-", "RLSA-", "RUSTSEC-", "SUSE-", "UBUNTU-",
+	}
 
 	var downloaderWg sync.WaitGroup
 	for range *numWorkers / 2 {
@@ -125,19 +129,19 @@ func main() {
 
 	prevPrefix := ""
 MainLoop:
-	for obj, err := range vulnClient.Objects(ctx, gcsProtoPrefix) {
+	for objName, err := range vulnClient.ObjectsFast(ctx, gcsProtoPrefix, breakdownPrefixes) {
 		if err != nil {
 			logger.FatalContext(ctx, "failed to list objects", slog.Any("err", err))
 		}
 		// Only log when we see a new ID prefix (i.e. roughly once per data source)
-		prefix := filepath.Base(obj.Name)
+		prefix := filepath.Base(objName)
 		prefix, _, _ = strings.Cut(prefix, "-")
 		if prefix != prevPrefix {
-			logger.InfoContext(ctx, "iterating vulnerabilities", slog.String("now_at", obj.Name))
+			// logger.InfoContext(ctx, "iterating vulnerabilities", slog.String("now_at", obj.Name))
 			prevPrefix = prefix
 		}
 		select {
-		case gcsPathToDownloaderCh <- obj.Name:
+		case gcsPathToDownloaderCh <- objName:
 		case <-ctx.Done():
 			break MainLoop
 		}

--- a/go/cmd/exporter/exporter.go
+++ b/go/cmd/exporter/exporter.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -31,10 +30,6 @@ func main() {
 
 	ctx, stopSignal := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stopSignal()
-
-	// traceFile, _ := os.Create("exporter.trace")
-	// trace.Start(traceFile)
-	// defer trace.Stop()
 
 	ctx, span := otel.Tracer("exporter").Start(ctx, "exporter")
 	defer span.End()
@@ -89,24 +84,6 @@ func main() {
 	downloaderToRouterCh := make(chan *osvschema.Vulnerability, 100)
 	routerToWriteCh := make(chan writeMsg, 100)
 
-	// statsDone := make(chan struct{})
-	// go func() {
-	// 	ticker := time.NewTicker(2 * time.Second)
-	// 	defer ticker.Stop()
-	// 	for {
-	// 		select {
-	// 		case <-statsDone:
-	// 			return
-	// 		case <-ticker.C:
-	// 			logger.InfoContext(ctx, "exporter channel stats",
-	// 				slog.Int("gcsPathToDownloaderCh", len(gcsPathToDownloaderCh)),
-	// 				slog.Int("downloaderToRouterCh", len(downloaderToRouterCh)),
-	// 				slog.Int("routerToWriteCh", len(routerToWriteCh)))
-	// 		}
-	// 	}
-	// }()
-	// defer close(statsDone)
-
 	breakdownPrefixes := []string{
 		"ALSA-", "BIT-", "CGA-0", "CGA-a", "CGA-m", "CVE-", "DLA-", "DSA-", "GHSA-", "GO-",
 		"MAL-", "MGASA-", "OSV-", "PYSEC-", "RLSA-", "RUSTSEC-", "SUSE-", "UBUNTU-",
@@ -127,18 +104,10 @@ func main() {
 	routerWg.Add(1)
 	go ecosystemRouter(ctx, downloaderToRouterCh, routerToWriteCh, &routerWg)
 
-	prevPrefix := ""
 MainLoop:
 	for objName, err := range vulnClient.ObjectsFast(ctx, gcsProtoPrefix, breakdownPrefixes) {
 		if err != nil {
 			logger.FatalContext(ctx, "failed to list objects", slog.Any("err", err))
-		}
-		// Only log when we see a new ID prefix (i.e. roughly once per data source)
-		prefix := filepath.Base(objName)
-		prefix, _, _ = strings.Cut(prefix, "-")
-		if prefix != prevPrefix {
-			// logger.InfoContext(ctx, "iterating vulnerabilities", slog.String("now_at", obj.Name))
-			prevPrefix = prefix
 		}
 		select {
 		case gcsPathToDownloaderCh <- objName:

--- a/go/cmd/exporter/exporter.go
+++ b/go/cmd/exporter/exporter.go
@@ -7,9 +7,12 @@ import (
 	"flag"
 	"log/slog"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/google/osv.dev/go/logger"
@@ -27,7 +30,14 @@ func main() {
 	logger.InitGlobalLogger()
 	defer logger.Close()
 
-	ctx, span := otel.Tracer("exporter").Start(context.Background(), "exporter")
+	ctx, stopSignal := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stopSignal()
+
+	// traceFile, _ := os.Create("exporter.trace")
+	// trace.Start(traceFile)
+	// defer trace.Stop()
+
+	ctx, span := otel.Tracer("exporter").Start(ctx, "exporter")
 	defer span.End()
 
 	outBucketName := flag.String("bucket", "osv-test-vulnerabilities", "Output bucket or directory name. If -local is true, this is a local path; otherwise, it's a GCS bucket name.")
@@ -76,9 +86,27 @@ func main() {
 	// 4. The `ecosystemWorker`s and the `allEcosystemWorker` process the vulnerabilities and
 	//    generate the final files, sending the data to be written to `routerToWriteCh`.
 	// 5. A pool of `writer` workers receive the file data and write it to the output.
-	gcsPathToDownloaderCh := make(chan string)
-	downloaderToRouterCh := make(chan *osvschema.Vulnerability)
-	routerToWriteCh := make(chan writeMsg)
+	gcsPathToDownloaderCh := make(chan string, 100)
+	downloaderToRouterCh := make(chan *osvschema.Vulnerability, 100)
+	routerToWriteCh := make(chan writeMsg, 100)
+
+	statsDone := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-statsDone:
+				return
+			case <-ticker.C:
+				logger.InfoContext(ctx, "exporter channel stats",
+					slog.Int("gcsPathToDownloaderCh", len(gcsPathToDownloaderCh)),
+					slog.Int("downloaderToRouterCh", len(downloaderToRouterCh)),
+					slog.Int("routerToWriteCh", len(routerToWriteCh)))
+			}
+		}
+	}()
+	defer close(statsDone)
 
 	var downloaderWg sync.WaitGroup
 	for range *numWorkers / 2 {

--- a/go/cmd/exporter/exporter.go
+++ b/go/cmd/exporter/exporter.go
@@ -38,6 +38,7 @@ func main() {
 	vulnBucketName := flag.String("osv-vulns-bucket", os.Getenv("OSV_VULNERABILITIES_BUCKET"), "GCS bucket to read vulnerability protobufs from. Can also be set with the OSV_VULNERABILITIES_BUCKET environment variable.")
 	uploadToGCS := flag.Bool("upload-to-gcs", false, "If false, writes the output to a local directory specified by -bucket instead of a GCS bucket.")
 	numWorkers := flag.Int("workers", 1000, "The total number of concurrent workers to use for downloading from GCS and writing the output.")
+	breakdownPrefixesStr := flag.String("breakdown-prefixes", "", "Comma-separated list of prefix breakdowns for parallel GCS object listing. Defaults to A-Z if empty.")
 
 	flag.Parse()
 
@@ -45,7 +46,8 @@ func main() {
 		slog.String("bucket", *outBucketName),
 		slog.String("osv-vulns-bucket", *vulnBucketName),
 		slog.Bool("upload-to-gcs", *uploadToGCS),
-		slog.Int("workers", *numWorkers))
+		slog.Int("workers", *numWorkers),
+		slog.String("breakdown-prefixes", *breakdownPrefixesStr))
 
 	if *vulnBucketName == "" {
 		logger.FatalContext(ctx, "OSV_VULNERABILITIES_BUCKET must be set")
@@ -84,9 +86,20 @@ func main() {
 	downloaderToRouterCh := make(chan *osvschema.Vulnerability, 100)
 	routerToWriteCh := make(chan writeMsg, 100)
 
-	breakdownPrefixes := []string{
-		"ALSA-", "BIT-", "CGA-0", "CGA-a", "CGA-m", "CVE-", "DLA-", "DSA-", "GHSA-", "GO-",
-		"MAL-", "MGASA-", "OSV-", "PYSEC-", "RLSA-", "RUSTSEC-", "SUSE-", "UBUNTU-",
+	var breakdownPrefixes []string
+	if *breakdownPrefixesStr != "" {
+		for _, p := range strings.Split(*breakdownPrefixesStr, ",") {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				breakdownPrefixes = append(breakdownPrefixes, p)
+			}
+		}
+	}
+	// Fall back to simple A-Z prefixes
+	if len(breakdownPrefixes) == 0 {
+		for ch := 'A'; ch <= 'Z'; ch++ {
+			breakdownPrefixes = append(breakdownPrefixes, string(ch))
+		}
 	}
 
 	var downloaderWg sync.WaitGroup

--- a/go/cmd/exporter/worker.go
+++ b/go/cmd/exporter/worker.go
@@ -185,6 +185,10 @@ WorkLoop:
 				ecosystems[e] = struct{}{}
 				csvData = append(csvData, []string{modified.Format(time.RFC3339Nano), e + "/" + v.GetId()})
 			}
+
+			if len(csvData)%10000 == 0 {
+				logger.InfoContext(ctx, "processed N vulnerabilities", slog.Int("n", len(csvData)))
+			}
 		}
 	}
 	writeModifiedIDCSV(ctx, modifiedCSVFilename, csvData, outCh)

--- a/go/cmd/exporter/worker.go
+++ b/go/cmd/exporter/worker.go
@@ -65,8 +65,9 @@ func (w *ecosystemWorker) run(ctx context.Context, outCh chan<- writeMsg, wg *sy
 	defer span.End()
 
 	logger.InfoContext(ctx, "new ecosystem worker started", slog.String("ecosystem", w.ecosystem))
-	var allVulns []vulnData
-	var csvData [][]string
+	// 500 size is around the minimum each ecosystem would need, most ecosystems are much bigger.
+	allVulns := make([]vulnData, 0, 500)
+	csvData := make([][]string, 0, 500)
 	var vanirVulns []vulnData
 	for v := range w.inCh {
 		// Process vulnerability.
@@ -151,8 +152,9 @@ func (w *allEcosystemWorker) run(ctx context.Context, outCh chan<- writeMsg, wg 
 	defer span.End()
 
 	logger.InfoContext(ctx, "all-ecosystem worker started")
-	var allVulns []vulnData
-	var csvData [][]string
+	// We have currently about 1.8 million entries, so start at 100k
+	allVulns := make([]vulnData, 0, 100000)
+	csvData := make([][]string, 0, 100000)
 	ecosystems := make(map[string]struct{})
 	for v := range w.inCh {
 		b, err := marshalToJSON(v.Vulnerability)

--- a/go/cmd/exporter/worker.go
+++ b/go/cmd/exporter/worker.go
@@ -38,7 +38,7 @@ type ecosystemWorker struct {
 
 // newEcosystemWorker creates and starts a new ecosystemWorker.
 func newEcosystemWorker(ctx context.Context, ecosystem string, outCh chan<- writeMsg, wg *sync.WaitGroup) *ecosystemWorker {
-	ch := make(chan *osvschema.Vulnerability)
+	ch := make(chan *osvschema.Vulnerability, 100)
 	worker := &ecosystemWorker{
 		ecosystem: ecosystem,
 		inCh:      ch,
@@ -143,7 +143,7 @@ type allEcosystemWorker struct {
 
 // newAllEcosystemWorker creates and starts a new allEcosystemWorker.
 func newAllEcosystemWorker(ctx context.Context, outCh chan<- writeMsg, wg *sync.WaitGroup) *allEcosystemWorker {
-	ch := make(chan vulnAndEcos)
+	ch := make(chan vulnAndEcos, 100)
 	worker := &allEcosystemWorker{
 		inCh: ch,
 	}

--- a/go/cmd/exporter/worker.go
+++ b/go/cmd/exporter/worker.go
@@ -68,21 +68,7 @@ func (w *ecosystemWorker) run(ctx context.Context, outCh chan<- writeMsg, wg *sy
 	var allVulns []vulnData
 	var csvData [][]string
 	var vanirVulns []vulnData
-WorkLoop:
-	for {
-		var v *osvschema.Vulnerability
-		var ok bool
-
-		// Wait to receive a vulnerability, or be cancelled.
-		select {
-		case <-ctx.Done():
-			logger.WarnContext(ctx, "ecosystem worker cancelled", slog.String("ecosystem", w.ecosystem), slog.Any("err", ctx.Err()))
-			return
-		case v, ok = <-w.inCh:
-			if !ok {
-				break WorkLoop
-			}
-		}
+	for v := range w.inCh {
 		// Process vulnerability.
 		b, err := marshalToJSON(v)
 		if err != nil {
@@ -112,6 +98,10 @@ WorkLoop:
 				}
 			}
 		}
+	}
+
+	if ctx.Err() != nil {
+		return
 	}
 
 	logger.InfoContext(ctx, "All vulnerabilities processed", slog.String("ecosystem", w.ecosystem))
@@ -164,33 +154,27 @@ func (w *allEcosystemWorker) run(ctx context.Context, outCh chan<- writeMsg, wg 
 	var allVulns []vulnData
 	var csvData [][]string
 	ecosystems := make(map[string]struct{})
-WorkLoop:
-	for {
-		select {
-		case <-ctx.Done():
-			logger.WarnContext(ctx, "all-ecosystem worker cancelled", slog.Any("err", ctx.Err()))
-			return
-		case v, ok := <-w.inCh:
-			if !ok {
-				break WorkLoop
-			}
-			b, err := marshalToJSON(v.Vulnerability)
-			if err != nil {
-				logger.ErrorContext(ctx, "failed to marshal vulnerability to json", slog.String("id", v.GetId()), slog.Any("err", err))
-				continue
-			}
-			modified := v.GetModified().AsTime()
-			allVulns = append(allVulns, vulnData{id: v.GetId(), modified: modified, data: b})
-			for _, e := range v.ecosystems {
-				ecosystems[e] = struct{}{}
-				csvData = append(csvData, []string{modified.Format(time.RFC3339Nano), e + "/" + v.GetId()})
-			}
-
+	for v := range w.inCh {
+		b, err := marshalToJSON(v.Vulnerability)
+		if err != nil {
+			logger.ErrorContext(ctx, "failed to marshal vulnerability to json", slog.String("id", v.GetId()), slog.Any("err", err))
+			continue
+		}
+		modified := v.GetModified().AsTime()
+		allVulns = append(allVulns, vulnData{id: v.GetId(), modified: modified, data: b})
+		for _, e := range v.ecosystems {
+			ecosystems[e] = struct{}{}
+			csvData = append(csvData, []string{modified.Format(time.RFC3339Nano), e + "/" + v.GetId()})
 			if len(csvData)%10000 == 0 {
 				logger.InfoContext(ctx, "processed N vulnerabilities", slog.Int("n", len(csvData)))
 			}
 		}
 	}
+
+	if ctx.Err() != nil {
+		return
+	}
+
 	writeModifiedIDCSV(ctx, modifiedCSVFilename, csvData, outCh)
 	writeZIP(ctx, allZipFilename, allVulns, outCh)
 	ecos := slices.Collect(maps.Keys(ecosystems))

--- a/go/cmd/exporter/writer.go
+++ b/go/cmd/exporter/writer.go
@@ -27,46 +27,37 @@ type writeMsg struct {
 // bucket or a local directory.
 func writer(ctx context.Context, cancel context.CancelFunc, inCh <-chan writeMsg, client clients.CloudStorage, pathPrefix string, wg *sync.WaitGroup) {
 	defer wg.Done()
-	for {
-		select {
-		case msg, ok := <-inCh:
-			if !ok {
-				// Channel closed.
-				return
+	for msg := range inCh {
+		path := filepath.Join(pathPrefix, msg.path)
+		if client != nil {
+			// Skip the upload if the object already has the same content.
+			if gcsContentUnchanged(ctx, client, path, msg.data) {
+				continue
 			}
-			path := filepath.Join(pathPrefix, msg.path)
-			if client != nil {
-				// Skip the upload if the object already has the same content.
-				if gcsContentUnchanged(ctx, client, path, msg.data) {
-					break
-				}
-				err := client.WriteObject(ctx, path, msg.data, &clients.WriteOptions{
-					ContentType: msg.mimeType,
-				})
-				if err != nil {
-					logger.Error("failed to write file", slog.String("path", path), slog.Any("err", err))
-					cancel()
+			err := client.WriteObject(ctx, path, msg.data, &clients.WriteOptions{
+				ContentType: msg.mimeType,
+			})
+			if err != nil {
+				logger.Error("failed to write file", slog.String("path", path), slog.Any("err", err))
+				cancel()
 
-					break
-				}
-			} else {
-				// Write locally.
-				dir := filepath.Dir(path)
-				if err := os.MkdirAll(dir, 0755); err != nil {
-					logger.Error("failed to create directories", slog.String("dir", dir), slog.Any("err", err))
-					cancel()
-
-					break
-				}
-				if err := os.WriteFile(path, msg.data, 0600); err != nil {
-					logger.Error("failed to write file", slog.String("path", path), slog.Any("err", err))
-					cancel()
-
-					break
-				}
+				break
 			}
-		case <-ctx.Done():
-			return
+		} else {
+			// Write locally.
+			dir := filepath.Dir(path)
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				logger.Error("failed to create directories", slog.String("dir", dir), slog.Any("err", err))
+				cancel()
+
+				break
+			}
+			if err := os.WriteFile(path, msg.data, 0600); err != nil {
+				logger.Error("failed to write file", slog.String("path", path), slog.Any("err", err))
+				cancel()
+
+				break
+			}
 		}
 	}
 }

--- a/go/internal/gcs/gcs.go
+++ b/go/internal/gcs/gcs.go
@@ -1,0 +1,184 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gcs provides helper utilities for Google Cloud Storage operations.
+package gcs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"iter"
+	"slices"
+	"strings"
+
+	"cloud.google.com/go/storage"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/api/iterator"
+)
+
+// ListBucketObjectsQuery lists object names matching a storage query.
+// It optimizes the GCS API request by retrieving only the Name attribute.
+func ListBucketObjectsQuery(ctx context.Context, bucket *storage.BucketHandle, query *storage.Query) ([]string, error) {
+	if query == nil {
+		query = &storage.Query{}
+	}
+	if err := query.SetAttrSelection([]string{"Name"}); err != nil {
+		return nil, fmt.Errorf("failed to set attribute selection: %w", err)
+	}
+
+	it := bucket.Objects(ctx, query)
+	var filenames []string
+	for {
+		attrs, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("bucket.Objects: %w", err)
+		}
+		if strings.HasSuffix(attrs.Name, "/") {
+			continue
+		}
+		filenames = append(filenames, attrs.Name)
+	}
+
+	return filenames, nil
+}
+
+// buildPartitionQueries constructs partitioned storage queries using StartOffset and EndOffset.
+func buildPartitionQueries(globalPrefix string, breakdownPrefixes []string) []*storage.Query {
+	globalPrefix = strings.TrimSuffix(globalPrefix, "/")
+	globalPrefixWithSlash := ""
+	if globalPrefix != "" {
+		globalPrefixWithSlash = globalPrefix + "/"
+	}
+
+	if len(breakdownPrefixes) == 0 {
+		return []*storage.Query{{Prefix: globalPrefixWithSlash}}
+	}
+
+	sortedBreakdowns := make([]string, len(breakdownPrefixes))
+	copy(sortedBreakdowns, breakdownPrefixes)
+	slices.Sort(sortedBreakdowns)
+
+	queries := make([]*storage.Query, 0, len(sortedBreakdowns)+1)
+
+	// 1. First query: everything before the first breakdown
+	queries = append(queries, &storage.Query{
+		Prefix:    globalPrefixWithSlash,
+		EndOffset: globalPrefixWithSlash + sortedBreakdowns[0],
+	})
+
+	// 2. Intermediate queries: ranges between breakdowns
+	for i := range len(sortedBreakdowns) - 1 {
+		queries = append(queries, &storage.Query{
+			Prefix:      globalPrefixWithSlash,
+			StartOffset: globalPrefixWithSlash + sortedBreakdowns[i],
+			EndOffset:   globalPrefixWithSlash + sortedBreakdowns[i+1],
+		})
+	}
+
+	// 3. Last query: everything from the last breakdown onwards
+	queries = append(queries, &storage.Query{
+		Prefix:      globalPrefixWithSlash,
+		StartOffset: globalPrefixWithSlash + sortedBreakdowns[len(sortedBreakdowns)-1],
+	})
+
+	return queries
+}
+
+// ListObjectsFast lists object names in parallel by partitioning the prefix space.
+// It partitions the space using StartOffset and EndOffset based on breakdownPrefixes.
+func ListObjectsFast(ctx context.Context, bucket *storage.BucketHandle, globalPrefix string, breakdownPrefixes []string) ([]string, error) {
+	queries := buildPartitionQueries(globalPrefix, breakdownPrefixes)
+
+	objsChan := make(chan []string, len(queries))
+	g, ctx := errgroup.WithContext(ctx)
+
+	for _, q := range queries {
+		g.Go(func() error {
+			objs, err := ListBucketObjectsQuery(ctx, bucket, q)
+			if err != nil {
+				return err
+			}
+			objsChan <- objs
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	close(objsChan)
+
+	var allObjs []string
+	for objs := range objsChan {
+		allObjs = append(allObjs, objs...)
+	}
+
+	return allObjs, nil
+}
+
+// ObjectsFastStream returns an iterator that streams object names in parallel as they are discovered.
+func ObjectsFastStream(ctx context.Context, bucket *storage.BucketHandle, globalPrefix string, breakdownPrefixes []string) iter.Seq2[string, error] {
+	return func(yield func(string, error) bool) {
+		queries := buildPartitionQueries(globalPrefix, breakdownPrefixes)
+
+		outCh := make(chan string, 100)
+		g, ctx := errgroup.WithContext(ctx)
+
+		for _, q := range queries {
+			g.Go(func() error {
+				if err := q.SetAttrSelection([]string{"Name"}); err != nil {
+					return fmt.Errorf("failed to set attribute selection: %w", err)
+				}
+				it := bucket.Objects(ctx, q)
+				for {
+					attrs, err := it.Next()
+					if errors.Is(err, iterator.Done) {
+						return nil
+					}
+					if err != nil {
+						return err
+					}
+					if strings.HasSuffix(attrs.Name, "/") {
+						continue
+					}
+					select {
+					case outCh <- attrs.Name:
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				}
+			})
+		}
+
+		go func() {
+			_ = g.Wait()
+			close(outCh)
+		}()
+
+		for name := range outCh {
+			if !yield(name, nil) {
+				return
+			}
+		}
+
+		if err := g.Wait(); err != nil {
+			yield("", err)
+		}
+	}
+}

--- a/go/internal/gcs/gcs.go
+++ b/go/internal/gcs/gcs.go
@@ -99,39 +99,6 @@ func buildPartitionQueries(globalPrefix string, breakdownPrefixes []string) []*s
 	return queries
 }
 
-// ListObjectsFast lists object names in parallel by partitioning the prefix space.
-// It partitions the space using StartOffset and EndOffset based on breakdownPrefixes.
-func ListObjectsFast(ctx context.Context, bucket *storage.BucketHandle, globalPrefix string, breakdownPrefixes []string) ([]string, error) {
-	queries := buildPartitionQueries(globalPrefix, breakdownPrefixes)
-
-	objsChan := make(chan []string, len(queries))
-	g, ctx := errgroup.WithContext(ctx)
-
-	for _, q := range queries {
-		g.Go(func() error {
-			objs, err := ListBucketObjectsQuery(ctx, bucket, q)
-			if err != nil {
-				return err
-			}
-			objsChan <- objs
-
-			return nil
-		})
-	}
-
-	if err := g.Wait(); err != nil {
-		return nil, err
-	}
-	close(objsChan)
-
-	var allObjs []string
-	for objs := range objsChan {
-		allObjs = append(allObjs, objs...)
-	}
-
-	return allObjs, nil
-}
-
 // ObjectsFastStream returns an iterator that streams object names in parallel as they are discovered.
 func ObjectsFastStream(ctx context.Context, bucket *storage.BucketHandle, globalPrefix string, breakdownPrefixes []string) iter.Seq2[string, error] {
 	return func(yield func(string, error) bool) {

--- a/go/internal/gcs/gcs_test.go
+++ b/go/internal/gcs/gcs_test.go
@@ -17,9 +17,9 @@ package gcs
 import (
 	"testing"
 
+	"cloud.google.com/go/storage"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"cloud.google.com/go/storage"
 )
 
 func TestBuildPartitionQueries(t *testing.T) {

--- a/go/internal/gcs/gcs_test.go
+++ b/go/internal/gcs/gcs_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcs
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"cloud.google.com/go/storage"
+)
+
+func TestBuildPartitionQueries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		globalPrefix      string
+		breakdownPrefixes []string
+		wantQueries       []*storage.Query
+	}{
+		{
+			name:              "empty breakdowns",
+			globalPrefix:      "all/pb/",
+			breakdownPrefixes: nil,
+			wantQueries: []*storage.Query{
+				{Prefix: "all/pb/"},
+			},
+		},
+		{
+			name:              "single breakdown",
+			globalPrefix:      "all/pb",
+			breakdownPrefixes: []string{"CVE-"},
+			wantQueries: []*storage.Query{
+				{Prefix: "all/pb/", EndOffset: "all/pb/CVE-"},
+				{Prefix: "all/pb/", StartOffset: "all/pb/CVE-"},
+			},
+		},
+		{
+			name:              "multiple breakdowns out of order",
+			globalPrefix:      "all/pb/",
+			breakdownPrefixes: []string{"GO-", "CVE-", "GHSA-"},
+			wantQueries: []*storage.Query{
+				{Prefix: "all/pb/", EndOffset: "all/pb/CVE-"},
+				{Prefix: "all/pb/", StartOffset: "all/pb/CVE-", EndOffset: "all/pb/GHSA-"},
+				{Prefix: "all/pb/", StartOffset: "all/pb/GHSA-", EndOffset: "all/pb/GO-"},
+				{Prefix: "all/pb/", StartOffset: "all/pb/GO-"},
+			},
+		},
+		{
+			name:              "empty global prefix",
+			globalPrefix:      "",
+			breakdownPrefixes: []string{"B-", "A-"},
+			wantQueries: []*storage.Query{
+				{Prefix: "", EndOffset: "A-"},
+				{Prefix: "", StartOffset: "A-", EndOffset: "B-"},
+				{Prefix: "", StartOffset: "B-"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildPartitionQueries(tt.globalPrefix, tt.breakdownPrefixes)
+			opts := cmpopts.IgnoreUnexported(storage.Query{})
+			if diff := cmp.Diff(tt.wantQueries, got, opts); diff != "" {
+				t.Errorf("buildPartitionQueries() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/go/osv/clients/gcs_client.go
+++ b/go/osv/clients/gcs_client.go
@@ -185,4 +185,3 @@ func (c *GCSClient) Bucket() *storage.BucketHandle {
 func (c *GCSClient) ObjectsFast(ctx context.Context, prefix string, breakdownPrefixes []string) iter.Seq2[string, error] {
 	return gcs.ObjectsFastStream(ctx, c.bucket, prefix, breakdownPrefixes)
 }
-

--- a/go/osv/clients/gcs_client.go
+++ b/go/osv/clients/gcs_client.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/google/osv.dev/go/internal/gcs"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
 )
@@ -176,3 +177,12 @@ func (c *GCSClient) Objects(ctx context.Context, prefix string) iter.Seq2[*Objec
 		}
 	}
 }
+
+func (c *GCSClient) Bucket() *storage.BucketHandle {
+	return c.bucket
+}
+
+func (c *GCSClient) ObjectsFast(ctx context.Context, prefix string, breakdownPrefixes []string) iter.Seq2[string, error] {
+	return gcs.ObjectsFastStream(ctx, c.bucket, prefix, breakdownPrefixes)
+}
+


### PR DESCRIPTION
Made a few changes to vastly increase the speed of the exporter.

- Increased each channel buffer up to 100 from 0.
- 5x ed the worker count from 600 to 3000
- Added a fast object list GCS library (mostly copied over from vulnfeeds), and split up the initial object listing loop at various places.
  -  This is mostly guesswork at the moment, ideally we should do a review of where to roughly evenly split the work every now and then. But good enough for now. 
  - This does mean the exporter will slow down near the end.
- Refactored message receiving to use the `for` syntax. This should be a slight behavior change where we won't cancel based on the context, but only when the channel is closed. (Or when the context is cancelled on the sending side, just never on the receiving side)
- Fixed README typos
- Use logger.ErrorContext instead of logger.Error
- 
