### PR TITLE
chore: bump memory for debian-cve-convert

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/feeds/debian-cve-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/base/feeds/debian-cve-convert.yaml
@@ -24,7 +24,7 @@ spec:
             resources:
               requests:
                 cpu: "2"
-                memory: "8G"
+                memory: "12G"
               limits:
                 cpu: "4"
                 memory: "12G"


### PR DESCRIPTION
it is occasionally OOMKilled rn