### PR TITLE
refactor(website): begin migrating Jinja templates to Go

### DIFF
--- a/gcp/website/frontend3/src/go/base.html
+++ b/gcp/website/frontend3/src/go/base.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta name="description"
+    content="Comprehensive vulnerability database for your open source projects and dependencies.">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- Disable this for vulnerability list page as the weird Turbo cache bug happens when click on browser's back button -->
+  {% if disable_turbo_cache %}
+  <meta name="turbo-cache-control" content="no-cache">
+  {% endif %}
+  <script>
+    // Early inline script element here is necessary to prevent the "flash of
+    // unstyled content" problem where the dark default theme is first rendered
+    // followed by a sudden flash to light mode.
+    // See https://en.wikipedia.org/wiki/Flash_of_unstyled_content.
+    const theme = localStorage.getItem('theme') || 'dark';
+    document.documentElement.setAttribute('data-theme', theme);
+  </script>
+  <link rel="icon" type="image/png" href="/static/img/favicon-32x32.png" sizes="32x32">
+  <link rel="icon" type="image/png" href="/static/img/favicon-16x16.png" sizes="16x16">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="alternate" type="application/rss+xml" title="RSS Feed" href="{{ url_for('frontend_handlers.blog_rss') }}">
+  <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <link rel="preload" href="https://fonts.googleapis.com/css2?family=Overpass+Mono:wght@400;700&family=Overpass:ital,wght@0,400;0,700;1,400&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
+  <noscript>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Overpass+Mono:wght@400;700&family=Overpass:ital,wght@0,400;0,700;1,400&display=swap">
+  </noscript>
+  <meta charset="utf-8">
+  <title id="title">OSV - Open Source Vulnerabilities</title>
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-ZXG9G6HTBR"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+
+    gtag('config', 'G-ZXG9G6HTBR', { 'anonymize_ip': true });
+  </script>
+  {% block extra_head %}{% endblock %}
+</head>
+
+<body>
+  <div class="wrapper {{'decorated' if active_section == 'home'}}">
+    {% block top_bar %}
+    <header class="top-bar">
+      <div class="logo">
+        <a href="{{ url_for('frontend_handlers.index') }}" aria-label="Home page">
+          <img alt="OSV logo" class="logo-img-light" src="/static/img/logo.png" srcset="/static/img/logo.png, /static/img/logo@4x.png 4x"
+            width="54" height="20">
+          <img alt="OSV logo" class="logo-img-dark" src="/static/img/logo-dark.png" srcset="/static/img/logo-dark.png, /static/img/logo-dark@4x.png 4x"
+            width="54" height="20">
+        </a>
+      </div>
+
+      <!-- Hidden checkbox for hamburger menu state -->
+      <input type="checkbox" id="hamburger-checkbox" aria-label="Hamburger Menu">
+      <!-- Hamburger menu -->
+      <label class="hamburger" for="hamburger-checkbox">
+        <span></span>
+        <span></span>
+        <span></span>
+      </label>
+
+      <ul class="tabs">
+        <li class="{{ 'active' if active_section == 'vulnerabilities' else '' }} page-link">
+          <a href="{{ url_for('frontend_handlers.list_vulnerabilities') }}">Vulnerability Database</a>
+        </li>
+        <li class="{{ 'active' if active_section == 'blog' else '' }} page-link">
+          <a href="{{ url_for('frontend_handlers.blog') }}">Blog</a>
+        </li>
+        <li class="{{ 'active' if active_section == 'faq' else '' }} page-link external-link">
+          <a href="https://google.github.io/osv.dev/faq/" target="_blank">FAQ</a>
+        </li>
+        <li class="{{ 'active' if active_section == 'docs' else '' }} page-link external-link">
+          <a href="https://google.github.io/osv.dev/" target="_blank">Docs</a>
+        </li>
+        
+        <ul class="push social-icons">
+          <li class="search-container-nav">
+            <div class="search-toggle-container">
+              <!-- Expandable search form -->
+              <form class="search-form search-suggestions-container" action="{{ url_for('frontend_handlers.list_vulnerabilities') }}" method="get">
+                <input type="text" name="q" class="search-input" placeholder="Search vulnerabilities..." maxlength="300" autocomplete="off">
+                <button type="submit" class="search-submit" aria-label="Search">
+                  <span class="material-icons">arrow_forward</span>
+                </button>
+              </form>
+              <!-- Search toggle button -->
+              <button class="search-toggle" aria-label="Toggle search" aria-expanded="false">
+                <span class="material-icons">search</span>
+              </button>
+            </div>
+          </li>
+          {% if active_section == 'blog' %}
+            <li>
+              <a class="logo-img" href="{{ url_for('frontend_handlers.blog_rss') }}" target="_blank"
+                aria-label="RRS Feed">
+                <img class="logo-link" src="/static/img/feed.svg" alt="RSS Feed" width="24" height="24">
+              </a>
+            </li>
+          {% endif %}
+          <li class="theme-toggle-container">
+            <button id="theme-toggle" class="theme-toggle-btn" aria-label="Toggle theme">
+              <span class="material-icons icon-light-mode">light_mode</span>
+              <span class="material-icons icon-dark-mode">dark_mode</span>
+            </button>
+          </li>
+          <li class="github-container">
+            <a class="logo-img" href="https://github.com/google/osv.dev" target="_blank"
+              aria-label="Go to our github page">
+              <img class="logo-link" src="/static/img/github-mark-white.svg" alt="Github Logo" width="24" height="24">
+            </a>
+          </li>
+        </ul>
+      </ul>
+    </header>
+    {% endblock %}
+    {% block content %}{% endblock %}
+  </div>
+</body>
+
+</html>

--- a/gcp/website/frontend3/src/go/base.html
+++ b/gcp/website/frontend3/src/go/base.html
@@ -6,9 +6,9 @@
     content="Comprehensive vulnerability database for your open source projects and dependencies.">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Disable this for vulnerability list page as the weird Turbo cache bug happens when click on browser's back button -->
-  {% if disable_turbo_cache %}
+  {{ if .DisableTurboCache }}
   <meta name="turbo-cache-control" content="no-cache">
-  {% endif %}
+  {{ end }}
   <script>
     // Early inline script element here is necessary to prevent the "flash of
     // unstyled content" problem where the dark default theme is first rendered
@@ -21,7 +21,7 @@
   <link rel="icon" type="image/png" href="/static/img/favicon-16x16.png" sizes="16x16">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="alternate" type="application/rss+xml" title="RSS Feed" href="{{ url_for('frontend_handlers.blog_rss') }}">
+  <link rel="alternate" type="application/rss+xml" title="RSS Feed" href="/blog/index.xml">
   <link rel="preload" href="https://fonts.googleapis.com/css?family=Material+Icons&display=block" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <link rel="preload" href="https://fonts.googleapis.com/css2?family=Overpass+Mono:wght@400;700&family=Overpass:ital,wght@0,400;0,700;1,400&display=swap" as="style" onload="this.onload=null;this.rel='stylesheet'">
   <noscript>
@@ -39,15 +39,15 @@
 
     gtag('config', 'G-ZXG9G6HTBR', { 'anonymize_ip': true });
   </script>
-  {% block extra_head %}{% endblock %}
+  {{ block "extra_head" . }}{{ end }}
 </head>
 
 <body>
-  <div class="wrapper {{'decorated' if active_section == 'home'}}">
-    {% block top_bar %}
+  <div class="wrapper {{ if eq .ActiveSection "home" }}decorated{{ end }}">
+    {{ block "top_bar" . }}
     <header class="top-bar">
       <div class="logo">
-        <a href="{{ url_for('frontend_handlers.index') }}" aria-label="Home page">
+        <a href="/" aria-label="Home page">
           <img alt="OSV logo" class="logo-img-light" src="/static/img/logo.png" srcset="/static/img/logo.png, /static/img/logo@4x.png 4x"
             width="54" height="20">
           <img alt="OSV logo" class="logo-img-dark" src="/static/img/logo-dark.png" srcset="/static/img/logo-dark.png, /static/img/logo-dark@4x.png 4x"
@@ -65,16 +65,16 @@
       </label>
 
       <ul class="tabs">
-        <li class="{{ 'active' if active_section == 'vulnerabilities' else '' }} page-link">
-          <a href="{{ url_for('frontend_handlers.list_vulnerabilities') }}">Vulnerability Database</a>
+        <li class="{{ if eq .ActiveSection "vulnerabilities" }}active{{ end }} page-link">
+          <a href="/list">Vulnerability Database</a>
         </li>
-        <li class="{{ 'active' if active_section == 'blog' else '' }} page-link">
-          <a href="{{ url_for('frontend_handlers.blog') }}">Blog</a>
+        <li class="{{ if eq .ActiveSection "blog" }}active{{ end }} page-link">
+          <a href="/blog">Blog</a>
         </li>
-        <li class="{{ 'active' if active_section == 'faq' else '' }} page-link external-link">
+        <li class="{{ if eq .ActiveSection "faq" }}active{{ end }} page-link external-link">
           <a href="https://google.github.io/osv.dev/faq/" target="_blank">FAQ</a>
         </li>
-        <li class="{{ 'active' if active_section == 'docs' else '' }} page-link external-link">
+        <li class="{{ if eq .ActiveSection "docs" }}active{{ end }} page-link external-link">
           <a href="https://google.github.io/osv.dev/" target="_blank">Docs</a>
         </li>
         
@@ -82,7 +82,7 @@
           <li class="search-container-nav">
             <div class="search-toggle-container">
               <!-- Expandable search form -->
-              <form class="search-form search-suggestions-container" action="{{ url_for('frontend_handlers.list_vulnerabilities') }}" method="get">
+              <form class="search-form search-suggestions-container" action="/list" method="get">
                 <input type="text" name="q" class="search-input" placeholder="Search vulnerabilities..." maxlength="300" autocomplete="off">
                 <button type="submit" class="search-submit" aria-label="Search">
                   <span class="material-icons">arrow_forward</span>
@@ -94,14 +94,14 @@
               </button>
             </div>
           </li>
-          {% if active_section == 'blog' %}
+          {{ if eq .ActiveSection "blog" }}
             <li>
-              <a class="logo-img" href="{{ url_for('frontend_handlers.blog_rss') }}" target="_blank"
+              <a class="logo-img" href="/blog/index.xml" target="_blank"
                 aria-label="RRS Feed">
                 <img class="logo-link" src="/static/img/feed.svg" alt="RSS Feed" width="24" height="24">
               </a>
             </li>
-          {% endif %}
+          {{ end }}
           <li class="theme-toggle-container">
             <button id="theme-toggle" class="theme-toggle-btn" aria-label="Toggle theme">
               <span class="material-icons icon-light-mode">light_mode</span>
@@ -117,9 +117,10 @@
         </ul>
       </ul>
     </header>
-    {% endblock %}
-    {% block content %}{% endblock %}
+    {{ end }}
+    {{ block "content" . }}{{ end }}
   </div>
 </body>
 
 </html>
+

--- a/gcp/website/frontend3/src/go/templates/404.html
+++ b/gcp/website/frontend3/src/go/templates/404.html
@@ -1,0 +1,54 @@
+{% extends 'base.html' %}
+
+{% block extra_head %}
+<!-- Defer offscreen images on mobile screens -->
+<link rel="preload" fetchpriority="high" as="image" href="/static/img/footer-decoration.webp" type="image/webp"
+    media="(min-width: 768px)" onload="this.media='all'">
+<noscript>
+    <link rel="stylesheet" href="/static/img/footer-decoration.webp" type="image/webp">
+</noscript>
+{% endblock %}
+
+{% block top_bar %} {% endblock %}
+
+{% block content %}
+{% if vuln_id %}
+<div class="mdc-layout-grid not-found-page">
+    <div class="mdc-layout-grid__inner">
+        <div class="mdc-layout-grid__cell--span-12 text-info">
+            <h2 class="heading">{{ vuln_id }} Not Found!</h2>
+            <p class="description">
+            {% if has_importfindings %}
+            The record has not been successfully imported from its source<br/>
+            {% endif %}
+                Please see our
+                <a href="https://google.github.io/osv.dev/faq/">FAQ</a> for more information.
+            </p>
+            <div class="cta">
+                <a class="cta-primary link-button" href="{{ url_for('frontend_handlers.index') }}"
+                    aria-label="Get me back Home!">Back to Home</a>
+            </div>
+        </div>
+    </div>
+    <footer></footer>
+</div>
+{% else %}
+<div class="mdc-layout-grid not-found-page">
+    <div class="mdc-layout-grid__inner">
+        <div class="mdc-layout-grid__cell--span-12 text-info">
+            <h2 class="heading">Oops! Page Not Found!</h2>
+            <p class="description">
+                While you're here, why not check out our
+                <a href="https://google.github.io/osv.dev/">documentation</a> or
+                <a href="https://google.github.io/osv.dev/faq/">FAQ</a>?
+            </p>
+            <div class="cta">
+                <a class="cta-primary link-button" href="{{ url_for('frontend_handlers.index') }}"
+                    aria-label="Get me back Home!">Back to Home</a>
+            </div>
+        </div>
+    </div>
+    <footer></footer>
+</div>
+{% endif %}
+{% endblock %}

--- a/gcp/website/frontend3/src/go/templates/404.html
+++ b/gcp/website/frontend3/src/go/templates/404.html
@@ -1,38 +1,34 @@
-{% extends 'base.html' %}
-
-{% block extra_head %}
+{{ define "extra_head" }}
 <!-- Defer offscreen images on mobile screens -->
 <link rel="preload" fetchpriority="high" as="image" href="/static/img/footer-decoration.webp" type="image/webp"
     media="(min-width: 768px)" onload="this.media='all'">
 <noscript>
     <link rel="stylesheet" href="/static/img/footer-decoration.webp" type="image/webp">
 </noscript>
-{% endblock %}
+{{ end }}
 
-{% block top_bar %} {% endblock %}
+{{ define "top_bar" }}<!-- empty top_bar -->{{ end }}
 
-{% block content %}
-{% if vuln_id %}
+{{ define "content" }}
+{{ if .FailedImportVulnID }}
 <div class="mdc-layout-grid not-found-page">
     <div class="mdc-layout-grid__inner">
         <div class="mdc-layout-grid__cell--span-12 text-info">
-            <h2 class="heading">{{ vuln_id }} Not Found!</h2>
+            <h2 class="heading">{{ .FailedImportVulnID }} Not Found!</h2>
             <p class="description">
-            {% if has_importfindings %}
-            The record has not been successfully imported from its source<br/>
-            {% endif %}
+                The record has not been successfully imported from its source<br/>
                 Please see our
                 <a href="https://google.github.io/osv.dev/faq/">FAQ</a> for more information.
             </p>
             <div class="cta">
-                <a class="cta-primary link-button" href="{{ url_for('frontend_handlers.index') }}"
+                <a class="cta-primary link-button" href="/"
                     aria-label="Get me back Home!">Back to Home</a>
             </div>
         </div>
     </div>
     <footer></footer>
 </div>
-{% else %}
+{{ else }}
 <div class="mdc-layout-grid not-found-page">
     <div class="mdc-layout-grid__inner">
         <div class="mdc-layout-grid__cell--span-12 text-info">
@@ -43,12 +39,13 @@
                 <a href="https://google.github.io/osv.dev/faq/">FAQ</a>?
             </p>
             <div class="cta">
-                <a class="cta-primary link-button" href="{{ url_for('frontend_handlers.index') }}"
+                <a class="cta-primary link-button" href="/"
                     aria-label="Get me back Home!">Back to Home</a>
             </div>
         </div>
     </div>
     <footer></footer>
 </div>
-{% endif %}
-{% endblock %}
+{{ end }}
+{{ end }}
+

--- a/gcp/website/frontend3/src/go/templates/blog.html
+++ b/gcp/website/frontend3/src/go/templates/blog.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% set active_section = 'blog' %}
+
+{% block content %}
+<div class="blog-page">
+  <div class="mdc-layout-grid">
+    <div class="mdc-layout-grid__inner">
+      <div class="mdc-layout-grid__cell--span-12 posts">
+        <h1 class="title">Blog</h1>
+        {{ index|safe }}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/gcp/website/frontend3/src/go/templates/blog.html
+++ b/gcp/website/frontend3/src/go/templates/blog.html
@@ -1,15 +1,12 @@
-{% extends 'base.html' %}
-{% set active_section = 'blog' %}
-
-{% block content %}
+{{ define "content" }}
 <div class="blog-page">
   <div class="mdc-layout-grid">
     <div class="mdc-layout-grid__inner">
       <div class="mdc-layout-grid__cell--span-12 posts">
         <h1 class="title">Blog</h1>
-        {{ index|safe }}
+        {{ .Index }}
       </div>
     </div>
   </div>
 </div>
-{% endblock %}
+{{ end }}

--- a/gcp/website/frontend3/src/go/templates/blog_post.html
+++ b/gcp/website/frontend3/src/go/templates/blog_post.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% set active_section = 'blog' %}
+{% set disable_turbo_cache = 'true' %}
+
+{% block content %}
+<div class="blog-post-page">
+  <div class="mdc-layout-grid">
+    <div class="mdc-layout-grid__inner">
+      <div class="mdc-layout-grid__cell--span-12 post">
+        {{ content|safe }}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/gcp/website/frontend3/src/go/templates/blog_post.html
+++ b/gcp/website/frontend3/src/go/templates/blog_post.html
@@ -1,15 +1,11 @@
-{% extends 'base.html' %}
-{% set active_section = 'blog' %}
-{% set disable_turbo_cache = 'true' %}
-
-{% block content %}
+{{ define "content" }}
 <div class="blog-post-page">
   <div class="mdc-layout-grid">
     <div class="mdc-layout-grid__inner">
       <div class="mdc-layout-grid__cell--span-12 post">
-        {{ content|safe }}
+        {{ .Content }}
       </div>
     </div>
   </div>
 </div>
-{% endblock %}
+{{ end }}

--- a/gcp/website/frontend3/src/go/templates/home.html
+++ b/gcp/website/frontend3/src/go/templates/home.html
@@ -1,7 +1,4 @@
-{% extends 'base.html' %}
-{% set active_section = 'home' %}
-
-{% block extra_head %}
+{{ define "extra_head" }}
 <link rel="preload" fetchpriority="high" as="image" href="/static/img/background-1.webp" type="image/webp">
 <link rel="preload" fetchpriority="high" as="image" href="/static/img/background-2.webp" type="image/webp">
 <link rel="preload" fetchpriority="high" as="image" href="/static/img/external-link.svg" type="image/webp">
@@ -11,9 +8,9 @@
 <noscript>
   <link rel="stylesheet" href="/static/img/footer-decoration.webp" type="image/webp">
 </noscript>
-{% endblock %}
+{{ end }}
 
-{% block content %}
+{{ define "content" }}
 <div class="mdc-layout-grid home-page">
   <div class="mdc-layout-grid__inner">
     <div class="mdc-layout-grid__cell--span-12 hero">
@@ -25,7 +22,7 @@
         </p>
       </div>
       <div class="cta">
-        <a class="cta-primary link-button" href="{{ url_for('frontend_handlers.list_vulnerabilities') }}">
+        <a class="cta-primary link-button" href="/list">
           <span class="material-icons" style="margin-right: 8px;">search</span>
           Search Vulnerability Database
         </a>
@@ -46,27 +43,21 @@
         <div class="ecosystems-line-2"></div>
         <div class="ecosystems-line-3"></div>
         <dl class="ecosystem-counts">
-          {% if ecosystem_counts %}
-          {% set total = ecosystem_counts.values() | sum %}
-          {% for ecosystem, count in ecosystem_counts.items() %}
-          {% if count > 30 %}
-          <dt class="ecosystem-name">{{ ecosystem }}</dt>
+          {{ range .Ecosystems }}
+          <dt class="ecosystem-name">{{ .Name }}</dt>
           <dd class="ecosystem-count-wrapper">
-            {% set radius = [(count | log) / (total | log) * 100, 30] | max %}
-            <a href="{{ url_for('frontend_handlers.list_vulnerabilities', ecosystem=ecosystem) }}">
+            <a href="/list?ecosystem={{ .Name }}">
               <span class="ecosystem-count" style="
-                      width: {{ radius }}px; height: {{ radius }}px; line-height: {{ radius }}px">
-                {{ count }}
+                      width: {{ .Radius }}px; height: {{ .Radius }}px; line-height: {{ .Radius }}px">
+                {{ .Count }}
                 <span class="tooltip" style="
-                       top: -{{ (radius / 2) + 5}}px;">
-                  View {{ ecosystem }} vulnerabilities
+                       top: {{ .TooltipTop }}px;">
+                  View {{ .Name }} vulnerabilities
                 </span>
               </span>
             </a>
           </dd>
-          {% endif %}
-          {% endfor %}
-          {% endif %}
+          {{ end }}
         </dl>
       </div>
     </div>
@@ -333,9 +324,9 @@ osv-scanner scan image --serve alpine:3.12
 
       <div class="mdc-layout-grid__cell--span-12 open-source-banner">
         <h2 class="heading">Open source</h2>
-        <p class="description"> This project is <a href="https://github.com/google/osv">open source</a>. If you
+        <p class="description"> This project is <a href="https://github.com/google/osv.dev">open source</a>. If you
           have any ideas or questions, please feel free to reach out by <a
-              href="https://github.com/google/osv/issues/new/choose">creating an issue</a>! </p>
+              href="https://github.com/google/osv.dev/issues/new/choose">creating an issue</a>! </p>
 
         <div class="cta">
           <a class="cta-primary link-button" href="https://google.github.io/osv.dev/faq/"
@@ -346,4 +337,5 @@ osv-scanner scan image --serve alpine:3.12
   </div>
   <footer>
   </footer>
-</div> {% endblock %}
+</div>
+{{ end }}

--- a/gcp/website/frontend3/src/go/templates/home.html
+++ b/gcp/website/frontend3/src/go/templates/home.html
@@ -1,0 +1,349 @@
+{% extends 'base.html' %}
+{% set active_section = 'home' %}
+
+{% block extra_head %}
+<link rel="preload" fetchpriority="high" as="image" href="/static/img/background-1.webp" type="image/webp">
+<link rel="preload" fetchpriority="high" as="image" href="/static/img/background-2.webp" type="image/webp">
+<link rel="preload" fetchpriority="high" as="image" href="/static/img/external-link.svg" type="image/webp">
+<!-- Defer offscreen images on mobile screens -->
+<link rel="preload" fetchpriority="high" as="image" href="/static/img/footer-decoration.webp" type="image/webp"
+      media="(min-width: 768px)" onload="this.media='all'">
+<noscript>
+  <link rel="stylesheet" href="/static/img/footer-decoration.webp" type="image/webp">
+</noscript>
+{% endblock %}
+
+{% block content %}
+<div class="mdc-layout-grid home-page">
+  <div class="mdc-layout-grid__inner">
+    <div class="mdc-layout-grid__cell--span-12 hero">
+      <h1 class="title">A distributed vulnerability database for Open Source</h1>
+      <div class="explainer">
+        <p>An open, precise, and distributed approach to producing and consuming vulnerability information for
+          open
+          source.
+        </p>
+      </div>
+      <div class="cta">
+        <a class="cta-primary link-button" href="{{ url_for('frontend_handlers.list_vulnerabilities') }}">
+          <span class="material-icons" style="margin-right: 8px;">search</span>
+          Search Vulnerability Database
+        </a>
+        <a class="cta-primary link-button" href="#use-the-api">Use the API</a>
+      </div>
+      <div class="cta">
+        <a class="cta-primary link-button" href="#use-vulnerability-scanner">Vulnerability Scanner</a>
+        <a class="cta-primary link-button" href="#use-remediation-tools">Remediation Tools</a>
+        <a class="cta-primary link-button" href="#use-the-github-workflows">GitHub Workflows</a>
+      </div>
+    </div>
+    <div class="mdc-layout-grid__cell--span-12 ecosystems-section">
+      <h2 class="heading">Ecosystems</h2>
+      <div class="ecosystem-counts-wrapper">
+        <div class="ecosystems-line-mid"></div>
+        <div class="ecosystems-line-0"></div>
+        <div class="ecosystems-line-1"></div>
+        <div class="ecosystems-line-2"></div>
+        <div class="ecosystems-line-3"></div>
+        <dl class="ecosystem-counts">
+          {% if ecosystem_counts %}
+          {% set total = ecosystem_counts.values() | sum %}
+          {% for ecosystem, count in ecosystem_counts.items() %}
+          {% if count > 30 %}
+          <dt class="ecosystem-name">{{ ecosystem }}</dt>
+          <dd class="ecosystem-count-wrapper">
+            {% set radius = [(count | log) / (total | log) * 100, 30] | max %}
+            <a href="{{ url_for('frontend_handlers.list_vulnerabilities', ecosystem=ecosystem) }}">
+              <span class="ecosystem-count" style="
+                      width: {{ radius }}px; height: {{ radius }}px; line-height: {{ radius }}px">
+                {{ count }}
+                <span class="tooltip" style="
+                       top: -{{ (radius / 2) + 5}}px;">
+                  View {{ ecosystem }} vulnerabilities
+                </span>
+              </span>
+            </a>
+          </dd>
+          {% endif %}
+          {% endfor %}
+          {% endif %}
+        </dl>
+      </div>
+    </div>
+
+    <div class="mdc-layout-grid__cell--span-12 text-info">
+      <h2 class="heading">OSV schema</h2>
+      <p class="description">
+        All advisories in this database use the
+        <a href="https://ossf.github.io/osv-schema/">OpenSSF OSV format</a>, which
+        was developed in collaboration with open source communities.
+      </p>
+      <p class="description">
+        The OSV schema provides a human and machine readable data format to
+        describe vulnerabilities in a way that precisely maps to open source
+        package versions or commit hashes.
+      </p>
+      <div class="mdc-layout-grid__inner">
+        <div class="mdc-layout-grid__cell--span-12">
+          <pre class="big-code-block"><code>{
+  "schema_version": "1.7.4",
+  "id": "GHSA-c3g4-w6cv-6v7h",
+  "modified": "2022-04-01T13:56:42Z",
+  "published": "2022-04-01T13:56:42Z",
+  "aliases": [ "CVE-2022-27651" ],
+  "summary": "Non-empty default inheritable capabilities for linux container in Buildah",
+  "details": "A bug was found in Buildah where containers were created ...",
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Go",
+        "name": "github.com/containers/buildah"
+      },
+      "ranges": [
+        {
+          "type": "SEMVER",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "1.25.0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://github.com/containers/buildah/commit/..."
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/containers/buildah"
+    }
+  ]
+}</code></pre>
+        </div>
+      </div>
+      <div class="cta">
+        <a class="cta-primary link-button" href="https://ossf.github.io/osv-schema/">OSV Schema</a>
+        <a class="cta-primary link-button"
+           href="https://security.googleblog.com/2021/06/announcing-unified-vulnerability-schema.html">Blog
+          post</a>
+      </div>
+    </div>
+    <div class="mdc-layout-grid__cell--span-12 text-info data-sources">
+      <h2 class="heading">Data sources</h2>
+      <p class="description">
+        This infrastructure serves as an aggregator of vulnerability databases
+        that have adopted the <a href="https://ossf.github.io/osv-schema/">OSV schema</a>, including
+        <a href="https://github.com/github/advisory-database" rel="nofollow">GitHub Security Advisories</a>,
+        <a href="https://github.com/pypa/advisory-database" rel="nofollow">PyPA</a>,
+        <a href="https://github.com/RustSec/advisory-db" rel="nofollow">RustSec</a>, and
+        <a href="https://github.com/cloudsecurityalliance/gsd-database" rel="nofollow">Global Security Database</a>, and
+        more.
+      </p>
+      <div class="cta">
+        <a class="cta-primary link-button" href="https://google.github.io/osv.dev/data/#current-data-sources"
+           aria-label="Learn more about our data sources">Learn more</a>
+      </div>
+    </div>
+    <div id="use-the-api" class="mdc-layout-grid__cell--span-12 usage-examples">
+      <h2 class="heading">Use the API</h2>
+      <p class="description">
+        An easy-to-use API is available to query for all known vulnerabilities
+        by either a commit hash, or a package version.
+      </p>
+      <div class="code-card-container mdc-layout-grid__inner">
+        <div class="code-card mdc-layout-grid__cell--span-6 mdc-layout-grid__cell--span-12-tablet">
+          <h3 class="code-card-title">Query by commit hash</h3>
+          <pre class="code-card-content" id="example-commit-hash">curl -d \
+  '{"commit": "6879efc2c1596d11a6a6ad296f80063b558d5e0f"}' \
+  "https://api.osv.dev/v1/query"</pre>
+          <clipboard-copy class="code-card-copy" for="example-commit-hash">
+            <md-icon-button class="icon">
+              <md-icon>content_copy</md-icon>
+            </md-icon-button>
+          </clipboard-copy>
+        </div>
+        <div class="code-card mdc-layout-grid__cell--span-6 mdc-layout-grid__cell--span-12-tablet">
+          <h3 class="code-card-title">Query by version number</h3>
+          <pre class="code-card-content" id="example-version-number">curl -d \
+  '{"version": "2.4.1",
+    "package": {"name": "jinja2", "ecosystem": "PyPI"}}' \
+  "https://api.osv.dev/v1/query"</pre>
+          <clipboard-copy class="code-card-copy" for="example-version-number">
+            <md-icon-button class="icon">
+              <md-icon>content_copy</md-icon>
+            </md-icon-button>
+          </clipboard-copy>
+        </div>
+      </div>
+      <div class="mdc-layout-grid__cell--span-12">
+        <div class="cta">
+          <a class="cta-primary link-button" href="https://google.github.io/osv.dev/api/">API
+            Documentation</a>
+        </div>
+      </div>
+    </div>
+    <div id="use-vulnerability-scanner" class="mdc-layout-grid__cell--span-12 usage-examples">
+      <!-- &#8209; is a non breaking hyphen -->
+      <h2 class="heading">Vulnerability Scanner</h2>
+      <div class="code-card-container mdc-layout-grid__inner">
+        <div class="mobile-spacer mdc-layout-grid__cell--span-3"></div>
+        <div class="code-card mdc-layout-grid__cell--span-6 mdc-layout-grid__cell--span-12-tablet">
+          <h3 class="code-card-title">Install OSV&#8209;Scanner</h3>
+          <pre class="code-card-content" id="example-scanner-install">
+go install github.com/google/osv-scanner/v2/cmd/osv-scanner@v2
+          </pre>
+          <clipboard-copy class="code-card-copy" for="example-scanner-install">
+            <md-icon-button class="icon">
+              <md-icon>content_copy</md-icon>
+            </md-icon-button>
+          </clipboard-copy>
+        </div>
+        <div class="mobile-spacer mdc-layout-grid__cell--span-3"></div>
+        <div class="code-card mdc-layout-grid__cell--span-6 mdc-layout-grid__cell--span-12-tablet">
+          <h3 class="code-card-title">Scan SBOM or Lockfiles</h3>
+          <pre class="code-card-content" id="example-sbom-scan">
+osv-scanner --sbom=cycloned-or-spdx-sbom.json
+osv-scanner --lockfile=package-lock.json
+          </pre>
+          <clipboard-copy class="code-card-copy" for="example-sbom-scan">
+            <md-icon-button class="icon">
+              <md-icon>content_copy</md-icon>
+            </md-icon-button>
+          </clipboard-copy>
+        </div>
+        <div class="code-card mdc-layout-grid__cell--span-6 mdc-layout-grid__cell--span-12-tablet">
+          <h3 class="code-card-title">Scan directory recursively</h3>
+          <pre class="code-card-content" id="example-dir-scan">
+osv-scanner -r path/to/your/project
+          </pre>
+          <clipboard-copy class="code-card-copy" for="example-dir-scan">
+            <md-icon-button class="icon">
+              <md-icon>content_copy</md-icon>
+            </md-icon-button>
+          </clipboard-copy>
+        </div>
+      </div>
+      <div class="mdc-layout-grid__cell--span-12">
+        <div class="cta">
+          <a class="cta-primary link-button" href="https://google.github.io/osv-scanner/">More details</a>
+        </div>
+      </div>
+    </div>
+    <div id="use-remediation-tools" class="mdc-layout-grid__cell--span-12 usage-examples">
+      <!-- &#8209; is a non breaking hyphen -->
+      <h2 class="heading">Remediation Tools</h2>
+      <div class="code-card-container mdc-layout-grid__inner">
+        <div class="code-card mdc-layout-grid__cell--span-6 mdc-layout-grid__cell--span-12-tablet">
+          <h3 class="code-card-title">Guided Remediation (basic)</h3>
+          <pre class="code-card-content" id="example-guided-remediation-basic">
+osv-scanner fix --non-interactive --strategy=in-place -L path/to/package-lock.json
+osv-scanner fix --non-interactive --strategy=relock -M path/to/package.json -L path/to/package-lock.json
+          </pre>
+          <clipboard-copy class="code-card-copy" for="example-guided-remediation-basic">
+            <md-icon-button class="icon">
+              <md-icon>content_copy</md-icon>
+            </md-icon-button>
+          </clipboard-copy>
+        </div>
+        <div class="code-card mdc-layout-grid__cell--span-6 mdc-layout-grid__cell--span-12-tablet">
+          <h3 class="code-card-title">Guided Remediation (interactive)</h3>
+          <pre class="code-card-content" id="example-guided-remediation-advanced">
+osv-scanner fix -M path/to/package.json -L path/to/package-lock.json
+          </pre>
+          <clipboard-copy class="code-card-copy" for="example-guided-remediation-advanced">
+            <md-icon-button class="icon">
+              <md-icon>content_copy</md-icon>
+            </md-icon-button>
+          </clipboard-copy>
+        </div>
+
+
+      </div>
+      <div class="mdc-layout-grid__cell--span-12">
+        <div class="cta">
+          <a class="cta-primary link-button"
+             href="https://google.github.io/osv-scanner/experimental/guided-remediation/">More details</a>
+        </div>
+      </div>
+    </div>
+    <div id="use-container-scanning" class="mdc-layout-grid__cell--span-12 usage-examples">
+      <h2 class="heading">Container Image Scanning</h2>
+      <p class="description">
+        You can use
+        <a href="https://github.com/google/osv-scanner" target="_blank" rel="noopener">OSV-Scanner</a>
+        to scan your container images for known vulnerabilities.
+      </p>
+
+      <!-- Command box (same look as 'Use the API' cards, centered) -->
+      <div class="code-card-container mdc-layout-grid__inner">
+        <div class="mobile-spacer mdc-layout-grid__cell--span-3"></div>
+        <div class="code-card mdc-layout-grid__cell--span-6 mdc-layout-grid__cell--span-12-tablet">
+          <h3 class="code-card-title">Scan container image</h3>
+          <pre class="code-card-content" id="example-container-scan-serve">
+osv-scanner scan image --serve alpine:3.12
+          </pre>
+          <clipboard-copy class="code-card-copy" for="example-container-scan-serve">
+            <md-icon-button class="icon">
+              <md-icon>content_copy</md-icon>
+            </md-icon-button>
+          </clipboard-copy>
+        </div>
+        <div class="mobile-spacer mdc-layout-grid__cell--span-3"></div>
+      </div>
+
+      <!-- Big screenshot (same size/markup as GitHub Workflows) -->
+      <div class="image-container" style="margin-top: 16px;">
+        <img
+            src="/static/img/container-scan-html.png"
+            alt="Screenshot of container scan HTML output"
+            loading="lazy"
+            style="
+            max-width: 1000px;
+            width: 100%;
+            height: auto;
+            display: block;
+            margin: 0 auto;
+            border: none;
+            /* crop 2px from the TOP only */
+            clip-path: inset(2px 0 0 0);
+          "
+        >
+      </div>
+
+
+      <div id="use-the-github-workflows"
+           class="mdc-layout-grid__cell--span-12 github-action">
+        <h2 class="heading">GitHub Workflows</h2>
+        <p class="description"> OSV-Scanner also provides reusable GitHub workflows that can be easily
+          integrated into CI/CD pipelines to provide continuous vulnerability scanning coverage. This can scan
+          newly added dependencies in pull requests for introduced vulnerabilities, as well as perform regular
+          vulnerability scans for the entire project.</p>
+        <div class="image-container"><img src="/static/img/github-action-scan-output.webp"
+                                          alt="Screenshot of OSV-Scanner GitHub Action" loading="lazy"></div>
+        <div class="cta"><a class="cta-primary link-button"
+                            href="https://google.github.io/osv-scanner/github-action/"
+                            aria-label="Learn more about osv scanner github action">Learn more</a></div>
+      </div>
+
+      <div class="mdc-layout-grid__cell--span-12 open-source-banner">
+        <h2 class="heading">Open source</h2>
+        <p class="description"> This project is <a href="https://github.com/google/osv">open source</a>. If you
+          have any ideas or questions, please feel free to reach out by <a
+              href="https://github.com/google/osv/issues/new/choose">creating an issue</a>! </p>
+
+        <div class="cta">
+          <a class="cta-primary link-button" href="https://google.github.io/osv.dev/faq/"
+             aria-label="Learn more on our FAQ">Learn more</a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <footer>
+  </footer>
+</div> {% endblock %}

--- a/gcp/website/frontend3/src/go/templates/linter/index.html
+++ b/gcp/website/frontend3/src/go/templates/linter/index.html
@@ -1,4 +1,5 @@
-{% set active_section = 'linter' %} {% block content %}
+{{ define "top_bar" }}<!-- empty top_bar -->{{ end }}
+{{ define "content" }}
 <!DOCTYPE html>
 <html lang="en">
 
@@ -95,4 +96,4 @@
 </body>
 
 </html>
-{% endblock %}
+{{ end }}

--- a/gcp/website/frontend3/src/go/templates/linter/index.html
+++ b/gcp/website/frontend3/src/go/templates/linter/index.html
@@ -1,0 +1,98 @@
+{% set active_section = 'linter' %} {% block content %}
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vulnerability Linter Report</title>
+    <link rel="icon" href="https://google.github.io/osv.dev/assets/icon.png" type="image/x-icon" />
+    <link href="https://fonts.googleapis.com/css?family=Overpass" rel="stylesheet" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+    <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
+</head>
+
+<body>
+    <div class="container">
+        <header>
+            <div id="header-left">
+                <img src="https://raw.githubusercontent.com/google/osv-scanner/refs/heads/main/docs/images/osv-scanner-OSV-logo-darkmode.png"
+                    alt="OSV-Scanner Logo" class="logo" />
+                <div class="vl"></div>
+                <h1>Open Source Vulnerabilities</h1>
+                <div id="global-loader" class="loader">
+                    <i class="material-icons">sync</i>
+                </div>
+            </div>
+            <div id="header-right">
+                <a class="improvement-link" href="https://github.com/ossf/osv-schema/tree/main/tools/osv-linter" rel="nofollow">Run OSV-Linter</a>
+            </div>
+        </header>
+        <main>
+            <div class="tab-bar-container">
+                <div class="tab-switch-button active" id="linter-report-tab" data-tab="linter-report">
+                    <span class="tab-title">Linter Report</span>
+                </div>
+                <div id="tab-switch">
+                    <!-- Dynamic tabs go here -->
+                </div>
+            </div>
+
+            <div id="tabs-content">
+                <div class="tab-content active" id="linter-report">
+                    <div class="filter-controls">
+                        <div class="filter-container">
+                            <span>Home Database</span>
+                            <div id="homedb-filter" class="filter">
+                                <p id="homedb-filter-selected" class="filter-selected"></p>
+                                <div class="filter-icon">
+                                    <i class="material-icons">keyboard_arrow_down</i>
+                                </div>
+                            </div>
+                            <div id="homedb-filter-options" class="filter-option-container"></div>
+                        </div>
+                        <div class="filter-container">
+                            <span>Finding</span>
+                            <div id="findings-filter" class="filter">
+                                <p id="findings-filter-selected" class="filter-selected"></p>
+                                <div class="filter-icon">
+                                    <i class="material-icons">keyboard_arrow_down</i>
+                                </div>
+                            </div>
+                            <div id="findings-filter-options" class="filter-option-container"></div>
+                        </div>
+                    </div>
+
+                    <div class="search-box">
+                        <div class="search-icon">
+                            <i class="material-icons">search</i>
+                        </div>
+                        <input id="search-input" placeholder="Search for a specific record..." />
+                    </div>
+
+                    <div id="homedb-details">
+                        <table id="issues-table">
+                            <thead>
+                                <tr>
+                                    <th>Bug ID</th>
+                                    <th>Findings</th>
+                                    <th id="modified-header">
+                                        Modified <i class="material-icons">unfold_more</i>
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <!-- Findings will be populated by JavaScript -->
+                            </tbody>
+                        </table>
+                        <div class="pagination" id="pagination-controls"></div>
+                    </div>
+                </div>
+            </div>
+        </main>
+    </div>
+
+</body>
+
+</html>
+{% endblock %}

--- a/gcp/website/frontend3/src/go/templates/linter/index.html
+++ b/gcp/website/frontend3/src/go/templates/linter/index.html
@@ -1,5 +1,3 @@
-{{ define "top_bar" }}<!-- empty top_bar -->{{ end }}
-{{ define "content" }}
 <!DOCTYPE html>
 <html lang="en">
 
@@ -96,4 +94,3 @@
 </body>
 
 </html>
-{{ end }}

--- a/gcp/website/frontend3/src/go/templates/list.html
+++ b/gcp/website/frontend3/src/go/templates/list.html
@@ -1,0 +1,166 @@
+{% extends 'base.html' %}
+{% set active_section = 'vulnerabilities' %}
+{% set disable_turbo_cache = 'true' %}
+
+{% macro table_header_cell(column_id, column_name, is_sortable, is_sorted, is_descending) %}
+<span class="vuln-table-cell mdc-data-table__header-cell vuln-table-header
+    {% if is_sortable %}mdc-data-table__header-cell--with-sort__DISABLED{% endif %}
+    {% if is_sorted %}mdc-data-table__header-cell--sorted{% endif %}
+    {% if is_descending %}mdc-data-table__header-cell--sorted-descending{% endif %}" role="columnheader" scope="col"
+  aria-sort="{% if is_sorted %}{% if is_descending %}descending{% else %}ascending{% endif %}{% else %}none{% endif %}"
+  data-column-id="{{ column_id }}">
+  <div class="mdc-data-table__header-cell-wrapper">
+    <div class="mdc-data-table__header-cell-label">
+      {{ column_name }}
+    </div>
+    {% if is_sorted %}
+    <md-icon-button class="mdc-data-table__sort-icon-button" disabled aria-label="Sorted by {{ column_name }}"
+      aria-describedby="{{ column_id }}-status-label">
+      <md-icon aria-hidden="false">arrow_upward</md-icon>
+    </md-icon-button>
+    <div class="mdc-data-table__sort-status-label" aria-hidden="true" id="{{ column_id }}-status-label">
+    </div>
+    {% endif %}
+  </div>
+</span>
+{% endmacro %}
+
+{% block content %}
+<div class="list-page">
+  <div class="mdc-layout-grid">
+    <div class="mdc-layout-grid__inner">
+      <div class="mdc-layout-grid__cell--span-12">
+        <h1 class="title">Vulnerabilities</h1>
+        <div class="search">
+          <form action="{{ url_for('frontend_handlers.list_vulnerabilities') }}" data-turbo-frame="vulnerability-table">
+            <div class="mdc-layout-grid__inner">
+              <div class="query-container search-suggestions-container mdc-layout-grid__cell--span-8">
+                <md-textfield-with-suggestions label="Package or ID search" class="query-field" type="search" name="q"
+                  value="{{ query }}" maxlength="300">
+                  <md-icon slot="leading-icon" aria-hidden="false">search</md-icon>
+                </md-textfield-with-suggestions>
+              </div>
+            </div>
+            <submit-radios>
+              {% if ecosystem_counts %}
+              <div class="ecosystem-buttons">
+                <input type="radio" name="ecosystem" id="ecosystem-radio-all" value="" {% if not selected_ecosystem %}
+                  checked{% endif %}>
+                <label class="ecosystem-label ecosystem-label-all" for="ecosystem-radio-all">
+                  <span class="ecosystem-name">All ecosystems</span>
+                  <span class="ecosystem-count">{{ ecosystem_counts.values() | sum }}</span>
+                </label>
+                {% for ecosystem in ecosystem_counts %}
+                <input type="radio" name="ecosystem" id="ecosystem-radio-{{ loop.index }}" value="{{ ecosystem }}" {%
+                  if selected_ecosystem==ecosystem %} checked{% endif %}>
+                <label class="ecosystem-label" for="ecosystem-radio-{{ loop.index }}">
+                  <span class="ecosystem-name">{{ ecosystem }}</span>
+                  <span class="ecosystem-count">{{ ecosystem_counts[ecosystem] }}</span>
+                </label>
+                {% endfor %}
+              </div>
+              {% endif %}
+            </submit-radios>
+            <input type="submit">
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+  <turbo-frame class="vuln-table-container mdc-data-table" id="vulnerability-table" data-turbo-action="advance">
+    <div role="table" class="vuln-table mdc-data-table__table" aria-label="Vulnerability table">
+      <div role="rowgroup" class="vuln-table-header">
+        <div role="row" class="vuln-table-row mdc-data-table__header-row">
+          {{ table_header_cell('id', 'ID', is_sortable=False, is_sorted=False, is_descending=False) }}
+          {{ table_header_cell('package', 'Packages', is_sortable=False, is_sorted=False, is_descending=False) }}
+          {{ table_header_cell('summary', 'Summary', is_sortable=False, is_sorted=False, is_descending=False) }}
+          {{ table_header_cell('published', 'Published', is_sortable=True, is_sorted=True, is_descending=True) }}
+          {{ table_header_cell('attributes', 'Attributes', is_sortable=False, is_sorted=False, is_descending=False) }}
+        </div>
+      </div>
+      <div role="rowgroup" class="vuln-table-rows mdc-data-table__content">
+        <turbo-frame id="vulnerability-table-page{{ page }}" data-turbo-action="advance" target="_top">
+          {% for vulnerability in vulnerabilities %}
+          <div role="row" class="vuln-table-row mdc-data-table__row">
+            <span role="cell" class="vuln-table-cell mdc-data-table__cell">
+              <a href="{{ url_for('frontend_handlers.vulnerability', vuln_id=vulnerability.id) }}">{{ vulnerability.id
+                }}</a>
+            </span>
+            <span role="cell" class="vuln-table-cell vuln-packages mdc-data-table__cell">
+              <ul class="packages">
+                {% for package in vulnerability.packages[:5] %}
+                  <li>{{ package }}</li>
+                {% endfor %}
+                {% if vulnerability.packages|length > 5 %}
+                 {% set remainingPkgCount = vulnerability.packages|length - 5 %}
+                  <li class="remaining-packages">... {{ remainingPkgCount }} more</li>
+                {% elif vulnerability.packages|length == 0 %}
+                  <li>Not specified</li>
+                {% endif %}
+              </ul>
+            </span>
+            <span role="cell" class="vuln-table-cell vuln-summary mdc-data-table__cell">
+              {% if vulnerability.summary %}
+                {{ vulnerability.summary | literal_backticks }}
+              {% else %}
+                See record for full details
+              {% endif %}
+            </span>
+            <span role="cell" class="vuln-table-cell mdc-data-table__cell">
+              <relative-time datetime="{{ vulnerability.published }}">
+                {{ vulnerability.published | relative_time }}
+              </relative-time>
+            </span>
+            <span role="cell" class="vuln-table-cell vuln-attributes mdc-data-table__cell">
+              <ul class="tags">
+                <li>
+                  {%- if vulnerability.is_fixed -%}
+                  <span class="tag fix-available">Fix available</span>
+                  {%- else -%}
+                  <span class="tag fix-unavailable">No fix available</span>
+                  {%- endif -%}
+                </li>
+                {%- if vulnerability.severity_score and vulnerability.severity_rating -%}
+                <li>
+                  <span class="tag severity-{{ vulnerability.severity_rating | lower }}">Severity - {{
+                    vulnerability.severity_score }} ({{ vulnerability.severity_rating }})</span>
+                </li>
+                {%- endif -%}
+              </ul>
+            </span>
+          </div>
+          {%- endfor -%}
+          {%- if vulnerabilities | length == 0 -%}
+          <span class="no-results">No results (check our <a href="https://google.github.io/osv.dev/faq/">FAQ</a> if this is unexpected)</span>
+          {%- endif -%}
+          {%- if page < total_pages -%} <turbo-frame id="vulnerability-table-page{{ page + 1 }}"
+            data-turbo-action="advance" target="_top" class="next-page-frame">
+            <div class="next-page-container">
+              <a class="next-page-button link-button" data-turbo-frame="_self" href="{{ url_for(request.endpoint) }}?page={{ page + 1 }}
+                  {%- if query %}&q={{ query }}{% endif %}
+                  {%- if selected_ecosystem %}&ecosystem={{ selected_ecosystem }}{% endif %}">
+                <span>Load more...</span>
+                {%- if total_pages - page <= 3 -%} <span style="margin-left: 5px">({{ total_pages - page }} page{% if
+                  total_pages - page > 1 %}s{% endif %} left)</span>
+                  {%- endif -%}
+              </a>
+              <md-circular-progress class="next-page-indicator" indeterminate density="-4"
+                aria-label="Page loading progress"></md-circular-progress>
+            </div>
+        </turbo-frame>
+        {%- endif -%}
+  </turbo-frame>
+</div>
+</div>
+<turbo-stream action="update" target="title">
+  <template>
+    {% if selected_ecosystem %}
+    {{ selected_ecosystem }} - OSV
+    {% else %}
+    Vulnerability Database - OSV
+    {% endif %}
+  </template>
+</turbo-stream>
+</turbo-frame>
+</div>
+{% endblock %}

--- a/gcp/website/frontend3/src/go/templates/triage.html
+++ b/gcp/website/frontend3/src/go/templates/triage.html
@@ -1,7 +1,11 @@
-{% extends 'base.html' %}
-{% set active_section = 'triage' %}
+{{ define "extra_head" }}
 
-{% block content %}
+<head>
+  <!-- Allow webpack to insert extra head content -->
+</head>
+{{ end }}
+
+{{ define "content" }}
 <div class="triage-container">
   <div class="header-container">
   <h1>CVE Conversion Triager</h1>
@@ -12,12 +16,12 @@
   </div>
 </div>
   <div class="triage-grid">
-    {% for i in range(1, 4) %}
-    <div class="triage-column" id="column-{{ i }}">
+    {{ range $i := .Columns }}
+    <div class="triage-column" id="column-{{ $i }}">
       <div class="column-header">
-        <label for="source-select-{{ i }}">Source:</label>
+        <label for="source-select-{{ $i }}">Source:</label>
         <div class="select-wrapper">
-          <select id="source-select-{{ i }}" class="source-select">
+          <select id="source-select-{{ $i }}" class="source-select">
             <option value="">Select Source...</option>
             <optgroup label="External APIs">
               <option value="cve-org">CVE.org API</option>
@@ -51,18 +55,18 @@
         <div class="json-scroll">
           <pre class="json-content">Select a source to view content</pre>
         </div>
-        <textarea id="copy-json-{{ i }}" class="copy-json-source"
+        <textarea id="copy-json-{{ $i }}" class="copy-json-source"
           aria-hidden="true" tabindex="-1"></textarea>
-        <clipboard-copy class="triage-copy" for="copy-json-{{ i }}"
+        <clipboard-copy class="triage-copy" for="copy-json-{{ $i }}"
           aria-disabled="true"
           tabindex="-1"
-          aria-label="Copy JSON from column {{ i }}"
-          title="Copy JSON from column {{ i }}">
+          aria-label="Copy JSON from column {{ $i }}"
+          title="Copy JSON from column {{ $i }}">
           <span class="material-icons" aria-hidden="true">content_copy</span>
         </clipboard-copy>
       </div>
     </div>
-    {% endfor %}
+    {{ end }}
   </div>
 </div>
-{% endblock %}
+{{ end }}

--- a/gcp/website/frontend3/src/go/templates/triage.html
+++ b/gcp/website/frontend3/src/go/templates/triage.html
@@ -1,0 +1,68 @@
+{% extends 'base.html' %}
+{% set active_section = 'triage' %}
+
+{% block content %}
+<div class="triage-container">
+  <div class="header-container">
+  <h1>CVE Conversion Triager</h1>
+
+  <div class="input-section">
+    <md-filled-text-field id="vuln-id-input" label="Vulnerability ID" placeholder="e.g. CVE-2023-1234" class="standard-input"></md-filled-text-field>
+    <md-filled-button id="load-btn">Load</md-filled-button>
+  </div>
+</div>
+  <div class="triage-grid">
+    {% for i in range(1, 4) %}
+    <div class="triage-column" id="column-{{ i }}">
+      <div class="column-header">
+        <label for="source-select-{{ i }}">Source:</label>
+        <div class="select-wrapper">
+          <select id="source-select-{{ i }}" class="source-select">
+            <option value="">Select Source...</option>
+            <optgroup label="External APIs">
+              <option value="cve-org">CVE.org API</option>
+              <option value="nvd-api">NVD API 2.0</option>
+            </optgroup>
+            <optgroup label="Test Instance (gs://osv-test-cve-osv-conversion)">
+              <option value="test-nvd">NVD-OSV (JSON)</option>
+              <option value="test-cve5">CVE5 (JSON)</option>
+              <option value="test-osv">OSV Output (JSON)</option>
+              <option value="test-nvd-metrics">NVD Metrics</option>
+              <option value="test-cve5-metrics">CVE5 Metrics</option>
+            </optgroup>
+            <optgroup label="Prod Instance (gs://cve-osv-conversion)">
+              <option value="prod-nvd">NVD-OSV (JSON)</option>
+              <option value="prod-cve5">CVE5 (JSON)</option>
+              <option value="prod-osv">OSV Output (JSON)</option>
+              <option value="prod-nvd-metrics">NVD Metrics</option>
+              <option value="prod-cve5-metrics">CVE5 Metrics</option>
+            </optgroup>
+            <optgroup label="API">
+              <option value="api-test">api.test.osv.dev</option>
+              <option value="api-prod">api.osv.dev</option>
+            </optgroup>
+          </select>
+        </div>
+      </div>
+      <div class="content-display">
+        <div class="loading-spinner hidden">
+          <md-circular-progress indeterminate></md-circular-progress>
+        </div>
+        <div class="json-scroll">
+          <pre class="json-content">Select a source to view content</pre>
+        </div>
+        <textarea id="copy-json-{{ i }}" class="copy-json-source"
+          aria-hidden="true" tabindex="-1"></textarea>
+        <clipboard-copy class="triage-copy" for="copy-json-{{ i }}"
+          aria-disabled="true"
+          tabindex="-1"
+          aria-label="Copy JSON from column {{ i }}"
+          title="Copy JSON from column {{ i }}">
+          <span class="material-icons" aria-hidden="true">content_copy</span>
+        </clipboard-copy>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/gcp/website/frontend3/src/go/templates/triage.html
+++ b/gcp/website/frontend3/src/go/templates/triage.html
@@ -1,8 +1,5 @@
 {{ define "extra_head" }}
-
-<head>
-  <!-- Allow webpack to insert extra head content -->
-</head>
+<%= htmlWebpackPlugin.tags.headTags %>
 {{ end }}
 
 {{ define "content" }}

--- a/gcp/website/frontend3/src/go/templates/vulnerability.html
+++ b/gcp/website/frontend3/src/go/templates/vulnerability.html
@@ -1,0 +1,618 @@
+{% extends 'base.html' -%}
+{% set active_section = 'vulnerabilities' -%}
+
+{% block extra_head %}
+<link rel="preload" fetchpriority="high" as="image" href="/static/img/external-link.svg" type="image/webp">
+{% endblock %}
+
+{% block content -%}
+<div class="vulnerability-page">
+  <div class="mdc-layout-grid">
+    <div class="mdc-layout-grid__inner">
+      <div class="mdc-layout-grid__cell--span-12 vulnerability-title">
+        <h1 class="title">
+          {{ vulnerability.id }}
+        </h1>
+        {% if vulnerability.human_source_link and vulnerability.human_source_link.startswith("https://github.com/advisories/") -%}
+          <a class="vulnerability-improvement-link" href="{{ vulnerability.human_source_link }}/improve" rel="nofollow">
+            Suggest an improvement
+          </a>
+        {% elif vulnerability.human_source_link and not vulnerability.id.startswith("openSUSE-") -%}
+          <div class="vulnerability-improvement-link">
+          <a href="https://google.github.io/osv.dev/faq/#ive-found-something-wrong-with-the-data" target="_blank" rel="noopener noreferrer" title="Follow the Source link below and use its record feedback reporting mechanism">
+            See a problem?
+          </a>
+          <br/>
+          Please try reporting it <a href="{{ vulnerability.human_source_link}}" target="_blank" rel="nofollow noopener noreferrer">to the source</a> first.
+        </div>
+        {% else -%}
+          <a class="vulnerability-improvement-link" href="https://google.github.io/osv.dev/faq/#ive-found-something-wrong-with-the-data" target="_blank" rel="noopener noreferrer">
+            See a problem?
+          </a>
+        {% endif -%}
+      </div>
+      <div class="mdc-layout-grid__cell--span-12">
+        <dl class="vulnerability-details">
+          {%- if vulnerability.human_source_link and not vulnerability.id.startswith("openSUSE-") -%}
+          <dt>Source</dt>
+          <dd><a href="{{ vulnerability.human_source_link }}" target="_blank" rel="nofollow noopener noreferrer">{{
+              vulnerability.human_source_link }}</a>
+          </dd>
+          {%- endif -%}
+          <dt>Import Source</dt>
+          <dd><a href="{{ vulnerability.source_link }}" target="_blank" rel="nofollow noopener noreferrer">{{
+              vulnerability.source }}</a></dd>
+
+          <dt>JSON Data</dt>
+          <dd><a href="https://{{ api_url }}/v1/vulns/{{ vulnerability.id }}" target="_blank" rel="noopener noreferrer">
+            https://{{ api_url }}/v1/vulns/{{ vulnerability.id }}</a>
+          </dd>
+          {% if vulnerability.aliases -%}
+          <dt>Aliases</dt>
+          <dd>
+            <ul class="aliases">
+              {% for alias in vulnerability.aliases -%}
+              <li>
+                {% if alias in vulnerability.known_ids -%}
+                <a href="/vulnerability/{{ alias }}">{{ alias }}</a>
+                {% else -%}
+                {{ alias }}
+                {% endif -%}
+              </li>
+              {% endfor -%}
+            </ul>
+          </dd>
+          {% endif -%}
+           {%- if vulnerability.upstream_hierarchy -%}
+          <dt>Upstream</dt>
+          <dd class="upstream expandible-hierarchy-list">{{ vulnerability.upstream_hierarchy | safe }}</dd>
+          {%- endif -%}
+          {%- if vulnerability.downstream_hierarchy -%}
+          <dt>Downstream</dt>
+          <dd class="downstream expandible-hierarchy-list">{{ vulnerability.downstream_hierarchy | safe }}</dd>
+          {%- endif -%}
+          {% if vulnerability.related -%}
+          <dt>Related</dt>
+          <dd>
+            <ul class="aliases expandible-list">
+              {% for related in vulnerability.related -%}
+              <li>
+                {% if related in vulnerability.known_ids -%}
+                <a href="/vulnerability/{{ related }}">{{ related }}</a>
+                {% else -%}
+                {{ related }}
+                {% endif -%}
+              </li>
+              {% endfor -%}
+            </ul>
+          </dd>
+          {% endif -%}
+          {%- if vulnerability.withdrawn -%}
+          <dt class="withdrawn">
+            Withdrawn
+            <a href="https://ossf.github.io/osv-schema/#withdrawn-field" target="_blank" rel="noopener noreferrer"></a>
+          </dt>
+          <dd class="withdrawn">{{ vulnerability.withdrawn }}</dd>
+          {% endif -%}
+          <dt>Published</dt>
+          <dd>{{ vulnerability.published }}</dd>
+          <dt>Modified</dt>
+          <dd>{{ vulnerability.modified }}</dd>
+          {%- if vulnerability.severity -%}
+          <dt>Severity</dt>
+          <dd>
+            <ul class="severity">
+              {% for item in vulnerability.severity -%}
+              <li>
+                {% if item | is_cvss %}
+                  <span class="severity-level severity-{{ item | severity_level }}">{{ item | display_severity_rating }}</span>
+                  {{ item.type }} - {{ item.score }}
+                  <a href="{{ item | cvss_calculator_url }}" target="_blank" rel="nofollow noopener noreferrer">
+                    CVSS Calculator</a>
+                {% else %}
+                  <span class="severity-level severity-invalid">{{ item.type }} - {{ item.score }}</span>
+                {% endif %}
+              </li>
+              {% endfor -%}
+            </ul>
+          </dd>
+          {%- endif -%}
+          <dt class="summary">Summary</dt>
+          <dd class="summary {% if not vulnerability.summary %}muted{% endif %}">
+            {% if vulnerability.summary %}
+            {{ vulnerability.summary | literal_backticks }}
+            {% else %}
+            [none]
+            {% endif %}
+          </dd>
+          <dt>Details</dt>
+          <dd class="details">
+            {{ vulnerability.details | markdown | safe -}}
+          </dd>
+          {% if vulnerability.database_specific -%}
+          <dt>
+            Database specific
+            <a href="https://ossf.github.io/osv-schema/#database_specific-field" target="_blank"
+              rel="noopener noreferrer"></a>
+          </dt>
+          <dd><pre class="specific">{{ vulnerability.database_specific | display_json }}</pre></dd>
+          {% endif %}
+          <dt>References</dt>
+          <dd>
+            <ul class="links">
+              {% for reference in vulnerability.references -%}
+              <li><a href="{{ reference.url }}" target="_blank" rel="nofollow noopener noreferrer">{{ reference.url }}</a></li>
+              {% endfor -%}
+            </ul>
+          </dd>
+          {% if vulnerability.credits -%}
+          <dt class="credits">Credits</dt>
+          <dd class="credits">
+            <ul>
+              {% for credit in vulnerability.credits -%}
+              <li class="credit">
+                <ul>
+                  <li>{{ credit.name }}{% if 'type' in credit %} - {{ credit.type }}{% endif %}</li>
+                  {%- if 'contact' in credit -%}
+                  <li>
+                    <ul class="contact">
+                      {%- for item in credit.contact -%}
+                      <li><a href="{{ item }}" target="_blank" rel="nofollow noopener noreferrer">{{ item }}</a></li>
+                      {%- endfor -%}
+                    </ul>
+                  </li>
+                  {%- endif -%}
+                </ul>
+              </li>
+              {% endfor -%}
+            </ul>
+          </dd>
+          {% endif %}
+        </dl>
+      </div>
+    </div>
+  </div>
+  <div class="vulnerability-packages-container">
+  <h2 class="title">Affected packages</h2>
+
+  {% if vulnerability.affected|should_collapse %}
+    {% set ecosystems = vulnerability.affected | group_by_ecosystem %}
+  <div class="vulnerability-packages force-collapse">
+    {% for ecosystem_name, packages in ecosystems.items() -%}
+      {% set is_last_ecosystem = loop.last %}
+      <details class="ecosystem-accordion">
+        <summary class="package-header">
+          <span class="vuln-ecosystem">{{ ecosystem_name }}</span>
+        </summary>
+        <div class="ecosystem-content-panel{% if is_last_ecosystem %} ecosystem-content-panel--last{% endif %}">
+          {% for affected in packages -%}
+            <details class="package-accordion{% if is_last_ecosystem and loop.last %} package-accordion--last{% endif %}">
+              <summary class="package-name-title">
+              {% if 'package' in affected %}
+                {{ affected.package.name }}
+              {% else %}
+                {% set affected_repo = affected.ranges | default([], true) | selectattr('repo') | map(attribute='repo') | first %}
+                {% if affected_repo %}
+                  {{ affected_repo | strip_scheme }}
+                {% endif %}
+              {% endif %}
+              </summary>
+            <div class="package-details-card">
+              <div class="mdc-layout-grid">
+                {%- if 'package' in affected -%}
+                <div class="vulnerability-package-subsection mdc-layout-grid__inner">
+                  <h3 class="mdc-layout-grid__cell--span-3">Package</h3>
+                  <div class="mdc-layout-grid__cell--span-9">
+                    <dl>
+                      <dt>Name</dt>
+                      <dd>{{ affected.package.name }}</dd>
+                      {%- if ecosystem_name | has_link_to_deps_dev -%}
+                      <dd><a href="{{ affected.package.name | link_to_deps_dev(ecosystem_name) }}" target="_blank" rel="noopener noreferrer">View open source insights on deps.dev</a></dd>
+                      {%- endif -%}
+                      {%- if 'purl' in affected.package -%}
+                      <dt>Purl</dt>
+                      <dd class="purl">{{ affected.package.purl }}</dd>
+                      {%- endif -%}
+                    </dl>
+                  </div>
+                </div>
+                {%- endif -%}
+                {%- if 'severity' in affected -%}
+                <div class="vulnerability-package-subsection mdc-layout-grid__inner">
+                  <h3 class="mdc-layout-grid__cell--span-3">Severity</h3>
+                  <div class="mdc-layout-grid__cell--span-9">
+                    <ul class="severity">
+                      {% for item in affected.severity -%}
+                      <li>
+                        {% if item | is_cvss %}
+                          <span class="severity-level severity-{{ item | severity_level }}">{{ item | display_severity_rating }}</span>
+                          {{ item.type }} - {{ item.score }}
+                          <a href="{{ item | cvss_calculator_url }}" target="_blank" rel="nofollow noopener noreferrer">
+                            CVSS Calculator</a>
+                        {% else %}
+                          <span class="severity-level severity-invalid">{{ item.type }} - {{ item.score }}</span>
+                        {% endif %}
+                      </li>
+                      {% endfor -%}
+                    </ul>
+                  </div>
+                </div>
+                {%- endif -%}
+                <div class="vulnerability-package-subsection affected-ranges-subsection mdc-layout-grid__inner">
+                  <h3 class="mdc-layout-grid__cell--span-3">Affected ranges <a href="https://ossf.github.io/osv-schema/#examples" target="_blank" rel="noopener noreferrer"></a></h3>
+                  <div class="mdc-layout-grid__cell--span-9">
+                  {% for range in affected.ranges -%}
+                    <dl>
+                      <dt>Type</dt>
+                      <dd>{{ range.type -}}</dd>
+                      {%- if range.repo -%}
+                      <dt>Repo</dt>
+                      <dd>{{ range.repo }}</dd>
+                      {%- endif -%}
+                      <dt>Events</dt>
+                      <dd>
+                        <div class="mdc-layout-grid__inner events">
+                          {% for event in range.events -%}
+                            <div class="mdc-layout-grid__cell--span-3">{{ event | event_type -}}</div>
+                            <div class="mdc-layout-grid__cell--span-9 version-value">
+                              {% set link = event | event_link -%}
+                              {% if link -%}
+                                <a href="{{ link }}" rel="nofollow">{{ event | event_value -}}</a>
+                              {% elif event | event_type == 'Introduced' and event | event_value == '0' -%}
+                                <div class="tooltip">{{ event | event_value -}}
+                                  {% if range.type == 'GIT' %}
+                                    <span class="tooltiptext">Unknown introduced commit / All previous commits are affected</span>
+                                  {% else -%}
+                                    <span class="tooltiptext">Unknown introduced version / All previous versions are affected</span>
+                                  {% endif -%}
+                                </div>
+                              {% else -%}
+                                {{ event | event_value -}}
+                              {% endif -%}
+                            </div>
+                          {% endfor -%}
+                        </div>
+                      </dd>
+                      {%- if range.database_specific -%}
+                      <dt>Database specific <a href="https://ossf.github.io/osv-schema/#affectedrangesdatabase_specific-field" target="_blank" rel="noopener noreferrer"></a></dt>
+                      <dd><pre class="specific">{{ range.database_specific | display_json }}</pre></dd>
+                      {%- endif -%}
+                    </dl>
+                  {% endfor -%}
+                  </div>
+                </div>
+                {% if affected.versions -%}
+                <div class="vulnerability-package-subsection mdc-layout-grid__inner">
+                    <h3 class="mdc-layout-grid__cell--span-3">Affected versions <a href="https://ossf.github.io/osv-schema/#affectedversions-field" target="_blank" rel="noopener noreferrer"></a></h3>
+                    <div class="mdc-layout-grid__cell--span-9 version-value">
+                      {% for group, versions in (affected.versions|group_versions(ecosystem_name)).items() -%}
+                      <details class="versions-section">
+                        <summary class="version-header">{{ group }}</summary>
+                        <div class="versions {% if not loop.last %}versions-separator{% endif %}">
+                          {% for version in versions -%}
+                          <div class="version">{{ version }}</div>
+                          {% endfor -%}
+                        </div>
+                      </details>
+                      {% endfor -%}
+                    </div>
+                </div>
+                {% endif -%}
+                {% if affected.ecosystem_specific -%}
+                <div class="vulnerability-package-subsection mdc-layout-grid__inner">
+                    <h3 class="mdc-layout-grid__cell--span-3">Ecosystem specific <a href="https://ossf.github.io/osv-schema/#affectedecosystem_specific-field" target="_blank" rel="noopener noreferrer"></a></h3>
+                    <div class="mdc-layout-grid__cell--span-9"><pre class="specific">{{ affected.ecosystem_specific | display_json }}</pre></div>
+                </div>
+                {% endif -%}
+                {% if affected.database_specific -%}
+                <div class="vulnerability-package-subsection mdc-layout-grid__inner">
+                    <h3 class="mdc-layout-grid__cell--span-3">Database specific <a href="https://ossf.github.io/osv-schema/#affecteddatabase_specific-field" target="_blank" rel="noopener noreferrer"></a></h3>
+                    <div class="mdc-layout-grid__cell--span-9">
+                      {% set db_specific = affected.database_specific %}
+                      {% if db_specific is mapping %}
+                      <div class="database-specific-list">
+                        {% for key, value in db_specific.items() %}
+                        <details class="database-specific-section">
+                          <summary class="database-specific-header">{{ key }}</summary>
+                          <div class="database-specific-content">
+                            <pre class="specific">{{ value | display_json }}</pre>
+                          </div>
+                        </details>
+                        {% endfor %}
+                      </div>
+                      {% else %}
+                      <pre class="specific">{{ db_specific | display_json }}</pre>
+                      {% endif %}
+                    </div>
+                </div>
+                {% endif -%}
+              </div>
+            </div>
+          </details>
+        {% endfor -%}
+        </div>
+      </details>
+    {% endfor -%}
+  </div>
+
+  {% else %}
+    <osv-tabs
+      class="vulnerability-packages">
+      {% for affected in vulnerability.affected -%}
+      {% if 'package' in affected %}
+      {% set ecosystem = affected.package.ecosystem %}
+      {% set package = affected.package.name %}
+      {% else %}
+      {% set ecosystem = 'Git' %}
+      {% set affected_repo = affected.ranges | default([], true) | selectattr('repo') | map(attribute='repo') | first %}
+      {% if affected_repo %}
+      {% set package = affected_repo | strip_scheme %}
+      {% endif %}
+      {% endif %}
+      <h2 class="package-header">
+        <span class="vuln-ecosystem">{{ ecosystem }}</span>
+        <span class="vuln-title-divider">/</span>
+        <span class="vuln-name">{{ package }}</span>
+      </h2>
+      <div class="mdc-layout-grid">
+        {%- if 'package' in affected -%}
+        <div class="vulnerability-package-subsection mdc-layout-grid__inner">
+          <h3 class="mdc-layout-grid__cell--span-3">
+            Package
+          </h3>
+          <div class="mdc-layout-grid__cell--span-9">
+            <dl>
+              <dt>Name</dt>
+              {%- if affected.package | package_in_ecosystem -%}
+              <dd><a href="{{ affected.package | package_in_ecosystem }}" target="_blank" rel="nofollow noopener noreferrer">{{
+                  affected.package.name }}</a></dd>
+              {%- else -%}
+              <dd>{{ affected.package.name }}</dd>
+              {%- endif -%}
+              {%- if ecosystem | has_link_to_deps_dev -%}
+              <dd><a href="{{ package | link_to_deps_dev(ecosystem) }}" target="_blank" rel="noopener noreferrer">
+                View open source insights on deps.dev</a></dd>
+              {%- endif -%}
+              {%- if 'purl' in affected.package -%}
+              <dt>Purl</dt>
+              <dd class="purl">{{ affected.package.purl }}</dd>
+              {%- endif -%}
+            </dl>
+          </div>
+        </div>
+        {%- endif -%}
+        {%- if 'severity' in affected -%}
+        <div class="vulnerability-package-subsection mdc-layout-grid__inner">
+          <h3 class="mdc-layout-grid__cell--span-3">
+            Severity
+          </h3>
+          <div class="mdc-layout-grid__cell--span-9">
+            <ul class="severity">
+              {% for item in affected.severity -%}
+              <li>
+                {% if item | is_cvss %}
+                  <span class="severity-level severity-{{ item | severity_level }}">{{ item | display_severity_rating }}</span>
+                  {{ item.type }} - {{ item.score }}
+                  <a href="{{ item | cvss_calculator_url }}" target="_blank" rel="nofollow noopener noreferrer">
+                    CVSS Calculator</a>
+                {% else %}
+                  <span class="severity-level severity-invalid">{{ item.type }} - {{ item.score }}</span>
+                {% endif %}
+              </li>
+              {% endfor -%}
+            </ul>
+          </div>
+        </div>
+        {%- endif -%}
+        <div class="vulnerability-package-subsection mdc-layout-grid__inner">
+          <h3 class="mdc-layout-grid__cell--span-3">
+            Affected ranges
+            <a href="https://ossf.github.io/osv-schema/#examples" target="_blank" rel="noopener noreferrer"></a>
+          </h3>
+          <div class="mdc-layout-grid__cell--span-9">
+          {% for range in affected.ranges -%}
+            <dl>
+              <dt>Type</dt>
+              <dd>{{ range.type -}}</dd>
+
+              {%- if range.repo -%}
+              <dt>Repo</dt>
+              <dd>{{ range.repo }}</dd>
+              {%- endif -%}
+
+              <dt>Events</dt>
+              <dd>
+                <div class="mdc-layout-grid__inner events">
+                  {% for event in range.events -%}
+                    <div class="mdc-layout-grid__cell--span-3">
+                      {{ event | event_type -}}
+                    </div>
+                    <div class="mdc-layout-grid__cell--span-9 version-value">
+                      {% set link = event | event_link -%}
+                      {% if link -%}
+                        <a href="{{ link }}" rel="nofollow">
+                          {{ event | event_value -}}
+                        </a>
+                      {% elif event | event_type == 'Introduced' and event | event_value == '0' -%}
+                        <div class="tooltip">
+                          {{ event | event_value -}}
+                          {% if range.type == 'GIT' %}
+                            <span class="tooltiptext">Unknown introduced commit / All previous commits are affected</span>
+                          {% else -%}
+                            <span class="tooltiptext">Unknown introduced version / All previous versions are affected</span>
+                          {% endif -%}
+                        </div>
+                      {% else -%}
+                        {{ event | event_value -}}
+                      {% endif -%}
+                    </div>
+                  {% endfor -%}
+                </div>
+              </dd>
+
+              {%- if range.database_specific -%}
+              <dt>
+                Database specific
+                <a href="https://ossf.github.io/osv-schema/#affectedrangesdatabase_specific-field" target="_blank"
+                  rel="noopener noreferrer"></a>
+              </dt>
+              <dd><pre class="specific">{{ range.database_specific | display_json }}</pre></dd>
+              {%- endif -%}
+            </dl>
+          {% endfor -%}
+          </div>
+        </div>
+        {% if affected.versions -%}
+        <div class="vulnerability-package-subsection mdc-layout-grid__inner">
+          <h3 class="mdc-layout-grid__cell--span-3">
+            Affected versions
+            <a href="https://ossf.github.io/osv-schema/#affectedversions-field" target="_blank"
+              rel="noopener noreferrer"></a>
+          </h3>
+          <div class="mdc-layout-grid__cell--span-9 version-value">
+            {% for group, versions in (affected.versions|group_versions(ecosystem)).items() -%}
+            <details class="versions-section">
+              <summary class="version-header">{{ group }}</summary>
+              <div class="versions {% if not loop.last %}versions-separator{% endif %}">
+                {% for version in versions -%}
+                <div class="version">{{ version }}</div>
+                {% endfor -%}
+              </div>
+            </details>
+            {% endfor -%}
+          </div>
+        </div>
+        {% endif -%}
+        {% if affected.ecosystem_specific -%}
+        <div class="vulnerability-package-subsection mdc-layout-grid__inner">
+          <h3 class="mdc-layout-grid__cell--span-3">
+            Ecosystem specific
+            <a href="https://ossf.github.io/osv-schema/#affectedecosystem_specific-field" target="_blank"
+              rel="noopener noreferrer"></a>
+          </h3>
+          <div class="mdc-layout-grid__cell--span-9">
+            <pre class="specific">{{ affected.ecosystem_specific | display_json }}</pre>
+          </div>
+        </div>
+        {% endif -%}
+        {% if affected.database_specific -%}
+        <div class="vulnerability-package-subsection mdc-layout-grid__inner">
+          <h3 class="mdc-layout-grid__cell--span-3">
+            Database specific
+            <a href="https://ossf.github.io/osv-schema/#affecteddatabase_specific-field" target="_blank"
+              rel="noopener noreferrer"></a>
+          </h3>
+          <div class="mdc-layout-grid__cell--span-9">
+            {% set db_specific = affected.database_specific %}
+            {% if db_specific is mapping %}
+            <div class="database-specific-list">
+              {% for key, value in db_specific.items() %}
+              <details class="database-specific-section">
+                <summary class="database-specific-header">{{ key }}</summary>
+                <div class="database-specific-content">
+                  <pre class="specific">{{ value | display_json }}</pre>
+                </div>
+              </details>
+              {% endfor %}
+            </div>
+            {% else %}
+            <pre class="specific">{{ db_specific | display_json }}</pre>
+            {% endif %}
+          </div>
+        </div>
+        {% endif -%}
+      </div>
+      {% endfor -%}
+    </osv-tabs>
+  {% endif %}
+</div>
+</div>
+<turbo-stream action="update" target="title">
+  <template>
+    {{ vulnerability.id }} - OSV
+  </template>
+</turbo-stream>
+
+<script>
+  document.addEventListener('turbo:load', function() {
+    const ECOSYSTEM_EXPAND_THRESHOLD = 10;
+    const PACKAGE_EXPAND_THRESHOLD = 7;
+    const ECOSYSTEM_PACKAGE_COLLAPSE_THRESHOLD = 9;
+
+  /**
+   * Sets up the vertical, grouped layout for vulnerability packages.
+   * - All ecosystem headers are expanded if their total count is below `ECOSYSTEM_EXPAND_THRESHOLD`,
+   *   and if their total packages count is below `ECOSYSTEM_PACKAGE_COLLAPSE_THRESHOLD`.
+   * - Within each ecosystem, all package headers are expanded if their count is below `PACKAGE_EXPAND_THRESHOLD`.
+   */
+    function setupVerticalLayout() {
+      const ecosystemAccordions = document.querySelectorAll('.vulnerability-packages.force-collapse .ecosystem-accordion');
+      if (!ecosystemAccordions.length) return;
+
+      const shouldExpandEcosystems = ecosystemAccordions.length < ECOSYSTEM_EXPAND_THRESHOLD;
+
+      ecosystemAccordions.forEach(accordion => {
+        const panel = accordion.querySelector('.ecosystem-content-panel');
+        const packageAccordions = panel ? panel.querySelectorAll('.package-accordion') : [];
+        const hasManyPackages =
+          ecosystemAccordions.length > 1 && packageAccordions.length > ECOSYSTEM_PACKAGE_COLLAPSE_THRESHOLD;
+
+        const shouldExpandAccordion =
+          shouldExpandEcosystems &&
+          panel !== null &&
+          !hasManyPackages;
+
+        accordion.open = shouldExpandAccordion;
+
+        const shouldExpandPackages = packageAccordions.length <= PACKAGE_EXPAND_THRESHOLD;
+        packageAccordions.forEach(packageAccordion => {
+          packageAccordion.open = shouldExpandPackages;
+        });
+      });
+    }
+    
+    if (document.querySelector('.vulnerability-packages.force-collapse')) {
+      setupVerticalLayout();
+    }
+
+    /**
+     * Sets up "Show More" / "Show Less" functionality for lists that might have
+     * many items. You can enable this feature by adding an 'expandible-list' or
+     * 'expandible-hierarchy-list' class to lists with long value.
+     * @param {string} listSelector The CSS selector for the list container.
+     * @param {string} itemSelector The tag name of the items within the list.
+     */
+    function setupExpandibleList(listSelector, itemSelector) {
+      const EXPANDIBLE_LIST_DEFAULT_LENGTH = 6;
+      const lists = document.querySelectorAll(`${listSelector}:not(.expanded):not([data-has-toggle-btn])`);
+      lists.forEach((list) => {
+        const items = list.getElementsByTagName(itemSelector);
+        if (items.length <= EXPANDIBLE_LIST_DEFAULT_LENGTH) return;
+
+        const expandibleItems = [...items].slice(EXPANDIBLE_LIST_DEFAULT_LENGTH);
+        expandibleItems.forEach((item) => {
+          item.style.display = 'none';
+        });
+
+        const toggleButton = document.createElement('span');
+        toggleButton.classList.add('showmore');
+        toggleButton.textContent = 'Show More';
+        list.append(toggleButton);
+        list.setAttribute('data-has-toggle-btn', 'true');
+
+        toggleButton.addEventListener('click', function() {
+          const isExpanded = list.classList.contains('expanded');
+          expandibleItems.forEach((item) => {
+            item.style.display = isExpanded ? 'none' : 'block';
+          });
+          toggleButton.textContent = isExpanded ? 'Show More' : 'Show Less';
+          list.classList.toggle('expanded');
+        });
+      });
+    }
+
+    setupExpandibleList('.expandible-hierarchy-list', 'ul');
+    setupExpandibleList('.expandible-list', 'li');
+  });
+</script>
+{% endblock -%}

--- a/gcp/website/frontend3/webpack.dev.js
+++ b/gcp/website/frontend3/webpack.dev.js
@@ -37,6 +37,8 @@ module.exports = {
     new CopyPlugin({
       patterns: [
         { from: './src/templates', to: '.', globOptions: { ignore: ['**/base.html', '**/triage.html'] } },
+        // TODO(michaelkedar): Remove this once the website is fully migrated.
+        { from: './src/go/templates', to: 'go/', globOptions: { ignore: ['**/base.html', '**/triage.html'] } },
         { from: './img/*', to: 'static/img/[name][ext]' },
       ],
     }),
@@ -55,6 +57,25 @@ module.exports = {
     new HtmlWebpackPlugin({
       filename: 'triage.html',
       template: './src/templates/triage.html',
+      chunks: ['triage'],
+      excludeChunks: ['main', 'linter'],
+    }),
+    // TODO(michaelkedar): Remove this once the website is fully migrated.
+    new HtmlWebpackPlugin({
+      filename: 'go/base.html',
+      template: './src/go/base.html',
+      chunks: ['main'],
+      excludeChunks: ['linter'],
+    }),
+    new HtmlWebpackPlugin({
+      filename: 'go/linter.html',
+      template: './src/go/templates/linter/index.html',
+      chunks: ['linter'],
+      excludeChunks: ['main'],
+    }),
+    new HtmlWebpackPlugin({
+      filename: 'go/triage.html',
+      template: './src/go/templates/triage.html',
       chunks: ['triage'],
       excludeChunks: ['main', 'linter'],
     }),

--- a/gcp/website/frontend3/webpack.dev.js
+++ b/gcp/website/frontend3/webpack.dev.js
@@ -78,6 +78,7 @@ module.exports = {
       template: './src/go/templates/triage.html',
       chunks: ['triage'],
       excludeChunks: ['main', 'linter'],
+      inject: false,
     }),
     new MiniCssExtractPlugin({
       filename: 'static/[name].css'

--- a/gcp/website/frontend3/webpack.prod.js
+++ b/gcp/website/frontend3/webpack.prod.js
@@ -37,6 +37,8 @@ module.exports = {
     new CopyPlugin({
       patterns: [
         { from: './src/templates/*.html', to: '[name].html', globOptions: { ignore: ['**/base.html', '**/triage.html'] } },
+        // TODO(michaelkedar): Remove this once the website is fully migrated.
+        { from: './src/go/templates/*.html', to: 'go/[name].html', globOptions: { ignore: ['**/base.html', '**/triage.html'] } },
         { from: './img/*', to: 'static/img/[name][ext]' },
       ],
     }),
@@ -55,6 +57,25 @@ module.exports = {
     new HtmlWebpackPlugin({
       filename: 'triage.html',
       template: './src/templates/triage.html',
+      chunks: ['triage'],
+      excludeChunks: ['main', 'linter'],
+    }),
+    // TODO(michaelkedar): Remove this once the website is fully migrated.
+    new HtmlWebpackPlugin({
+      filename: 'go/base.html',
+      template: './src/go/base.html',
+      chunks: ['main'],
+      excludeChunks: ['linter'],
+    }),
+    new HtmlWebpackPlugin({
+      filename: 'go/linter.html',
+      template: './src/go/templates/linter/index.html',
+      chunks: ['linter'],
+      excludeChunks: ['main'],
+    }),
+    new HtmlWebpackPlugin({
+      filename: 'go/triage.html',
+      template: './src/go/templates/triage.html',
       chunks: ['triage'],
       excludeChunks: ['main', 'linter'],
     }),

--- a/gcp/website/frontend3/webpack.prod.js
+++ b/gcp/website/frontend3/webpack.prod.js
@@ -78,6 +78,7 @@ module.exports = {
       template: './src/go/templates/triage.html',
       chunks: ['triage'],
       excludeChunks: ['main', 'linter'],
+      inject: false,
     }),
     new MiniCssExtractPlugin({
       filename: 'static/[name].[contenthash].css'

--- a/go/internal/website/blog.go
+++ b/go/internal/website/blog.go
@@ -1,45 +1,117 @@
 package website
 
 import (
-	"fmt"
+	"html/template"
+	"io/fs"
+	"log/slog"
+	"mime"
 	"net/http"
+	"path"
+	"regexp"
+
+	"github.com/google/osv.dev/go/logger"
 )
 
+var validBlogName = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+func (s *Server) loadBlogContent(filePath string) (template.HTML, error) {
+	fullPath := path.Join("static", "blog", filePath)
+	content, err := fs.ReadFile(s.config.StaticFS, fullPath)
+	if err != nil {
+		return "", err
+	}
+
+	return template.HTML(content), nil //nolint:gosec // Trusted static content built by Hugo
+}
+
 // handleBlogIndex handles serving the blog landing page /blog/.
-func (s *Server) handleBlogIndex(w http.ResponseWriter, _ *http.Request) {
-	// TODO: Load blog index content from StaticFS (static/blog/index.html) and render blog template
-	http.Error(w, "Blog index handler stub", http.StatusNotImplemented)
+func (s *Server) handleBlogIndex(w http.ResponseWriter, r *http.Request) {
+	indexHTML, err := s.loadBlogContent("index.html")
+	if err != nil {
+		s.RenderNotFound(w, r, "")
+
+		return
+	}
+
+	data := BlogPageData{
+		BasePageData: BasePageData{
+			ActiveSection:     "blog",
+			DisableTurboCache: false,
+		},
+		Index: indexHTML,
+	}
+
+	s.render(w, r, "blog.html", http.StatusOK, data)
 }
 
 // handleBlogRSS handles serving the blog RSS feed /blog/index.xml.
-func (s *Server) handleBlogRSS(w http.ResponseWriter, _ *http.Request) {
-	// TODO: Serve static/blog/index.xml from StaticFS
-	http.Error(w, "Blog RSS handler stub", http.StatusNotImplemented)
+func (s *Server) handleBlogRSS(w http.ResponseWriter, r *http.Request) {
+	fullPath := path.Join("static", "blog", "index.xml")
+	rssContent, err := fs.ReadFile(s.config.StaticFS, fullPath)
+	if err != nil {
+		s.RenderNotFound(w, r, "")
+
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(rssContent); err != nil {
+		logger.ErrorContext(r.Context(), "Failed to write blog RSS response", slog.Any("error", err))
+	}
 }
 
 // handleBlogPost handles serving individual blog posts /blog/posts/{blog_name}/.
 func (s *Server) handleBlogPost(w http.ResponseWriter, r *http.Request) {
 	blogName := r.PathValue("blog_name")
-	if blogName == "" {
-		http.NotFound(w, r)
+	if blogName == "" || !validBlogName.MatchString(blogName) {
+		s.RenderNotFound(w, r, "")
 
 		return
 	}
 
-	// TODO: Validate blog_name, load static/blog/posts/{blog_name}/index.html and render post template
-	http.Error(w, fmt.Sprintf("Blog post handler stub (blogName=%q)", blogName), http.StatusNotImplemented)
+	postHTML, err := s.loadBlogContent(path.Join("posts", blogName, "index.html"))
+	if err != nil {
+		s.RenderNotFound(w, r, "")
+
+		return
+	}
+
+	data := BlogPostPageData{
+		BasePageData: BasePageData{
+			ActiveSection:     "blog",
+			DisableTurboCache: true,
+		},
+		Content: postHTML,
+	}
+
+	s.render(w, r, "blog_post.html", http.StatusOK, data)
 }
 
 // handleBlogPostFile handles serving static assets inside blog post directories /blog/posts/{blog_name}/{file_name}.
 func (s *Server) handleBlogPostFile(w http.ResponseWriter, r *http.Request) {
 	blogName := r.PathValue("blog_name")
 	fileName := r.PathValue("file_name")
-	if blogName == "" || fileName == "" {
-		http.NotFound(w, r)
+	if blogName == "" || fileName == "" || !validBlogName.MatchString(blogName) {
+		s.RenderNotFound(w, r, "")
 
 		return
 	}
 
-	// TODO: Serve static/blog/posts/{blog_name}/{file_name} from StaticFS
-	http.Error(w, fmt.Sprintf("Blog post asset handler stub (blogName=%q, fileName=%q)", blogName, fileName), http.StatusNotImplemented)
+	assetPath := path.Join("static", "blog", "posts", blogName, path.Base(fileName))
+	assetContent, err := fs.ReadFile(s.config.StaticFS, assetPath)
+	if err != nil {
+		s.RenderNotFound(w, r, "")
+
+		return
+	}
+
+	contentType := mime.TypeByExtension(path.Ext(fileName))
+	if contentType != "" {
+		w.Header().Set("Content-Type", contentType)
+	}
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(assetContent); err != nil {
+		logger.ErrorContext(r.Context(), "Failed to write blog asset response", slog.String("asset", assetPath), slog.Any("error", err))
+	}
 }

--- a/go/internal/website/blog.go
+++ b/go/internal/website/blog.go
@@ -28,7 +28,7 @@ func (s *Server) loadBlogContent(filePath string) (template.HTML, error) {
 func (s *Server) handleBlogIndex(w http.ResponseWriter, r *http.Request) {
 	indexHTML, err := s.loadBlogContent("index.html")
 	if err != nil {
-		s.RenderNotFound(w, r, "")
+		s.RenderNotFound(w, r)
 
 		return
 	}
@@ -49,7 +49,7 @@ func (s *Server) handleBlogRSS(w http.ResponseWriter, r *http.Request) {
 	fullPath := path.Join("static", "blog", "index.xml")
 	rssContent, err := fs.ReadFile(s.config.StaticFS, fullPath)
 	if err != nil {
-		s.RenderNotFound(w, r, "")
+		s.RenderNotFound(w, r)
 
 		return
 	}
@@ -65,14 +65,14 @@ func (s *Server) handleBlogRSS(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleBlogPost(w http.ResponseWriter, r *http.Request) {
 	blogName := r.PathValue("blog_name")
 	if blogName == "" || !validBlogName.MatchString(blogName) {
-		s.RenderNotFound(w, r, "")
+		s.RenderNotFound(w, r)
 
 		return
 	}
 
 	postHTML, err := s.loadBlogContent(path.Join("posts", blogName, "index.html"))
 	if err != nil {
-		s.RenderNotFound(w, r, "")
+		s.RenderNotFound(w, r)
 
 		return
 	}
@@ -93,20 +93,33 @@ func (s *Server) handleBlogPostFile(w http.ResponseWriter, r *http.Request) {
 	blogName := r.PathValue("blog_name")
 	fileName := r.PathValue("file_name")
 	if blogName == "" || fileName == "" || !validBlogName.MatchString(blogName) {
-		s.RenderNotFound(w, r, "")
+		s.RenderNotFound(w, r)
 
 		return
 	}
 
-	assetPath := path.Join("static", "blog", "posts", blogName, path.Base(fileName))
+	baseName := path.Base(fileName)
+	if baseName == "." || baseName == ".." {
+		s.RenderNotFound(w, r)
+
+		return
+	}
+
+	assetPath := path.Join("static", "blog", "posts", blogName, baseName)
+	if !fs.ValidPath(assetPath) {
+		s.RenderNotFound(w, r)
+
+		return
+	}
+
 	assetContent, err := fs.ReadFile(s.config.StaticFS, assetPath)
 	if err != nil {
-		s.RenderNotFound(w, r, "")
+		s.RenderNotFound(w, r)
 
 		return
 	}
 
-	contentType := mime.TypeByExtension(path.Ext(fileName))
+	contentType := mime.TypeByExtension(path.Ext(baseName))
 	if contentType != "" {
 		w.Header().Set("Content-Type", contentType)
 	}

--- a/go/internal/website/linter.go
+++ b/go/internal/website/linter.go
@@ -1,21 +1,27 @@
 package website
 
 import (
-	"fmt"
+	"encoding/json"
 	"net/http"
 )
 
 // handleLinterPage handles serving the linter findings UI page.
-func (s *Server) handleLinterPage(w http.ResponseWriter, _ *http.Request) {
-	// TODO: Serve linter UI page / template
-	http.Error(w, "Linter UI page stub", http.StatusNotImplemented)
+func (s *Server) handleLinterPage(w http.ResponseWriter, r *http.Request) {
+	data := LinterPageData{
+		BasePageData: BasePageData{
+			ActiveSection: "linter",
+		},
+	}
+
+	s.render(w, r, "linter.html", http.StatusOK, data)
 }
 
 // handleLinterSources handles listing sources that have linter findings from GCS.
 func (s *Server) handleLinterSources(w http.ResponseWriter, _ *http.Request) {
 	// TODO: List prefixes in GCS bucket osv-test-public-import-logs under linter-result/
 	w.Header().Set("Content-Type", "application/json")
-	http.Error(w, `{"error": "Linter sources handler stub"}`, http.StatusNotImplemented)
+	//nolint:errchkjson
+	_ = json.NewEncoder(w).Encode([]string{"ghsa", "cve-osv", "malicious-packages"})
 }
 
 // handleLinterFindings handles fetching linter findings JSON for a specific source from GCS.
@@ -29,5 +35,10 @@ func (s *Server) handleLinterFindings(w http.ResponseWriter, r *http.Request) {
 
 	// TODO: Download linter-result/<source>/result.json from GCS bucket
 	w.Header().Set("Content-Type", "application/json")
-	http.Error(w, fmt.Sprintf(`{"error": "Linter findings handler stub", "source": %q}`, source), http.StatusNotImplemented)
+	//nolint:errchkjson
+	_ = json.NewEncoder(w).Encode(map[string][]map[string]string{
+		"path/OSV-1234-5678.json": {{
+			"Code":    "SCH:001",
+			"Message": "record is bad",
+		}}})
 }

--- a/go/internal/website/linter.go
+++ b/go/internal/website/linter.go
@@ -13,7 +13,7 @@ func (s *Server) handleLinterPage(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 
-	s.render(w, r, "linter.html", http.StatusOK, data)
+	s.renderStandalone(w, r, "linter.html", http.StatusOK, data)
 }
 
 // handleLinterSources handles listing sources that have linter findings from GCS.

--- a/go/internal/website/pagedata.go
+++ b/go/internal/website/pagedata.go
@@ -1,0 +1,29 @@
+package website
+
+// BasePageData contains common fields required by the base.html layout template.
+type BasePageData struct {
+	ActiveSection     string
+	DisableTurboCache bool
+}
+
+// EcosystemDisplay holds pre-calculated bubble data for ecosystem vulnerability counts on the home page.
+type EcosystemDisplay struct {
+	Name       string
+	Count      int
+	Radius     float64
+	TooltipTop float64
+}
+
+// HomePageData represents the data context passed to home.html template.
+type HomePageData struct {
+	BasePageData
+
+	Ecosystems []EcosystemDisplay
+}
+
+// NotFoundPageData represents the data context passed to 404.html template.
+type NotFoundPageData struct {
+	BasePageData
+
+	FailedImportVulnID string
+}

--- a/go/internal/website/pagedata.go
+++ b/go/internal/website/pagedata.go
@@ -48,3 +48,12 @@ type BlogPostPageData struct {
 type LinterPageData struct {
 	BasePageData
 }
+
+// TriagePageData represents the data context passed to triage.html template.
+type TriagePageData struct {
+	BasePageData
+
+	// Columns contains 1-indexed column numbers (e.g., []int{1, 2, 3}) to match
+	// element IDs (e.g. column-1) and URL query parameters (s1, s2, s3) expected by triage.js.
+	Columns []int
+}

--- a/go/internal/website/pagedata.go
+++ b/go/internal/website/pagedata.go
@@ -43,3 +43,8 @@ type BlogPostPageData struct {
 
 	Content template.HTML
 }
+
+// LinterPageData represents the data context passed to linter.html template.
+type LinterPageData struct {
+	BasePageData
+}

--- a/go/internal/website/pagedata.go
+++ b/go/internal/website/pagedata.go
@@ -1,5 +1,7 @@
 package website
 
+import "html/template"
+
 // BasePageData contains common fields required by the base.html layout template.
 type BasePageData struct {
 	ActiveSection     string
@@ -26,4 +28,18 @@ type NotFoundPageData struct {
 	BasePageData
 
 	FailedImportVulnID string
+}
+
+// BlogPageData represents the data context passed to blog.html template.
+type BlogPageData struct {
+	BasePageData
+
+	Index template.HTML
+}
+
+// BlogPostPageData represents the data context passed to blog_post.html template.
+type BlogPostPageData struct {
+	BasePageData
+
+	Content template.HTML
 }

--- a/go/internal/website/server.go
+++ b/go/internal/website/server.go
@@ -170,6 +170,7 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /linter-findings/{source}", s.handleLinterFindings)
 
 	// Triage workflow
+	// TODO: auth stuff
 	s.mux.HandleFunc("GET /triage", s.handleTriagePage)
 	s.mux.HandleFunc("POST /triage/proxy", s.handleTriageProxy)
 

--- a/go/internal/website/server.go
+++ b/go/internal/website/server.go
@@ -2,11 +2,14 @@
 package website
 
 import (
+	"bytes"
 	"errors"
+	"html/template"
 	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
+	"path"
 	"time"
 
 	"github.com/google/osv.dev/go/logger"
@@ -16,8 +19,9 @@ const goVanityMetadata = `<meta name="go-import" content="osv.dev git https://gi
 
 // Config holds configuration options for the website server.
 type Config struct {
-	StaticFS fs.FS
-	DocsFS   fs.FS
+	StaticFS    fs.FS
+	DocsFS      fs.FS
+	TemplateDir string
 }
 
 // Server handles website routing and HTTP requests.
@@ -165,4 +169,36 @@ func (s *Server) registerRoutes() {
 func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("OK"))
+}
+
+func (s *Server) render(w http.ResponseWriter, r *http.Request, pageFile string, status int, data any) {
+	templateDir := s.config.TemplateDir
+	if templateDir == "" {
+		templateDir = "go"
+	}
+
+	basePath := path.Join(templateDir, "base.html")
+	pagePath := path.Join(templateDir, pageFile)
+
+	tmpl, err := template.ParseFS(s.config.StaticFS, basePath, pagePath)
+	if err != nil {
+		logger.ErrorContext(r.Context(), "Failed to parse template", slog.String("page", pageFile), slog.Any("error", err))
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	var buf bytes.Buffer
+	if err := tmpl.ExecuteTemplate(&buf, "base.html", data); err != nil {
+		logger.ErrorContext(r.Context(), "Failed to execute template", slog.String("page", pageFile), slog.Any("error", err))
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+
+		return
+	}
+
+	w.WriteHeader(status)
+	if _, err := buf.WriteTo(w); err != nil {
+		logger.ErrorContext(r.Context(), "Failed to write rendered template response", slog.String("page", pageFile), slog.Any("error", err))
+	}
 }

--- a/go/internal/website/server.go
+++ b/go/internal/website/server.go
@@ -69,8 +69,8 @@ func NewServer(cfg Config) (*Server, error) {
 	}
 	s.registerRoutes()
 
-	// Middlewares: Logging (if local/dev) -> ServeMux
-	var h http.Handler = s.mux
+	// Middlewares: 404 Fallback -> Logging (if local/dev) -> ServeMux
+	h := s.notFoundMiddleware(s.mux)
 
 	// Skip HTTP access logging in Cloud Run production to avoid duplicating Cloud Run infrastructure logs.
 	if os.Getenv("K_SERVICE") == "" {
@@ -102,6 +102,19 @@ func loggingMiddleware(next http.Handler) http.Handler {
 			slog.Duration("duration", time.Since(start)),
 			slog.Int64("bytes", rw.bytesWritten),
 		)
+	})
+}
+
+// notFoundMiddleware returns an http.Handler that renders 404.html for unmatched routes.
+func (s *Server) notFoundMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, pattern := s.mux.Handler(r)
+		if pattern == "" {
+			s.RenderNotFound(w, r, "")
+
+			return
+		}
+		next.ServeHTTP(w, r)
 	})
 }
 

--- a/go/internal/website/server.go
+++ b/go/internal/website/server.go
@@ -110,7 +110,7 @@ func (s *Server) notFoundMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, pattern := s.mux.Handler(r)
 		if pattern == "" {
-			s.RenderNotFound(w, r, "")
+			s.RenderNotFound(w, r)
 
 			return
 		}
@@ -172,7 +172,7 @@ func (s *Server) registerRoutes() {
 	// Triage workflow
 	// TODO: auth stuff
 	s.mux.HandleFunc("GET /triage", s.handleTriagePage)
-	s.mux.HandleFunc("POST /triage/proxy", s.handleTriageProxy)
+	s.mux.HandleFunc("/triage/proxy", s.handleTriageProxy)
 
 	// Google OAuth authentication
 	s.mux.HandleFunc("GET /login", s.handleLogin)
@@ -185,18 +185,27 @@ func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
 	_, _ = w.Write([]byte("OK"))
 }
 
-func (s *Server) render(w http.ResponseWriter, r *http.Request, pageFile string, status int, data any) {
+// renderTemplates parses the specified template files relative to config.TemplateDir
+// and executes the entry template identified by path.Base(files[0]).
+func (s *Server) renderTemplates(w http.ResponseWriter, r *http.Request, status int, data any, files ...string) {
+	if len(files) == 0 {
+		return
+	}
+
 	templateDir := s.config.TemplateDir
 	if templateDir == "" {
 		templateDir = "go"
 	}
 
-	basePath := path.Join(templateDir, "base.html")
-	pagePath := path.Join(templateDir, pageFile)
+	paths := make([]string, len(files))
+	for i, f := range files {
+		paths[i] = path.Join(templateDir, f)
+	}
 
-	tmpl, err := template.ParseFS(s.config.StaticFS, basePath, pagePath)
+	entryName := path.Base(files[0])
+	tmpl, err := template.ParseFS(s.config.StaticFS, paths...)
 	if err != nil {
-		logger.ErrorContext(r.Context(), "Failed to parse template", slog.String("page", pageFile), slog.Any("error", err))
+		logger.ErrorContext(r.Context(), "Failed to parse template", slog.String("page", entryName), slog.Any("error", err))
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 
 		return
@@ -204,8 +213,8 @@ func (s *Server) render(w http.ResponseWriter, r *http.Request, pageFile string,
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	var buf bytes.Buffer
-	if err := tmpl.ExecuteTemplate(&buf, "base.html", data); err != nil {
-		logger.ErrorContext(r.Context(), "Failed to execute template", slog.String("page", pageFile), slog.Any("error", err))
+	if err := tmpl.ExecuteTemplate(&buf, entryName, data); err != nil {
+		logger.ErrorContext(r.Context(), "Failed to execute template", slog.String("page", entryName), slog.Any("error", err))
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 
 		return
@@ -213,6 +222,14 @@ func (s *Server) render(w http.ResponseWriter, r *http.Request, pageFile string,
 
 	w.WriteHeader(status)
 	if _, err := buf.WriteTo(w); err != nil {
-		logger.ErrorContext(r.Context(), "Failed to write rendered template response", slog.String("page", pageFile), slog.Any("error", err))
+		logger.ErrorContext(r.Context(), "Failed to write rendered template response", slog.String("page", entryName), slog.Any("error", err))
 	}
+}
+
+func (s *Server) render(w http.ResponseWriter, r *http.Request, pageFile string, status int, data any) {
+	s.renderTemplates(w, r, status, data, "base.html", pageFile)
+}
+
+func (s *Server) renderStandalone(w http.ResponseWriter, r *http.Request, pageFile string, status int, data any) {
+	s.renderTemplates(w, r, status, data, pageFile)
 }

--- a/go/internal/website/server_test.go
+++ b/go/internal/website/server_test.go
@@ -214,6 +214,9 @@ func TestStaticFiles(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(goDir, "home.html"), []byte(`{{ define "content" }}Home{{ end }}`), 0600); err != nil {
 		t.Fatalf("failed to write home.html: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(goDir, "404.html"), []byte(`{{ define "content" }}404 {{ .FailedImportVulnID }}{{ end }}`), 0600); err != nil {
+		t.Fatalf("failed to write 404.html: %v", err)
+	}
 	if err := os.WriteFile(filepath.Join(imgDir, "favicon-32x32.png"), []byte("FAVICON"), 0600); err != nil {
 		t.Fatalf("failed to write favicon: %v", err)
 	}
@@ -228,6 +231,28 @@ func TestStaticFiles(t *testing.T) {
 
 		if rec.Code != http.StatusOK {
 			t.Errorf("expected status 200 OK, got %d", rec.Code)
+		}
+	})
+
+	t.Run("renderNotFound", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/404", nil)
+		rec := httptest.NewRecorder()
+		srv.RenderNotFound(rec, req, "GHSA-1234")
+
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("expected status 404 Not Found, got %d", rec.Code)
+		}
+	})
+
+	t.Run("UnmatchedRoute_returns_404", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/foo/bar", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("expected status 404 Not Found, got %d", rec.Code)
 		}
 	})
 
@@ -300,8 +325,8 @@ func TestEndpointRegistration(t *testing.T) {
 			rec := httptest.NewRecorder()
 			srv.ServeHTTP(rec, req)
 
-			if rec.Code == http.StatusNotFound {
-				t.Errorf("expected route %s %s to be registered, got 404 Not Found", ep.method, ep.path)
+			if rec.Code != http.StatusNotImplemented {
+				t.Errorf("expected status 501 Not Implemented, got %d", rec.Code)
 			}
 		})
 	}

--- a/go/internal/website/server_test.go
+++ b/go/internal/website/server_test.go
@@ -244,11 +244,25 @@ func TestStaticFiles(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(postDir, "hero.png"), []byte("PNG_DATA"), 0600); err != nil {
 		t.Fatalf("failed to write blog post image asset: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(goDir, "linter.html"), []byte("<html>Linter Report</html>"), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(goDir, "triage.html"), []byte(`{{ define "content" }}Triage{{ end }}`), 0600); err != nil {
+		t.Fatalf("failed to write triage.html: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(goDir, "linter.html"), []byte(`{{ define "content" }}Linter Report{{ end }}`), 0600); err != nil {
 		t.Fatalf("failed to write linter.html: %v", err)
 	}
 
 	srv := newTestServer(t, website.Config{StaticFS: os.DirFS(tmpDir)})
+
+	t.Run("Triage_page", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/triage", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200 OK, got %d", rec.Code)
+		}
+	})
 
 	t.Run("Linter_page", func(t *testing.T) {
 		t.Parallel()
@@ -386,7 +400,6 @@ func TestEndpointRegistration(t *testing.T) {
 		{http.MethodGet, "/GHSA-1234"},
 		{http.MethodGet, "/vulnerability/GHSA-1234.json"},
 		{http.MethodGet, "/GHSA-1234.json"},
-		{http.MethodGet, "/triage"},
 		{http.MethodPost, "/triage/proxy"},
 		{http.MethodGet, "/login"},
 		{http.MethodGet, "/auth/callback"},

--- a/go/internal/website/server_test.go
+++ b/go/internal/website/server_test.go
@@ -204,7 +204,14 @@ func TestStaticFiles(t *testing.T) {
 		t.Fatalf("failed to create static img dir: %v", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(tmpDir, "home.html"), []byte("<html>Home</html>"), 0600); err != nil {
+	goDir := filepath.Join(tmpDir, "go")
+	if err := os.MkdirAll(goDir, 0755); err != nil {
+		t.Fatalf("failed to create go dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(goDir, "base.html"), []byte(`<html>{{ block "content" . }}{{ end }}</html>`), 0600); err != nil {
+		t.Fatalf("failed to write base.html: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(goDir, "home.html"), []byte(`{{ define "content" }}Home{{ end }}`), 0600); err != nil {
 		t.Fatalf("failed to write home.html: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(imgDir, "favicon-32x32.png"), []byte("FAVICON"), 0600); err != nil {
@@ -213,7 +220,7 @@ func TestStaticFiles(t *testing.T) {
 
 	srv := newTestServer(t, website.Config{StaticFS: os.DirFS(tmpDir)})
 
-	t.Run("Root serves home.html", func(t *testing.T) {
+	t.Run("Root", func(t *testing.T) {
 		t.Parallel()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		rec := httptest.NewRecorder()
@@ -221,9 +228,6 @@ func TestStaticFiles(t *testing.T) {
 
 		if rec.Code != http.StatusOK {
 			t.Errorf("expected status 200 OK, got %d", rec.Code)
-		}
-		if rec.Body.String() != "<html>Home</html>" {
-			t.Errorf("expected body <html>Home</html>, got %q", rec.Body.String())
 		}
 	})
 

--- a/go/internal/website/server_test.go
+++ b/go/internal/website/server_test.go
@@ -221,7 +221,81 @@ func TestStaticFiles(t *testing.T) {
 		t.Fatalf("failed to write favicon: %v", err)
 	}
 
+	blogDir := filepath.Join(tmpDir, "static", "blog")
+	postDir := filepath.Join(blogDir, "posts", "hello-world")
+	if err := os.MkdirAll(postDir, 0755); err != nil {
+		t.Fatalf("failed to create blog post dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(goDir, "blog.html"), []byte(`{{ define "content" }}Blog Index: {{ .Index }}{{ end }}`), 0600); err != nil {
+		t.Fatalf("failed to write blog.html: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(goDir, "blog_post.html"), []byte(`{{ define "content" }}Blog Post: {{ .Content }}{{ end }}`), 0600); err != nil {
+		t.Fatalf("failed to write blog_post.html: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(blogDir, "index.html"), []byte("<h1>Blog Index</h1>"), 0600); err != nil {
+		t.Fatalf("failed to write blog index: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(blogDir, "index.xml"), []byte("<rss>RSS</rss>"), 0600); err != nil {
+		t.Fatalf("failed to write blog rss: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(postDir, "index.html"), []byte("<article>Hello World</article>"), 0600); err != nil {
+		t.Fatalf("failed to write blog post content: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(postDir, "hero.png"), []byte("PNG_DATA"), 0600); err != nil {
+		t.Fatalf("failed to write blog post image asset: %v", err)
+	}
+
 	srv := newTestServer(t, website.Config{StaticFS: os.DirFS(tmpDir)})
+
+	t.Run("Blog_index", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/blog", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200 OK, got %d", rec.Code)
+		}
+	})
+
+	t.Run("Blog_rss_serves_xml", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/blog/index.xml", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200 OK, got %d", rec.Code)
+		}
+		if contentType := rec.Header().Get("Content-Type"); contentType != "application/xml; charset=utf-8" {
+			t.Errorf("expected content-type 'application/xml; charset=utf-8', got %q", contentType)
+		}
+	})
+
+	t.Run("Blog_post", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/blog/posts/hello-world/", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200 OK, got %d", rec.Code)
+		}
+	})
+
+	t.Run("Blog_post_asset_serves_file", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/blog/posts/hello-world/hero.png", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200 OK, got %d", rec.Code)
+		}
+		if rec.Body.String() != "PNG_DATA" {
+			t.Errorf("expected body 'PNG_DATA', got %q", rec.Body.String())
+		}
+	})
 
 	t.Run("Root", func(t *testing.T) {
 		t.Parallel()
@@ -294,12 +368,6 @@ func TestEndpointRegistration(t *testing.T) {
 		method string
 		path   string
 	}{
-		{http.MethodGet, "/blog"},
-		{http.MethodGet, "/blog/"},
-		{http.MethodGet, "/blog/index.xml"},
-		{http.MethodGet, "/blog/posts/test-post"},
-		{http.MethodGet, "/blog/posts/test-post/"},
-		{http.MethodGet, "/blog/posts/test-post/image.png"},
 		{http.MethodGet, "/vulnerability/GHSA-1234"},
 		{http.MethodGet, "/GHSA-1234"},
 		{http.MethodGet, "/vulnerability/GHSA-1234.json"},

--- a/go/internal/website/server_test.go
+++ b/go/internal/website/server_test.go
@@ -244,8 +244,22 @@ func TestStaticFiles(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(postDir, "hero.png"), []byte("PNG_DATA"), 0600); err != nil {
 		t.Fatalf("failed to write blog post image asset: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(goDir, "linter.html"), []byte("<html>Linter Report</html>"), 0600); err != nil {
+		t.Fatalf("failed to write linter.html: %v", err)
+	}
 
 	srv := newTestServer(t, website.Config{StaticFS: os.DirFS(tmpDir)})
+
+	t.Run("Linter_page", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/linter", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200 OK, got %d", rec.Code)
+		}
+	})
 
 	t.Run("Blog_index", func(t *testing.T) {
 		t.Parallel()
@@ -372,13 +386,6 @@ func TestEndpointRegistration(t *testing.T) {
 		{http.MethodGet, "/GHSA-1234"},
 		{http.MethodGet, "/vulnerability/GHSA-1234.json"},
 		{http.MethodGet, "/GHSA-1234.json"},
-		{http.MethodGet, "/list"},
-		{http.MethodGet, "/api/search_suggestions"},
-		{http.MethodGet, "/linter"},
-		{http.MethodGet, "/linter/"},
-		{http.MethodGet, "/linter-findings"},
-		{http.MethodGet, "/linter-findings/"},
-		{http.MethodGet, "/linter-findings/test-source"},
 		{http.MethodGet, "/triage"},
 		{http.MethodPost, "/triage/proxy"},
 		{http.MethodGet, "/login"},

--- a/go/internal/website/server_test.go
+++ b/go/internal/website/server_test.go
@@ -247,7 +247,7 @@ func TestStaticFiles(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(goDir, "triage.html"), []byte(`{{ define "content" }}Triage{{ end }}`), 0600); err != nil {
 		t.Fatalf("failed to write triage.html: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(goDir, "linter.html"), []byte(`{{ define "content" }}Linter Report{{ end }}`), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(goDir, "linter.html"), []byte(`Linter Report`), 0600); err != nil {
 		t.Fatalf("failed to write linter.html: %v", err)
 	}
 
@@ -325,6 +325,17 @@ func TestStaticFiles(t *testing.T) {
 		}
 	})
 
+	t.Run("Blog_post_asset_invalid_base", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/blog/posts/hello-world/..", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusNotFound && rec.Code != http.StatusBadRequest && rec.Code != http.StatusMovedPermanently && rec.Code != http.StatusTemporaryRedirect {
+			t.Errorf("expected status 404, 400, 301, or 307, got %d", rec.Code)
+		}
+	})
+
 	t.Run("Root", func(t *testing.T) {
 		t.Parallel()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -340,7 +351,18 @@ func TestStaticFiles(t *testing.T) {
 		t.Parallel()
 		req := httptest.NewRequest(http.MethodGet, "/404", nil)
 		rec := httptest.NewRecorder()
-		srv.RenderNotFound(rec, req, "GHSA-1234")
+		srv.RenderNotFound(rec, req)
+
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("expected status 404 Not Found, got %d", rec.Code)
+		}
+	})
+
+	t.Run("renderNotFoundWithVuln", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/404", nil)
+		rec := httptest.NewRecorder()
+		srv.RenderNotFoundWithVuln(rec, req, "GHSA-1234")
 
 		if rec.Code != http.StatusNotFound {
 			t.Errorf("expected status 404 Not Found, got %d", rec.Code)

--- a/go/internal/website/static.go
+++ b/go/internal/website/static.go
@@ -1,10 +1,71 @@
 package website
 
 import (
+	"context"
 	"fmt"
 	"io/fs"
+	"math"
 	"net/http"
+	"sort"
+	"strings"
 )
+
+// EcosystemDisplay holds pre-calculated bubble data for ecosystem vulnerability counts on the home page.
+type EcosystemDisplay struct {
+	Name       string
+	Count      int
+	Radius     float64
+	TooltipTop float64
+}
+
+// HomePageData represents the data context passed to home.html template.
+type HomePageData struct {
+	ActiveSection     string
+	DisableTurboCache bool
+	Ecosystems        []EcosystemDisplay
+}
+
+func computeEcosystemDisplays(counts map[string]int) []EcosystemDisplay {
+	var total int
+	for _, c := range counts {
+		total += c
+	}
+	if total == 0 {
+		return nil
+	}
+
+	totalLog := math.Log(float64(total))
+	displays := make([]EcosystemDisplay, 0, len(counts))
+	for eco, count := range counts {
+		if count <= 30 {
+			continue
+		}
+		radius := math.Max((math.Log(float64(count))/totalLog)*100, 30)
+		tooltipTop := -((radius / 2) + 5)
+		displays = append(displays, EcosystemDisplay{
+			Name:       eco,
+			Count:      count,
+			Radius:     radius,
+			TooltipTop: tooltipTop,
+		})
+	}
+	sort.Slice(displays, func(i, j int) bool {
+		return strings.ToLower(displays[i].Name) < strings.ToLower(displays[j].Name)
+	})
+
+	return displays
+}
+
+func (s *Server) getEcosystemCounts(_ context.Context) map[string]int {
+	// Stub for ecosystem count fetch (Datastore or cache integration)
+	return map[string]int{
+		"PyPI": 23174,
+		"npm":  222222,
+		"Go":   8010,
+		"GIT":  943411,
+		"Pub":  11,
+	}
+}
 
 func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Query().Get("go-get") == "1" {
@@ -13,7 +74,14 @@ func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
 
 		return
 	}
-	http.ServeFileFS(w, r, s.config.StaticFS, "home.html")
+
+	data := HomePageData{
+		ActiveSection:     "home",
+		DisableTurboCache: false,
+		Ecosystems:        computeEcosystemDisplays(s.getEcosystemCounts(r.Context())),
+	}
+
+	s.render(w, r, "home.html", http.StatusOK, data)
 }
 
 func (s *Server) handleGoBindingsVanity(w http.ResponseWriter, r *http.Request) {

--- a/go/internal/website/static.go
+++ b/go/internal/website/static.go
@@ -10,19 +10,16 @@ import (
 	"strings"
 )
 
-// EcosystemDisplay holds pre-calculated bubble data for ecosystem vulnerability counts on the home page.
-type EcosystemDisplay struct {
-	Name       string
-	Count      int
-	Radius     float64
-	TooltipTop float64
-}
+func (s *Server) RenderNotFound(w http.ResponseWriter, r *http.Request, failedImportVulnID string) {
+	data := NotFoundPageData{
+		BasePageData: BasePageData{
+			ActiveSection:     "",
+			DisableTurboCache: false,
+		},
+		FailedImportVulnID: failedImportVulnID,
+	}
 
-// HomePageData represents the data context passed to home.html template.
-type HomePageData struct {
-	ActiveSection     string
-	DisableTurboCache bool
-	Ecosystems        []EcosystemDisplay
+	s.render(w, r, "404.html", http.StatusNotFound, data)
 }
 
 func computeEcosystemDisplays(counts map[string]int) []EcosystemDisplay {
@@ -76,9 +73,11 @@ func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := HomePageData{
-		ActiveSection:     "home",
-		DisableTurboCache: false,
-		Ecosystems:        computeEcosystemDisplays(s.getEcosystemCounts(r.Context())),
+		BasePageData: BasePageData{
+			ActiveSection:     "home",
+			DisableTurboCache: false,
+		},
+		Ecosystems: computeEcosystemDisplays(s.getEcosystemCounts(r.Context())),
 	}
 
 	s.render(w, r, "home.html", http.StatusOK, data)

--- a/go/internal/website/static.go
+++ b/go/internal/website/static.go
@@ -10,7 +10,13 @@ import (
 	"strings"
 )
 
-func (s *Server) RenderNotFound(w http.ResponseWriter, r *http.Request, failedImportVulnID string) {
+// RenderNotFound renders the standard 404 Not Found page.
+func (s *Server) RenderNotFound(w http.ResponseWriter, r *http.Request) {
+	s.RenderNotFoundWithVuln(w, r, "")
+}
+
+// RenderNotFoundWithVuln renders the 404 Not Found page with a failed import vulnerability ID.
+func (s *Server) RenderNotFoundWithVuln(w http.ResponseWriter, r *http.Request, failedImportVulnID string) {
 	data := NotFoundPageData{
 		BasePageData: BasePageData{
 			ActiveSection:     "",

--- a/go/internal/website/triage.go
+++ b/go/internal/website/triage.go
@@ -5,9 +5,15 @@ import (
 )
 
 // handleTriagePage handles serving the vulnerability triage UI page.
-func (s *Server) handleTriagePage(w http.ResponseWriter, _ *http.Request) {
-	// TODO: Serve triage page / template
-	http.Error(w, "Triage UI page stub", http.StatusNotImplemented)
+func (s *Server) handleTriagePage(w http.ResponseWriter, r *http.Request) {
+	data := TriagePageData{
+		BasePageData: BasePageData{
+			ActiveSection: "triage",
+		},
+		Columns: []int{1, 2, 3},
+	}
+
+	s.render(w, r, "triage.html", http.StatusOK, data)
 }
 
 // handleTriageProxy handles proxying triage workflow actions.


### PR DESCRIPTION
Start migrating many of the website templates from Jinja templates to use go's native `html/template` syntax.
This does most pages except the individual vulnerability page and the list page (because those templates are more involved, and were going to make the PR too big).

The first commit on this branch is me copying over the original Python templates to a new folder - you may want to compare against that commit to see the actual changes to the templates