### PR TITLE
feat: increase debian-cve-convert memory limit and request to 16G

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/feeds/debian-cve-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/base/feeds/debian-cve-convert.yaml
@@ -24,10 +24,10 @@ spec:
             resources:
               requests:
                 cpu: "2"
-                memory: "12G"
+                memory: "16G"
               limits:
                 cpu: "4"
-                memory: "12G"
+                memory: "16G"
           restartPolicy: Never
           volumes:
             - name: "ssd"


### PR DESCRIPTION
Increases the memory request and limit for the `debian-cve-convert` CronJob container to 16G.

agy