### PR TITLE
feat(website): custom collapsible JSON viewer with finding path highlighting

### DIFF
--- a/gcp/website/frontend3/src/linter.js
+++ b/gcp/website/frontend3/src/linter.js
@@ -104,7 +104,10 @@ document.addEventListener("DOMContentLoaded", function () {
             const url = `/linter-findings/${sourceName}`;
             return fetch(url)
               .then((res) => (res.ok ? res.json() : {}))
-              .catch(() => ({}));
+              .catch((e) => {
+                  console.warn(`Failed to fetch linter source: ${sourceName}`, e);
+                  return {};
+              });
           });
           const linterResults = await Promise.all(linterPromises);
           linterResults.forEach((data) => {

--- a/gcp/website/frontend3/src/linter.js
+++ b/gcp/website/frontend3/src/linter.js
@@ -1,10 +1,15 @@
 import "./linter.scss";
+import "@github/clipboard-copy-element";
+
+
 
 document.addEventListener("DOMContentLoaded", function () {
   let allIssues = [];
   let issuesByHomeDb = {};
   let filteredIssues = [];
   let findingDetails = {};
+  let activeVulnData = {};
+  let activeVulnValueMaps = {};
   const issuesPerPage = 15;
   let currentPage = 1;
   let sortDirection = "desc";
@@ -90,20 +95,29 @@ document.addEventListener("DOMContentLoaded", function () {
 
     // Get the detailed linter results from GCS bucket
     const linterPromise = (async () => {
-      const linterPromises = sourceNames.map((sourceName) => {
-        const url = `/linter-findings/${sourceName}`;
-        return fetch(url)
-          .then((res) => (res.ok ? res.json() : {}))
-          .catch(() => ({}));
-      });
-      const linterResults = await Promise.all(linterPromises);
-      linterResults.forEach((data) => {
-        for (const path in data) {
-          const bugId = path.split("/").pop().replace(".json", "");
-          if (!findingDetails[bugId]) findingDetails[bugId] = [];
-          findingDetails[bugId].push(...data[path]);
+      try {
+        const rootRes = await fetch("/linter-findings/");
+        if (rootRes.ok) {
+          const activeSources = await rootRes.json();
+          const sourcesToFetch = sourceNames.filter((name) => activeSources.includes(name));
+          const linterPromises = sourcesToFetch.map((sourceName) => {
+            const url = `/linter-findings/${sourceName}`;
+            return fetch(url)
+              .then((res) => (res.ok ? res.json() : {}))
+              .catch(() => ({}));
+          });
+          const linterResults = await Promise.all(linterPromises);
+          linterResults.forEach((data) => {
+            for (const path in data) {
+              const bugId = path.split("/").pop().replace(".json", "");
+              if (!findingDetails[bugId]) findingDetails[bugId] = [];
+              findingDetails[bugId].push(...data[path]);
+            }
+          });
         }
-      });
+      } catch (e) {
+        console.error("Failed to fetch active linter sources", e);
+      }
     })();
     allPromises.push(linterPromise);
 
@@ -390,11 +404,21 @@ document.addEventListener("DOMContentLoaded", function () {
     paginationControls.appendChild(nextButton);
   }
 
+  /**
+   * Sanitizes a vulnerability ID string by stripping special characters for safe DOM element ID usage.
+   * @param {string} bugId - Raw vulnerability identifier.
+   * @returns {string} Sanitized ID string.
+   */
   function sanitiseBugId(bugId) {
-    // This regular expression keeps only letters, numbers, hyphens, and colons.
+    // Keep only alphanumeric characters, hyphens, and colons
     return bugId.replace(/[^a-zA-Z0-9-:]/g, "");
   }
 
+  /**
+   * Opens a detailed tab view split into Vulnerability JSON and Linter Findings columns.
+   * Fetches full vulnerability record JSON from the API and renders the interactive JSON tree.
+   * @param {string} bugId - Vulnerability identifier.
+   */
   function openCombinedView(bugId) {
     const safeBugId = sanitiseBugId(bugId);
 
@@ -424,6 +448,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
     const vulnJsonId = `vuln-json-${safeBugId}`;
     const findingsJsonId = `findings-json-${safeBugId}`;
+    const copyButtonId = `copy-json-${safeBugId}`;
 
     const tabContent = document.createElement("div");
     tabContent.className = "tab-content";
@@ -432,15 +457,24 @@ document.addEventListener("DOMContentLoaded", function () {
     tabContent.innerHTML = `
       <div class="details-grid">
           <div class="details-column">
-              <h2>Vulnerability Data</h2>
-              <pre id="${vulnJsonId}" class="json-pre">Loading...</pre>
+              <div class="details-header">
+                  <h2>Vulnerability Data</h2>
+                  <clipboard-copy id="${copyButtonId}" class="copy-button" title="Copy raw JSON">
+                      <i class="material-icons">content_copy</i>
+                  </clipboard-copy>
+              </div>
+              <div id="${vulnJsonId}" class="json-container">Loading...</div>
           </div>
           <div class="details-column">
-              <h2>Linter Findings</h2>
+              <div class="details-header">
+                  <h2>Linter Findings</h2>
+              </div>
               <div id="${findingsJsonId}" class="json-pre">Loading...</div>
           </div>
       </div>
                 `;
+
+
 
     tabsContent.appendChild(tabContent);
     setActiveTab(tabId);
@@ -451,8 +485,45 @@ document.addEventListener("DOMContentLoaded", function () {
         res.ok ? res.json() : { error: `Failed to load: ${res.status}` }
       )
       .then((data) => {
-        document.getElementById(vulnJsonId).textContent = 
-          JSON.stringify(data, null, 2);
+        const container = document.getElementById(vulnJsonId);
+        container.textContent = ''; // Clear "Loading..."
+        if (data.error) {
+          container.textContent = data.error;
+          return;
+        }
+        activeVulnData[bugId] = data;
+
+        const copyButton = document.getElementById(copyButtonId);
+        if (copyButton) {
+          const jsonStr = JSON.stringify(data, null, 2);
+          copyButton.value = jsonStr;
+          copyButton.setAttribute('value', jsonStr);
+          copyButton.addEventListener('clipboard-copy', () => {
+            const icon = copyButton.querySelector('.material-icons');
+            if (icon) icon.textContent = 'check';
+            setTimeout(() => {
+              if (icon) icon.textContent = 'content_copy';
+            }, 2000);
+          });
+        }
+
+        const valueMap = {};
+        activeVulnValueMaps[bugId] = valueMap;
+        
+        container.appendChild(renderCustomJSON(data, '', true, valueMap));
+
+        // Use Event Delegation on the container for collapsible JSON nodes
+        container.addEventListener('click', (e) => {
+          const toggle = e.target.closest('.json-toggle');
+          if (!toggle) return;
+          e.stopPropagation();
+          const isOpen = toggle.classList.toggle('open');
+          setToggleState(toggle, isOpen);
+          const children = toggle.nextElementSibling;
+          if (children && children.classList.contains('json-children')) {
+            children.style.display = isOpen ? 'block' : 'none';
+          }
+        });
       })
       .catch((err) => {
         document.getElementById(
@@ -460,25 +531,45 @@ document.addEventListener("DOMContentLoaded", function () {
         ).textContent = `Error: ${err.message}`;
       });
 
+
     // Display finding data
     const details = findingDetails[bugId];
     const findingsEl = document.getElementById(findingsJsonId);
     if (details?.length) {
       findingsEl.textContent = ''; // Clear "Loading..."
-      findingsEl.appendChild(formatFindings(details));
+      findingsEl.appendChild(formatFindings(details, bugId));
     } else {
       findingsEl.textContent =
           "No linter findings available for this vulnerability.";
     }
   }
 
-  function formatFindings(details) {
+  /**
+   * Updates the visual open/collapsed state and label text of a JSON toggle element.
+   * @param {HTMLElement} toggle - The toggle span element.
+   * @param {boolean} isOpen - Whether the section is expanded.
+   */
+  function setToggleState(toggle, isOpen) {
+    toggle.classList.toggle('open', isOpen);
+    const isArray = toggle.dataset.isObject !== 'true';
+    toggle.textContent = isOpen 
+      ? (isArray ? '▼ [' : '▼ {') 
+      : (isArray ? '▶ [...]' : '▶ {...}');
+  }
+
+  /**
+   * Generates an HTML table displaying linter findings for a given vulnerability.
+   * @param {Array<Object>} details - List of linter finding objects.
+   * @param {string} bugId - The vulnerability identifier.
+   * @returns {HTMLTableElement} The constructed findings table element.
+   */
+  function formatFindings(details, bugId) {
     const table = document.createElement('table');
     table.className = 'findings-table';
 
     const thead = table.createTHead();
     const headerRow = thead.insertRow();
-    ['Code', 'Message'].forEach(headerText => {
+    ['Code', 'Message', ''].forEach(headerText => {
       const th = document.createElement('th');
       th.textContent = headerText;
       headerRow.appendChild(th);
@@ -487,11 +578,274 @@ document.addEventListener("DOMContentLoaded", function () {
     const tbody = table.createTBody();
     details.forEach((finding) => {
       const row = tbody.insertRow();
+      row.className = 'clickable-finding-row';
       row.insertCell().textContent = finding.Code || '';
       row.insertCell().textContent = finding.Message || '';
+      
+      const actionCell = row.insertCell();
+      actionCell.className = 'action-cell';
+      actionCell.innerHTML = '<i class="material-icons">search</i>';
+
+      row.addEventListener('click', () => {
+        highlightFinding(bugId, finding);
+      });
     });
 
     return table;
+  }
+
+  /**
+   * Recursively searches an object for a target value and returns all dot-separated JSON paths leading to it.
+   * @param {*} obj - The object or value to inspect.
+   * @param {*} value - The target value to locate.
+   * @param {string[]} [currentPath=[]] - Accumulated path segments.
+   * @param {string[]} [results=[]] - Accumulated path string results.
+   * @returns {string[]} Found path strings.
+   */
+  function findPathsForValue(obj, value, currentPath = [], results = []) {
+    if (obj === value) {
+      results.push(currentPath.join('.'));
+      return results;
+    }
+    if (typeof obj === 'object' && obj !== null) {
+      for (const key in obj) {
+        findPathsForValue(obj[key], value, [...currentPath, key], results);
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Compares two range objects to check if their type, repo, and events match.
+   * @param {Object} r1 - First range object.
+   * @param {Object} r2 - Second range object.
+   * @returns {boolean} True if ranges match.
+   */
+  function isSameRange(r1, r2) {
+    if (r1.type !== r2.type) return false;
+    if (r1.repo !== r2.repo) return false;
+    if (!r1.events || !r2.events) return r1.events === r2.events;
+    if (r1.events.length !== r2.events.length) return false;
+    return JSON.stringify(r1.events) === JSON.stringify(r2.events);
+  }
+
+  /**
+   * Finds the path to a specific affected range within the vulnerability record.
+   * @param {Object} vulnData - The vulnerability protocol buffer JSON data.
+   * @param {Object} targetRange - Range object to find.
+   * @returns {string|null} Path string if found, otherwise null.
+   */
+  function findRangePath(vulnData, targetRange) {
+    if (!vulnData || !vulnData.affected) return null;
+    for (let i = 0; i < vulnData.affected.length; i++) {
+      const affected = vulnData.affected[i];
+      if (!affected.ranges) continue;
+      for (let j = 0; j < affected.ranges.length; j++) {
+        if (isSameRange(affected.ranges[j], targetRange)) {
+          return `affected.${i}.ranges.${j}`;
+        }
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Extracts JSON paths from a linter finding message.
+   * Handles schema errors (SCH:xxx), quote/value matches (RNG:002), range types, and top-level properties (REC:xxx).
+   * @param {Object} finding - Finding record with Code and Message properties.
+   * @param {string} bugId - Vulnerability ID.
+   * @returns {string[]} Array of target JSON path strings.
+   */
+  function extractPathsFromFinding(finding, bugId) {
+    const paths = [];
+    if (!finding || !finding.Message) return paths;
+
+    const vulnData = activeVulnData[bugId];
+    const valueMap = activeVulnValueMaps[bugId];
+
+    // 1. Check for schema paths (SCH:xxx)
+    const schemaPathRegex = /(?:^|\s)-\s*([a-zA-Z0-9_\.]+):/g;
+    let match;
+    while ((match = schemaPathRegex.exec(finding.Message)) !== null) {
+      paths.push(match[1]);
+    }
+
+    // 2. Check for overlapping event values (RNG:002) or anything in quotes using O(1) indexed valueMap
+    const quoteRegex = /"([^"]+)"/g;
+    let quoteMatch;
+    while ((quoteMatch = quoteRegex.exec(finding.Message)) !== null) {
+      const value = quoteMatch[1];
+      if (!value.startsWith('{')) {
+        if (valueMap && valueMap[value]) {
+          paths.push(...valueMap[value]);
+        } else if (vulnData) {
+          const valuePaths = findPathsForValue(vulnData, value);
+          paths.push(...valuePaths);
+        }
+      }
+    }
+
+    // 3. Check for unexpected range type (RNG:002 case 2)
+    const rngTypeRegex = /unexpected range type "[^"]+" for (\{[\s\S]*\})/;
+    const rngTypeMatch = rngTypeRegex.exec(finding.Message);
+    if (rngTypeMatch) {
+      try {
+        const targetRange = JSON.parse(rngTypeMatch[1]);
+        const path = findRangePath(vulnData, targetRange);
+        if (path) {
+          paths.push(path);
+        }
+      } catch (e) {
+        console.error("Failed to parse range JSON from finding", e);
+      }
+    }
+
+    // 4. Check for invalid top-level properties (REC:xxx)
+    const invalidPropRegex = /Invalid ([a-zA-Z0-9_]+):/i;
+    const invalidPropMatch = invalidPropRegex.exec(finding.Message);
+    if (invalidPropMatch) {
+      paths.push(invalidPropMatch[1].toLowerCase());
+    }
+
+    return paths;
+  }
+
+  /**
+   * Highlights target finding elements in the interactive JSON tree and auto-expands parent nodes.
+   * @param {string} bugId - Vulnerability ID.
+   * @param {Object} finding - Linter finding object to highlight.
+   */
+  function highlightFinding(bugId, finding) {
+    const safeBugId = sanitiseBugId(bugId);
+    const vulnJsonId = `vuln-json-${safeBugId}`;
+    const container = document.getElementById(vulnJsonId);
+    if (!container) return;
+
+    // Clear previous highlights
+    container.querySelectorAll('.json-highlighted').forEach(el => {
+      el.classList.remove('json-highlighted');
+    });
+
+    const paths = extractPathsFromFinding(finding, bugId);
+    let firstHighlighted = null;
+
+    paths.forEach(path => {
+      const row = container.querySelector(`[data-json-path="${path}"]`);
+      if (row) {
+        row.classList.add('json-highlighted');
+        
+        // Ensure all parent elements are expanded
+        let parent = row.parentElement;
+        while (parent && parent !== container) {
+          if (parent.classList.contains('json-children')) {
+            parent.style.display = 'block';
+            const toggle = parent.previousElementSibling;
+            if (toggle?.classList.contains('json-toggle')) {
+              setToggleState(toggle, true);
+            }
+          }
+          parent = parent.parentElement;
+        }
+
+        // Expand the highlighted row itself if it is collapsed
+        const myChildren = row.querySelector(':scope > .custom-json-node > .json-children');
+        if (myChildren) {
+          myChildren.style.display = 'block';
+          const myToggle = row.querySelector(':scope > .custom-json-node > .json-toggle');
+          if (myToggle) {
+            setToggleState(myToggle, true);
+          }
+        }
+
+        if (!firstHighlighted) {
+          firstHighlighted = row;
+        }
+      }
+    });
+
+    if (firstHighlighted) {
+      firstHighlighted.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }
+
+  /**
+   * Recursively builds an interactive HTML DOM tree for rendering JSON structures with data-json-path attributes.
+   * 
+   * @param {*} data - The primitive or object value to render.
+   * @param {string} [path=''] - The dot-separated JSON path leading to this node.
+   * @param {boolean} [isRoot=false] - Whether this node is the root container of the JSON tree.
+   * @param {Object<string, string[]>} [valueMap=null] - Optional lookup map populated with value -> path[] for O(1) searches.
+   * @returns {HTMLElement} The root div.custom-json-node container element.
+   */
+  function renderCustomJSON(data, path = '', isRoot = false, valueMap = null) {
+    const container = document.createElement('div');
+    container.className = 'custom-json-node';
+    if (path !== '') container.dataset.jsonPath = path;
+
+    if (data === null || typeof data !== 'object') {
+      if (valueMap && path && (typeof data === 'string' || typeof data === 'number')) {
+        const strVal = String(data);
+        if (!valueMap[strVal]) valueMap[strVal] = [];
+        valueMap[strVal].push(path);
+      }
+      const span = document.createElement('span');
+      const type = data === null ? 'null' : typeof data;
+      span.className = `json-value-${type}`;
+      span.textContent = type === 'string' ? `"${data}"` : String(data);
+      container.appendChild(span);
+      return container;
+    }
+
+    const isArray = Array.isArray(data);
+    const keys = Object.keys(data);
+    const openChar = isArray ? '[' : '{';
+    const closeChar = isArray ? ']' : '}';
+
+    if (keys.length === 0) {
+      const span = document.createElement('span');
+      span.className = 'json-bracket';
+      span.textContent = `${openChar}${closeChar}`;
+      container.appendChild(span);
+      return container;
+    }
+
+    const toggle = document.createElement('span');
+    toggle.className = 'json-toggle open';
+    toggle.dataset.isObject = (!isArray).toString();
+    toggle.textContent = `▼ ${openChar}`;
+
+    const children = document.createElement('div');
+    children.className = 'json-children';
+
+    keys.forEach(key => {
+      const val = data[key];
+      const childPath = path ? `${path}.${key}` : `${key}`;
+      const row = document.createElement('div');
+      row.className = 'json-row';
+      row.dataset.jsonPath = childPath;
+
+      const keySpan = document.createElement('span');
+      keySpan.className = isArray ? 'json-key array-index' : 'json-key';
+      keySpan.textContent = isArray ? `${key}:` : `"${key}": `;
+      row.appendChild(keySpan);
+
+      row.appendChild(renderCustomJSON(val, childPath, false, valueMap));
+      children.appendChild(row);
+    });
+
+    if (isRoot) {
+      container.appendChild(document.createTextNode(openChar));
+    } else {
+      container.appendChild(toggle);
+    }
+    container.appendChild(children);
+
+    const closeSpan = document.createElement('span');
+    closeSpan.className = 'json-bracket';
+    closeSpan.textContent = closeChar;
+    container.appendChild(closeSpan);
+
+    return container;
   }
 
   function handleTabClick(e) {

--- a/gcp/website/frontend3/src/linter.scss
+++ b/gcp/website/frontend3/src/linter.scss
@@ -9,6 +9,7 @@
   --osv-body-font-family: "Overpass", sans-serif;
   --osv-heading-font-family: "Overpass Mono", monospace;
   --osv-border-radius-small: 4px;
+  --osv-red-300: #f23835;
 }
 
 /** Reset */
@@ -428,6 +429,31 @@ tr:hover {
   border-radius: 4px;
 }
 
+.json-container {
+  background-color: var(--osv-surface-color);
+  padding: 15px;
+  border-radius: 4px;
+  overflow-y: auto;
+  color: var(--osv-text-color);
+  flex-grow: 1;
+  font-family: var(--osv-heading-font-family);
+  font-size: 14px;
+}
+
+.json-container::-webkit-scrollbar {
+  width: 8px;
+}
+
+.json-container::-webkit-scrollbar-track {
+  background: var(--osv-surface-color);
+}
+
+.json-container::-webkit-scrollbar-thumb {
+  background-color: var(--osv-grey-800);
+  border-radius: 4px;
+}
+
+
 .close-tab {
   margin-left: 8px;
   cursor: pointer;
@@ -492,3 +518,139 @@ tr.clickable {
 .findings-table tr:hover {
   background-color: var(--osv-grey-800);
 }
+
+
+
+/* ==========================================================================
+   Details Tab Header & Copy Button
+   ========================================================================== */
+
+.details-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+  min-height: 26px; /* Ensures uniform header height across grid columns */
+
+  h2 {
+    margin-bottom: 0;
+  }
+}
+
+.copy-button {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  border-radius: var(--osv-border-radius-small);
+  border: 1px solid var(--osv-border-color);
+  background-color: var(--osv-surface-color);
+  color: var(--osv-text-color);
+  transition: background-color 0.2s ease-in-out;
+
+  &:hover {
+    background-color: var(--osv-grey-800);
+  }
+
+  .material-icons {
+    font-size: 16px;
+  }
+}
+
+/* ==========================================================================
+   Linter Findings Table
+   ========================================================================== */
+
+.clickable-finding-row {
+  cursor: pointer;
+
+  &:hover {
+    .action-cell {
+      color: var(--osv-red-300);
+    }
+  }
+}
+
+.findings-table th:last-child {
+  width: 60px;
+}
+
+.action-cell {
+  vertical-align: middle !important;
+  text-align: center;
+  color: var(--osv-grey-600);
+  transition: color 0.2s ease-in-out;
+
+  .material-icons {
+    font-size: 18px;
+    display: block;
+  }
+}
+
+/* ==========================================================================
+   Interactive Custom JSON Tree Viewer
+   ========================================================================== */
+
+.custom-json-node {
+  font-family: var(--osv-heading-font-family);
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--osv-text-color);
+  display: inline; /* Keeps JSON values on the same line as their key span */
+
+  /* Primitive Data Type Syntax Highlighting */
+  .json-value-null { color: var(--osv-grey-600); font-weight: bold; }
+  .json-value-boolean { color: #f48fb1; font-weight: bold; }
+  .json-value-number { color: #81d4fa; }
+  .json-value-string { color: #c5e1a5; white-space: pre-wrap; word-break: break-all; }
+  .json-bracket { color: var(--osv-grey-600); font-weight: bold; }
+
+  /* Interactive Expand / Collapse Toggle Span */
+  .json-toggle {
+    cursor: pointer;
+    color: var(--osv-grey-600);
+    font-weight: bold;
+    user-select: none;
+    display: inline-block;
+    padding: 0 4px;
+    transition: color 0.2s ease-in-out;
+
+    &:hover { color: #fff; }
+  }
+
+  /* Indented Child Container with Left Dotted Alignment Line */
+  .json-children {
+    padding-left: 20px;
+    border-left: 1px dotted var(--osv-border-color);
+    margin-left: 6px;
+  }
+
+  /* Key-Value Row Item */
+  .json-row {
+    margin: 2px 0;
+    padding: 2px 4px;
+    border-radius: var(--osv-border-radius-small);
+    border-left: 3px solid transparent;
+    transition: background-color 0.2s ease-in-out, border-left-color 0.2s ease-in-out;
+  }
+
+  /* JSON Property Key & Array Index Styling */
+  .json-key {
+    color: #90caf9;
+    margin-right: 4px;
+    &.array-index {
+      color: var(--osv-grey-600);
+    }
+  }
+
+  /* Highlighted JSON Row (Triggered by Clicking a Linter Finding) */
+  .json-row.json-highlighted {
+    background-color: rgba(255, 193, 7, 0.15); /* Soft amber background tint */
+    border-left-color: #ffc107;                 /* Solid amber indicator bar */
+
+    > .json-key { color: #ffca28; }
+    > .custom-json-node > .json-value-string { color: #d4e157; }
+  }
+}
+

--- a/gcp/website/frontend3/webpack.dev.js
+++ b/gcp/website/frontend3/webpack.dev.js
@@ -6,6 +6,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
 module.exports = {
   mode: 'development',
+  devtool: 'source-map',
   entry: {
     main: './src/index.js',
     linter: './src/linter.js',


### PR DESCRIPTION
Note this was heavily assisted by Antigravity to paper over my failings as a frontend developer.

Right now the code is probably a little more complex than it needs to be, which we can refactor if we provide more specific information where the linting errors are occurring in the file.

You can collapse/expand JSON, there is a JSON copy button now and also you can click on a finding and it will be highlighted in yellow. See attached screenshots.

<img width="2190" height="1149" alt="Screenshot 2026-07-27 11 39 21 AM" src="https://github.com/user-attachments/assets/75a2e1ea-e0c9-467b-85c8-785cfb7c27e2" />
<img width="2190" height="1149" alt="Screenshot 2026-07-27 11 39 04 AM" src="https://github.com/user-attachments/assets/86551dc1-9af3-4584-8390-9fb9dc0dfdc1" />
