### PR TITLE
chore(vulnfeeds): clean up the tests that rely on schema version

### DIFF
--- a/vulnfeeds/conversion/cve5/__snapshots__/converter_test.snap
+++ b/vulnfeeds/conversion/cve5/__snapshots__/converter_test.snap
@@ -16,7 +16,7 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-9999"
     }
   ],
-  "schema_version": "1.8.0"
+  "schema_version": "1.0.0"
 }
 ---
 
@@ -80,7 +80,7 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-1110"
     }
   ],
-  "schema_version": "1.8.0",
+  "schema_version": "1.0.0",
   "severity": [
     {
       "score": "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:N/A:N",
@@ -146,7 +146,7 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-21634"
     }
   ],
-  "schema_version": "1.8.0",
+  "schema_version": "1.0.0",
   "severity": [
     {
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
@@ -333,7 +333,7 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2025-21772"
     }
   ],
-  "schema_version": "1.8.0",
+  "schema_version": "1.0.0",
   "summary": "partitions: mac: fix handling of bogus partition table"
 }
 ---
@@ -400,7 +400,7 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-23522"
     }
   ],
-  "schema_version": "1.8.0",
+  "schema_version": "1.0.0",
   "severity": [
     {
       "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
@@ -480,7 +480,7 @@
       "url": "https://pypi.org/project/protobuf/"
     }
   ],
-  "schema_version": "1.8.0",
+  "schema_version": "1.0.0",
   "severity": [
     {
       "score": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N",
@@ -560,7 +560,7 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-20912"
     }
   ],
-  "schema_version": "1.8.0",
+  "schema_version": "1.0.0",
   "severity": [
     {
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N",
@@ -659,7 +659,7 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-22466"
     }
   ],
-  "schema_version": "1.8.0",
+  "schema_version": "1.0.0",
   "severity": [
     {
       "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:L",
@@ -754,7 +754,7 @@
       "url": "https://www.rfc-editor.org/rfc/rfc9110.html#name-get"
     }
   ],
-  "schema_version": "1.8.0",
+  "schema_version": "1.0.0",
   "severity": [
     {
       "score": "CVSS:3.1/AV:A/AC:H/PR:H/UI:N/S:U/C:H/I:N/A:N",
@@ -829,7 +829,7 @@
       "url": "https://vuldb.com/?id.217619"
     }
   ],
-  "schema_version": "1.8.0",
+  "schema_version": "1.0.0",
   "severity": [
     {
       "score": "CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
@@ -1130,7 +1130,7 @@
       "url": "https://xeiaso.net/notes/2024/xz-vuln/"
     }
   ],
-  "schema_version": "1.8.0",
+  "schema_version": "1.0.0",
   "severity": [
     {
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
@@ -1876,7 +1876,7 @@
       "url": "https://security.netapp.com/advisory/ntap-20241025-0010/"
     }
   ],
-  "schema_version": "1.8.0",
+  "schema_version": "1.0.0",
   "severity": [
     {
       "score": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L",
@@ -1924,7 +1924,7 @@
       "url": "https://security.gentoo.org/glsa/202209-11"
     }
   ],
-  "schema_version": "1.8.0"
+  "schema_version": "1.0.0"
 }
 {
   "database_specific": {
@@ -1989,7 +1989,7 @@
       "url": "https://www.kb.cert.org/vuls/id/772447"
     }
   ],
-  "schema_version": "1.8.0"
+  "schema_version": "1.0.0"
 }
 {
   "database_specific": {
@@ -2075,7 +2075,7 @@
       "url": "https://www.debian.org/security/2018/dsa-4286"
     }
   ],
-  "schema_version": "1.8.0",
+  "schema_version": "1.0.0",
   "severity": [
     {
       "score": "CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H",
@@ -2122,7 +2122,7 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-1055"
     }
   ],
-  "schema_version": "1.8.0"
+  "schema_version": "1.0.0"
 }
 {
   "database_specific": {
@@ -2179,7 +2179,7 @@
       "url": "https://nvd.nist.gov/vuln/detail/CVE-2024-2002"
     }
   ],
-  "schema_version": "1.8.0",
+  "schema_version": "1.0.0",
   "severity": [
     {
       "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",

--- a/vulnfeeds/conversion/cve5/converter_test.go
+++ b/vulnfeeds/conversion/cve5/converter_test.go
@@ -390,19 +390,9 @@ func TestFromCVE5(t *testing.T) {
 }
 
 func TestConvertAndExportCVEToOSV(t *testing.T) {
-	cve1110Pub, _ := models.ParseCVE5Timestamp("2025-05-22T14:02:31.385Z")
-	cve1110Mod, _ := models.ParseCVE5Timestamp("2025-05-22T14:17:44.379Z")
-	cve21634Pub, _ := models.ParseCVE5Timestamp("2024-01-03T22:46:03.585Z")
-	cve21634Mod, _ := models.ParseCVE5Timestamp("2025-06-16T19:45:37.088Z")
-	cve21772Pub, _ := models.ParseCVE5Timestamp("2025-02-27T02:18:19.528Z")
-	cve21772Mod, _ := models.ParseCVE5Timestamp("2025-05-04T07:20:46.575Z")
-	cvePlaceholder, _ := models.ParseCVE5Timestamp("2025-05-04T07:20:46.575Z")
 	testCases := []struct {
 		name string
 		cve  models.CVE5
-
-		refs         []models.Reference
-		expectedVuln *vulns.Vulnerability
 	}{
 		{
 			name: "disputed record",
@@ -429,151 +419,18 @@ func TestConvertAndExportCVEToOSV(t *testing.T) {
 					},
 				},
 			},
-			refs: []models.Reference{},
-			expectedVuln: &vulns.Vulnerability{
-				Vulnerability: &osvschema.Vulnerability{
-					Id:            "CVE-2025-9999",
-					SchemaVersion: osvconstants.SchemaVersion,
-					Published:     timestamppb.New(cvePlaceholder),
-					Modified:      timestamppb.New(cvePlaceholder),
-					Details:       "A disputed vulnerability.",
-					DatabaseSpecific: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							"isDisputed":         structpb.NewBoolValue(true),
-							"cna_assigner":       structpb.NewStringValue("unknown"),
-							"osv_generated_from": structpb.NewStringValue("unknown"),
-						},
-					},
-				},
-			},
 		},
 		{
 			name: "CVE-2025-1110",
 			cve:  loadTestData(t, "CVE-2025-1110"),
-			refs: []models.Reference{
-				{URL: "https://gitlab.com/gitlab-org/gitlab/-/issues/517693", Tags: []string{"issue-tracking", "permissions-required"}},
-				{URL: "https://hackerone.com/reports/2972576", Tags: []string{"technical-description", "exploit", "permissions-required"}},
-			},
-			expectedVuln: &vulns.Vulnerability{
-				Vulnerability: &osvschema.Vulnerability{
-					Id:            "CVE-2025-1110",
-					SchemaVersion: osvconstants.SchemaVersion,
-					Published:     timestamppb.New(cve1110Pub),
-					Modified:      timestamppb.New(cve1110Mod),
-					Summary:       "Insufficient Granularity of Access Control in GitLab",
-					Details:       "An issue has been discovered in GitLab CE/EE affecting all versions from 18.0 before 18.0.1. In certain circumstances, a user with limited permissions could access Job Data via a crafted GraphQL query.",
-					Aliases:       nil,
-					Related:       nil,
-					DatabaseSpecific: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							"cna_assigner": structpb.NewStringValue("GitLab"),
-							"cwe_ids": structpb.NewListValue(
-								&structpb.ListValue{
-									Values: []*structpb.Value{
-										structpb.NewStringValue("CWE-1220"),
-									},
-								},
-							),
-							"osv_generated_from": structpb.NewStringValue("unknown"),
-						},
-					},
-					References: []*osvschema.Reference{
-						{Type: osvschema.Reference_ARTICLE, Url: "https://hackerone.com/reports/2972576"},
-						{Type: osvschema.Reference_EVIDENCE, Url: "https://hackerone.com/reports/2972576"},
-						{Type: osvschema.Reference_REPORT, Url: "https://gitlab.com/gitlab-org/gitlab/-/issues/517693"},
-						{Type: osvschema.Reference_REPORT, Url: "https://hackerone.com/reports/2972576"},
-					},
-					Severity: []*osvschema.Severity{
-						{
-							Type:  osvschema.Severity_CVSS_V3,
-							Score: "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:N/A:N",
-						},
-					},
-				},
-			},
 		},
 		{
 			name: "CVE-2024-21634",
 			cve:  loadTestData(t, "CVE-2024-21634"),
-			refs: []models.Reference{
-				{Tags: []string{"x_refsource_CONFIRM"}, URL: "https://github.com/amazon-ion/ion-java/security/advisories/GHSA-264p-99wq-f4j6"},
-			},
-			expectedVuln: &vulns.Vulnerability{
-				Vulnerability: &osvschema.Vulnerability{
-					Id:            "CVE-2024-21634",
-					SchemaVersion: osvconstants.SchemaVersion,
-					Published:     timestamppb.New(cve21634Pub),
-					Modified:      timestamppb.New(cve21634Mod),
-					Summary:       "Ion Java StackOverflow vulnerability",
-					Details:       "Amazon Ion is a Java implementation of the Ion data notation. Prior to version 1.10.5, a potential denial-of-service issue exists in\u00a0`ion-java`\u00a0for applications that use\u00a0`ion-java`\u00a0to deserialize Ion text encoded data, or deserialize Ion text or binary encoded data into the\u00a0`IonValue`\u00a0model and then invoke certain\u00a0`IonValue`\u00a0methods on that in-memory representation. An actor could craft Ion data that, when loaded by the affected application and/or processed using the\u00a0`IonValue`\u00a0model, results in a\u00a0`StackOverflowError`\u00a0originating from the\u00a0`ion-java`\u00a0library. The patch is included in `ion-java` 1.10.5. As a workaround, do not load data which originated from an untrusted source or that could have been tampered with.",
-					Aliases:       []string{"GHSA-264p-99wq-f4j6"},
-					Related:       nil,
-					References: []*osvschema.Reference{
-						{Type: osvschema.Reference_ADVISORY, Url: "https://github.com/amazon-ion/ion-java/security/advisories/GHSA-264p-99wq-f4j6"},
-					},
-					Severity: []*osvschema.Severity{
-						{
-							Type:  osvschema.Severity_CVSS_V3,
-							Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-						},
-					},
-					DatabaseSpecific: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							"cna_assigner": structpb.NewStringValue("GitHub_M"),
-							"cwe_ids": structpb.NewListValue(
-								&structpb.ListValue{
-									Values: []*structpb.Value{
-										structpb.NewStringValue("CWE-770"),
-									},
-								},
-							),
-							"osv_generated_from": structpb.NewStringValue("unknown"),
-						},
-					},
-				},
-			},
 		},
 		{
 			name: "CVE-2025-21772",
 			cve:  loadTestData(t, "CVE-2025-21772"),
-			refs: []models.Reference{
-				{URL: "https://git.kernel.org/stable/c/a3e77da9f843e4ab93917d30c314f0283e28c124"},
-				{URL: "https://git.kernel.org/stable/c/213ba5bd81b7e97ac6e6190b8f3bc6ba76123625"},
-				{URL: "https://git.kernel.org/stable/c/40a35d14f3c0dc72b689061ec72fc9b193f37d1f"},
-				{URL: "https://git.kernel.org/stable/c/27a39d006f85e869be68c1d5d2ce05e5d6445bf5"},
-				{URL: "https://git.kernel.org/stable/c/92527100be38ede924768f4277450dfe8a40e16b"},
-				{URL: "https://git.kernel.org/stable/c/6578717ebca91678131d2b1f4ba4258e60536e9f"},
-				{URL: "https://git.kernel.org/stable/c/7fa9706722882f634090bfc9af642bf9ed719e27"},
-				{URL: "https://git.kernel.org/stable/c/80e648042e512d5a767da251d44132553fe04ae0"},
-			},
-			expectedVuln: &vulns.Vulnerability{
-				Vulnerability: &osvschema.Vulnerability{
-					Id:            "CVE-2025-21772",
-					SchemaVersion: osvconstants.SchemaVersion,
-					Published:     timestamppb.New(cve21772Pub),
-					Modified:      timestamppb.New(cve21772Mod),
-					Summary:       "partitions: mac: fix handling of bogus partition table",
-					Details:       "In the Linux kernel, the following vulnerability has been resolved:\n\npartitions: mac: fix handling of bogus partition table\n\nFix several issues in partition probing:\n\n - The bailout for a bad partoffset must use put_dev_sector(), since the\n   preceding read_part_sector() succeeded.\n - If the partition table claims a silly sector size like 0xfff bytes\n   (which results in partition table entries straddling sector boundaries),\n   bail out instead of accessing out-of-bounds memory.\n - We must not assume that the partition table contains proper NUL\n   termination - use strnlen() and strncmp() instead of strlen() and\n   strcmp().",
-					Aliases:       nil,
-					Related:       nil,
-					DatabaseSpecific: &structpb.Struct{
-						Fields: map[string]*structpb.Value{
-							"cna_assigner":       structpb.NewStringValue("Linux"),
-							"osv_generated_from": structpb.NewStringValue("unknown"),
-						},
-					},
-					References: []*osvschema.Reference{
-						{Type: osvschema.Reference_WEB, Url: "https://git.kernel.org/stable/c/a3e77da9f843e4ab93917d30c314f0283e28c124"},
-						{Type: osvschema.Reference_WEB, Url: "https://git.kernel.org/stable/c/213ba5bd81b7e97ac6e6190b8f3bc6ba76123625"},
-						{Type: osvschema.Reference_WEB, Url: "https://git.kernel.org/stable/c/40a35d14f3c0dc72b689061ec72fc9b193f37d1f"},
-						{Type: osvschema.Reference_WEB, Url: "https://git.kernel.org/stable/c/27a39d006f85e869be68c1d5d2ce05e5d6445bf5"},
-						{Type: osvschema.Reference_WEB, Url: "https://git.kernel.org/stable/c/92527100be38ede924768f4277450dfe8a40e16b"},
-						{Type: osvschema.Reference_WEB, Url: "https://git.kernel.org/stable/c/6578717ebca91678131d2b1f4ba4258e60536e9f"},
-						{Type: osvschema.Reference_WEB, Url: "https://git.kernel.org/stable/c/7fa9706722882f634090bfc9af642bf9ed719e27"},
-						{Type: osvschema.Reference_WEB, Url: "https://git.kernel.org/stable/c/80e648042e512d5a767da251d44132553fe04ae0"},
-					},
-				},
-			},
 		},
 	}
 
@@ -585,7 +442,7 @@ func TestConvertAndExportCVEToOSV(t *testing.T) {
 			if err != nil {
 				t.Errorf("Unexpected error from ConvertAndExportCVEToOSV: %v", err)
 			}
-			snaps.MatchSnapshot(t, vWriter.String())
+			snaps.MatchSnapshot(t, strings.ReplaceAll(vWriter.String(), `"schema_version": "`+osvconstants.SchemaVersion+`"`, `"schema_version": "1.0.0"`))
 		})
 	}
 }
@@ -623,7 +480,7 @@ func TestCVE5Snapshot(t *testing.T) {
 			t.Fatalf("Failed to convert %s: %v", path, err)
 		}
 
-		results = append(results, vWriter.String())
+		results = append(results, strings.ReplaceAll(vWriter.String(), `"schema_version": "`+osvconstants.SchemaVersion+`"`, `"schema_version": "1.0.0"`))
 	}
 
 	// Sort results for deterministic snapshot


### PR DESCRIPTION
these tests are snapshot tests - not actually checking against expected. also ignore schema version changes