### PR TITLE
fix: add oss-fuzz subnetwork to NAT config

### DIFF
--- a/deployment/terraform/environments/oss-vdb/main.tf
+++ b/deployment/terraform/environments/oss-vdb/main.tf
@@ -51,6 +51,8 @@ module "osv" {
     "reimport",
     "cves",
   ]
+
+  create_oss_fuzz_subnet = true
 }
 
 module "oss_fuzz" {
@@ -59,6 +61,12 @@ module "oss_fuzz" {
   tasks_topic_id               = module.osv.tasks_topic_id
   failed_tasks_topic_id        = module.osv.failed_tasks_topic_id
   pubsub_service_account_email = module.osv.pubsub_service_account_email
+  subnetwork                   = module.osv.oss_fuzz_subnet_self_link
+}
+
+moved {
+  from = module.oss_fuzz.google_compute_subnetwork.oss_fuzz_subnet
+  to   = module.osv.google_compute_subnetwork.oss_fuzz_subnet[0]
 }
 
 module "k8s_cron_alert" {

--- a/deployment/terraform/modules/oss_fuzz/main.tf
+++ b/deployment/terraform/modules/oss_fuzz/main.tf
@@ -1,17 +1,8 @@
-resource "google_compute_subnetwork" "oss_fuzz_subnet" {
-  project                  = var.project_id
-  name                     = "oss-fuzz-subnet"
-  network                  = var.network
-  ip_cidr_range            = "10.45.36.0/22"
-  private_ip_google_access = true
-  region                   = var.region
-}
-
 resource "google_container_cluster" "workers" {
   project    = var.project_id
   name       = "oss-fuzz-workers"
   location   = "${var.region}-f"
-  subnetwork = google_compute_subnetwork.oss_fuzz_subnet.self_link
+  subnetwork = var.subnetwork
 
   private_cluster_config {
     enable_private_endpoint = false

--- a/deployment/terraform/modules/oss_fuzz/variables.tf
+++ b/deployment/terraform/modules/oss_fuzz/variables.tf
@@ -28,3 +28,9 @@ variable "pubsub_service_account_email" {
   type        = string
   description = "The email of the Pub/Sub service account."
 }
+
+variable "subnetwork" {
+  type        = string
+  description = "The self link of the subnetwork for oss-fuzz workers."
+}
+

--- a/deployment/terraform/modules/osv/outputs.tf
+++ b/deployment/terraform/modules/osv/outputs.tf
@@ -16,3 +16,9 @@ output "pubsub_service_account_email" {
   value       = google_project_service_identity.pubsub.email
   description = "The email of the Pub/Sub service account"
 }
+
+output "oss_fuzz_subnet_self_link" {
+  value       = one(google_compute_subnetwork.oss_fuzz_subnet[*].self_link)
+  description = "The self link of the OSS-Fuzz subnetwork"
+}
+

--- a/deployment/terraform/modules/osv/variables.tf
+++ b/deployment/terraform/modules/osv/variables.tf
@@ -73,3 +73,10 @@ variable "extra_work_pools" {
   description = "Additional Pub/Sub worker pool subscriptions to create"
   default     = []
 }
+
+variable "create_oss_fuzz_subnet" {
+  type        = bool
+  description = "Whether to create the OSS-Fuzz subnetwork and add it to NAT."
+  default     = false
+}
+

--- a/deployment/terraform/modules/osv/workers_network.tf
+++ b/deployment/terraform/modules/osv/workers_network.tf
@@ -24,6 +24,16 @@ resource "google_compute_router" "router" {
   region  = "us-central1"
 }
 
+resource "google_compute_subnetwork" "oss_fuzz_subnet" {
+  count                    = var.create_oss_fuzz_subnet ? 1 : 0
+  project                  = var.project_id
+  name                     = "oss-fuzz-subnet"
+  network                  = "default"
+  ip_cidr_range            = "10.45.36.0/22"
+  private_ip_google_access = true
+  region                   = "us-central1"
+}
+
 resource "google_compute_router_nat" "nat_config" {
   project                             = var.project_id
   name                                = "nat-config"
@@ -36,6 +46,14 @@ resource "google_compute_router_nat" "nat_config" {
   subnetwork {
     name                    = google_compute_subnetwork.my_subnet_0.id
     source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  dynamic "subnetwork" {
+    for_each = var.create_oss_fuzz_subnet ? [1] : []
+    content {
+      name                    = google_compute_subnetwork.oss_fuzz_subnet[0].id
+      source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+    }
   }
 
   log_config {


### PR DESCRIPTION
Fix problems preventing oss-fuzz workloads for talking to the internet (which is important), adding the oss-fuzz subnet's IP range back to the NAT config.

Doing this required a bit moving and reorganising to avoid having circular imports in the modules.
TBH, it might be cleaner having OSS-Fuzz have its own NAT config, but I don't want to mess with it any more right now.