### PR TITLE
feat: gitter client

### DIFF
--- a/go/internal/gitter/client.go
+++ b/go/internal/gitter/client.go
@@ -9,11 +9,12 @@ import (
 	pb "github.com/google/osv.dev/go/internal/gitter/pb/repository"
 )
 
+// Map the HTTP status codes into Gitter-specific errors
 var (
 	ErrRepoInaccessible = errors.New("repository is inaccessible (forbidden)")
-	ErrRepoNotFound     = errors.New("repository could not be found")
+	ErrRepoNotFound     = errors.New("repository not found")
 	ErrInvalidInput     = errors.New("invalid request payload or query parameters")
-	ErrInternalService  = errors.New("gitter service encountered an internal failure")
+	ErrInternalService  = errors.New("gitter internal server error")
 )
 
 // Client exposes the capability contract of Gitter.
@@ -27,10 +28,10 @@ type Client interface {
 	// GetTags returns the full list of tags/refs mapped to their commit hashes.
 	GetTags(ctx context.Context, repoURL string) (*pb.TagsResponse, error)
 
-	// GetAffectedCommits resolves equivalent/affected scope ranges (cherry-picks).
+	// GetAffectedCommits resolves and lists affected commits based on introduced/fixed/last_affected commit ranges.
 	GetAffectedCommits(ctx context.Context, req *pb.AffectedCommitsRequest) (*pb.AffectedCommitsResponse, error)
 
-	// GetFileDiffs retrieves the tree changes since the last synced commit.
+	// GetFileDiffs retrieves the file changes since given last synced commit.
 	GetFileDiffs(ctx context.Context, req *pb.FileDiffsRequest) (*pb.FileDiffsResponse, error)
 
 	// GetFileContent retrieves the raw, uncompressed content of a single file path.

--- a/go/internal/gitter/client.go
+++ b/go/internal/gitter/client.go
@@ -1,0 +1,38 @@
+// Package gitter provides a client interface and HTTP client implementation for the gitter caching service.
+package gitter
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	pb "github.com/google/osv.dev/go/internal/gitter/pb/repository"
+)
+
+var (
+	ErrRepoInaccessible = errors.New("repository is inaccessible (forbidden)")
+	ErrRepoNotFound     = errors.New("repository could not be found")
+	ErrInvalidInput     = errors.New("invalid request payload or query parameters")
+	ErrInternalService  = errors.New("gitter service encountered an internal failure")
+)
+
+// Client exposes the capability contract of Gitter.
+type Client interface {
+	// GetGit streams down a compressed tarball archive of the target repository.
+	GetGit(ctx context.Context, repoURL string, forceUpdate bool) (io.ReadCloser, error)
+
+	// Cache triggers proactive caching of a target repository.
+	Cache(ctx context.Context, repoURL string) error
+
+	// GetTags returns the full list of tags/refs mapped to their commit hashes.
+	GetTags(ctx context.Context, repoURL string) (*pb.TagsResponse, error)
+
+	// GetAffectedCommits resolves equivalent/affected scope ranges (cherry-picks).
+	GetAffectedCommits(ctx context.Context, req *pb.AffectedCommitsRequest) (*pb.AffectedCommitsResponse, error)
+
+	// GetFileDiffs retrieves the tree changes since the last synced commit.
+	GetFileDiffs(ctx context.Context, req *pb.FileDiffsRequest) (*pb.FileDiffsResponse, error)
+
+	// GetFileContent retrieves the raw, uncompressed content of a single file path.
+	GetFileContent(ctx context.Context, req *pb.FileContentRequest) (*pb.FileContentResponse, error)
+}

--- a/go/internal/gitter/http.go
+++ b/go/internal/gitter/http.go
@@ -99,6 +99,20 @@ func (c *httpClient) do(ctx context.Context, method, path string, query url.Valu
 	}
 }
 
+// Helper function to unmarshal the response body into target proto message
+func unmarshalProtoResponse(r io.Reader, msg proto.Message) error {
+	bodyBytes, err := io.ReadAll(r)
+	if err != nil {
+		return fmt.Errorf("failed reading response body: %w", err)
+	}
+
+	if err := proto.Unmarshal(bodyBytes, msg); err != nil {
+		return fmt.Errorf("failed decoding response: %w", err)
+	}
+
+	return nil
+}
+
 // GetGit handles GET /git (streaming tarball)
 func (c *httpClient) GetGit(ctx context.Context, repoURL string, forceUpdate bool) (io.ReadCloser, error) {
 	q := url.Values{}
@@ -125,6 +139,7 @@ func (c *httpClient) Cache(ctx context.Context, repoURL string) error {
 	if err != nil {
 		return err
 	}
+	_, _ = io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
 
 	return nil
@@ -135,20 +150,15 @@ func (c *httpClient) GetTags(ctx context.Context, repoURL string) (*pb.TagsRespo
 	q := url.Values{}
 	q.Set("url", repoURL)
 
-	resp, err := c.do(ctx, http.MethodGet, "/tags", q, nil)
+	httpResp, err := c.do(ctx, http.MethodGet, "/tags", q, nil)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed reading tags response body: %w", err)
-	}
+	defer httpResp.Body.Close()
 
 	var tagsResp pb.TagsResponse
-	if err := proto.Unmarshal(bodyBytes, &tagsResp); err != nil {
-		return nil, fmt.Errorf("failed decoding tags response: %w", err)
+	if err := unmarshalProtoResponse(httpResp.Body, &tagsResp); err != nil {
+		return nil, err
 	}
 
 	return &tagsResp, nil
@@ -156,41 +166,31 @@ func (c *httpClient) GetTags(ctx context.Context, repoURL string) (*pb.TagsRespo
 
 // GetAffectedCommits handles POST /affected-commits
 func (c *httpClient) GetAffectedCommits(ctx context.Context, req *pb.AffectedCommitsRequest) (*pb.AffectedCommitsResponse, error) {
-	resp, err := c.do(ctx, http.MethodPost, "/affected-commits", nil, req)
+	httpResp, err := c.do(ctx, http.MethodPost, "/affected-commits", nil, req)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer httpResp.Body.Close()
 
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed reading affected commits response body: %w", err)
+	var acResp pb.AffectedCommitsResponse
+	if err := unmarshalProtoResponse(httpResp.Body, &acResp); err != nil {
+		return nil, err
 	}
 
-	var affectedResp pb.AffectedCommitsResponse
-	if err := proto.Unmarshal(bodyBytes, &affectedResp); err != nil {
-		return nil, fmt.Errorf("failed decoding affected commits response: %w", err)
-	}
-
-	return &affectedResp, nil
+	return &acResp, nil
 }
 
 // GetFileDiffs handles POST /file-diffs
 func (c *httpClient) GetFileDiffs(ctx context.Context, req *pb.FileDiffsRequest) (*pb.FileDiffsResponse, error) {
-	resp, err := c.do(ctx, http.MethodPost, "/file-diffs", nil, req)
+	httpResp, err := c.do(ctx, http.MethodPost, "/file-diffs", nil, req)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed reading file diffs response body: %w", err)
-	}
+	defer httpResp.Body.Close()
 
 	var diffsResp pb.FileDiffsResponse
-	if err := proto.Unmarshal(bodyBytes, &diffsResp); err != nil {
-		return nil, fmt.Errorf("failed decoding file diffs response: %w", err)
+	if err := unmarshalProtoResponse(httpResp.Body, &diffsResp); err != nil {
+		return nil, err
 	}
 
 	return &diffsResp, nil
@@ -198,20 +198,15 @@ func (c *httpClient) GetFileDiffs(ctx context.Context, req *pb.FileDiffsRequest)
 
 // GetFileContent handles POST /file-content
 func (c *httpClient) GetFileContent(ctx context.Context, req *pb.FileContentRequest) (*pb.FileContentResponse, error) {
-	resp, err := c.do(ctx, http.MethodPost, "/file-content", nil, req)
+	httpResp, err := c.do(ctx, http.MethodPost, "/file-content", nil, req)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed reading file content response body: %w", err)
-	}
+	defer httpResp.Body.Close()
 
 	var fileContentResp pb.FileContentResponse
-	if err := proto.Unmarshal(bodyBytes, &fileContentResp); err != nil {
-		return nil, fmt.Errorf("failed decoding file content response: %w", err)
+	if err := unmarshalProtoResponse(httpResp.Body, &fileContentResp); err != nil {
+		return nil, err
 	}
 
 	return &fileContentResp, nil

--- a/go/internal/gitter/http.go
+++ b/go/internal/gitter/http.go
@@ -1,0 +1,221 @@
+package gitter
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	pb "github.com/google/osv.dev/go/internal/gitter/pb/repository"
+	"google.golang.org/protobuf/proto"
+)
+
+type httpClient struct {
+	baseURL *url.URL
+	client  *http.Client
+}
+
+// NewClient returns a fully initialized Gitter Client or an error.
+func NewClient(hostURL string, client *http.Client) (Client, error) {
+	parsedURL, err := url.Parse(hostURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid host URL %q: %w", hostURL, err)
+	}
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	return &httpClient{baseURL: parsedURL, client: client}, nil
+}
+
+func (c *httpClient) do(ctx context.Context, method, path string, query url.Values, body proto.Message) (*http.Response, error) {
+	reqURL := c.baseURL.JoinPath(path)
+	if len(query) > 0 {
+		reqURL.RawQuery = query.Encode()
+	}
+
+	var bodyReader io.Reader
+	if body != nil {
+		payload, err := proto.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed encoding request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(payload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL.String(), bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed creating HTTP request: %w", err)
+	}
+
+	req.Header.Set("Accept", "application/x-protobuf")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/x-protobuf")
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("network execution failure: %w", err)
+	}
+
+	// Return all 2xx responses
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		return resp, nil
+	}
+
+	// Read error detail from response body up to 1KB.
+	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+	resp.Body.Close()
+	errMsg := strings.TrimSpace(string(bodyBytes))
+
+	switch resp.StatusCode {
+	case http.StatusForbidden:
+		if errMsg != "" {
+			return nil, fmt.Errorf("%w: %s", ErrRepoInaccessible, errMsg)
+		}
+
+		return nil, ErrRepoInaccessible
+	case http.StatusNotFound:
+		if errMsg != "" {
+			return nil, fmt.Errorf("%w: %s", ErrRepoNotFound, errMsg)
+		}
+
+		return nil, ErrRepoNotFound
+	case http.StatusBadRequest:
+		if errMsg != "" {
+			return nil, fmt.Errorf("%w: %s", ErrInvalidInput, errMsg)
+		}
+
+		return nil, ErrInvalidInput
+	default:
+		if errMsg != "" {
+			return nil, fmt.Errorf("%w: status %d: %s", ErrInternalService, resp.StatusCode, errMsg)
+		}
+
+		return nil, fmt.Errorf("%w: received unexpected status code %d", ErrInternalService, resp.StatusCode)
+	}
+}
+
+// GetGit handles GET /git (streaming tarball)
+func (c *httpClient) GetGit(ctx context.Context, repoURL string, forceUpdate bool) (io.ReadCloser, error) {
+	q := url.Values{}
+	q.Set("url", repoURL)
+	if forceUpdate {
+		q.Set("force-update", "true")
+	}
+
+	resp, err := c.do(ctx, http.MethodGet, "/git", q, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Body, nil // Caller is responsible for closing the stream.
+}
+
+// Cache handles POST /cache (proactive background indexing)
+func (c *httpClient) Cache(ctx context.Context, repoURL string) error {
+	req := &pb.CacheRequest{
+		Url: repoURL,
+	}
+
+	resp, err := c.do(ctx, http.MethodPost, "/cache", nil, req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+
+	return nil
+}
+
+// GetTags handles GET /tags (resolves ref list)
+func (c *httpClient) GetTags(ctx context.Context, repoURL string) (*pb.TagsResponse, error) {
+	q := url.Values{}
+	q.Set("url", repoURL)
+
+	resp, err := c.do(ctx, http.MethodGet, "/tags", q, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed reading tags response body: %w", err)
+	}
+
+	var tagsResp pb.TagsResponse
+	if err := proto.Unmarshal(bodyBytes, &tagsResp); err != nil {
+		return nil, fmt.Errorf("failed decoding tags response: %w", err)
+	}
+
+	return &tagsResp, nil
+}
+
+// GetAffectedCommits handles POST /affected-commits
+func (c *httpClient) GetAffectedCommits(ctx context.Context, req *pb.AffectedCommitsRequest) (*pb.AffectedCommitsResponse, error) {
+	resp, err := c.do(ctx, http.MethodPost, "/affected-commits", nil, req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed reading affected commits response body: %w", err)
+	}
+
+	var affectedResp pb.AffectedCommitsResponse
+	if err := proto.Unmarshal(bodyBytes, &affectedResp); err != nil {
+		return nil, fmt.Errorf("failed decoding affected commits response: %w", err)
+	}
+
+	return &affectedResp, nil
+}
+
+// GetFileDiffs handles POST /file-diffs
+func (c *httpClient) GetFileDiffs(ctx context.Context, req *pb.FileDiffsRequest) (*pb.FileDiffsResponse, error) {
+	resp, err := c.do(ctx, http.MethodPost, "/file-diffs", nil, req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed reading file diffs response body: %w", err)
+	}
+
+	var diffsResp pb.FileDiffsResponse
+	if err := proto.Unmarshal(bodyBytes, &diffsResp); err != nil {
+		return nil, fmt.Errorf("failed decoding file diffs response: %w", err)
+	}
+
+	return &diffsResp, nil
+}
+
+// GetFileContent handles POST /file-content
+func (c *httpClient) GetFileContent(ctx context.Context, req *pb.FileContentRequest) (*pb.FileContentResponse, error) {
+	resp, err := c.do(ctx, http.MethodPost, "/file-content", nil, req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed reading file content response body: %w", err)
+	}
+
+	var fileContentResp pb.FileContentResponse
+	if err := proto.Unmarshal(bodyBytes, &fileContentResp); err != nil {
+		return nil, fmt.Errorf("failed decoding file content response: %w", err)
+	}
+
+	return &fileContentResp, nil
+}
+
+// Verify interface compliance at compile time.
+var _ Client = (*httpClient)(nil)

--- a/go/internal/gitter/http.go
+++ b/go/internal/gitter/http.go
@@ -99,14 +99,19 @@ func (c *httpClient) do(ctx context.Context, method, path string, query url.Valu
 	}
 }
 
-// Helper function to unmarshal the response body into target proto message
-func unmarshalProtoResponse(r io.Reader, msg proto.Message) error {
-	bodyBytes, err := io.ReadAll(r)
+func (c *httpClient) doAndUnmarshal(ctx context.Context, method, path string, query url.Values, reqBody, respMsg proto.Message) error {
+	httpResp, err := c.do(ctx, method, path, query, reqBody)
+	if err != nil {
+		return err
+	}
+	defer httpResp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		return fmt.Errorf("failed reading response body: %w", err)
 	}
 
-	if err := proto.Unmarshal(bodyBytes, msg); err != nil {
+	if err := proto.Unmarshal(bodyBytes, respMsg); err != nil {
 		return fmt.Errorf("failed decoding response: %w", err)
 	}
 
@@ -150,14 +155,8 @@ func (c *httpClient) GetTags(ctx context.Context, repoURL string) (*pb.TagsRespo
 	q := url.Values{}
 	q.Set("url", repoURL)
 
-	httpResp, err := c.do(ctx, http.MethodGet, "/tags", q, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer httpResp.Body.Close()
-
 	var tagsResp pb.TagsResponse
-	if err := unmarshalProtoResponse(httpResp.Body, &tagsResp); err != nil {
+	if err := c.doAndUnmarshal(ctx, http.MethodGet, "/tags", q, nil, &tagsResp); err != nil {
 		return nil, err
 	}
 
@@ -166,14 +165,8 @@ func (c *httpClient) GetTags(ctx context.Context, repoURL string) (*pb.TagsRespo
 
 // GetAffectedCommits handles POST /affected-commits
 func (c *httpClient) GetAffectedCommits(ctx context.Context, req *pb.AffectedCommitsRequest) (*pb.AffectedCommitsResponse, error) {
-	httpResp, err := c.do(ctx, http.MethodPost, "/affected-commits", nil, req)
-	if err != nil {
-		return nil, err
-	}
-	defer httpResp.Body.Close()
-
 	var acResp pb.AffectedCommitsResponse
-	if err := unmarshalProtoResponse(httpResp.Body, &acResp); err != nil {
+	if err := c.doAndUnmarshal(ctx, http.MethodPost, "/affected-commits", nil, req, &acResp); err != nil {
 		return nil, err
 	}
 
@@ -182,14 +175,8 @@ func (c *httpClient) GetAffectedCommits(ctx context.Context, req *pb.AffectedCom
 
 // GetFileDiffs handles POST /file-diffs
 func (c *httpClient) GetFileDiffs(ctx context.Context, req *pb.FileDiffsRequest) (*pb.FileDiffsResponse, error) {
-	httpResp, err := c.do(ctx, http.MethodPost, "/file-diffs", nil, req)
-	if err != nil {
-		return nil, err
-	}
-	defer httpResp.Body.Close()
-
 	var diffsResp pb.FileDiffsResponse
-	if err := unmarshalProtoResponse(httpResp.Body, &diffsResp); err != nil {
+	if err := c.doAndUnmarshal(ctx, http.MethodPost, "/file-diffs", nil, req, &diffsResp); err != nil {
 		return nil, err
 	}
 
@@ -198,14 +185,8 @@ func (c *httpClient) GetFileDiffs(ctx context.Context, req *pb.FileDiffsRequest)
 
 // GetFileContent handles POST /file-content
 func (c *httpClient) GetFileContent(ctx context.Context, req *pb.FileContentRequest) (*pb.FileContentResponse, error) {
-	httpResp, err := c.do(ctx, http.MethodPost, "/file-content", nil, req)
-	if err != nil {
-		return nil, err
-	}
-	defer httpResp.Body.Close()
-
 	var fileContentResp pb.FileContentResponse
-	if err := unmarshalProtoResponse(httpResp.Body, &fileContentResp); err != nil {
+	if err := c.doAndUnmarshal(ctx, http.MethodPost, "/file-content", nil, req, &fileContentResp); err != nil {
 		return nil, err
 	}
 

--- a/go/internal/gitter/http_test.go
+++ b/go/internal/gitter/http_test.go
@@ -1,0 +1,518 @@
+package gitter_test
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/osv.dev/go/internal/gitter"
+	pb "github.com/google/osv.dev/go/internal/gitter/pb/repository"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func hexDecode(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("failed decoding hex string %q: %v", s, err)
+	}
+
+	return b
+}
+
+func TestNewClient(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		hostURL string
+		client  *http.Client
+		wantErr bool
+	}{
+		{
+			name:    "valid URL",
+			hostURL: "http://localhost:8080",
+			client:  nil,
+			wantErr: false,
+		},
+		{
+			name:    "invalid URL",
+			hostURL: ":%invalid",
+			client:  nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c, err := gitter.NewClient(tt.hostURL, tt.client)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NewClient(%q) error = %v, wantErr = %v", tt.hostURL, err, tt.wantErr)
+			}
+			if !tt.wantErr && c == nil {
+				t.Fatal("NewClient() returned nil client without error")
+			}
+		})
+	}
+}
+
+func TestGetGit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		repoURL     string
+		forceUpdate bool
+		statusCode  int
+		respData    string
+		wantData    string
+		wantErr     error
+	}{
+		{
+			name:        "success with force update",
+			repoURL:     "https://github.com/google/oss-fuzz-vulns.git",
+			forceUpdate: true,
+			statusCode:  http.StatusOK,
+			respData:    "tarball-content",
+			wantData:    "tarball-content",
+		},
+		{
+			name:       "forbidden repo mapping",
+			repoURL:    "https://github.com/google/this-repo-does-not-exist-12345.git",
+			statusCode: http.StatusForbidden,
+			respData:   "Authentication failed",
+			wantErr:    gitter.ErrRepoInaccessible,
+		},
+		{
+			name:       "not found error mapping",
+			repoURL:    "https://github.com/google/oss-fuzz-vulns.git",
+			statusCode: http.StatusNotFound,
+			respData:   "Repository not found",
+			wantErr:    gitter.ErrRepoNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.statusCode == http.StatusOK {
+					if r.Method != http.MethodGet || r.URL.Path != "/git" {
+						t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					}
+					if got := r.URL.Query().Get("url"); got != tt.repoURL {
+						t.Errorf("unexpected url query: %s", got)
+					}
+				}
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.respData))
+			}))
+			t.Cleanup(ts.Close)
+
+			client, err := gitter.NewClient(ts.URL, nil)
+			if err != nil {
+				t.Fatalf("failed to create client: %v", err)
+			}
+
+			rc, err := client.GetGit(context.Background(), tt.repoURL, tt.forceUpdate)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("GetGit() error = %v, wantErr = %v", err, tt.wantErr)
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected GetGit() error: %v", err)
+			}
+			defer rc.Close()
+
+			data, err := io.ReadAll(rc)
+			if err != nil {
+				t.Fatalf("failed reading response body: %v", err)
+			}
+			if string(data) != tt.wantData {
+				t.Errorf("GetGit() data = %q, want %q", string(data), tt.wantData)
+			}
+		})
+	}
+}
+
+func TestCache(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		repoURL    string
+		statusCode int
+		wantErr    error
+	}{
+		{
+			name:       "success",
+			repoURL:    "https://github.com/google/oss-fuzz-vulns.git",
+			statusCode: http.StatusOK,
+		},
+		{
+			name:       "error mapping",
+			repoURL:    "https://github.com/google/this-repo-does-not-exist-12345.git",
+			statusCode: http.StatusForbidden,
+			wantErr:    gitter.ErrRepoInaccessible,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.statusCode == http.StatusOK {
+					if r.Method != http.MethodPost || r.URL.Path != "/cache" {
+						t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					}
+					bodyBytes, _ := io.ReadAll(r.Body)
+					var req pb.CacheRequest
+					_ = proto.Unmarshal(bodyBytes, &req)
+					if req.GetUrl() != tt.repoURL {
+						t.Errorf("expected URL %q, got %q", tt.repoURL, req.GetUrl())
+					}
+				}
+				w.WriteHeader(tt.statusCode)
+			}))
+			t.Cleanup(ts.Close)
+
+			client, err := gitter.NewClient(ts.URL, nil)
+			if err != nil {
+				t.Fatalf("failed to create client: %v", err)
+			}
+
+			err = client.Cache(context.Background(), tt.repoURL)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("Cache() error = %v, wantErr = %v", err, tt.wantErr)
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected Cache() error: %v", err)
+			}
+		})
+	}
+}
+
+func TestGetTags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		repoURL    string
+		statusCode int
+		respProto  *pb.TagsResponse
+		wantResp   *pb.TagsResponse
+		wantErr    error
+	}{
+		{
+			name:       "success",
+			repoURL:    "https://github.com/oliverchang/osv-test.git",
+			statusCode: http.StatusOK,
+			respProto: &pb.TagsResponse{
+				Tags: []*pb.Ref{
+					{Label: "v0.1", Hash: hexDecode(t, "a2ba949290915d445d34d0e8e9de2e7ce38198fc")},
+					{Label: "v0.2", Hash: hexDecode(t, "8d8242f545e9cec3e6d0d2e3f5bde8be1c659735")},
+				},
+			},
+			wantResp: &pb.TagsResponse{
+				Tags: []*pb.Ref{
+					{Label: "v0.1", Hash: hexDecode(t, "a2ba949290915d445d34d0e8e9de2e7ce38198fc")},
+					{Label: "v0.2", Hash: hexDecode(t, "8d8242f545e9cec3e6d0d2e3f5bde8be1c659735")},
+				},
+			},
+		},
+		{
+			name:       "error mapping",
+			repoURL:    "https://github.com/google/this-repo-does-not-exist-12345.git",
+			statusCode: http.StatusForbidden,
+			wantErr:    gitter.ErrRepoInaccessible,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				if tt.statusCode == http.StatusOK && tt.respProto != nil {
+					w.Header().Set("Content-Type", "application/x-protobuf")
+					payload, _ := proto.Marshal(tt.respProto)
+					_, _ = w.Write(payload)
+				}
+			}))
+			t.Cleanup(ts.Close)
+
+			client, err := gitter.NewClient(ts.URL, nil)
+			if err != nil {
+				t.Fatalf("failed to create client: %v", err)
+			}
+
+			resp, err := client.GetTags(context.Background(), tt.repoURL)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("GetTags() error = %v, wantErr = %v", err, tt.wantErr)
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected GetTags() error: %v", err)
+			}
+
+			if diff := cmp.Diff(tt.wantResp, resp, protocmp.Transform()); diff != "" {
+				t.Errorf("GetTags() response mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetAffectedCommits(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		req        *pb.AffectedCommitsRequest
+		statusCode int
+		respProto  *pb.AffectedCommitsResponse
+		wantResp   *pb.AffectedCommitsResponse
+		wantErr    error
+	}{
+		{
+			name: "success",
+			req: &pb.AffectedCommitsRequest{
+				Url: "https://github.com/google/oss-fuzz-vulns.git",
+				Events: []*pb.Event{
+					{EventType: pb.EventType_INTRODUCED, Hash: "3350c55f9525cb83fc3e0b61bde076433c2da8dc"},
+					{EventType: pb.EventType_FIXED, Hash: "8920ed8e47c660a0c20c28cb1004a600780c5b59"},
+				},
+			},
+			statusCode: http.StatusOK,
+			respProto: &pb.AffectedCommitsResponse{
+				Commits: []*pb.Commit{
+					{Hash: hexDecode(t, "3350c55f9525cb83fc3e0b61bde076433c2da8dc")},
+				},
+			},
+			wantResp: &pb.AffectedCommitsResponse{
+				Commits: []*pb.Commit{
+					{Hash: hexDecode(t, "3350c55f9525cb83fc3e0b61bde076433c2da8dc")},
+				},
+			},
+		},
+		{
+			name: "bad request error mapping",
+			req: &pb.AffectedCommitsRequest{
+				Url: "https://github.com/google/oss-fuzz-vulns.git",
+			},
+			statusCode: http.StatusBadRequest,
+			wantErr:    gitter.ErrInvalidInput,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				if tt.statusCode == http.StatusOK && tt.respProto != nil {
+					w.Header().Set("Content-Type", "application/x-protobuf")
+					payload, _ := proto.Marshal(tt.respProto)
+					_, _ = w.Write(payload)
+				}
+			}))
+			t.Cleanup(ts.Close)
+
+			client, err := gitter.NewClient(ts.URL, nil)
+			if err != nil {
+				t.Fatalf("failed to create client: %v", err)
+			}
+
+			resp, err := client.GetAffectedCommits(context.Background(), tt.req)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("GetAffectedCommits() error = %v, wantErr = %v", err, tt.wantErr)
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected GetAffectedCommits() error: %v", err)
+			}
+
+			if diff := cmp.Diff(tt.wantResp, resp, protocmp.Transform()); diff != "" {
+				t.Errorf("GetAffectedCommits() response mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetFileDiffs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		req        *pb.FileDiffsRequest
+		statusCode int
+		respProto  *pb.FileDiffsResponse
+		wantResp   *pb.FileDiffsResponse
+		wantErr    error
+	}{
+		{
+			name: "success",
+			req: &pb.FileDiffsRequest{
+				Url:              "https://github.com/oliverchang/osv-test.git",
+				LastSyncedCommit: "b1c95a196f22d06fcf80df8c6691cd113d8fefff",
+			},
+			statusCode: http.StatusOK,
+			respProto: &pb.FileDiffsResponse{
+				LatestCommit: "b9b3fd4732695b83c3068b7b6a14bb372ec31f98",
+				Changes: []*pb.FileChange{
+					{ToPath: "branch"},
+				},
+			},
+			wantResp: &pb.FileDiffsResponse{
+				LatestCommit: "b9b3fd4732695b83c3068b7b6a14bb372ec31f98",
+				Changes: []*pb.FileChange{
+					{ToPath: "branch"},
+				},
+			},
+		},
+		{
+			name: "error mapping",
+			req: &pb.FileDiffsRequest{
+				Url: "https://github.com/google/this-repo-does-not-exist-12345.git",
+			},
+			statusCode: http.StatusForbidden,
+			wantErr:    gitter.ErrRepoInaccessible,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				if tt.statusCode == http.StatusOK && tt.respProto != nil {
+					w.Header().Set("Content-Type", "application/x-protobuf")
+					payload, _ := proto.Marshal(tt.respProto)
+					_, _ = w.Write(payload)
+				}
+			}))
+			t.Cleanup(ts.Close)
+
+			client, err := gitter.NewClient(ts.URL, nil)
+			if err != nil {
+				t.Fatalf("failed to create client: %v", err)
+			}
+
+			resp, err := client.GetFileDiffs(context.Background(), tt.req)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("GetFileDiffs() error = %v, wantErr = %v", err, tt.wantErr)
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected GetFileDiffs() error: %v", err)
+			}
+
+			if diff := cmp.Diff(tt.wantResp, resp, protocmp.Transform()); diff != "" {
+				t.Errorf("GetFileDiffs() response mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetFileContent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		req        *pb.FileContentRequest
+		statusCode int
+		respProto  *pb.FileContentResponse
+		wantResp   *pb.FileContentResponse
+		wantErr    error
+	}{
+		{
+			name: "success",
+			req: &pb.FileContentRequest{
+				Url:    "https://github.com/oliverchang/osv-test.git",
+				Commit: "b9b3fd4732695b83c3068b7b6a14bb372ec31f98",
+				Path:   "abc",
+			},
+			statusCode: http.StatusOK,
+			respProto: &pb.FileContentResponse{
+				Content: []byte("abcd\n"),
+			},
+			wantResp: &pb.FileContentResponse{
+				Content: []byte("abcd\n"),
+			},
+		},
+		{
+			name: "not found error mapping",
+			req: &pb.FileContentRequest{
+				Url:    "https://github.com/oliverchang/osv-test.git",
+				Commit: "b9b3fd4732695b83c3068b7b6a14bb372ec31f98",
+				Path:   "nonexistent",
+			},
+			statusCode: http.StatusNotFound,
+			wantErr:    gitter.ErrRepoNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				if tt.statusCode == http.StatusOK && tt.respProto != nil {
+					w.Header().Set("Content-Type", "application/x-protobuf")
+					payload, _ := proto.Marshal(tt.respProto)
+					_, _ = w.Write(payload)
+				}
+			}))
+			t.Cleanup(ts.Close)
+
+			client, err := gitter.NewClient(ts.URL, nil)
+			if err != nil {
+				t.Fatalf("failed to create client: %v", err)
+			}
+
+			resp, err := client.GetFileContent(context.Background(), tt.req)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("GetFileContent() error = %v, wantErr = %v", err, tt.wantErr)
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected GetFileContent() error: %v", err)
+			}
+
+			if diff := cmp.Diff(tt.wantResp, resp, protocmp.Transform()); diff != "" {
+				t.Errorf("GetFileContent() response mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the `go/internal/gitter` package containing the `Client` interface and HTTP implementation for interacting with Gitter.
This will also make it easier to swap to gRPC in the future.

Follow-up PR for importer integration: #5744