### PR TITLE
feat: gitter importer integration

### DIFF
--- a/go/cmd/importer/main.go
+++ b/go/cmd/importer/main.go
@@ -16,6 +16,7 @@ import (
 	"cloud.google.com/go/pubsub/v2"
 	"cloud.google.com/go/storage"
 	db "github.com/google/osv.dev/go/internal/database/datastore"
+	"github.com/google/osv.dev/go/internal/gitter"
 	"github.com/google/osv.dev/go/internal/importer"
 	"github.com/google/osv.dev/go/logger"
 	"github.com/google/osv.dev/go/osv/clients"
@@ -78,6 +79,17 @@ func main() {
 	httpClient.RetryWaitMax = 4 * time.Second
 	httpClient.Logger = importer.RetryableHTTPLeveledLogger{}
 	config.HTTPClient = httpClient.StandardClient()
+
+	gitterHost := os.Getenv("GITTER_HOST")
+	if gitterHost == "" {
+		logger.FatalContext(ctx, "GITTER_HOST environment variable is not set")
+	}
+	// Use the same HTTP client with retry and logger with gitter
+	gitterClient, err := gitter.NewClient(gitterHost, config.HTTPClient)
+	if err != nil {
+		logger.FatalContext(ctx, "Failed to create gitter client", slog.Any("error", err))
+	}
+	config.GitterClient = gitterClient
 
 	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/go/internal/importer/git.go
+++ b/go/internal/importer/git.go
@@ -89,9 +89,6 @@ func handleImportGit(ctx context.Context, ch chan<- WorkItem, config Config, sou
 
 	resp, err := fetchGitterFileDiffs(ctx, config.GitterClient, sourceRepo, sourceRepo.Git.LastSyncedCommit)
 	if err != nil {
-		logger.ErrorContext(ctx, "Failed to get file diffs from gitter",
-			slog.Any("error", err), slog.String("source", sourceRepo.Name))
-
 		return err
 	}
 

--- a/go/internal/importer/git.go
+++ b/go/internal/importer/git.go
@@ -3,113 +3,49 @@ package importer
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"io"
-	"io/fs"
 	"log/slog"
-	"os"
 	"path"
-	"path/filepath"
 	"strings"
-	"sync"
 
-	"github.com/go-git/go-git/v6"
-	"github.com/go-git/go-git/v6/plumbing"
-	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/google/osv.dev/go/internal/gitter"
+	pb "github.com/google/osv.dev/go/internal/gitter/pb/repository"
 	"github.com/google/osv.dev/go/internal/models"
-	"github.com/google/osv.dev/go/internal/repos"
 	"github.com/google/osv.dev/go/logger"
-	"golang.org/x/sync/singleflight"
 )
 
 type gitSourceRecord struct {
-	repo   sharedRepo
-	commit *object.Commit
-	path   string
+	client  gitter.Client
+	repoURL string
+	commit  string
+	path    string
 }
 
 var _ SourceRecord = gitSourceRecord{}
 
-func (g gitSourceRecord) Open(_ context.Context) (io.ReadCloser, error) {
-	g.repo.mu.Lock()
-	defer g.repo.mu.Unlock()
-	f, err := g.commit.File(g.path)
-	if err != nil {
-		return nil, err
-	}
-	// read out the whole file so that the mutex is not held for too long
-	reader, err := f.Reader()
-	if err != nil {
-		return nil, err
-	}
-	content, err := io.ReadAll(reader)
-	if err != nil {
-		return nil, err
-	}
-
-	return io.NopCloser(bytes.NewReader(content)), nil
-}
-
-// Some sourceRepository entries share the same git repository (e.g. ubuntu).
-// We use singleflight.Group to share the repository between them.
-var repoGroup singleflight.Group
-
-type sharedRepo struct {
-	*git.Repository
-
-	mu *sync.Mutex
-}
-
-func handleImportGit(ctx context.Context, ch chan<- WorkItem, config Config, sourceRepo *models.SourceRepository) error {
-	if sourceRepo.Type != models.SourceRepositoryTypeGit || sourceRepo.Git == nil {
-		return errors.New("invalid SourceRepository for git import")
-	}
-	logger.InfoContext(ctx, "Importing git source repository",
-		slog.String("source", sourceRepo.Name), slog.String("url", sourceRepo.Git.URL))
-
-	compiledIgnorePatterns := compileIgnorePatterns(sourceRepo)
-	repoInterface, err, _ := repoGroup.Do(sourceRepo.Git.URL, func() (any, error) {
-		// Temporary migration from Python to Go
-		// TODO(michaelkedar): Remove when python is gone
-		// If the sha name of the repo doesn't exist, check if the source repo name exists from python.
-		// If it does, move it and use it.
-		sha := sha256.Sum256([]byte(sourceRepo.Git.URL))
-		path := hex.EncodeToString(sha[:])
-		path = filepath.Join(config.GitWorkDir, path)
-		if _, err := os.Stat(path); err != nil {
-			pythonPath := filepath.Join(config.GitWorkDir, sourceRepo.Name)
-			if _, err := os.Stat(pythonPath); err == nil {
-				// try rename it, but don't error if it fails
-				_ = os.Rename(pythonPath, path)
-			}
-		}
-		repo, err := repos.CloneToDir(ctx, sourceRepo.Git.URL, path, true)
-		if err != nil {
-			return nil, err
-		}
-
-		return sharedRepo{
-			Repository: repo,
-			mu:         &sync.Mutex{},
-		}, nil
+// Open retrieves uncompressed file content from Gitter for the target commit and path.
+func (g gitSourceRecord) Open(ctx context.Context) (io.ReadCloser, error) {
+	resp, err := g.client.GetFileContent(ctx, &pb.FileContentRequest{
+		Url:    g.repoURL,
+		Commit: g.commit,
+		Path:   g.path,
 	})
 	if err != nil {
-		logger.ErrorContext(ctx, "Failed to clone git source repository", slog.Any("error", err), slog.String("source", sourceRepo.Name))
-		return err
+		return nil, err
 	}
-	repo := repoInterface.(sharedRepo)
 
-	format := extensionToFormat(sourceRepo.Extension)
-	isReimport := sourceRepo.Git.LastSyncedCommit == ""
+	return io.NopCloser(bytes.NewReader(resp.GetContent())), nil
+}
 
-	changedFiles, commit, err := changedFiles(ctx, repo, sourceRepo)
-	if err != nil {
-		logger.ErrorContext(ctx, "Failed to get changed files", slog.Any("error", err), slog.String("source", sourceRepo.Name))
-		return err
-	}
-	filterPath := func(p string) string {
+// makeGitPathFilter path filtering function based on the SourceRepository rules.
+func makeGitPathFilter(sourceRepo *models.SourceRepository) func(string) string {
+	compiledIgnorePatterns := compileIgnorePatterns(sourceRepo)
+
+	return func(p string) string {
+		if p == "" {
+			return ""
+		}
 		if !strings.HasSuffix(p, sourceRepo.Extension) {
 			return ""
 		}
@@ -127,12 +63,49 @@ func handleImportGit(ctx context.Context, ch chan<- WorkItem, config Config, sou
 
 		return p
 	}
-	for _, fileChange := range changedFiles {
+}
+
+// fetchGitterFileDiffs requests file diffs from Gitter for a repo.
+// When lastSyncedCommit is empty, Gitter diffs against an empty tree to return all files in the repo as "add"
+func fetchGitterFileDiffs(ctx context.Context, client gitter.Client, sourceRepo *models.SourceRepository, lastSyncedCommit string) (*pb.FileDiffsResponse, error) {
+	req := &pb.FileDiffsRequest{
+		Url:              sourceRepo.Git.URL,
+		LastSyncedCommit: lastSyncedCommit,
+		Branch:           sourceRepo.Git.Branch,
+	}
+
+	return client.GetFileDiffs(ctx, req)
+}
+
+func handleImportGit(ctx context.Context, ch chan<- WorkItem, config Config, sourceRepo *models.SourceRepository) error {
+	if sourceRepo.Type != models.SourceRepositoryTypeGit || sourceRepo.Git == nil {
+		return errors.New("invalid SourceRepository for git import")
+	}
+	if config.GitterClient == nil {
+		return errors.New("gitter client is required for git import")
+	}
+	logger.InfoContext(ctx, "Importing git source repository",
+		slog.String("source", sourceRepo.Name), slog.String("url", sourceRepo.Git.URL))
+
+	resp, err := fetchGitterFileDiffs(ctx, config.GitterClient, sourceRepo, sourceRepo.Git.LastSyncedCommit)
+	if err != nil {
+		logger.ErrorContext(ctx, "Failed to get file diffs from gitter",
+			slog.Any("error", err), slog.String("source", sourceRepo.Name))
+
+		return err
+	}
+
+	format := extensionToFormat(sourceRepo.Extension)
+	isReimport := sourceRepo.Git.LastSyncedCommit == ""
+	filterPath := makeGitPathFilter(sourceRepo)
+	latestCommit := resp.GetLatestCommit()
+
+	for _, fileChange := range resp.GetChanges() {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		from := filterPath(fileChange.from)
-		to := filterPath(fileChange.to)
+		from := filterPath(fileChange.GetFromPath())
+		to := filterPath(fileChange.GetToPath())
 		if from == "" && to == "" {
 			// file was ignored/removed in both commits
 			continue
@@ -149,8 +122,10 @@ func handleImportGit(ctx context.Context, ch chan<- WorkItem, config Config, sou
 			case ch <- WorkItem{
 				Context: ctx,
 				SourceRecord: gitSourceRecord{
-					path: from,
-					repo: repo,
+					client:  config.GitterClient,
+					repoURL: sourceRepo.Git.URL,
+					commit:  latestCommit,
+					path:    from,
 				},
 				SourceRepository: sourceRepo.Name,
 				SourcePath:       from,
@@ -172,9 +147,10 @@ func handleImportGit(ctx context.Context, ch chan<- WorkItem, config Config, sou
 		case ch <- WorkItem{
 			Context: ctx,
 			SourceRecord: gitSourceRecord{
-				repo:   repo,
-				commit: commit,
-				path:   to,
+				client:  config.GitterClient,
+				repoURL: sourceRepo.Git.URL,
+				commit:  latestCommit,
+				path:    to,
 			},
 			SourceRepository: sourceRepo.Name,
 			SourcePath:       to,
@@ -187,9 +163,10 @@ func handleImportGit(ctx context.Context, ch chan<- WorkItem, config Config, sou
 		}
 	}
 
-	sourceRepo.Git.LastSyncedCommit = commit.Hash.String()
+	sourceRepo.Git.LastSyncedCommit = latestCommit
 	if err := config.SourceRepoStore.Update(ctx, sourceRepo.Name, sourceRepo); err != nil {
 		logger.ErrorContext(ctx, "Failed to update source repository", slog.Any("error", err), slog.String("source", sourceRepo.Name))
+
 		return err
 	}
 	logger.InfoContext(ctx, "Finished importing git source repository",
@@ -199,128 +176,15 @@ func handleImportGit(ctx context.Context, ch chan<- WorkItem, config Config, sou
 	return nil
 }
 
-type fileChange struct {
-	from string
-	to   string
-}
-
-func changedFiles(ctx context.Context, repo sharedRepo, sourceRepo *models.SourceRepository) ([]fileChange, *object.Commit, error) {
-	repo.mu.Lock()
-	defer repo.mu.Unlock()
-	var current plumbing.Hash
-	if sourceRepo.Git.Branch != "" {
-		ref, err := repo.Reference(plumbing.NewRemoteReferenceName("origin", sourceRepo.Git.Branch), true)
-		if err != nil {
-			return nil, nil, err
-		}
-		current = ref.Hash()
-	} else {
-		ref, err := repo.Reference(plumbing.NewRemoteHEADReferenceName("origin"), true)
-		if err != nil {
-			return nil, nil, err
-		}
-		current = ref.Hash()
-	}
-	currentCommit, err := repo.CommitObject(current)
-	if err != nil {
-		return nil, nil, err
-	}
-	currentTree, err := currentCommit.Tree()
-	if err != nil {
-		return nil, nil, err
-	}
-	var prevSyncTree *object.Tree
-	if sourceRepo.Git.LastSyncedCommit != "" {
-		prevSyncCommit, err := repo.CommitObject(plumbing.NewHash(sourceRepo.Git.LastSyncedCommit))
-		if err != nil {
-			return nil, nil, err
-		}
-		prevSyncTree, err = prevSyncCommit.Tree()
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-	// tree.Diff(nil) returns all files, which is what we want.
-	diff, err := currentTree.DiffContext(ctx, prevSyncTree)
-	if err != nil {
-		return nil, nil, err
-	}
-	changedFiles := make([]fileChange, 0, len(diff))
-	for _, d := range diff {
-		// Note: since we're doing child.Diff(parent), to/from are reversed from what you might expect.
-		changedFiles = append(changedFiles, fileChange{
-			from: d.To.Name,
-			to:   d.From.Name,
-		})
-	}
-
-	return changedFiles, currentCommit, nil
-}
-
-type localFileSourceRecord struct {
-	path string
-}
-
-func (r localFileSourceRecord) Open(_ context.Context) (io.ReadCloser, error) {
-	return os.Open(r.path)
-}
-
 func handleReconcileGit(ctx context.Context, ch chan<- WorkItem, config Config, sourceRepo *models.SourceRepository) error {
 	if sourceRepo.Type != models.SourceRepositoryTypeGit || sourceRepo.Git == nil {
 		return errors.New("invalid SourceRepository for git reconcile")
 	}
+	if config.GitterClient == nil {
+		return errors.New("gitter client is required for git reconcile")
+	}
 	logger.InfoContext(ctx, "Processing git reconcile",
 		slog.String("source", sourceRepo.Name), slog.String("url", sourceRepo.Git.URL))
-
-	compiledIgnorePatterns := compileIgnorePatterns(sourceRepo)
-
-	sha := sha256.Sum256([]byte(sourceRepo.Git.URL))
-	pathStr := hex.EncodeToString(sha[:])
-	pathStr = filepath.Join(config.GitWorkDir, pathStr)
-
-	// TODO: We don't support multiple sources with the same repo but different branches.
-	_, err, _ := repoGroup.Do(sourceRepo.Git.URL, func() (any, error) {
-		repo, err := repos.CloneToDir(ctx, sourceRepo.Git.URL, pathStr, true)
-		if err != nil {
-			return nil, err
-		}
-
-		var branch plumbing.ReferenceName
-		if sourceRepo.Git.Branch == "" {
-			branch = plumbing.NewRemoteHEADReferenceName("origin")
-		} else {
-			branch = plumbing.NewRemoteReferenceName("origin", sourceRepo.Git.Branch)
-		}
-
-		wt, err := repo.Worktree()
-		if err != nil {
-			return nil, err
-		}
-
-		err = wt.Checkout(&git.CheckoutOptions{
-			Branch: branch,
-			Force:  true,
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		err = wt.Clean(&git.CleanOptions{
-			Dir: true,
-		})
-
-		return sharedRepo{
-			Repository: repo,
-			mu:         &sync.Mutex{},
-		}, err
-	})
-	if err != nil {
-		if !errors.Is(err, context.Canceled) {
-			logger.ErrorContext(ctx, "Failed to clone git source repository for reconcile", slog.Any("error", err), slog.String("source", sourceRepo.Name))
-		}
-
-		return err
-	}
 
 	// Fetch datastore records for the source
 	dbRecords, err := fetchDBRecords(ctx, config, sourceRepo)
@@ -330,52 +194,37 @@ func handleReconcileGit(ctx context.Context, ch chan<- WorkItem, config Config, 
 
 	format := extensionToFormat(sourceRepo.Extension)
 
-	searchDir := pathStr
-	if sourceRepo.Git.Path != "" {
-		searchDir = filepath.Join(pathStr, sourceRepo.Git.Path)
+	// Query Gitter with empty lastSyncedCommit to get all files in the repository
+	resp, err := fetchGitterFileDiffs(ctx, config.GitterClient, sourceRepo, "")
+	if err != nil {
+		if !errors.Is(err, context.Canceled) {
+			logger.ErrorContext(ctx, "Failed to get file diffs for git reconcile", slog.Any("error", err), slog.String("source", sourceRepo.Name))
+		}
+
+		return err
 	}
 
-	err = filepath.WalkDir(searchDir, func(p string, d fs.DirEntry, err error) error {
+	filterPath := makeGitPathFilter(sourceRepo)
+	latestCommit := resp.GetLatestCommit()
+
+	for _, fileChange := range resp.GetChanges() {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			if d.Name() == ".git" {
-				return filepath.SkipDir
-			}
 
-			return nil
+		relPath := filterPath(fileChange.GetToPath())
+		if relPath == "" {
+			continue
 		}
 
-		if !strings.HasSuffix(p, sourceRepo.Extension) {
-			return nil
-		}
-
-		relPath, err := filepath.Rel(pathStr, p)
-		if err != nil {
-			return err
-		}
-		// Always use forward slashes for relative paths inside git repositories
-		relPath = filepath.ToSlash(relPath)
-
-		if shouldIgnore(path.Base(p), sourceRepo.IDPrefixes, compiledIgnorePatterns) {
-			return nil
-		}
-
-		sourceRecord := localFileSourceRecord{
-			path: p, // Absolute path on disk
+		sourceRecord := gitSourceRecord{
+			client:  config.GitterClient,
+			repoURL: sourceRepo.Git.URL,
+			commit:  latestCommit,
+			path:    relPath,
 		}
 
 		checkReconcile(ctx, ch, sourceRepo, dbRecords, relPath, nil, sourceRecord, format, config.ReimportTaskPool)
-
-		return nil
-	})
-
-	if err != nil {
-		return err
 	}
 
 	logger.InfoContext(ctx, "Finished reconciling git source repository",

--- a/go/internal/importer/git.go
+++ b/go/internal/importer/git.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/osv.dev/go/internal/gitter"
 	pb "github.com/google/osv.dev/go/internal/gitter/pb/repository"
 	"github.com/google/osv.dev/go/internal/models"
+	"github.com/google/osv.dev/go/internal/osvutil"
 	"github.com/google/osv.dev/go/logger"
 )
 
@@ -117,13 +118,8 @@ func handleImportGit(ctx context.Context, ch chan<- WorkItem, config Config, sou
 			case <-ctx.Done():
 				return ctx.Err()
 			case ch <- WorkItem{
-				Context: ctx,
-				SourceRecord: gitSourceRecord{
-					client:  config.GitterClient,
-					repoURL: sourceRepo.Git.URL,
-					commit:  latestCommit,
-					path:    from,
-				},
+				Context:          ctx,
+				SourceRecord:     nil,
 				SourceRepository: sourceRepo.Name,
 				SourcePath:       from,
 				Action:           ActionWithdraw,
@@ -194,7 +190,7 @@ func handleReconcileGit(ctx context.Context, ch chan<- WorkItem, config Config, 
 	// Query Gitter with empty lastSyncedCommit to get all files in the repository
 	resp, err := fetchGitterFileDiffs(ctx, config.GitterClient, sourceRepo, "")
 	if err != nil {
-		if !errors.Is(err, context.Canceled) {
+		if !osvutil.IsContextError(err) {
 			logger.ErrorContext(ctx, "Failed to get file diffs for git reconcile", slog.Any("error", err), slog.String("source", sourceRepo.Name))
 		}
 

--- a/go/internal/importer/git_test.go
+++ b/go/internal/importer/git_test.go
@@ -1,62 +1,35 @@
 package importer
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
+	"context"
+	"errors"
 	"io"
-	"os"
-	"path/filepath"
-	"sync"
 	"testing"
-	"time"
 
-	"github.com/go-git/go-git/v6"
-	"github.com/go-git/go-git/v6/plumbing/object"
+	pb "github.com/google/osv.dev/go/internal/gitter/pb/repository"
 	"github.com/google/osv.dev/go/internal/models"
 )
 
-func TestGitSourceRecord_Open(t *testing.T) {
-	// Setup a temporary git repo
-	dir := t.TempDir()
-	repo, err := git.PlainInit(dir, false)
-	if err != nil {
-		t.Fatalf("Failed to init git repo: %v", err)
-	}
-	wt, err := repo.Worktree()
-	if err != nil {
-		t.Fatalf("Failed to get worktree: %v", err)
-	}
+// Just some randomly SHA1 strings as commit hash
+const (
+	commitA = "aba9cc47a746783b86f16425e27afb1c044d47df"
+	commitB = "3eff134ce2a70d0af05040691ffb4c9cb763c980"
+)
 
-	// Create a file
-	filePath := filepath.Join(dir, "test.json")
-	if err := os.WriteFile(filePath, []byte("data"), 0600); err != nil {
-		t.Fatalf("Failed to write file: %v", err)
-	}
-	if _, err := wt.Add("test.json"); err != nil {
-		t.Fatalf("Failed to add file: %v", err)
-	}
-	hash, err := wt.Commit("Init", &git.CommitOptions{
-		Author: &object.Signature{
-			Name:  "Test",
-			Email: "test@example.com",
-			When:  time.Now(),
+func TestGitSourceRecord_Open(t *testing.T) {
+	mockClient := &mockGitterClient{
+		fileContentFunc: func(_ context.Context, _ *pb.FileContentRequest) (*pb.FileContentResponse, error) {
+			return &pb.FileContentResponse{
+				Content: []byte("data"),
+			}, nil
 		},
-	})
-	if err != nil {
-		t.Fatalf("Failed to commit: %v", err)
-	}
-	commit, err := repo.CommitObject(hash)
-	if err != nil {
-		t.Fatalf("Failed to get commit: %v", err)
 	}
 
 	record := gitSourceRecord{
-		repo: sharedRepo{
-			Repository: repo,
-			mu:         &sync.Mutex{},
-		},
-		commit: commit,
-		path:   "test.json",
+		client:  mockClient,
+		repoURL: "https://github.com/mock/test-repo.git",
+		commit:  commitA,
+		path:    "test.go",
 	}
 
 	reader, err := record.Open(t.Context())
@@ -74,60 +47,47 @@ func TestGitSourceRecord_Open(t *testing.T) {
 	}
 }
 
+func TestGitSourceRecord_Open_Error(t *testing.T) {
+	mockClient := &mockGitterClient{
+		fileContentFunc: func(_ context.Context, _ *pb.FileContentRequest) (*pb.FileContentResponse, error) {
+			return nil, errors.New("gitter fetch content error")
+		},
+	}
+
+	record := gitSourceRecord{
+		client:  mockClient,
+		repoURL: "https://github.com/mock/test-repo.git",
+		commit:  commitA,
+		path:    "test.go",
+	}
+
+	_, err := record.Open(t.Context())
+	if err == nil {
+		t.Fatalf("Expected error from Open, got nil")
+	}
+}
+
 func TestHandleImportGit(t *testing.T) {
-	// Setup a temporary git repo acting as the remote source
-	remoteDir := t.TempDir()
-	remoteRepo, err := git.PlainInit(remoteDir, false)
-	if err != nil {
-		t.Fatalf("Failed to init remote repo: %v", err)
+	mockClient := &mockGitterClient{
+		fileDiffsFunc: func(_ context.Context, _ *pb.FileDiffsRequest) (*pb.FileDiffsResponse, error) {
+			return &pb.FileDiffsResponse{
+				LatestCommit: commitB,
+				Changes: []*pb.FileChange{
+					{FromPath: "ignore-1.json", ToPath: "ignore-1.json"}, // should be ignored
+					{FromPath: "CVE-A.json", ToPath: "CVE-A.json"},       // modified
+					{FromPath: "", ToPath: "CVE-B.json"},                 // added
+				},
+			}, nil
+		},
 	}
-	remoteWt, err := remoteRepo.Worktree()
-	if err != nil {
-		t.Fatalf("Failed to get remote worktree: %v", err)
-	}
-
-	// Initial commit: ignored file and old file
-	if err := os.WriteFile(filepath.Join(remoteDir, "ignore.json"), []byte("{}"), 0600); err != nil {
-		t.Fatalf("Failed to write file: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(remoteDir, "CVE-A.json"), []byte("{}"), 0600); err != nil {
-		t.Fatalf("Failed to write file: %v", err)
-	}
-	if _, err := remoteWt.Add("ignore.json"); err != nil {
-		t.Fatalf("Failed to add file: %v", err)
-	}
-	if _, err := remoteWt.Add("CVE-A.json"); err != nil {
-		t.Fatalf("Failed to add file: %v", err)
-	}
-	commitA, _ := remoteWt.Commit("Initial", &git.CommitOptions{
-		Author: &object.Signature{Name: "Test", Email: "test@example.com", When: time.Now()},
-	})
-
-	// Second commit: Modify old file, add new file
-	if err := os.WriteFile(filepath.Join(remoteDir, "CVE-A.json"), []byte(`{"modified": true}`), 0600); err != nil {
-		t.Fatalf("Failed to write file: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(remoteDir, "CVE-B.json"), []byte("{}"), 0600); err != nil {
-		t.Fatalf("Failed to write file: %v", err)
-	}
-	if _, err := remoteWt.Add("CVE-A.json"); err != nil {
-		t.Fatalf("Failed to add file: %v", err)
-	}
-	if _, err := remoteWt.Add("CVE-B.json"); err != nil {
-		t.Fatalf("Failed to add file: %v", err)
-	}
-	commitB, _ := remoteWt.Commit("Second", &git.CommitOptions{
-		Author: &object.Signature{Name: "Test", Email: "test@example.com", When: time.Now()},
-	})
 
 	mockStore := &mockSourceRepositoryStore{
 		updates: make(map[string]any),
 	}
-	workDir := t.TempDir()
 
 	config := Config{
 		SourceRepoStore: mockStore,
-		GitWorkDir:      workDir,
+		GitterClient:    mockClient,
 	}
 
 	sourceRepo := &models.SourceRepository{
@@ -136,13 +96,13 @@ func TestHandleImportGit(t *testing.T) {
 		Extension:      ".json",
 		IgnorePatterns: []string{"ignore.*"},
 		Git: &models.SourceRepoGit{
-			URL:              remoteDir,
-			LastSyncedCommit: commitA.String(),
+			URL:              "https://github.com/mock/test-repo.git",
+			LastSyncedCommit: commitA,
 		},
 	}
 
 	ch := make(chan WorkItem, 10)
-	err = handleImportGit(t.Context(), ch, config, sourceRepo)
+	err := handleImportGit(t.Context(), ch, config, sourceRepo)
 	if err != nil {
 		t.Fatalf("handleImportGit failed: %v", err)
 	}
@@ -153,8 +113,6 @@ func TestHandleImportGit(t *testing.T) {
 		items = append(items, r)
 	}
 
-	// We expect 2 records based on diff from commitA to commitB
-	// CVE-A.json was modified, CVE-B.json was added.
 	if len(items) != 2 {
 		t.Fatalf("Expected 2 records, got %d", len(items))
 	}
@@ -171,49 +129,30 @@ func TestHandleImportGit(t *testing.T) {
 		t.Errorf("Expected CVE-B.json to be processed")
 	}
 
-	// Verify the LastSyncedCommit was updated
-	if sourceRepo.Git.LastSyncedCommit != commitB.String() {
-		t.Errorf("Expected LastSyncedCommit %s, got %s", commitB.String(), sourceRepo.Git.LastSyncedCommit)
+	if sourceRepo.Git.LastSyncedCommit != commitB {
+		t.Errorf("Expected LastSyncedCommit %s, got %s", commitB, sourceRepo.Git.LastSyncedCommit)
 	}
 }
 
 func TestHandleImportGit_Deletion(t *testing.T) {
-	// Setup a temporary git repo acting as the remote source
-	remoteDir := t.TempDir()
-	remoteRepo, err := git.PlainInit(remoteDir, false)
-	if err != nil {
-		t.Fatalf("Failed to init remote repo: %v", err)
+	mockClient := &mockGitterClient{
+		fileDiffsFunc: func(_ context.Context, _ *pb.FileDiffsRequest) (*pb.FileDiffsResponse, error) {
+			return &pb.FileDiffsResponse{
+				LatestCommit: commitB,
+				Changes: []*pb.FileChange{
+					{FromPath: "CVE-A.json", ToPath: ""}, // deleted
+				},
+			}, nil
+		},
 	}
-	remoteWt, err := remoteRepo.Worktree()
-	if err != nil {
-		t.Fatalf("Failed to get remote worktree: %v", err)
-	}
-
-	// Initial commit: one file
-	if err := os.WriteFile(filepath.Join(remoteDir, "CVE-A.json"), []byte("{}"), 0600); err != nil {
-		t.Fatalf("Failed to write file: %v", err)
-	}
-	if _, err := remoteWt.Add("CVE-A.json"); err != nil {
-		t.Fatalf("Failed to add file: %v", err)
-	}
-	commitA, _ := remoteWt.Commit("Initial", &git.CommitOptions{
-		Author: &object.Signature{Name: "Test", Email: "test@example.com", When: time.Now()},
-	})
-
-	// Second commit: Delete the file
-	_, _ = remoteWt.Remove("CVE-A.json")
-	commitB, _ := remoteWt.Commit("Second (Delete)", &git.CommitOptions{
-		Author: &object.Signature{Name: "Test", Email: "test@example.com", When: time.Now()},
-	})
 
 	mockStore := &mockSourceRepositoryStore{
 		updates: make(map[string]any),
 	}
-	workDir := t.TempDir()
 
 	config := Config{
 		SourceRepoStore: mockStore,
-		GitWorkDir:      workDir,
+		GitterClient:    mockClient,
 	}
 
 	sourceRepo := &models.SourceRepository{
@@ -221,13 +160,13 @@ func TestHandleImportGit_Deletion(t *testing.T) {
 		Type:      models.SourceRepositoryTypeGit,
 		Extension: ".json",
 		Git: &models.SourceRepoGit{
-			URL:              remoteDir,
-			LastSyncedCommit: commitA.String(),
+			URL:              "https://github.com/mock/test-repo.git",
+			LastSyncedCommit: commitA,
 		},
 	}
 
 	ch := make(chan WorkItem, 10)
-	err = handleImportGit(t.Context(), ch, config, sourceRepo)
+	err := handleImportGit(t.Context(), ch, config, sourceRepo)
 	if err != nil {
 		t.Fatalf("handleImportGit failed: %v", err)
 	}
@@ -238,7 +177,6 @@ func TestHandleImportGit_Deletion(t *testing.T) {
 		items = append(items, r)
 	}
 
-	// We expect 1 record: the deletion of CVE-A.json
 	if len(items) != 1 {
 		t.Fatalf("Expected 1 record, got %d", len(items))
 	}
@@ -250,45 +188,51 @@ func TestHandleImportGit_Deletion(t *testing.T) {
 		t.Errorf("Expected record to be marked as Action=Withdraw")
 	}
 
-	// Verify the LastSyncedCommit was updated
-	if sourceRepo.Git.LastSyncedCommit != commitB.String() {
-		t.Errorf("Expected LastSyncedCommit %s, got %s", commitB.String(), sourceRepo.Git.LastSyncedCommit)
+	if sourceRepo.Git.LastSyncedCommit != commitB {
+		t.Errorf("Expected LastSyncedCommit %s, got %s", commitB, sourceRepo.Git.LastSyncedCommit)
 	}
 }
 
-func TestHandleReconcileGit_CleanUntracked(t *testing.T) {
-	// Setup a temporary git repo acting as the remote source
-	remoteDir := t.TempDir()
-	remoteRepo, err := git.PlainInit(remoteDir, false)
-	if err != nil {
-		t.Fatalf("Failed to init remote repo: %v", err)
-	}
-	remoteWt, err := remoteRepo.Worktree()
-	if err != nil {
-		t.Fatalf("Failed to get remote worktree: %v", err)
+func TestHandleImportGit_GitterError(t *testing.T) {
+	mockClient := &mockGitterClient{
+		fileDiffsFunc: func(_ context.Context, _ *pb.FileDiffsRequest) (*pb.FileDiffsResponse, error) {
+			return nil, errors.New("gitter diff error")
+		},
 	}
 
-	// Initial commit: tracked files in root and subdir
-	if err := os.WriteFile(filepath.Join(remoteDir, "CVE-A.json"), []byte("{}"), 0600); err != nil {
-		t.Fatalf("Failed to write file: %v", err)
+	config := Config{
+		SourceRepoStore: &mockSourceRepositoryStore{},
+		GitterClient:    mockClient,
 	}
-	if err := os.Mkdir(filepath.Join(remoteDir, "tracked_dir"), 0755); err != nil {
-		t.Fatalf("Failed to create tracked dir: %v", err)
+
+	sourceRepo := &models.SourceRepository{
+		Name:      "test-git-repo",
+		Type:      models.SourceRepositoryTypeGit,
+		Extension: ".json",
+		Git: &models.SourceRepoGit{
+			URL: "https://github.com/mock/test-repo.git",
+		},
 	}
-	if err := os.WriteFile(filepath.Join(remoteDir, "tracked_dir", "CVE-B.json"), []byte("{}"), 0600); err != nil {
-		t.Fatalf("Failed to write file in tracked dir: %v", err)
+
+	ch := make(chan WorkItem, 10)
+	err := handleImportGit(t.Context(), ch, config, sourceRepo)
+	if err == nil {
+		t.Fatalf("Expected error from handleImportGit, got nil")
 	}
-	if _, err := remoteWt.Add("CVE-A.json"); err != nil {
-		t.Fatalf("Failed to add file: %v", err)
-	}
-	if _, err := remoteWt.Add("tracked_dir/CVE-B.json"); err != nil {
-		t.Fatalf("Failed to add file in tracked dir: %v", err)
-	}
-	_, err = remoteWt.Commit("Initial", &git.CommitOptions{
-		Author: &object.Signature{Name: "Test", Email: "test@example.com", When: time.Now()},
-	})
-	if err != nil {
-		t.Fatalf("Failed to commit: %v", err)
+}
+
+func TestHandleReconcileGit(t *testing.T) {
+	mockClient := &mockGitterClient{
+		fileDiffsFunc: func(_ context.Context, _ *pb.FileDiffsRequest) (*pb.FileDiffsResponse, error) {
+			return &pb.FileDiffsResponse{
+				LatestCommit: commitB,
+				Changes: []*pb.FileChange{
+					{FromPath: "", ToPath: "CVE-A.json"},
+					{FromPath: "", ToPath: "tracked_dir/CVE-B.json"},
+					{FromPath: "", ToPath: "ignored.txt"},
+				},
+			}, nil
+		},
 	}
 
 	mockStore := &mockSourceRepositoryStore{
@@ -297,12 +241,11 @@ func TestHandleReconcileGit_CleanUntracked(t *testing.T) {
 	mockVulnStore := &mockVulnerabilityStore{
 		Entries: make(map[string][]*models.VulnSourceRef),
 	}
-	workDir := t.TempDir()
 
 	config := Config{
 		SourceRepoStore:    mockStore,
 		VulnerabilityStore: mockVulnStore,
-		GitWorkDir:         workDir,
+		GitterClient:       mockClient,
 	}
 
 	sourceRepo := &models.SourceRepository{
@@ -310,100 +253,64 @@ func TestHandleReconcileGit_CleanUntracked(t *testing.T) {
 		Type:      models.SourceRepositoryTypeGit,
 		Extension: ".json",
 		Git: &models.SourceRepoGit{
-			URL: remoteDir,
+			URL: "https://github.com/mock/test-repo.git",
 		},
 	}
 
-	// 1. Run reconcile first time to clone the repo
 	ch := make(chan WorkItem, 10)
-	err = handleReconcileGit(t.Context(), ch, config, sourceRepo)
+	err := handleReconcileGit(t.Context(), ch, config, sourceRepo)
 	if err != nil {
 		t.Fatalf("handleReconcileGit failed: %v", err)
 	}
 	close(ch)
 
-	// Consume channel to avoid blocking
-	for range ch {
-		continue
+	items := make([]WorkItem, 0, 10)
+	for r := range ch {
+		items = append(items, r)
 	}
 
-	// Calculate local clone path
-	sha := sha256.Sum256([]byte(sourceRepo.Git.URL))
-	localCloneDir := filepath.Join(workDir, hex.EncodeToString(sha[:]))
-
-	// Verify the local clone exists and has the tracked files
-	trackedFilePathA := filepath.Join(localCloneDir, "CVE-A.json")
-	if _, err := os.Stat(trackedFilePathA); err != nil {
-		t.Fatalf("Expected tracked file A to exist at %s, got error: %v", trackedFilePathA, err)
-	}
-	trackedFilePathB := filepath.Join(localCloneDir, "tracked_dir", "CVE-B.json")
-	if _, err := os.Stat(trackedFilePathB); err != nil {
-		t.Fatalf("Expected tracked file B to exist at %s, got error: %v", trackedFilePathB, err)
+	if len(items) != 2 {
+		t.Fatalf("Expected 2 records to be reconciled, got %d", len(items))
 	}
 
-	// 2. Create untracked files/dirs in the local clone
-	// 2a. Untracked file in root
-	untrackedRootFile := filepath.Join(localCloneDir, "untracked.json")
-	if err := os.WriteFile(untrackedRootFile, []byte("untracked"), 0600); err != nil {
-		t.Fatalf("Failed to write untracked file in root: %v", err)
+	paths := make(map[string]bool)
+	for _, it := range items {
+		paths[it.SourcePath] = true
 	}
 
-	// 2b. Untracked file in tracked subdir
-	untrackedInTrackedDir := filepath.Join(localCloneDir, "tracked_dir", "untracked_in_tracked.json")
-	if err := os.WriteFile(untrackedInTrackedDir, []byte("untracked"), 0600); err != nil {
-		t.Fatalf("Failed to write untracked file in tracked dir: %v", err)
+	if !paths["CVE-A.json"] {
+		t.Errorf("Expected CVE-A.json to be reconciled")
+	}
+	if !paths["tracked_dir/CVE-B.json"] {
+		t.Errorf("Expected tracked_dir/CVE-B.json to be reconciled")
+	}
+}
+
+func TestHandleReconcileGit_GitterError(t *testing.T) {
+	mockClient := &mockGitterClient{
+		fileDiffsFunc: func(_ context.Context, _ *pb.FileDiffsRequest) (*pb.FileDiffsResponse, error) {
+			return nil, errors.New("gitter reconcile error")
+		},
 	}
 
-	// 2c. Untracked subdir in tracked subdir (with a file)
-	untrackedDirInTrackedDir := filepath.Join(localCloneDir, "tracked_dir", "untracked_dir_in_tracked")
-	if err := os.Mkdir(untrackedDirInTrackedDir, 0755); err != nil {
-		t.Fatalf("Failed to create untracked dir in tracked dir: %v", err)
-	}
-	fileInUntrackedDirInTrackedDir := filepath.Join(untrackedDirInTrackedDir, "file.json")
-	if err := os.WriteFile(fileInUntrackedDirInTrackedDir, []byte("untracked"), 0600); err != nil {
-		t.Fatalf("Failed to write file in untracked dir in tracked dir: %v", err)
+	config := Config{
+		SourceRepoStore:    &mockSourceRepositoryStore{},
+		VulnerabilityStore: &mockVulnerabilityStore{},
+		GitterClient:       mockClient,
 	}
 
-	// 2d. Untracked subdir in root (with a file)
-	untrackedRootDir := filepath.Join(localCloneDir, "untracked_dir")
-	if err := os.Mkdir(untrackedRootDir, 0755); err != nil {
-		t.Fatalf("Failed to create untracked dir in root: %v", err)
-	}
-	fileInUntrackedRootDir := filepath.Join(untrackedRootDir, "file.json")
-	if err := os.WriteFile(fileInUntrackedRootDir, []byte("untracked"), 0600); err != nil {
-		t.Fatalf("Failed to write file in untracked root dir: %v", err)
-	}
-
-	// 3. Run reconcile again. It should clean up untracked files/dirs.
-	ch2 := make(chan WorkItem, 10)
-	err = handleReconcileGit(t.Context(), ch2, config, sourceRepo)
-	if err != nil {
-		t.Fatalf("handleReconcileGit failed second time: %v", err)
-	}
-	close(ch2)
-	for range ch2 {
-		continue
+	sourceRepo := &models.SourceRepository{
+		Name:      "test-git-repo",
+		Type:      models.SourceRepositoryTypeGit,
+		Extension: ".json",
+		Git: &models.SourceRepoGit{
+			URL: "https://github.com/mock/test-repo.git",
+		},
 	}
 
-	// 4. Verify all untracked files and dirs are GONE
-	if _, err := os.Stat(untrackedRootFile); !os.IsNotExist(err) {
-		t.Errorf("Expected untracked root file to be deleted, but it still exists (or got error: %v)", err)
-	}
-	if _, err := os.Stat(untrackedInTrackedDir); !os.IsNotExist(err) {
-		t.Errorf("Expected untracked file in tracked dir to be deleted, but it still exists (or got error: %v)", err)
-	}
-	if _, err := os.Stat(untrackedDirInTrackedDir); !os.IsNotExist(err) {
-		t.Errorf("Expected untracked dir in tracked dir to be deleted, but it still exists (or got error: %v)", err)
-	}
-	if _, err := os.Stat(untrackedRootDir); !os.IsNotExist(err) {
-		t.Errorf("Expected untracked root dir to be deleted, but it still exists (or got error: %v)", err)
-	}
-
-	// Verify tracked files still exist
-	if _, err := os.Stat(trackedFilePathA); err != nil {
-		t.Errorf("Expected tracked file A to still exist, got error: %v", err)
-	}
-	if _, err := os.Stat(trackedFilePathB); err != nil {
-		t.Errorf("Expected tracked file B to still exist, got error: %v", err)
+	ch := make(chan WorkItem, 10)
+	err := handleReconcileGit(t.Context(), ch, config, sourceRepo)
+	if err == nil {
+		t.Fatalf("Expected error from handleReconcileGit, got nil")
 	}
 }

--- a/go/internal/importer/importer.go
+++ b/go/internal/importer/importer.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/pubsub/v2"
+	"github.com/google/osv.dev/go/internal/gitter"
 	"github.com/google/osv.dev/go/internal/models"
 	"github.com/google/osv.dev/go/internal/osvutil/schema"
 	"github.com/google/osv.dev/go/logger"
@@ -50,6 +51,7 @@ type Config struct {
 	GCSProvider        clients.CloudStorageProvider
 	HTTPClient         *http.Client
 	GitWorkDir         string
+	GitterClient       gitter.Client
 
 	StrictValidation bool
 	DeleteThreshold  float64

--- a/go/internal/importer/mock_gitter_client_test.go
+++ b/go/internal/importer/mock_gitter_client_test.go
@@ -1,0 +1,51 @@
+package importer
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/google/osv.dev/go/internal/gitter"
+	pb "github.com/google/osv.dev/go/internal/gitter/pb/repository"
+)
+
+// mockGitterClient is a mock implementation of gitter.Client for unit testing importer Git operations.
+// Tests can set file-diffs and file-content funcs to mock specific responses or errors.
+type mockGitterClient struct {
+	fileDiffsFunc   func(ctx context.Context, req *pb.FileDiffsRequest) (*pb.FileDiffsResponse, error)
+	fileContentFunc func(ctx context.Context, req *pb.FileContentRequest) (*pb.FileContentResponse, error)
+}
+
+func (m *mockGitterClient) GetGit(_ context.Context, _ string, _ bool) (io.ReadCloser, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockGitterClient) Cache(_ context.Context, _ string) error {
+	return nil
+}
+
+func (m *mockGitterClient) GetTags(_ context.Context, _ string) (*pb.TagsResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockGitterClient) GetAffectedCommits(_ context.Context, _ *pb.AffectedCommitsRequest) (*pb.AffectedCommitsResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *mockGitterClient) GetFileDiffs(ctx context.Context, req *pb.FileDiffsRequest) (*pb.FileDiffsResponse, error) {
+	if m.fileDiffsFunc != nil {
+		return m.fileDiffsFunc(ctx, req)
+	}
+
+	return &pb.FileDiffsResponse{}, nil
+}
+
+func (m *mockGitterClient) GetFileContent(ctx context.Context, req *pb.FileContentRequest) (*pb.FileContentResponse, error) {
+	if m.fileContentFunc != nil {
+		return m.fileContentFunc(ctx, req)
+	}
+
+	return &pb.FileContentResponse{}, nil
+}
+
+var _ gitter.Client = (*mockGitterClient)(nil)


### PR DESCRIPTION
Make importer use gitter's new /file-diffs and /file-content endpoints via gitter client, instead of cloning the source repos and reading from local.

~Stack PR isn't a thing yet so this PR also includes changes from #5742. But once we merge and rebase, this PR should be nicer to look at.~ GitHub released stack PR today just to spite me I guess 😔 