### PR TITLE
refactor(relations): abstract database interactions behind models.RelationsComputationStore interface

### DIFF
--- a/go/cmd/relations/alias.go
+++ b/go/cmd/relations/alias.go
@@ -16,17 +16,13 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
 	"time"
 
-	"cloud.google.com/go/datastore"
-	"github.com/google/osv.dev/go/internal/sharding"
+	internalmodels "github.com/google/osv.dev/go/internal/models"
 	"github.com/google/osv.dev/go/logger"
-	"github.com/google/osv.dev/go/osv/models"
-	"google.golang.org/api/iterator"
 )
 
 const (
@@ -34,30 +30,15 @@ const (
 	vulnAliasesLimit    = 5
 )
 
-// updateAliasGroup updates the alias group in the datastore.
-func updateAliasGroup(
-	ctx context.Context,
-	cl *datastore.Client,
-	vulnIDs []string,
-	key *datastore.Key,
-	group models.AliasGroup,
-	changedVulns map[string]*models.AliasGroup,
-) error {
+// updateAliasGroup updates an existing alias group in the store.
+func updateAliasGroup(ctx context.Context, store internalmodels.RelationsComputationStore, vulnIDs []string, key string, group internalmodels.AliasGroup, changedVulns map[string]*internalmodels.AliasGroup) error {
 	if len(vulnIDs) <= 1 {
-		logger.Info("Deleting alias group due to too few vulns", slog.Any("ids", vulnIDs))
-		for _, vID := range vulnIDs {
+		logger.Info("Deleting alias group due to too few vulns", slog.Any("vulnIDs", vulnIDs))
+		for _, vID := range group.VulnIDs {
 			changedVulns[vID] = nil
 		}
 
-		return cl.Delete(ctx, key)
-	}
-	if len(vulnIDs) > aliasGroupVulnLimit {
-		logger.Warn("Deleting alias group due to too many vulns", slog.Any("ids", vulnIDs))
-		for _, vID := range vulnIDs {
-			changedVulns[vID] = nil
-		}
-
-		return cl.Delete(ctx, key)
+		return store.DeleteAliasGroup(ctx, key)
 	}
 
 	if slices.Equal(vulnIDs, group.VulnIDs) {
@@ -66,7 +47,7 @@ func updateAliasGroup(
 
 	group.VulnIDs = vulnIDs
 	group.Modified = time.Now().UTC()
-	if _, err := cl.Put(ctx, key, &group); err != nil {
+	if err := store.SaveAliasGroup(ctx, &group); err != nil {
 		return err
 	}
 	for _, vID := range vulnIDs {
@@ -76,8 +57,8 @@ func updateAliasGroup(
 	return nil
 }
 
-// createAliasGroup creates a new alias group in the datastore.
-func createAliasGroup(ctx context.Context, cl *datastore.Client, vulnIDs []string, changedVulns map[string]*models.AliasGroup) error {
+// createAliasGroup creates a new alias group in the store.
+func createAliasGroup(ctx context.Context, store internalmodels.RelationsComputationStore, vulnIDs []string, changedVulns map[string]*internalmodels.AliasGroup) error {
 	if len(vulnIDs) <= 1 {
 		logger.Info("Skipping alias group creation due to too few vulns", slog.Any("vulnIDs", vulnIDs))
 		return nil
@@ -87,12 +68,12 @@ func createAliasGroup(ctx context.Context, cl *datastore.Client, vulnIDs []strin
 		return nil
 	}
 
-	newGroup := &models.AliasGroup{
+	newGroup := &internalmodels.AliasGroup{
 		VulnIDs:  vulnIDs,
 		Modified: time.Now().UTC(),
 	}
 
-	if _, err := cl.Put(ctx, datastore.IncompleteKey("AliasGroup", nil), newGroup); err != nil {
+	if err := store.SaveAliasGroup(ctx, newGroup); err != nil {
 		return err
 	}
 
@@ -132,7 +113,7 @@ func computeAliases(vulnID string, visited map[string]struct{}, vulnAliases map[
 
 // updateVulnWithAliasGroup sends an update for the vuln in Datastore and GCS with the new alias group.
 // if aliasGroup is nil, assumes a preexisting AliasGroup was just deleted.
-func updateVulnWithAliasGroup(ch chan<- Update, vulnID string, aliasGroup *models.AliasGroup) {
+func updateVulnWithAliasGroup(ch chan<- Update, vulnID string, aliasGroup *internalmodels.AliasGroup) {
 	update := Update{ID: vulnID, Field: updateFieldAlias}
 	if aliasGroup == nil {
 		update.Timestamp = time.Now().UTC()
@@ -149,61 +130,39 @@ func updateVulnWithAliasGroup(ch chan<- Update, vulnID string, aliasGroup *model
 
 // ComputeAliasGroups updates all alias groups in the datastore by re-computing existing AliasGroups
 // and creating new AliasGroups for un-computed vulns across key shards.
-func ComputeAliasGroups(ctx context.Context, cl *datastore.Client, ch chan<- Update, keyShards []sharding.KeyShard) error {
-	if len(keyShards) == 0 {
-		keyShards = []sharding.KeyShard{{Start: "", End: ""}}
-	}
-	query := datastore.NewQuery("AliasAllowListEntry")
-	var allowListEntries []models.AliasAllowListEntry
-	if _, err := cl.GetAll(ctx, query, &allowListEntries); err != nil {
-		return fmt.Errorf("failed querying AliasAllowListEntries: %w", err)
-	}
-	allowList := make(map[string]struct{})
-	for _, ale := range allowListEntries {
-		allowList[ale.VulnID] = struct{}{}
-	}
-	query = datastore.NewQuery("AliasDenyListEntry")
-	var denyListEntries []models.AliasDenyListEntry
-	if _, err := cl.GetAll(ctx, query, &denyListEntries); err != nil {
-		return fmt.Errorf("failed querying AliasDenyListEntries: %w", err)
-	}
-	denyList := make(map[string]struct{})
-	for _, dle := range denyListEntries {
-		denyList[dle.VulnID] = struct{}{}
-	}
-
-	logger.Info("Retrieving vulns for alias computation across key shards...")
-	vulnAliases := make(map[string]map[string]struct{})
-	err := sharding.RunShardedQuery(
-		ctx, cl, keyShards,
-		func(shard sharding.KeyShard) *datastore.Query {
-			query := datastore.NewQuery("Vulnerability").FilterField("alias_raw", ">", "")
-
-			return sharding.ApplyNameKeyFilter(query, "Vulnerability", shard)
-		},
-		func(key *datastore.Key, vuln *models.Vulnerability) {
-			vulnID := key.Name
-			if vuln.IsWithdrawn {
-				return
-			}
-			if _, ok := denyList[vulnID]; ok {
-				return
-			}
-			if _, ok := allowList[vulnID]; len(vuln.AliasRaw) > vulnAliasesLimit && !ok {
-				logger.Warn("Skipping computation of vuln with too many aliases",
-					slog.String("id", vulnID), slog.Any("aliases", vuln.AliasRaw))
-
-				return
-			}
-
-			for _, alias := range vuln.AliasRaw {
-				addToSet(vulnAliases, vulnID, alias)
-				addToSet(vulnAliases, alias, vulnID)
-			}
-		},
-	)
+func ComputeAliasGroups(ctx context.Context, store internalmodels.RelationsComputationStore, ch chan<- Update) error {
+	allowList, denyList, err := store.GetAliasAllowAndDenyLists(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to retrieve raw aliases: %w", err)
+		return err
+	}
+
+	logger.Info("Retrieving vulns for alias computation...")
+	vulnAliases := make(map[string]map[string]struct{})
+	err = store.ListRawAliases(ctx, func(ref internalmodels.RawAliasRef) {
+		vulnID := ref.ID
+		if ref.IsWithdrawn {
+			return
+		}
+		if _, ok := denyList[vulnID]; ok {
+			return
+		}
+		if _, ok := allowList[vulnID]; len(ref.Aliases) > vulnAliasesLimit && !ok {
+			logger.Warn("Skipping computation of vuln with too many aliases",
+				slog.String("id", vulnID), slog.Any("aliases", ref.Aliases))
+
+			return
+		}
+
+		for _, alias := range ref.Aliases {
+			if _, ok := denyList[alias]; ok {
+				continue
+			}
+			addToSet(vulnAliases, vulnID, alias)
+			addToSet(vulnAliases, alias, vulnID)
+		}
+	})
+	if err != nil {
+		return fmt.Errorf("failed retrieving raw aliases: %w", err)
 	}
 	logger.Info("Vulns successfully retrieved", slog.Int("count", len(vulnAliases)))
 
@@ -211,21 +170,11 @@ func ComputeAliasGroups(ctx context.Context, cl *datastore.Client, ch chan<- Upd
 
 	// Keep track of vulnerabilities that have been modified, to update GCS later.
 	// nil means the AliasGroup has been removed
-	changedVulns := make(map[string]*models.AliasGroup)
+	changedVulns := make(map[string]*internalmodels.AliasGroup)
 
 	// For each alias group, re-compute the vuln IDs in the group and update the group
 	// with the computed vuln IDs.
-	query = datastore.NewQuery("AliasGroup")
-	it := cl.Run(ctx, query)
-	for {
-		var aliasGroup models.AliasGroup
-		key, err := it.Next(&aliasGroup)
-		if errors.Is(err, iterator.Done) {
-			break
-		}
-		if err != nil {
-			return fmt.Errorf("failed to query AliasGroups: %w", err)
-		}
+	err = store.FetchAliasGroups(ctx, func(key string, aliasGroup internalmodels.AliasGroup) {
 		vulnID := aliasGroup.VulnIDs[0] // AliasGroups always contain more than one vuln
 		// If the vuln has already been counted in a different alias group,
 		// we delete the original one to merge the two alias groups.
@@ -235,23 +184,26 @@ func ComputeAliasGroups(ctx context.Context, cl *datastore.Client, ch chan<- Upd
 					changedVulns[vID] = nil
 				}
 			}
-			if err := cl.Delete(ctx, key); err != nil {
-				return err
+			if err := store.DeleteAliasGroup(ctx, key); err != nil {
+				logger.ErrorContext(ctx, "failed to delete AliasGroup", slog.String("key", key), slog.Any("err", err))
 			}
 
-			continue
+			return
 		}
 		vulnIDs := computeAliases(vulnID, visited, vulnAliases)
-		if err := updateAliasGroup(ctx, cl, vulnIDs, key, aliasGroup, changedVulns); err != nil {
-			return fmt.Errorf("failed to update AliasGroup: %w", err)
+		if err := updateAliasGroup(ctx, store, vulnIDs, key, aliasGroup, changedVulns); err != nil {
+			logger.ErrorContext(ctx, "failed to update AliasGroup", slog.String("key", key), slog.Any("err", err))
 		}
+	})
+	if err != nil {
+		return fmt.Errorf("failed fetching alias groups: %w", err)
 	}
 
 	// For each vuln ID that has not been visited, create new alias groups.
 	for vulnID := range vulnAliases {
 		if _, ok := visited[vulnID]; !ok {
 			vulnIDs := computeAliases(vulnID, visited, vulnAliases)
-			if err := createAliasGroup(ctx, cl, vulnIDs, changedVulns); err != nil {
+			if err := createAliasGroup(ctx, store, vulnIDs, changedVulns); err != nil {
 				return fmt.Errorf("failed to create AliasGroup: %w", err)
 			}
 		}

--- a/go/cmd/relations/alias_test.go
+++ b/go/cmd/relations/alias_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/datastore"
+	osvdatastore "github.com/google/osv.dev/go/internal/database/datastore"
 	"github.com/google/osv.dev/go/osv/clients"
 	"github.com/google/osv.dev/go/osv/models"
 	"github.com/google/osv.dev/go/testutils"
@@ -69,7 +70,8 @@ func TestBasic(t *testing.T) {
 
 	// Run computation
 	updater := NewUpdater(ctx, dsClient, gcsClient, publisher)
-	if err := ComputeAliasGroups(ctx, dsClient, updater.Ch, nil); err != nil {
+	store := osvdatastore.NewRelationsComputationStore(dsClient, "")
+	if err := ComputeAliasGroups(ctx, store, updater.Ch); err != nil {
 		t.Fatalf("ComputeAliasGroups failed: %v", err)
 	}
 	updater.Finish()
@@ -125,7 +127,8 @@ func TestMissingVuln(t *testing.T) {
 
 	// Run computation
 	updater := NewUpdater(ctx, dsClient, gcsClient, publisher)
-	if err := ComputeAliasGroups(ctx, dsClient, updater.Ch, nil); err != nil {
+	store := osvdatastore.NewRelationsComputationStore(dsClient, "")
+	if err := ComputeAliasGroups(ctx, store, updater.Ch); err != nil {
 		t.Fatalf("ComputeAliasGroups failed: %v", err)
 	}
 	updater.Finish()
@@ -194,7 +197,8 @@ func TestMissingGCSButInDatastore(t *testing.T) {
 
 	// Run computation
 	updater := NewUpdater(ctx, dsClient, gcsClient, publisher)
-	if err := ComputeAliasGroups(ctx, dsClient, updater.Ch, nil); err != nil {
+	store := osvdatastore.NewRelationsComputationStore(dsClient, "")
+	if err := ComputeAliasGroups(ctx, store, updater.Ch); err != nil {
 		t.Fatalf("ComputeAliasGroups failed: %v", err)
 	}
 	updater.Finish()
@@ -263,7 +267,8 @@ func TestGenerationMismatch(t *testing.T) {
 	gcsClient.WriteErrors["all/pb/aaa-123.pb"] = clients.ErrPreconditionFailed
 
 	updater := NewUpdater(ctx, dsClient, gcsClient, publisher)
-	if err := ComputeAliasGroups(ctx, dsClient, updater.Ch, nil); err != nil {
+	store := osvdatastore.NewRelationsComputationStore(dsClient, "")
+	if err := ComputeAliasGroups(ctx, store, updater.Ch); err != nil {
 		t.Fatalf("ComputeAliasGroups failed: %v", err)
 	}
 	updater.Finish()
@@ -307,7 +312,8 @@ func TestBugReachesLimit(t *testing.T) {
 
 	// Run computation
 	updater := NewUpdater(ctx, dsClient, gcsClient, publisher)
-	if err := ComputeAliasGroups(ctx, dsClient, updater.Ch, nil); err != nil {
+	store := osvdatastore.NewRelationsComputationStore(dsClient, "")
+	if err := ComputeAliasGroups(ctx, store, updater.Ch); err != nil {
 		t.Fatalf("ComputeAliasGroups failed: %v", err)
 	}
 	updater.Finish()
@@ -380,7 +386,8 @@ func TestUpdateAliasGroup(t *testing.T) {
 
 	// Run computation
 	updater := NewUpdater(ctx, dsClient, gcsClient, publisher)
-	if err := ComputeAliasGroups(ctx, dsClient, updater.Ch, nil); err != nil {
+	store := osvdatastore.NewRelationsComputationStore(dsClient, "")
+	if err := ComputeAliasGroups(ctx, store, updater.Ch); err != nil {
 		t.Fatalf("ComputeAliasGroups failed: %v", err)
 	}
 	updater.Finish()
@@ -471,7 +478,8 @@ func TestCreateAliasGroup(t *testing.T) {
 
 	// Run computation
 	updater := NewUpdater(ctx, dsClient, gcsClient, publisher)
-	if err := ComputeAliasGroups(ctx, dsClient, updater.Ch, nil); err != nil {
+	store := osvdatastore.NewRelationsComputationStore(dsClient, "")
+	if err := ComputeAliasGroups(ctx, store, updater.Ch); err != nil {
 		t.Fatalf("ComputeAliasGroups failed: %v", err)
 	}
 	updater.Finish()
@@ -561,7 +569,8 @@ func TestDeleteAliasGroup(t *testing.T) {
 
 	// Run computation
 	updater := NewUpdater(ctx, dsClient, gcsClient, publisher)
-	if err := ComputeAliasGroups(ctx, dsClient, updater.Ch, nil); err != nil {
+	store := osvdatastore.NewRelationsComputationStore(dsClient, "")
+	if err := ComputeAliasGroups(ctx, store, updater.Ch); err != nil {
 		t.Fatalf("ComputeAliasGroups failed: %v", err)
 	}
 	updater.Finish()
@@ -638,7 +647,8 @@ func TestSplitAliasGroup(t *testing.T) {
 
 	// Run computation
 	updater := NewUpdater(ctx, dsClient, gcsClient, publisher)
-	if err := ComputeAliasGroups(ctx, dsClient, updater.Ch, nil); err != nil {
+	store := osvdatastore.NewRelationsComputationStore(dsClient, "")
+	if err := ComputeAliasGroups(ctx, store, updater.Ch); err != nil {
 		t.Fatalf("ComputeAliasGroups failed: %v", err)
 	}
 	updater.Finish()
@@ -711,7 +721,8 @@ func TestAllowList(t *testing.T) {
 
 	// Run computation
 	updater := NewUpdater(ctx, dsClient, gcsClient, publisher)
-	if err := ComputeAliasGroups(ctx, dsClient, updater.Ch, nil); err != nil {
+	store := osvdatastore.NewRelationsComputationStore(dsClient, "")
+	if err := ComputeAliasGroups(ctx, store, updater.Ch); err != nil {
 		t.Fatalf("ComputeAliasGroups failed: %v", err)
 	}
 	updater.Finish()
@@ -783,7 +794,8 @@ func TestDenyList(t *testing.T) {
 
 	// Run computation
 	updater := NewUpdater(ctx, dsClient, gcsClient, publisher)
-	if err := ComputeAliasGroups(ctx, dsClient, updater.Ch, nil); err != nil {
+	store := osvdatastore.NewRelationsComputationStore(dsClient, "")
+	if err := ComputeAliasGroups(ctx, store, updater.Ch); err != nil {
 		t.Fatalf("ComputeAliasGroups failed: %v", err)
 	}
 	updater.Finish()
@@ -846,7 +858,8 @@ func TestMergeAliasGroup(t *testing.T) {
 
 	// Run computation
 	updater := NewUpdater(ctx, dsClient, gcsClient, publisher)
-	if err := ComputeAliasGroups(ctx, dsClient, updater.Ch, nil); err != nil {
+	store := osvdatastore.NewRelationsComputationStore(dsClient, "")
+	if err := ComputeAliasGroups(ctx, store, updater.Ch); err != nil {
 		t.Fatalf("ComputeAliasGroups failed: %v", err)
 	}
 	updater.Finish()
@@ -917,7 +930,8 @@ func TestPartialMergeAliasGroup(t *testing.T) {
 
 	// Run computation
 	updater := NewUpdater(ctx, dsClient, gcsClient, publisher)
-	if err := ComputeAliasGroups(ctx, dsClient, updater.Ch, nil); err != nil {
+	store := osvdatastore.NewRelationsComputationStore(dsClient, "")
+	if err := ComputeAliasGroups(ctx, store, updater.Ch); err != nil {
 		t.Fatalf("ComputeAliasGroups failed: %v", err)
 	}
 	updater.Finish()
@@ -992,7 +1006,8 @@ func TestAliasGroupReachesLimit(t *testing.T) {
 
 	// Run computation
 	updater := NewUpdater(ctx, dsClient, gcsClient, publisher)
-	if err := ComputeAliasGroups(ctx, dsClient, updater.Ch, nil); err != nil {
+	store := osvdatastore.NewRelationsComputationStore(dsClient, "")
+	if err := ComputeAliasGroups(ctx, store, updater.Ch); err != nil {
 		t.Fatalf("ComputeAliasGroups failed: %v", err)
 	}
 	updater.Finish()

--- a/go/cmd/relations/related.go
+++ b/go/cmd/relations/related.go
@@ -7,10 +7,8 @@ import (
 	"slices"
 	"time"
 
-	"cloud.google.com/go/datastore"
-	"github.com/google/osv.dev/go/internal/sharding"
+	internalmodels "github.com/google/osv.dev/go/internal/models"
 	"github.com/google/osv.dev/go/logger"
-	"github.com/google/osv.dev/go/osv/models"
 )
 
 // computeRelated computes all related groups for the given vulns.
@@ -41,10 +39,10 @@ func computeRelated(groups map[string][]string, withdrawnVulns map[string]struct
 	return groups
 }
 
-func updateRelated(ctx context.Context, cl *datastore.Client, id string, relatedIDs []string, ch chan<- Update) error {
+func updateRelated(ctx context.Context, store internalmodels.RelationsComputationStore, id string, relatedIDs []string, ch chan<- Update) error {
 	if len(relatedIDs) == 0 {
 		logger.Info("Deleting related group due to no related vulns", slog.String("id", id))
-		if err := cl.Delete(ctx, datastore.NameKey("RelatedGroup", id, nil)); err != nil {
+		if err := store.DeleteRelatedGroup(ctx, id); err != nil {
 			return err
 		}
 		ch <- Update{
@@ -57,11 +55,12 @@ func updateRelated(ctx context.Context, cl *datastore.Client, id string, related
 		return nil
 	}
 
-	group := models.RelatedGroup{
+	group := internalmodels.RelatedGroup{
+		VulnID:     id,
 		RelatedIDs: relatedIDs,
 		Modified:   time.Now().UTC(),
 	}
-	if _, err := cl.Put(ctx, datastore.NameKey("RelatedGroup", id, nil), &group); err != nil {
+	if err := store.SaveRelatedGroup(ctx, &group); err != nil {
 		return err
 	}
 	ch <- Update{
@@ -74,51 +73,29 @@ func updateRelated(ctx context.Context, cl *datastore.Client, id string, related
 	return nil
 }
 
-// ComputeRelatedGroups updates all related groups in the datastore by re-computing existing RelatedGroups
-// across key shards.
-func ComputeRelatedGroups(ctx context.Context, cl *datastore.Client, ch chan<- Update, keyShards []sharding.KeyShard) error {
-	if len(keyShards) == 0 {
-		keyShards = []sharding.KeyShard{{Start: "", End: ""}}
-	}
-
-	logger.Info("Retrieving vulns for related computation across key shards...")
+// ComputeRelatedGroups updates all related groups in the store by re-computing existing RelatedGroups.
+func ComputeRelatedGroups(ctx context.Context, store internalmodels.RelationsComputationStore, ch chan<- Update) error {
+	logger.Info("Retrieving vulns for related computation...")
 	rawRelated := make(map[string][]string)
 	withdrawnVulns := make(map[string]struct{})
-	err := sharding.RunShardedQuery(
-		ctx, cl, keyShards,
-		func(shard sharding.KeyShard) *datastore.Query {
-			query := datastore.NewQuery("Vulnerability").FilterField("related_raw", ">", "")
-
-			return sharding.ApplyNameKeyFilter(query, "Vulnerability", shard)
-		},
-		func(key *datastore.Key, v *models.Vulnerability) {
-			if v.IsWithdrawn {
-				withdrawnVulns[key.Name] = struct{}{}
-			}
-			related := slices.Clone(v.RelatedRaw)
-			slices.Sort(related)
-			rawRelated[key.Name] = slices.Compact(related)
-		},
-	)
+	err := store.ListRawRelated(ctx, func(ref internalmodels.RawRelatedRef) {
+		if ref.IsWithdrawn {
+			withdrawnVulns[ref.ID] = struct{}{}
+		}
+		related := slices.Clone(ref.RelatedIDs)
+		slices.Sort(related)
+		rawRelated[ref.ID] = slices.Compact(related)
+	})
 	if err != nil {
 		return fmt.Errorf("failed to retrieve raw related vulnerabilities: %w", err)
 	}
 	logger.Info("Retrieved vulns with related ids", slog.Int("count", len(rawRelated)))
 
-	logger.Info("Retrieving related groups across key shards...")
-	relatedGroups := make(map[string]models.RelatedGroup)
-	err = sharding.RunShardedQuery(
-		ctx, cl, keyShards,
-		func(shard sharding.KeyShard) *datastore.Query {
-			query := datastore.NewQuery("RelatedGroup")
-
-			return sharding.ApplyNameKeyFilter(query, "RelatedGroup", shard)
-		},
-		func(key *datastore.Key, group *models.RelatedGroup) {
-			group.Key = key
-			relatedGroups[key.Name] = *group
-		},
-	)
+	logger.Info("Retrieving related groups...")
+	relatedGroups := make(map[string]internalmodels.RelatedGroup)
+	err = store.FetchRelatedGroups(ctx, func(id string, group internalmodels.RelatedGroup) {
+		relatedGroups[id] = group
+	})
 	if err != nil {
 		return fmt.Errorf("failed to retrieve related groups: %w", err)
 	}
@@ -130,7 +107,7 @@ func ComputeRelatedGroups(ctx context.Context, cl *datastore.Client, ch chan<- U
 		g, ok := relatedGroups[id]
 		delete(relatedGroups, id)
 		if !ok || !slices.Equal(g.RelatedIDs, relatedIDs) {
-			if err := updateRelated(ctx, cl, id, relatedIDs, ch); err != nil {
+			if err := updateRelated(ctx, store, id, relatedIDs, ch); err != nil {
 				return fmt.Errorf("failed to update related group: %w", err)
 			}
 		}
@@ -139,7 +116,7 @@ func ComputeRelatedGroups(ctx context.Context, cl *datastore.Client, ch chan<- U
 	// The remaining groups in relatedGroups are the ones that are no longer
 	// present in the vulns, so we delete them.
 	for id := range relatedGroups {
-		if err := updateRelated(ctx, cl, id, nil, ch); err != nil {
+		if err := updateRelated(ctx, store, id, nil, ch); err != nil {
 			return fmt.Errorf("failed to delete related group: %w", err)
 		}
 	}

--- a/go/cmd/relations/related_test.go
+++ b/go/cmd/relations/related_test.go
@@ -8,6 +8,7 @@ import (
 
 	"cloud.google.com/go/datastore"
 	"github.com/google/go-cmp/cmp"
+	osvdatastore "github.com/google/osv.dev/go/internal/database/datastore"
 	"github.com/google/osv.dev/go/osv/models"
 	"github.com/google/osv.dev/go/testutils"
 )
@@ -93,7 +94,8 @@ func TestComputeRelatedGroups(t *testing.T) {
 	}
 
 	ch := make(chan Update, 100)
-	if err := ComputeRelatedGroups(ctx, dsClient, ch, nil); err != nil {
+	store := osvdatastore.NewRelationsComputationStore(dsClient, "")
+	if err := ComputeRelatedGroups(ctx, store, ch); err != nil {
 		t.Fatalf("ComputeRelatedGroups failed: %v", err)
 	}
 	close(ch)

--- a/go/cmd/relations/relations.go
+++ b/go/cmd/relations/relations.go
@@ -27,7 +27,7 @@ import (
 	"cloud.google.com/go/datastore"
 	"cloud.google.com/go/pubsub/v2"
 	"cloud.google.com/go/storage"
-	"github.com/google/osv.dev/go/internal/sharding"
+	osvdatastore "github.com/google/osv.dev/go/internal/database/datastore"
 	"github.com/google/osv.dev/go/logger"
 	"github.com/google/osv.dev/go/osv/clients"
 	"go.opentelemetry.io/otel"
@@ -46,8 +46,6 @@ func main() {
 	flag.StringVar(&breakdownPrefixesStr, "breakdown-prefixes", "", "Comma-separated list of prefix breakdowns for parallel Datastore key sharding.")
 	flag.Parse()
 
-	keyShards := sharding.ParseBreakdownPrefixes(breakdownPrefixesStr)
-
 	// Set up logging / other clients
 	logger.InitGlobalLogger()
 	defer logger.Close()
@@ -61,6 +59,7 @@ func main() {
 	}
 	defer gc.closeAll()
 
+	store := osvdatastore.NewRelationsComputationStore(gc.datastoreClient, breakdownPrefixesStr)
 	updater := NewUpdater(ctx, gc.datastoreClient, gc.gcsClient, gc.publisher)
 
 	tr := otel.Tracer("relations")
@@ -68,21 +67,21 @@ func main() {
 	wg.Go(func() {
 		ctx, span := tr.Start(ctx, "alias")
 		defer span.End()
-		if err := ComputeAliasGroups(ctx, gc.datastoreClient, updater.Ch, keyShards); err != nil {
+		if err := ComputeAliasGroups(ctx, store, updater.Ch); err != nil {
 			logger.ErrorContext(ctx, "failed to compute alias groups", slog.Any("err", err))
 		}
 	})
 	wg.Go(func() {
 		ctx, span := tr.Start(ctx, "upstream")
 		defer span.End()
-		if err := ComputeUpstreamGroups(ctx, gc.datastoreClient, updater.Ch, keyShards); err != nil {
+		if err := ComputeUpstreamGroups(ctx, store, updater.Ch); err != nil {
 			logger.ErrorContext(ctx, "failed to compute upstream groups", slog.Any("err", err))
 		}
 	})
 	wg.Go(func() {
 		ctx, span := tr.Start(ctx, "related")
 		defer span.End()
-		if err := ComputeRelatedGroups(ctx, gc.datastoreClient, updater.Ch, keyShards); err != nil {
+		if err := ComputeRelatedGroups(ctx, store, updater.Ch); err != nil {
 			logger.ErrorContext(ctx, "failed to compute related groups", slog.Any("err", err))
 		}
 	})

--- a/go/cmd/relations/upstream.go
+++ b/go/cmd/relations/upstream.go
@@ -23,10 +23,8 @@ import (
 	"slices"
 	"time"
 
-	"cloud.google.com/go/datastore"
-	"github.com/google/osv.dev/go/internal/sharding"
+	internalmodels "github.com/google/osv.dev/go/internal/models"
 	"github.com/google/osv.dev/go/logger"
-	"github.com/google/osv.dev/go/osv/models"
 )
 
 // computeUpstream computes all upstream vulnerabilities for the given vuln ID.
@@ -60,29 +58,26 @@ func computeUpstream(vulnID string, rawUpstreams map[string][]string) []string {
 	return result
 }
 
-// createUpstreamGroup creates a new upstream group in the datastore and sends it to the updater.
-func createUpstreamGroup(ctx context.Context, cl *datastore.Client, vulnID string, upstreamIDs []string, ch chan<- Update) (*models.UpstreamGroup, error) {
-	key := datastore.IncompleteKey("UpstreamGroup", nil)
-	group := &models.UpstreamGroup{
+// createUpstreamGroup creates a new upstream group in the store and sends it to the updater.
+func createUpstreamGroup(ctx context.Context, store internalmodels.RelationsComputationStore, vulnID string, upstreamIDs []string, ch chan<- Update) (*internalmodels.UpstreamGroup, error) {
+	group := &internalmodels.UpstreamGroup{
 		VulnID:      vulnID,
 		UpstreamIDs: upstreamIDs,
 		Modified:    time.Now().UTC(),
 	}
-	var err error
-	if key, err = cl.Put(ctx, key, group); err != nil {
+	if err := store.SaveUpstreamGroup(ctx, group); err != nil {
 		return nil, err
 	}
-	group.Key = key
 	updateVulnWithUpstream(ch, vulnID, group)
 
 	return group, nil
 }
 
-// updateUpstreamGroup updates the upstream group in the datastore, and sends it to the updater.
-func updateUpstreamGroup(ctx context.Context, cl *datastore.Client, group *models.UpstreamGroup, upstreamIDs []string, ch chan<- Update) (*models.UpstreamGroup, error) {
+// updateUpstreamGroup updates the upstream group in the store, and sends it to the updater.
+func updateUpstreamGroup(ctx context.Context, store internalmodels.RelationsComputationStore, group *internalmodels.UpstreamGroup, upstreamIDs []string, ch chan<- Update) (*internalmodels.UpstreamGroup, error) {
 	if len(upstreamIDs) == 0 {
 		logger.Info("Deleting upstream group due to no upstream vulns", slog.String("id", group.VulnID))
-		if err := cl.Delete(ctx, group.Key); err != nil {
+		if err := store.DeleteUpstreamGroup(ctx, group.VulnID); err != nil {
 			return nil, err
 		}
 		updateVulnWithUpstream(ch, group.VulnID, nil)
@@ -96,7 +91,7 @@ func updateUpstreamGroup(ctx context.Context, cl *datastore.Client, group *model
 
 	group.UpstreamIDs = upstreamIDs
 	group.Modified = time.Now().UTC()
-	if _, err := cl.Put(ctx, group.Key, group); err != nil {
+	if err := store.SaveUpstreamGroup(ctx, group); err != nil {
 		return nil, err
 	}
 	updateVulnWithUpstream(ch, group.VulnID, group)
@@ -106,7 +101,7 @@ func updateUpstreamGroup(ctx context.Context, cl *datastore.Client, group *model
 
 // updateVulnWithUpstream sends an update for the vuln in Datastore & GCS with the new upstream group.
 // If group is nil, assumes a preexisting UpstreamGroup was just deleted.
-func updateVulnWithUpstream(ch chan<- Update, vulnID string, group *models.UpstreamGroup) {
+func updateVulnWithUpstream(ch chan<- Update, vulnID string, group *internalmodels.UpstreamGroup) {
 	update := Update{ID: vulnID, Field: updateFieldUpstream}
 	if group == nil { // group was deleted
 		update.Timestamp = time.Now().UTC()
@@ -129,7 +124,7 @@ func updateVulnWithUpstream(ch chan<- Update, vulnID string, group *models.Upstr
 //	   last_modified_date: date
 //	   upstream_hierarchy: JSON string of upstream hierarchy
 //	}
-func computeUpstreamHierarchy(ctx context.Context, cl *datastore.Client, targetUpstreamGroup *models.UpstreamGroup, allUpstreamGroups map[string]*models.UpstreamGroup) error {
+func computeUpstreamHierarchy(ctx context.Context, store internalmodels.RelationsComputationStore, targetUpstreamGroup *internalmodels.UpstreamGroup, allUpstreamGroups map[string]*internalmodels.UpstreamGroup) error {
 	visited := make(map[string]struct{})
 	upstreamMap := make(map[string][]string)
 	toVisit := []string{targetUpstreamGroup.VulnID}
@@ -199,59 +194,32 @@ func computeUpstreamHierarchy(ctx context.Context, cl *datastore.Client, targetU
 		return nil
 	}
 	targetUpstreamGroup.UpstreamHierarchy = upstreamJSON
-	_, err = cl.Put(ctx, targetUpstreamGroup.Key, targetUpstreamGroup)
 
-	return err
+	return store.SaveUpstreamGroup(ctx, targetUpstreamGroup)
 }
 
 // ComputeUpstreamGroups updates all upstream groups in the datastore by re-computing existing UpstreamGroups
 // and creating new UpstreamGroups across key shards.
-func ComputeUpstreamGroups(ctx context.Context, cl *datastore.Client, ch chan<- Update, keyShards []sharding.KeyShard) error {
-	if len(keyShards) == 0 {
-		keyShards = []sharding.KeyShard{{Start: "", End: ""}}
-	}
-
-	var updatedGroups []*models.UpstreamGroup
-	logger.Info("Retrieving vulns for upstream computation across key shards...")
+func ComputeUpstreamGroups(ctx context.Context, store internalmodels.RelationsComputationStore, ch chan<- Update) error {
+	var updatedGroups []*internalmodels.UpstreamGroup
+	logger.Info("Retrieving vulns for upstream computation...")
 	rawUpstreams := make(map[string][]string)
-	err := sharding.RunShardedQuery(
-		ctx, cl, keyShards,
-		func(shard sharding.KeyShard) *datastore.Query {
-			query := datastore.NewQuery("Vulnerability").FilterField("upstream_raw", ">", "")
-
-			return sharding.ApplyNameKeyFilter(query, "Vulnerability", shard)
-		},
-		func(key *datastore.Key, vuln *models.Vulnerability) {
-			upstream := slices.Clone(vuln.UpstreamRaw)
-			slices.Sort(upstream)
-			rawUpstreams[key.Name] = slices.Compact(upstream)
-		},
-	)
+	err := store.ListRawUpstreams(ctx, func(ref internalmodels.RawUpstreamRef) {
+		upstream := slices.Clone(ref.Upstreams)
+		slices.Sort(upstream)
+		rawUpstreams[ref.ID] = slices.Compact(upstream)
+	})
 	if err != nil {
 		return fmt.Errorf("failed to retrieve raw upstreams: %w", err)
 	}
 	logger.Info("Vulns successfully retrieved", slog.Int("count", len(rawUpstreams)))
 
-	logger.Info("Retrieving upstream groups across key shards...")
-	upstreamGroups := make(map[string]*models.UpstreamGroup)
-	err = sharding.RunShardedQuery(
-		ctx, cl, keyShards,
-		func(shard sharding.KeyShard) *datastore.Query {
-			query := datastore.NewQuery("UpstreamGroup")
-			if shard.Start != "" {
-				query = query.FilterField("db_id", ">=", shard.Start)
-			}
-			if shard.End != "" {
-				query = query.FilterField("db_id", "<", shard.End)
-			}
-
-			return query
-		},
-		func(key *datastore.Key, group *models.UpstreamGroup) {
-			group.Key = key
-			upstreamGroups[group.VulnID] = group
-		},
-	)
+	logger.Info("Retrieving upstream groups...")
+	upstreamGroups := make(map[string]*internalmodels.UpstreamGroup)
+	err = store.FetchUpstreamGroups(ctx, func(id string, group internalmodels.UpstreamGroup) {
+		g := group
+		upstreamGroups[id] = &g
+	})
 	if err != nil {
 		return fmt.Errorf("failed to retrieve upstream groups: %w", err)
 	}
@@ -265,7 +233,7 @@ func ComputeUpstreamGroups(ctx context.Context, cl *datastore.Client, ch chan<- 
 		if exists {
 			// Update the existing UpstreamGroup
 			var err error
-			existingUpstreamGroup, err = updateUpstreamGroup(ctx, cl, existingUpstreamGroup, newUpstreamIDs, ch)
+			existingUpstreamGroup, err = updateUpstreamGroup(ctx, store, existingUpstreamGroup, newUpstreamIDs, ch)
 			if err != nil {
 				return fmt.Errorf("failed to update upstream group: %w", err)
 			}
@@ -277,7 +245,7 @@ func ComputeUpstreamGroups(ctx context.Context, cl *datastore.Client, ch chan<- 
 			logger.Info("Upstream group updated", slog.String("id", vulnID))
 		} else {
 			// Create a new UpstreamGroup
-			newGroup, err := createUpstreamGroup(ctx, cl, vulnID, newUpstreamIDs, ch)
+			newGroup, err := createUpstreamGroup(ctx, store, vulnID, newUpstreamIDs, ch)
 			if err != nil {
 				return fmt.Errorf("failed to create upstream group: %w", err)
 			}
@@ -292,7 +260,7 @@ func ComputeUpstreamGroups(ctx context.Context, cl *datastore.Client, ch chan<- 
 
 	for _, group := range updatedGroups {
 		// Recompute the upstream hierarchies
-		if err := computeUpstreamHierarchy(ctx, cl, group, upstreamGroups); err != nil {
+		if err := computeUpstreamHierarchy(ctx, store, group, upstreamGroups); err != nil {
 			return fmt.Errorf("failed to compute upstream hierarchy: %w", err)
 		}
 		logger.Info("Upstream hierarchy updated", slog.String("id", group.VulnID))

--- a/go/cmd/relations/upstream_test.go
+++ b/go/cmd/relations/upstream_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/datastore"
-	"github.com/google/osv.dev/go/internal/sharding"
+	osvdatastore "github.com/google/osv.dev/go/internal/database/datastore"
 	"github.com/google/osv.dev/go/osv/models"
 	"github.com/google/osv.dev/go/testutils"
 )
@@ -126,7 +126,8 @@ func TestComputeUpstreamGroups(t *testing.T) {
 	}
 
 	ch := make(chan Update, 100)
-	if err := ComputeUpstreamGroups(ctx, dsClient, ch, nil); err != nil {
+	store := osvdatastore.NewRelationsComputationStore(dsClient, "")
+	if err := ComputeUpstreamGroups(ctx, store, ch); err != nil {
 		t.Fatalf("ComputeUpstreamGroups failed: %v", err)
 	}
 	close(ch)
@@ -234,37 +235,6 @@ func TestComputeUpstreamGroups(t *testing.T) {
 			if !slices.Equal(hierarchy[k], v) {
 				t.Errorf("for key %s, expected %v, got %v", k, v, hierarchy[k])
 			}
-		}
-	})
-
-	t.Run("test_parse_breakdown_prefixes", func(t *testing.T) {
-		shards := sharding.ParseBreakdownPrefixes("ALSA-,BIT-,CVE-")
-		expectedShards := []sharding.KeyShard{
-			{Start: "", End: "ALSA-"},
-			{Start: "ALSA-", End: "BIT-"},
-			{Start: "BIT-", End: "CVE-"},
-			{Start: "CVE-", End: ""},
-		}
-		if !slices.Equal(shards, expectedShards) {
-			t.Errorf("expected %v, got %v", expectedShards, shards)
-		}
-
-		emptyShards := sharding.ParseBreakdownPrefixes("")
-		expectedEmpty := []sharding.KeyShard{{Start: "", End: ""}}
-		if !slices.Equal(emptyShards, expectedEmpty) {
-			t.Errorf("expected %v, got %v", expectedEmpty, emptyShards)
-		}
-
-		braceShards := sharding.ParseBreakdownPrefixes("ALSA-,CGA-{a..c}")
-		expectedBraceShards := []sharding.KeyShard{
-			{Start: "", End: "ALSA-"},
-			{Start: "ALSA-", End: "CGA-a"},
-			{Start: "CGA-a", End: "CGA-b"},
-			{Start: "CGA-b", End: "CGA-c"},
-			{Start: "CGA-c", End: ""},
-		}
-		if !slices.Equal(braceShards, expectedBraceShards) {
-			t.Errorf("expected brace shards %v, got %v", expectedBraceShards, braceShards)
 		}
 	})
 }

--- a/go/internal/database/datastore/relations.go
+++ b/go/internal/database/datastore/relations.go
@@ -8,6 +8,7 @@ import (
 
 	"cloud.google.com/go/datastore"
 	"github.com/google/osv.dev/go/internal/models"
+	"github.com/google/osv.dev/go/internal/sharding"
 )
 
 type RelationsStore struct {
@@ -84,4 +85,207 @@ func (s *RelationsStore) GetUpstream(ctx context.Context, id string) (*models.Ge
 		Upstream: upstream,
 		Modified: upstreamGroup.Modified,
 	}, nil
+}
+
+type RelationsComputationStore struct {
+	client    *datastore.Client
+	keyShards []sharding.KeyShard
+}
+
+var _ models.RelationsComputationStore = (*RelationsComputationStore)(nil)
+
+func NewRelationsComputationStore(client *datastore.Client, breakdownPrefixesStr string) *RelationsComputationStore {
+	return &RelationsComputationStore{
+		client:    client,
+		keyShards: sharding.ParseBreakdownPrefixes(breakdownPrefixesStr),
+	}
+}
+
+func (s *RelationsComputationStore) ListRawAliases(ctx context.Context, handle func(ref models.RawAliasRef)) error {
+	return sharding.RunShardedQuery(
+		ctx, s.client, s.keyShards,
+		func(shard sharding.KeyShard) *datastore.Query {
+			query := datastore.NewQuery("Vulnerability").FilterField("alias_raw", ">", "")
+
+			return sharding.ApplyNameKeyFilter(query, "Vulnerability", shard)
+		},
+		func(key *datastore.Key, vuln *Vulnerability) {
+			ref := models.RawAliasRef{
+				ID:          key.Name,
+				Aliases:     vuln.AliasRaw,
+				IsWithdrawn: vuln.IsWithdrawn,
+			}
+			handle(ref)
+		},
+	)
+}
+
+func (s *RelationsComputationStore) ListRawUpstreams(ctx context.Context, handle func(ref models.RawUpstreamRef)) error {
+	return sharding.RunShardedQuery(
+		ctx, s.client, s.keyShards,
+		func(shard sharding.KeyShard) *datastore.Query {
+			query := datastore.NewQuery("Vulnerability").FilterField("upstream_raw", ">", "")
+
+			return sharding.ApplyNameKeyFilter(query, "Vulnerability", shard)
+		},
+		func(key *datastore.Key, vuln *Vulnerability) {
+			ref := models.RawUpstreamRef{
+				ID:        key.Name,
+				Upstreams: vuln.UpstreamRaw,
+			}
+			handle(ref)
+		},
+	)
+}
+
+func (s *RelationsComputationStore) ListRawRelated(ctx context.Context, handle func(ref models.RawRelatedRef)) error {
+	return sharding.RunShardedQuery(
+		ctx, s.client, s.keyShards,
+		func(shard sharding.KeyShard) *datastore.Query {
+			query := datastore.NewQuery("Vulnerability").FilterField("related_raw", ">", "")
+
+			return sharding.ApplyNameKeyFilter(query, "Vulnerability", shard)
+		},
+		func(key *datastore.Key, vuln *Vulnerability) {
+			ref := models.RawRelatedRef{
+				ID:          key.Name,
+				RelatedIDs:  vuln.RelatedRaw,
+				IsWithdrawn: vuln.IsWithdrawn,
+			}
+			handle(ref)
+		},
+	)
+}
+
+func (s *RelationsComputationStore) GetAliasAllowAndDenyLists(ctx context.Context) (map[string]struct{}, map[string]struct{}, error) {
+	queryAllow := datastore.NewQuery("AliasAllowListEntry")
+	var allowListEntries []AliasAllowListEntry
+	if _, err := s.client.GetAll(ctx, queryAllow, &allowListEntries); err != nil {
+		return nil, nil, fmt.Errorf("failed querying AliasAllowListEntries: %w", err)
+	}
+	allowList := make(map[string]struct{}, len(allowListEntries))
+	for _, ale := range allowListEntries {
+		allowList[ale.VulnID] = struct{}{}
+	}
+
+	queryDeny := datastore.NewQuery("AliasDenyListEntry")
+	var denyListEntries []AliasDenyListEntry
+	if _, err := s.client.GetAll(ctx, queryDeny, &denyListEntries); err != nil {
+		return nil, nil, fmt.Errorf("failed querying AliasDenyListEntries: %w", err)
+	}
+	denyList := make(map[string]struct{}, len(denyListEntries))
+	for _, dle := range denyListEntries {
+		denyList[dle.VulnID] = struct{}{}
+	}
+
+	return allowList, denyList, nil
+}
+
+func (s *RelationsComputationStore) FetchAliasGroups(ctx context.Context, handle func(id string, group models.AliasGroup)) error {
+	query := datastore.NewQuery("AliasGroup")
+	var aliasGroups []AliasGroup
+	keys, err := s.client.GetAll(ctx, query, &aliasGroups)
+	if err != nil {
+		return fmt.Errorf("failed retrieving alias groups: %w", err)
+	}
+	for i, group := range aliasGroups {
+		mGroup := models.AliasGroup{
+			VulnIDs:  group.VulnIDs,
+			Modified: group.Modified,
+		}
+		handle(keys[i].Name, mGroup)
+	}
+
+	return nil
+}
+
+func (s *RelationsComputationStore) SaveAliasGroup(ctx context.Context, group *models.AliasGroup) error {
+	dsGroup := AliasGroup{
+		VulnIDs:  group.VulnIDs,
+		Modified: group.Modified,
+	}
+	_, err := s.client.Put(ctx, datastore.IncompleteKey("AliasGroup", nil), &dsGroup)
+
+	return err
+}
+
+func (s *RelationsComputationStore) DeleteAliasGroup(ctx context.Context, id string) error {
+	return s.client.Delete(ctx, datastore.NameKey("AliasGroup", id, nil))
+}
+
+func (s *RelationsComputationStore) FetchUpstreamGroups(ctx context.Context, handle func(id string, group models.UpstreamGroup)) error {
+	return sharding.RunShardedQuery(
+		ctx, s.client, s.keyShards,
+		func(shard sharding.KeyShard) *datastore.Query {
+			query := datastore.NewQuery("UpstreamGroup")
+			if shard.Start != "" {
+				query = query.FilterField("db_id", ">=", shard.Start)
+			}
+			if shard.End != "" {
+				query = query.FilterField("db_id", "<", shard.End)
+			}
+
+			return query
+		},
+		func(_ *datastore.Key, group *UpstreamGroup) {
+			mGroup := models.UpstreamGroup{
+				VulnID:            group.VulnID,
+				UpstreamIDs:       group.UpstreamIDs,
+				Modified:          group.Modified,
+				UpstreamHierarchy: group.UpstreamHierarchy,
+			}
+			handle(group.VulnID, mGroup)
+		},
+	)
+}
+
+func (s *RelationsComputationStore) SaveUpstreamGroup(ctx context.Context, group *models.UpstreamGroup) error {
+	dsGroup := UpstreamGroup{
+		VulnID:            group.VulnID,
+		UpstreamIDs:       group.UpstreamIDs,
+		Modified:          group.Modified,
+		UpstreamHierarchy: group.UpstreamHierarchy,
+	}
+	key := datastore.IncompleteKey("UpstreamGroup", nil)
+	_, err := s.client.Put(ctx, key, &dsGroup)
+
+	return err
+}
+
+func (s *RelationsComputationStore) DeleteUpstreamGroup(ctx context.Context, id string) error {
+	return s.client.Delete(ctx, datastore.NameKey("UpstreamGroup", id, nil))
+}
+
+func (s *RelationsComputationStore) FetchRelatedGroups(ctx context.Context, handle func(id string, group models.RelatedGroup)) error {
+	return sharding.RunShardedQuery(
+		ctx, s.client, s.keyShards,
+		func(shard sharding.KeyShard) *datastore.Query {
+			query := datastore.NewQuery("RelatedGroup")
+
+			return sharding.ApplyNameKeyFilter(query, "RelatedGroup", shard)
+		},
+		func(key *datastore.Key, group *RelatedGroup) {
+			mGroup := models.RelatedGroup{
+				VulnID:     key.Name,
+				RelatedIDs: group.RelatedIDs,
+				Modified:   group.Modified,
+			}
+			handle(key.Name, mGroup)
+		},
+	)
+}
+
+func (s *RelationsComputationStore) SaveRelatedGroup(ctx context.Context, group *models.RelatedGroup) error {
+	key := datastore.NameKey("RelatedGroup", group.VulnID, nil)
+	dsGroup := RelatedGroup{
+		RelatedIDs: group.RelatedIDs,
+		Modified:   group.Modified,
+	}
+	_, err := s.client.Put(ctx, key, &dsGroup)
+
+	return err
+}
+
+func (s *RelationsComputationStore) DeleteRelatedGroup(ctx context.Context, id string) error {
+	return s.client.Delete(ctx, datastore.NameKey("RelatedGroup", id, nil))
 }

--- a/go/internal/models/relations.go
+++ b/go/internal/models/relations.go
@@ -32,3 +32,74 @@ type RelationsStore interface {
 	// Returns ErrNotFound if no upstream vulnerabilities are known.
 	GetUpstream(ctx context.Context, id string) (*GetUpstreamResult, error)
 }
+
+type RawAliasRef struct {
+	ID          string
+	Aliases     []string
+	IsWithdrawn bool
+}
+
+type RawUpstreamRef struct {
+	ID        string
+	Upstreams []string
+}
+
+type RawRelatedRef struct {
+	ID          string
+	RelatedIDs  []string
+	IsWithdrawn bool
+}
+
+type AliasGroup struct {
+	VulnIDs  []string
+	Modified time.Time
+}
+
+type UpstreamGroup struct {
+	VulnID            string
+	UpstreamIDs       []string
+	Modified          time.Time
+	UpstreamHierarchy []byte
+}
+
+type RelatedGroup struct {
+	VulnID     string
+	RelatedIDs []string
+	Modified   time.Time
+}
+
+//nolint:interfacebloat
+type RelationsComputationStore interface {
+	// ListRawAliases streams all vulnerabilities that define raw aliases.
+	ListRawAliases(ctx context.Context, handle func(ref RawAliasRef)) error
+
+	// ListRawUpstreams streams all vulnerabilities that define raw upstreams.
+	ListRawUpstreams(ctx context.Context, handle func(ref RawUpstreamRef)) error
+
+	// ListRawRelated streams all vulnerabilities that define raw related IDs.
+	ListRawRelated(ctx context.Context, handle func(ref RawRelatedRef)) error
+
+	// GetAliasAllowAndDenyLists retrieves allowlist and denylist entries.
+	GetAliasAllowAndDenyLists(ctx context.Context) (allowList map[string]struct{}, denyList map[string]struct{}, err error)
+
+	// FetchAliasGroups streams all existing AliasGroup entities.
+	FetchAliasGroups(ctx context.Context, handle func(id string, group AliasGroup)) error
+	// SaveAliasGroup puts an AliasGroup entity into the store.
+	SaveAliasGroup(ctx context.Context, group *AliasGroup) error
+	// DeleteAliasGroup deletes an AliasGroup entity from the store.
+	DeleteAliasGroup(ctx context.Context, id string) error
+
+	// FetchUpstreamGroups streams all existing UpstreamGroup entities.
+	FetchUpstreamGroups(ctx context.Context, handle func(id string, group UpstreamGroup)) error
+	// SaveUpstreamGroup puts an UpstreamGroup entity into the store.
+	SaveUpstreamGroup(ctx context.Context, group *UpstreamGroup) error
+	// DeleteUpstreamGroup deletes an UpstreamGroup entity from the store.
+	DeleteUpstreamGroup(ctx context.Context, id string) error
+
+	// FetchRelatedGroups streams all existing RelatedGroup entities.
+	FetchRelatedGroups(ctx context.Context, handle func(id string, group RelatedGroup)) error
+	// SaveRelatedGroup puts a RelatedGroup entity into the store.
+	SaveRelatedGroup(ctx context.Context, group *RelatedGroup) error
+	// DeleteRelatedGroup deletes a RelatedGroup entity from the store.
+	DeleteRelatedGroup(ctx context.Context, id string) error
+}


### PR DESCRIPTION
Abstracts the database access layer in the relations worker to prepare for future database migrations (e.g. PostgreSQL).

- Defines domain-level `RelationsComputationStore` interface in `go/internal/models/relations.go` with pure domain structs (`AliasGroup`, `UpstreamGroup`, `RelatedGroup`).
- Implements `RelationsComputationStore` on `DatastoreRelationsStore` in `go/internal/database/datastore/relations.go`
  -  All the database sharding and optimisations are placed in the datastore specific layer
- Refactors `go/cmd/relations/` (`alias.go`, `upstream.go`, `related.go`, `relations.go`) to use `models.RelationsComputationStore` instead of direct Datastore queries.