### PR TITLE
fix: standardize default pub/sub pool name

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/core/importer-deleter.yaml
+++ b/deployment/clouddeploy/gke-workers/base/core/importer-deleter.yaml
@@ -16,6 +16,9 @@ spec:
           - name: importer-deleter
             image: importer
             imagePullPolicy: Always
+            env:
+              - name: DEFAULT_TASK_POOL
+                value: "default"
             volumeMounts:
               - mountPath: "/work"
                 name: "ssd"

--- a/deployment/clouddeploy/gke-workers/base/core/importer-reconciler.yaml
+++ b/deployment/clouddeploy/gke-workers/base/core/importer-reconciler.yaml
@@ -27,8 +27,8 @@ spec:
                 value: "1.0"
               - name: TRACE_SAMPLE_RATE # for the individual vulnerability entries
                 value: "0.05"
-              - name: REIMPORT_TASK_POOL
-                value: "reimport"
+              - name: DEFAULT_TASK_POOL
+                value: "default"
             resources:
               requests:
                 cpu: "1"

--- a/deployment/clouddeploy/gke-workers/base/core/importer-reconciler.yaml
+++ b/deployment/clouddeploy/gke-workers/base/core/importer-reconciler.yaml
@@ -27,8 +27,8 @@ spec:
                 value: "1.0"
               - name: TRACE_SAMPLE_RATE # for the individual vulnerability entries
                 value: "0.05"
-              - name: DEFAULT_TASK_POOL
-                value: "default"
+              - name: REIMPORT_TASK_POOL
+                value: "reimport"
             resources:
               requests:
                 cpu: "1"

--- a/deployment/clouddeploy/gke-workers/base/core/importer.yaml
+++ b/deployment/clouddeploy/gke-workers/base/core/importer.yaml
@@ -30,6 +30,8 @@ spec:
                 value: "1.0"
               - name: TRACE_SAMPLE_RATE # for the individual vulnerability entries
                 value: "0.05"
+              - name: DEFAULT_TASK_POOL
+                value: "default"
               - name: REIMPORT_TASK_POOL
                 value: "reimport"
             resources:

--- a/deployment/clouddeploy/gke-workers/base/core/scaler.yaml
+++ b/deployment/clouddeploy/gke-workers/base/core/scaler.yaml
@@ -25,7 +25,7 @@ spec:
         name: pubsub.googleapis.com|subscription|num_undelivered_messages
         selector:
           matchLabels:
-            resource.labels.subscription_id: default-pool
+            resource.labels.subscription_id: default
       target:
         type: AverageValue
         averageValue: 10  # each worker can handle 10 tasks now

--- a/deployment/clouddeploy/gke-workers/base/core/workers.yaml
+++ b/deployment/clouddeploy/gke-workers/base/core/workers.yaml
@@ -34,7 +34,7 @@ spec:
           - name: GITTER_HOST
             value: http://gitter-service:8888
           - name: PUBSUB_SUBSCRIPTION
-            value: default-pool
+            value: default
           - name: DATASTORE_DATABASE_ID
             value: "" # default
           - name: FAILED_TASKS_TOPIC

--- a/deployment/clouddeploy/gke-workers/environments/private/importer-deleter.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/private/importer-deleter.yaml
@@ -14,6 +14,8 @@ spec:
               value: private-osv
             - name: WORKER_TASK_TOPIC
               value: "osv-work"
+            - name: DEFAULT_TASK_POOL
+              value: "default"
             image: importer
             args:
               - --delete

--- a/deployment/clouddeploy/gke-workers/environments/private/importer-reconciler.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/private/importer-reconciler.yaml
@@ -14,7 +14,9 @@ spec:
               value: private-osv
             - name: WORKER_TASK_TOPIC
               value: "osv-work"
-            - name: DEFAULT_TASK_POOL
+            # We don't have a dedicated reimport pool for this private deployment,
+            # so route reimports to the default pool.
+            - name: REIMPORT_TASK_POOL
               value: "default"
             args: ["--reconcile=true"]
 ---

--- a/deployment/clouddeploy/gke-workers/environments/private/importer-reconciler.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/private/importer-reconciler.yaml
@@ -14,10 +14,8 @@ spec:
               value: private-osv
             - name: WORKER_TASK_TOPIC
               value: "osv-work"
-            # We don't have a dedicated reimport pool for this private deployment,
-            # so route reimports to the default pool.
-            - name: REIMPORT_TASK_POOL
-              value: "default-pool"
+            - name: DEFAULT_TASK_POOL
+              value: "default"
             args: ["--reconcile=true"]
 ---
 apiVersion: v1

--- a/deployment/clouddeploy/gke-workers/environments/private/importer.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/private/importer.yaml
@@ -17,7 +17,7 @@ spec:
             # We don't have a dedicated reimport pool for this private deployment,
             # so route reimports to the default pool.
             - name: REIMPORT_TASK_POOL
-              value: "default-pool"
+              value: "default"
             args:
               # Note that with https://github.com/google/osv.dev/pull/2766
               # addition per-repository settings make this *really* take effect, see

--- a/deployment/clouddeploy/gke-workers/environments/private/workers.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/private/workers.yaml
@@ -19,7 +19,7 @@ spec:
           - name: OSV_VULNERABILITIES_BUCKET
             value: private-osv-vulnerabilities
           - name: PUBSUB_SUBSCRIPTION
-            value: "default-pool"
+            value: "default"
           - name: FAILED_TASKS_TOPIC
             value: "failed-osv-work"
         resources:

--- a/deployment/terraform/environments/private-osv/main.tf
+++ b/deployment/terraform/environments/private-osv/main.tf
@@ -8,7 +8,7 @@ module "osv_pipeline" {
   affected_commits_backups_bucket            = "private-osv-affected-commits-backups"
   pubsub_topic_name                          = "osv-work"
   pubsub_topic_failed_tasks_name             = "failed-osv-work"
-  pubsub_subscription_default_work_pool_name = "default-pool"
+  pubsub_subscription_default_work_pool_name = "default"
   pubsub_subscription_recovery_name          = "recovery"
   cluster_name                               = "workers"
   cluster_location                           = "us-central1-f"

--- a/deployment/terraform/modules/osv/pubsub_tasks.tf
+++ b/deployment/terraform/modules/osv/pubsub_tasks.tf
@@ -20,7 +20,7 @@ resource "google_pubsub_topic" "failed_tasks" {
 
 resource "google_pubsub_subscription" "default_work" {
   project                    = var.project_id
-  name                       = "default-pool"
+  name                       = "default"
   topic                      = google_pubsub_topic.tasks.id
   message_retention_duration = "604800s"
   ack_deadline_seconds       = 600

--- a/deployment/terraform/modules/osv_pipeline/pubsub_tasks.tf
+++ b/deployment/terraform/modules/osv_pipeline/pubsub_tasks.tf
@@ -34,7 +34,7 @@ resource "google_pubsub_subscription" "default_work" {
     goog-dm = "pubsub"
   }
 
-  filter = "attributes.work_pool = \"default\""
+  filter = "attributes.work_pool = \"${var.pubsub_subscription_default_work_pool_name}\""
 }
 
 resource "google_pubsub_subscription" "work_pools" {

--- a/deployment/terraform/modules/osv_pipeline/variables.tf
+++ b/deployment/terraform/modules/osv_pipeline/variables.tf
@@ -50,7 +50,7 @@ variable "pubsub_topic_failed_tasks_name" {
 variable "pubsub_subscription_default_work_pool_name" {
   type        = string
   description = "The name of the default work pool Pub/Sub subscription."
-  default     = "default-pool"
+  default     = "default"
 }
 
 variable "pubsub_subscription_recovery_name" {


### PR DESCRIPTION
> [!IMPORTANT]
> Before merging / deploying this, make sure the importers are paused and the Pub/Sub queues are empty!
> Renaming the Pub/Sub subscriptions forces them to be destroyed and re-created

After being confused for a while on the private instance, I discovered that having the name of the default Pub/Sub subscription be `default-pool` while having the filter that applies to it be `default` (which is different to how all our extra pools are done, which have the same name/field filter) is a confusing footgun.

I'm renaming things so these are both `default` so I don't spend an hour wondering why my Pub/Sub messages are disappearing again.