### PR TITLE
fix(purl): keep the package repository in generated PURLs

### DIFF
--- a/gcp/workers/worker/worker.py
+++ b/gcp/workers/worker/worker.py
@@ -552,9 +552,8 @@ class TaskRunner:
         source_link = source_repo.link + relative_path
       for affected in vulnerability.affected:
         if not affected.package.purl:
-          if purl := purl_helpers.package_to_purl(
-              osv.ecosystems.normalize(affected.package.ecosystem),
-              affected.package.name):
+          if purl := purl_helpers.package_to_purl(affected.package.ecosystem,
+                                                  affected.package.name):
             affected.package.purl = purl
         if source_link:
           affected.database_specific.update({'source': source_link})

--- a/osv/models.py
+++ b/osv/models.py
@@ -381,8 +381,8 @@ class Bug(ndb.Model):
     for pkg in self.affected_packages:
       # Set PURL if it wasn't provided.
       if not pkg.package.purl:
-        pkg.package.purl = purl_helpers.package_to_purl(
-            ecosystems.normalize(pkg.package.ecosystem), pkg.package.name)
+        pkg.package.purl = purl_helpers.package_to_purl(pkg.package.ecosystem,
+                                                        pkg.package.name)
 
     self.project = list({
         pkg.package.name for pkg in self.affected_packages if pkg.package.name

--- a/osv/purl_helpers.py
+++ b/osv/purl_helpers.py
@@ -126,7 +126,11 @@ def _url_encode(package_name):
 
 def package_to_purl(ecosystem: str, package_name: str) -> str | None:
   """Convert a ecosystem and package name to PURL."""
-  purl_data = ECOSYSTEM_PURL_DATA.get(ecosystem)
+  # Some ecosystems name a non-default package repository after a colon, e.g.
+  # `Packagist:https://packages.drupal.org/8`. Other suffixes (release numbers
+  # such as `Debian:11`) carry no repository information.
+  base_ecosystem, _, ecosystem_suffix = ecosystem.partition(':')
+  purl_data = ECOSYSTEM_PURL_DATA.get(base_ecosystem)
   if not purl_data:
     return None
 
@@ -136,18 +140,26 @@ def package_to_purl(ecosystem: str, package_name: str) -> str | None:
   else:
     purl_ecosystem = purl_type
 
-  suffix = ''
+  qualifiers = {}
 
   if purl_type == 'maven':
     # PURLs use / to separate the group ID and the artifact ID.
     package_name = package_name.replace(':', '/', 1)
 
-  if purl_type == 'deb' and ecosystem == 'Debian':
-    suffix = '?arch=source'
+  if purl_type == 'deb' and base_ecosystem == 'Debian':
+    qualifiers['arch'] = 'source'
 
-  if purl_type == 'apk' and ecosystem in ('Alpine', 'Alpaquita',
-                                          'BellSoft Hardened Containers'):
-    suffix = '?arch=source'
+  if purl_type == 'apk' and base_ecosystem in ('Alpine', 'Alpaquita',
+                                               'BellSoft Hardened Containers'):
+    qualifiers['arch'] = 'source'
+
+  if ecosystem_suffix.startswith(('http://', 'https://')):
+    qualifiers['repository_url'] = ecosystem_suffix
+
+  # PURL qualifiers are sorted by key.
+  suffix = ''
+  if qualifiers:
+    suffix = '?' + '&'.join(f'{key}={qualifiers[key]}' for key in sorted(qualifiers))
 
   # Encode package name: preserve '/' in specific cases
   # - When no namespace is defined
@@ -156,6 +168,13 @@ def package_to_purl(ecosystem: str, package_name: str) -> str | None:
   encoded_name = quote(package_name, safe=safe_chars)
 
   return f'pkg:{purl_ecosystem}/{encoded_name}{suffix}'
+
+
+def _with_repository(ecosystem: str, repository_url: str) -> str:
+  """Append a non-default package repository to the ecosystem name."""
+  if not repository_url:
+    return ecosystem
+  return f'{ecosystem}:{repository_url}'
 
 
 def parse_purl(purl_str: str) -> ParsedPURL | None:
@@ -175,11 +194,17 @@ def parse_purl(purl_str: str) -> ParsedPURL | None:
 
   package = purl.name
   version = purl.version
+  # A repository_url qualifier names a non-default package repository, which OSV
+  # records after a colon in the ecosystem (e.g. Packagist:https://...).
+  repository_url = (purl.qualifiers or {}).get('repository_url', '')
+  if not repository_url.startswith(('http://', 'https://')):
+    repository_url = ''
 
   # Find a matching ecosystem using both type and namespace.
   ecosystem = PURL_ECOSYSTEM_MAP.get(EcosystemPURL(purl.type, purl.namespace))
   if ecosystem:
-    return ParsedPURL(ecosystem, package, version)
+    return ParsedPURL(_with_repository(ecosystem, repository_url), package,
+                      version)
 
   # If no match is found, try again using only the type.
   # Some ecosystems may use the namespace to represent additional
@@ -206,4 +231,5 @@ def parse_purl(purl_str: str) -> ParsedPURL | None:
     # Handle the case where the namespace is not supported.
     return None
 
-  return ParsedPURL(ecosystem, package, version)
+  return ParsedPURL(_with_repository(ecosystem, repository_url), package,
+                    version)

--- a/osv/purl_helpers_test.py
+++ b/osv/purl_helpers_test.py
@@ -357,3 +357,39 @@ class PurlHelpersTest(unittest.TestCase):
 
 if __name__ == '__main__':
   unittest.main()
+
+  def test_package_to_purl_repository_url(self):
+    """A non-default package repository becomes a repository_url qualifier."""
+    self.assertEqual(
+        'pkg:composer/drupal/commerce_guest_registration'
+        '?repository_url=https://packages.drupal.org/8',
+        purl_helpers.package_to_purl('Packagist:https://packages.drupal.org/8',
+                                     'drupal/commerce_guest_registration'))
+
+    # The default repository is left implicit.
+    self.assertEqual('pkg:composer/symfony/http-kernel',
+                     purl_helpers.package_to_purl('Packagist',
+                                                  'symfony/http-kernel'))
+
+    # A release suffix is not a repository and must not leak into the PURL.
+    self.assertEqual('pkg:deb/debian/nginx?arch=source',
+                     purl_helpers.package_to_purl('Debian:11', 'nginx'))
+
+    # Qualifiers stay sorted by key.
+    self.assertEqual(
+        'pkg:deb/debian/nginx?arch=source&repository_url=https://example.com/deb',
+        purl_helpers.package_to_purl('Debian:https://example.com/deb', 'nginx'))
+
+  def test_parse_purl_repository_url(self):
+    """The repository_url qualifier is carried back into the ecosystem."""
+    self.assertEqual(
+        purl_helpers.ParsedPURL('Packagist:https://packages.drupal.org/8',
+                                'drupal/commerce_guest_registration', None),
+        purl_helpers.parse_purl(
+            'pkg:composer/drupal/commerce_guest_registration'
+            '?repository_url=https://packages.drupal.org/8'))
+
+    # Without the qualifier the ecosystem is unchanged.
+    self.assertEqual(
+        purl_helpers.ParsedPURL('Packagist', 'symfony/http-kernel', '6.0.0'),
+        purl_helpers.parse_purl('pkg:composer/symfony/http-kernel@6.0.0'))

--- a/osv/purl_helpers_test.py
+++ b/osv/purl_helpers_test.py
@@ -354,10 +354,6 @@ class PurlHelpersTest(unittest.TestCase):
         '2.11.2',
         purl_helpers.parse_purl('pkg:deb/ubuntu/pygments@2.11.2').version)
 
-
-if __name__ == '__main__':
-  unittest.main()
-
   def test_package_to_purl_repository_url(self):
     """A non-default package repository becomes a repository_url qualifier."""
     self.assertEqual(
@@ -393,3 +389,7 @@ if __name__ == '__main__':
     self.assertEqual(
         purl_helpers.ParsedPURL('Packagist', 'symfony/http-kernel', '6.0.0'),
         purl_helpers.parse_purl('pkg:composer/symfony/http-kernel@6.0.0'))
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Fixes #5683

`package_to_purl` was called with `ecosystems.normalize(...)`, which drops everything after the colon ΓÇö
so `Packagist:https://packages.drupal.org/8` became `Packagist` and the repository was lost from the
generated PURL.

Both callers now pass the full ecosystem, and `package_to_purl` turns a repository suffix into the
`repository_url` qualifier:

```
Packagist:https://packages.drupal.org/8 + drupal/commerce_guest_registration
  -> pkg:composer/drupal/commerce_guest_registration?repository_url=https://packages.drupal.org/8
```

Only a suffix that starts with `http://` or `https://` is treated as a repository, so release suffixes
keep behaving exactly as before (`Debian:11`, `Alpine:v3.17`). Qualifiers are emitted sorted by key, so
an ecosystem that has both still produces a valid PURL
(`?arch=source&repository_url=...`).

`parse_purl` does the reverse: a `repository_url` qualifier is appended back to the ecosystem name, so an
API query with the generated PURL resolves to `Packagist:https://packages.drupal.org/8` ΓÇö that is the
second half of the issue.

### Verified

The repo's own `osv/purl_helpers_test.py` imports through `osv/__init__.py`, which pulls the Cloud
dependencies, so I could not run it as-is locally; I ran the same expectations against the module loaded
directly in `python:3.12`:

```
== package_to_purl ==
  OK  Packagist:https://packages.drupal.org/8 -> pkg:composer/drupal/commerce_guest_registration?repository_url=https://packages.drupal.org/8
  OK  Packagist                               -> pkg:composer/symfony/http-kernel
  OK  Debian:11                               -> pkg:deb/debian/nginx?arch=source
  OK  Debian:https://example.com/deb          -> pkg:deb/debian/nginx?arch=source&repository_url=https://example.com/deb
  OK  Alpine:v3.17                            -> pkg:apk/alpine/postgresql14?arch=source
  OK  Maven                                   -> pkg:maven/org.apache.struts/struts2-core
== parse_purl ==
  OK  ...?repository_url=https://packages.drupal.org/8  -> ('Packagist:https://packages.drupal.org/8', 'drupal/commerce_guest_registration', None)
  OK  pkg:composer/symfony/http-kernel@6.0.0            -> ('Packagist', 'symfony/http-kernel', '6.0.0')
  OK  pkg:deb/debian/nginx?arch=source                  -> ('Debian', 'nginx', None)
```

The same cases are added to `purl_helpers_test.py` as `test_package_to_purl_repository_url` and
`test_parse_purl_repository_url`, so CI runs them with the real dependencies.

One thing I deliberately did not do: the qualifier value is written verbatim, matching the example in the
issue. If you'd rather have it percent-encoded per the PURL spec, say so and I'll change it ΓÇö that also
affects what existing consumers would need to match on.

AI-assisted (LLM used for drafting); the change and the runs above are mine.

---

*Note on this PR:* this replaces #5747, which was the same branch and the same commits. The CLA check
there ran before I had signed the Google CLA; I have signed it now (individual CLA, GitHub username
`Eljees`, commit email `3.14hell@gmail.com`), but GitHub would not let me reopen #5747 afterwards, so
this is the same change in a fresh PR. Nothing in the diff has changed.
