### PR TITLE
fix: point private-osv importer-reconciler to correct persistant volume

### DIFF
--- a/deployment/clouddeploy/gke-workers/environments/private/importer-reconciler.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/private/importer-reconciler.yaml
@@ -27,5 +27,5 @@ metadata:
 spec:
   csi:
     driver: pd.csi.storage.gke.io
-    volumeHandle: projects/oss-vdb-test/zones/us-central1-f/disks/importer-reconciler-git-cache-private
+    volumeHandle: projects/private-osv/zones/us-central1-f/disks/importer-reconciler-git-cache
     fsType: ext4


### PR DESCRIPTION
This misconfiguration is preventing it from starting.

This disk probably won't even be needed after #5744 is merged anyway 🤷 