### PR TITLE
perf: Move to new n4 nodes to avoid scaling issues and save on costs

### DIFF
--- a/deployment/terraform/modules/osv/workers_gke.tf
+++ b/deployment/terraform/modules/osv/workers_gke.tf
@@ -67,13 +67,11 @@ resource "google_container_node_pool" "default_pool" {
 
 
   node_config {
-    machine_type    = "n1-highmem-2"
-    disk_type       = "pd-ssd"
-    disk_size_gb    = 64
-    local_ssd_count = 1
+    machine_type = "n4-standard-8"
+    disk_type    = "hyperdisk-balanced"
+    disk_size_gb = 64
 
     oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
-
   }
 }
 
@@ -101,13 +99,8 @@ resource "google_container_node_pool" "highend" {
 
 
   node_config {
-    machine_type = "n2-highmem-32"
-    disk_type    = "pd-ssd"
-    disk_size_gb = 100
-    ephemeral_storage_config { // This is used for emptyDir storage in kubernetes
-      // Minimum is 4 ssds for n2-highmem-32, for 375GB * 4 = 1.5TB of storage
-      local_ssd_count = 4
-    }
+    machine_type = "n4-highmem-32"
+    disk_type    = "hyperdisk-balanced"
 
     oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
 
@@ -179,7 +172,7 @@ resource "google_container_node_pool" "worker_pool_temp" {
   }
 
   node_config {
-    machine_type = "n4-highcpu-8"
+    machine_type = "n4-standard-8"
     disk_type    = "hyperdisk-balanced"
 
     oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]

--- a/deployment/terraform/modules/osv/workers_gke.tf
+++ b/deployment/terraform/modules/osv/workers_gke.tf
@@ -101,6 +101,7 @@ resource "google_container_node_pool" "highend" {
   node_config {
     machine_type = "n4-highmem-32"
     disk_type    = "hyperdisk-balanced"
+    disk_size_gb = 500
 
     oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
 
@@ -172,7 +173,7 @@ resource "google_container_node_pool" "worker_pool_temp" {
   }
 
   node_config {
-    machine_type = "n4-standard-8"
+    machine_type = "n4-highcpu-8"
     disk_type    = "hyperdisk-balanced"
 
     oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]

--- a/deployment/terraform/modules/osv_pipeline/gke.tf
+++ b/deployment/terraform/modules/osv_pipeline/gke.tf
@@ -100,6 +100,7 @@ resource "google_container_node_pool" "highend" {
     service_account = google_service_account.worker_sa.email
     machine_type    = "n4-highmem-32"
     disk_type       = "hyperdisk-balanced"
+    disk_size_gb    = 500
 
     oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
 
@@ -171,7 +172,7 @@ resource "google_container_node_pool" "worker_pool" {
 
   node_config {
     service_account = google_service_account.worker_sa.email
-    machine_type    = "n4-standard-8"
+    machine_type    = "n4-highcpu-8"
     disk_type       = "hyperdisk-balanced"
 
     oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]

--- a/deployment/terraform/modules/osv_pipeline/gke.tf
+++ b/deployment/terraform/modules/osv_pipeline/gke.tf
@@ -66,13 +66,11 @@ resource "google_container_node_pool" "default_pool" {
 
   node_config {
     service_account = google_service_account.worker_sa.email
-    machine_type    = "n1-highmem-2"
-    disk_type       = "pd-ssd"
+    machine_type    = "n4-standard-8"
+    disk_type       = "hyperdisk-balanced"
     disk_size_gb    = 64
-    local_ssd_count = 1
 
     oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
-
   }
 }
 
@@ -100,13 +98,8 @@ resource "google_container_node_pool" "highend" {
 
   node_config {
     service_account = google_service_account.worker_sa.email
-    machine_type    = "n2-highmem-32"
-    disk_type       = "pd-ssd"
-    disk_size_gb    = 100
-    ephemeral_storage_config { // This is used for emptyDir storage in kubernetes
-      // Minimum is 4 ssds for n2-highmem-32, for 375GB * 4 = 1.5TB of storage
-      local_ssd_count = 4
-    }
+    machine_type    = "n4-highmem-32"
+    disk_type       = "hyperdisk-balanced"
 
     oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
 
@@ -178,7 +171,7 @@ resource "google_container_node_pool" "worker_pool" {
 
   node_config {
     service_account = google_service_account.worker_sa.email
-    machine_type    = "n4-highcpu-8"
+    machine_type    = "n4-standard-8"
     disk_type       = "hyperdisk-balanced"
 
     oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]


### PR DESCRIPTION
- Faster
- Cheaper
- More reliable (Because we actually have more instances of n4 that can be scaled up to.

Why not.

Apparently emptyDir is shares/uses the boot drive now. Not that we really need it. Adding a extra 500 for highend for uses like the indexer.
