### PR TITLE
chore: ignore changes on GKE disk type in terraform

### DIFF
--- a/deployment/terraform/modules/osv/workers_gke.tf
+++ b/deployment/terraform/modules/osv/workers_gke.tf
@@ -216,6 +216,12 @@ resource "google_compute_disk" "gitter_disk" {
   type    = "pd-ssd"
   zone    = google_container_cluster.workers.location
   size    = 6144 # 6TiB
+
+  lifecycle {
+    ignore_changes = [
+      type,
+    ]
+  }
 }
 
 # SSD for Importer Reconciler
@@ -225,5 +231,11 @@ resource "google_compute_disk" "importer_reconciler_git_cache" {
   type    = "pd-ssd"
   zone    = google_container_cluster.workers.location
   size    = 200
+
+  lifecycle {
+    ignore_changes = [
+      type,
+    ]
+  }
 }
 


### PR DESCRIPTION
We want to convert these to hyperdisks, but I don't want terraform getting confused while they are being converted.

I hope this `ignore_changes` will let us run the conversion command, and then can be removed when we make terraform use the new disk type.