### PR TITLE
fix: Bump memory limits for exporter

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/core/exporter.yaml
+++ b/deployment/clouddeploy/gke-workers/base/core/exporter.yaml
@@ -28,10 +28,10 @@ spec:
             resources:
               requests:
                 cpu: "12"
-                memory: "40Gi"
+                memory: "100Gi"
               limits:
                 cpu: "20"
-                memory: "64Gi"
+                memory: "150Gi"
             env:
               - name: TRACE_SAMPLE_RATE
                 value: "0.0"


### PR DESCRIPTION
It was running too fast and running out of memory. Since it used ~70GB, this should give it enough headroom for the foreseeable future <sup><sub>I'm short sighted</sub></sup>