### PR TITLE
fix(vulnfeeds): dont cache invalid for a week if a 500 error

### DIFF
--- a/vulnfeeds/conversion/common.go
+++ b/vulnfeeds/conversion/common.go
@@ -157,6 +157,7 @@ func GitVersionsToCommits(versionRanges []models.RangeWithMetadata, repos []stri
 			break // All ranges have been resolved.
 		}
 		if cache.IsInvalid(repo) {
+			logger.Debug("Repo is marked invalid in cache", slog.String("repo", repo))
 			continue
 		}
 

--- a/vulnfeeds/git/repository.go
+++ b/vulnfeeds/git/repository.go
@@ -211,6 +211,7 @@ func (c *RedisRepoTagsCache) Get(repo string) (RepoTagsMap, bool) {
 		if !errors.Is(err, redis.Nil) {
 			logger.Warn("Redis Get failed", slog.String("key", key), slog.Any("error", err))
 		}
+
 		return RepoTagsMap{}, false
 	}
 
@@ -264,6 +265,7 @@ func (c *RedisRepoTagsCache) IsInvalid(repo string) bool {
 		if !errors.Is(err, redis.Nil) {
 			logger.Warn("Redis Get failed", slog.String("key", key), slog.Any("error", err))
 		}
+
 		return false
 	}
 
@@ -291,6 +293,7 @@ func (c *RedisRepoTagsCache) GetCanonicalLink(repo string) (string, bool) {
 		if !errors.Is(err, redis.Nil) {
 			logger.Warn("Redis Get failed", slog.String("key", key), slog.Any("error", err))
 		}
+
 		return "", false
 	}
 

--- a/vulnfeeds/git/repository.go
+++ b/vulnfeeds/git/repository.go
@@ -52,7 +52,8 @@ const (
 
 var ErrRateLimit = errors.New("rate limit exceeded")
 
-// IsRateLimit checks if the error represents an HTTP 429 Rate Limit / Too Many Requests error.
+// IsRateLimit checks if the error represents an HTTP 429 Rate Limit / Too Many Requests error
+// or a transient server error (5xx).
 func IsRateLimit(err error) bool {
 	if err == nil {
 		return false
@@ -60,6 +61,14 @@ func IsRateLimit(err error) bool {
 	if errors.Is(err, ErrRateLimit) {
 		return true
 	}
+
+	var gitterErr *GitterError
+	if errors.As(err, &gitterErr) {
+		if gitterErr.StatusCode == http.StatusTooManyRequests || (gitterErr.StatusCode >= 500 && gitterErr.StatusCode < 600) {
+			return true
+		}
+	}
+
 	errStr := err.Error()
 
 	return strings.Contains(errStr, "status code 429") ||
@@ -70,7 +79,15 @@ func IsRateLimit(err error) bool {
 		strings.Contains(errStr, "code: 429") ||
 		strings.Contains(errStr, "status: 429") ||
 		strings.Contains(errStr, "HTTP 429") ||
-		strings.Contains(errStr, "http: 429")
+		strings.Contains(errStr, "http: 429") ||
+		strings.Contains(errStr, "status code 500") ||
+		strings.Contains(errStr, "status code 502") ||
+		strings.Contains(errStr, "status code 503") ||
+		strings.Contains(errStr, "status code 504") ||
+		strings.Contains(errStr, "status 500") ||
+		strings.Contains(errStr, "status 502") ||
+		strings.Contains(errStr, "status 503") ||
+		strings.Contains(errStr, "status 504")
 }
 
 // A GitTag holds a Git tag and corresponding commit hash.
@@ -191,11 +208,15 @@ func (c *RedisRepoTagsCache) Get(repo string) (RepoTagsMap, bool) {
 	key := "repo_tags:" + repo
 	val, err := c.redisClient.Get(ctx, key).Result()
 	if err != nil {
+		if !errors.Is(err, redis.Nil) {
+			logger.Warn("Redis Get failed", slog.String("key", key), slog.Any("error", err))
+		}
 		return RepoTagsMap{}, false
 	}
 
 	var tags RepoTagsMap
 	if err := json.Unmarshal([]byte(val), &tags); err != nil {
+		logger.Warn("Failed to unmarshal tags from Redis", slog.String("key", key), slog.Any("error", err))
 		return RepoTagsMap{}, false
 	}
 
@@ -209,11 +230,14 @@ func (c *RedisRepoTagsCache) Set(repo string, tags RepoTagsMap) {
 	key := "repo_tags:" + repo
 	val, err := json.Marshal(tags)
 	if err != nil {
+		logger.Warn("Failed to marshal tags for Redis", slog.String("key", key), slog.Any("error", err))
 		return
 	}
 
 	ttl := randomTTL()
-	c.redisClient.Set(ctx, key, val, ttl)
+	if err := c.redisClient.Set(ctx, key, val, ttl).Err(); err != nil {
+		logger.Warn("Redis Set failed", slog.String("key", key), slog.Any("error", err))
+	}
 }
 
 func (c *RedisRepoTagsCache) SetInvalid(repo string) {
@@ -225,7 +249,9 @@ func (c *RedisRepoTagsCache) SetInvalidWithTTL(repo string, ttl time.Duration) {
 	defer cancel()
 
 	key := "invalid_repo:" + repo
-	c.redisClient.Set(ctx, key, "true", ttl)
+	if err := c.redisClient.Set(ctx, key, "true", ttl).Err(); err != nil {
+		logger.Warn("Redis Set failed", slog.String("key", key), slog.Any("error", err))
+	}
 }
 
 func (c *RedisRepoTagsCache) IsInvalid(repo string) bool {
@@ -235,6 +261,9 @@ func (c *RedisRepoTagsCache) IsInvalid(repo string) bool {
 	key := "invalid_repo:" + repo
 	val, err := c.redisClient.Get(ctx, key).Result()
 	if err != nil {
+		if !errors.Is(err, redis.Nil) {
+			logger.Warn("Redis Get failed", slog.String("key", key), slog.Any("error", err))
+		}
 		return false
 	}
 
@@ -247,7 +276,9 @@ func (c *RedisRepoTagsCache) SetCanonicalLink(repo string, canonicalLink string)
 
 	key := "canonical_link:" + repo
 	ttl := randomTTL()
-	c.redisClient.Set(ctx, key, canonicalLink, ttl)
+	if err := c.redisClient.Set(ctx, key, canonicalLink, ttl).Err(); err != nil {
+		logger.Warn("Redis Set failed", slog.String("key", key), slog.Any("error", err))
+	}
 }
 
 func (c *RedisRepoTagsCache) GetCanonicalLink(repo string) (string, bool) {
@@ -257,6 +288,9 @@ func (c *RedisRepoTagsCache) GetCanonicalLink(repo string) (string, bool) {
 	key := "canonical_link:" + repo
 	val, err := c.redisClient.Get(ctx, key).Result()
 	if err != nil {
+		if !errors.Is(err, redis.Nil) {
+			logger.Warn("Redis Get failed", slog.String("key", key), slog.Any("error", err))
+		}
 		return "", false
 	}
 
@@ -348,19 +382,25 @@ func gitterRepoRefs(repoURL string) ([]*plumbing.Reference, error) {
 	}
 	defer resp.Body.Close()
 
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read gitter response: %w", err)
+	}
+
 	if resp.StatusCode == http.StatusNoContent {
 		return nil, nil
 	}
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		logger.Warn("Gitter request failed", slog.Int("status", resp.StatusCode), slog.String("body", string(bodyBytes)), slog.String("repo", repoURL))
 		return nil, &GitterError{
 			StatusCode: resp.StatusCode,
-			Body:       string(body),
+			Body:       string(bodyBytes),
 		}
 	}
 
 	var tagsResp GitterTagsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&tagsResp); err != nil {
+	if err := json.Unmarshal(bodyBytes, &tagsResp); err != nil {
+		logger.Warn("Failed to decode Gitter response", slog.String("body", string(bodyBytes)), slog.String("repo", repoURL), slog.Any("error", err))
 		return nil, fmt.Errorf("failed to decode gitter response: %w", err)
 	}
 

--- a/vulnfeeds/git/versions.go
+++ b/vulnfeeds/git/versions.go
@@ -99,13 +99,13 @@ func VersionToCommit(version string, normalizedTags map[string]NormalizedTag) (s
 		return "", err
 	}
 	logger.Debug("VersionToCommit normalized version", slog.String("version", version), slog.String("normalizedVersion", normalizedVersion))
-	
+
 	// Try a straight out (case-insensitive) match first.
 	if normalizedTag, ok := normalizedTags[strings.ToLower(normalizedVersion)]; ok {
 		logger.Debug("VersionToCommit found exact match", slog.String("version", version), slog.String("normalizedVersion", normalizedVersion), slog.String("commit", normalizedTag.Commit))
 		return normalizedTag.Commit, nil
 	}
-	
+
 	// Then try to fuzzy-match.
 	if commitHash, ok := findFuzzyCommit(normalizedVersion, normalizedTags); ok {
 		logger.Debug("VersionToCommit found fuzzy match", slog.String("version", version), slog.String("normalizedVersion", normalizedVersion), slog.String("commit", commitHash))
@@ -113,6 +113,7 @@ func VersionToCommit(version string, normalizedTags map[string]NormalizedTag) (s
 	}
 
 	logger.Debug("VersionToCommit failed to find match", slog.String("version", version), slog.String("normalizedVersion", normalizedVersion))
+
 	return "", fmt.Errorf("failed to find a commit for version %q normalized as %q", version, normalizedVersion)
 }
 

--- a/vulnfeeds/git/versions.go
+++ b/vulnfeeds/git/versions.go
@@ -17,6 +17,7 @@ package git
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -25,6 +26,7 @@ import (
 	"time"
 
 	"github.com/google/osv/vulnfeeds/models"
+	"github.com/google/osv/vulnfeeds/utility/logger"
 	"github.com/sethvargo/go-retry"
 )
 
@@ -93,17 +95,24 @@ func VersionToCommit(version string, normalizedTags map[string]NormalizedTag) (s
 	// TODO: try unnormalized version first.
 	normalizedVersion, err := NormalizeVersion(version)
 	if err != nil {
+		logger.Debug("VersionToCommit failed to normalize version", slog.String("version", version), slog.Any("error", err))
 		return "", err
 	}
+	logger.Debug("VersionToCommit normalized version", slog.String("version", version), slog.String("normalizedVersion", normalizedVersion))
+	
 	// Try a straight out (case-insensitive) match first.
 	if normalizedTag, ok := normalizedTags[strings.ToLower(normalizedVersion)]; ok {
+		logger.Debug("VersionToCommit found exact match", slog.String("version", version), slog.String("normalizedVersion", normalizedVersion), slog.String("commit", normalizedTag.Commit))
 		return normalizedTag.Commit, nil
 	}
+	
 	// Then try to fuzzy-match.
 	if commitHash, ok := findFuzzyCommit(normalizedVersion, normalizedTags); ok {
+		logger.Debug("VersionToCommit found fuzzy match", slog.String("version", version), slog.String("normalizedVersion", normalizedVersion), slog.String("commit", commitHash))
 		return commitHash, nil
 	}
 
+	logger.Debug("VersionToCommit failed to find match", slog.String("version", version), slog.String("normalizedVersion", normalizedVersion))
 	return "", fmt.Errorf("failed to find a commit for version %q normalized as %q", version, normalizedVersion)
 }
 


### PR DESCRIPTION
funkiness with gitter being down lead to some weird record resolutions as far as I can tell. the redis cache has seemingly cached temporary service errors for repos as 7 day invalid cache errors.


also added a bunch of debug statements 