### PR TITLE
fix(purl): preserve Packagist repository URLs

### DIFF
--- a/go/internal/worker/pipeline/purl/purl_test.go
+++ b/go/internal/worker/pipeline/purl/purl_test.go
@@ -61,6 +61,13 @@ func TestEnricher_Enrich(t *testing.T) {
 			initialPurl:  "",
 			expectedPurl: "pkg:deb/debian/curl?arch=source&distro=bullseye",
 		},
+		{
+			name:         "Generate Packagist PURL with repository",
+			ecosystem:    "Packagist:https://packages.drupal.org/8",
+			pkgName:      "drupal/commerce_guest_registration",
+			initialPurl:  "",
+			expectedPurl: "pkg:composer/drupal/commerce_guest_registration?repository_url=https:%2F%2Fpackages.drupal.org%2F8",
+		},
 	}
 
 	for _, tc := range tests {

--- a/go/purl/ecosystem_packagist.go
+++ b/go/purl/ecosystem_packagist.go
@@ -1,0 +1,51 @@
+package purl
+
+import (
+	"strings"
+
+	"github.com/ossf/osv-schema/bindings/go/osvconstants"
+	packageurl "github.com/package-url/packageurl-go"
+)
+
+const repositoryURLQualifier = "repository_url"
+
+//nolint:gochecknoinits // init is used here to register the ecosystem with the global PURL registry.
+func init() {
+	registerGenerator(osvconstants.EcosystemPackagist, generatorFunc(packagistGenerator))
+	registerParser("composer", "", parserFunc(packagistParser))
+}
+
+func packagistGenerator(ecosystem, packageName string) (packageurl.PackageURL, error) {
+	purl, err := (slashGenerator{purlType: "composer"}).generate(ecosystem, packageName)
+	if err != nil {
+		return packageurl.PackageURL{}, err
+	}
+
+	_, repositoryURL, hasRepository := strings.Cut(ecosystem, ":")
+	if hasRepository && repositoryURL != "" {
+		purl.Qualifiers = packageurl.Qualifiers{
+			{Key: repositoryURLQualifier, Value: repositoryURL},
+		}
+	}
+
+	return purl, nil
+}
+
+func packagistParser(purl packageurl.PackageURL) (packageName string, ecosystem string, err error) {
+	packageName, ecosystem, err = (simpleParser{
+		ecosystem:     osvconstants.EcosystemPackagist,
+		joinNamespace: true,
+	}).parse(purl)
+	if err != nil {
+		return "", "", err
+	}
+
+	for _, qualifier := range purl.Qualifiers {
+		if qualifier.Key == repositoryURLQualifier && qualifier.Value != "" {
+			ecosystem += ":" + qualifier.Value
+			break
+		}
+	}
+
+	return packageName, ecosystem, nil
+}

--- a/go/purl/ecosystems_simple.go
+++ b/go/purl/ecosystems_simple.go
@@ -73,7 +73,6 @@ func init() {
 	registerSimple(osvconstants.EcosystemJulia, "julia", "", nil)
 	registerSimple(osvconstants.EcosystemNuGet, "nuget", "", nil)
 	registerSimple(osvconstants.EcosystemOSSFuzz, "generic", "", nil)
-	registerSlash(osvconstants.EcosystemPackagist, "composer")
 	registerSimple(osvconstants.EcosystemPub, "pub", "", nil)
 	registerSimple(osvconstants.EcosystemPyPI, "pypi", "", nil)
 	registerSimple(osvconstants.EcosystemRubyGems, "gem", "", nil)

--- a/go/purl/purl_test.go
+++ b/go/purl/purl_test.go
@@ -85,3 +85,36 @@ func TestParse(t *testing.T) {
 		}
 	}
 }
+
+func TestPackagistRepositoryRoundTrip(t *testing.T) {
+	const (
+		ecosystem   = "Packagist:https://packages.drupal.org/8"
+		packageName = "drupal/commerce_guest_registration"
+		wantPURL    = "pkg:composer/drupal/commerce_guest_registration?repository_url=https:%2F%2Fpackages.drupal.org%2F8"
+	)
+
+	gotPURL, err := Generate(ecosystem, packageName)
+	if err != nil {
+		t.Fatalf("Generate(%q, %q) returned an error: %v", ecosystem, packageName, err)
+	}
+	if gotPURL != wantPURL {
+		t.Fatalf("Generate(%q, %q) = %q, want %q", ecosystem, packageName, gotPURL, wantPURL)
+	}
+
+	gotEcosystem, gotPackage, gotVersion, err := Parse(gotPURL)
+	if err != nil {
+		t.Fatalf("Parse(%q) returned an error: %v", gotPURL, err)
+	}
+	if gotEcosystem != ecosystem || gotPackage != packageName || gotVersion != "" {
+		t.Errorf(
+			"Parse(%q) = (%q, %q, %q), want (%q, %q, %q)",
+			gotPURL,
+			gotEcosystem,
+			gotPackage,
+			gotVersion,
+			ecosystem,
+			packageName,
+			"",
+		)
+	}
+}


### PR DESCRIPTION
## Overview

Preserve non-default Packagist repositories when converting between OSV ecosystems and Package URLs.

Fixes #5683

## Details

The active Go PURL registry treated Packagist as a generic slash-separated ecosystem. That preserved the Composer namespace and package name, but discarded the repository suffix from ecosystems such as `Packagist:https://packages.drupal.org/8`. The reverse parser likewise ignored the `repository_url` qualifier.

This change:

- registers a dedicated Packagist generator/parser;
- writes the ecosystem suffix as the standard `repository_url` qualifier;
- restores that qualifier to the OSV ecosystem during PURL parsing;
- keeps unqualified `Packagist` behavior unchanged; and
- relies on `packageurl-go` for canonical qualifier escaping.

The production worker enrichment path has a focused Drupal regression case, and the PURL package has a generation/parse round-trip test.

## Testing

```console
$ cd go
$ go test ./purl ./internal/worker/pipeline/purl
ok  github.com/google/osv.dev/go/purl
ok  github.com/google/osv.dev/go/internal/worker/pipeline/purl
```

`gofmt -d` reports no differences for the changed Go files.

AI-assisted contribution: Codex was used for code and test drafting, repository inspection, diff review, and local validation.
