### PR TITLE
fix(worker): chunk AffectedVersions to prevent datastore errors

### DIFF
--- a/go/internal/database/datastore/affected_versions.go
+++ b/go/internal/database/datastore/affected_versions.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	minCoarseVersion = "00:00000000.00000000.00000000"
-	maxCoarseVersion = "99:99999999.99999999.99999999"
+	minCoarseVersion     = "00:00000000.00000000.00000000"
+	maxCoarseVersion     = "99:99999999.99999999.99999999"
+	maxVersionsPerEntity = 1000
 )
 
 func normalizeRepo(repoURL string) string {
@@ -126,34 +127,40 @@ func computeAffectedVersions(vuln *osvschema.Vulnerability) []AffectedVersions {
 			}
 		}
 
-		if pkgName != "" && len(affected.GetVersions()) > 0 {
-			hasAffected = true
-			coarseMin := minCoarseVersion
-			coarseMax := maxCoarseVersion
+		// In some extreme cases, we may have too many enumerated versions to fit
+		// in a single Datastore entity. Chunk them to prevent issues.
+		chunkedVersions := slices.Collect(slices.Chunk(affected.GetVersions(), maxVersionsPerEntity))
 
-			if exists {
-				var allCoarse []string
-				for _, v := range affected.GetVersions() {
-					if cm, err := eHelper.Coarse(v); err == nil {
-						allCoarse = append(allCoarse, cm)
+		if pkgName != "" && len(chunkedVersions) > 0 {
+			hasAffected = true
+			for _, chunk := range chunkedVersions {
+				coarseMin := minCoarseVersion
+				coarseMax := maxCoarseVersion
+
+				if exists {
+					var allCoarse []string
+					for _, v := range chunk {
+						if cm, err := eHelper.Coarse(v); err == nil {
+							allCoarse = append(allCoarse, cm)
+						}
+					}
+					if len(allCoarse) > 0 {
+						slices.Sort(allCoarse)
+						coarseMin = allCoarse[0]
+						coarseMax = allCoarse[len(allCoarse)-1]
 					}
 				}
-				if len(allCoarse) > 0 {
-					slices.Sort(allCoarse)
-					coarseMin = allCoarse[0]
-					coarseMax = allCoarse[len(allCoarse)-1]
-				}
-			}
 
-			for _, e := range allPkgEcosystems {
-				res = append(res, AffectedVersions{
-					VulnID:    vuln.GetId(),
-					Ecosystem: e,
-					Name:      pkgName,
-					Versions:  affected.GetVersions(),
-					CoarseMin: coarseMin,
-					CoarseMax: coarseMax,
-				})
+				for _, e := range allPkgEcosystems {
+					res = append(res, AffectedVersions{
+						VulnID:    vuln.GetId(),
+						Ecosystem: e,
+						Name:      pkgName,
+						Versions:  chunk,
+						CoarseMin: coarseMin,
+						CoarseMax: coarseMax,
+					})
+				}
 			}
 		}
 
@@ -174,15 +181,26 @@ func computeAffectedVersions(vuln *osvschema.Vulnerability) []AffectedVersions {
 		}
 
 		if repoURL != "" {
-			// If we have a repository, always add a GIT entry.
-			// Even if affected.versions is empty, we still want to return this vuln
-			// for the API queries with no versions specified.
-			res = append(res, AffectedVersions{
-				VulnID:    vuln.GetId(),
-				Ecosystem: "GIT",
-				Name:      normalizeRepo(repoURL),
-				Versions:  affected.GetVersions(),
-			})
+			if len(chunkedVersions) == 0 {
+				// If we have a repository, always add a GIT entry.
+				// Even if affected.versions is empty, we still want to return this vuln
+				// for the API queries with no versions specified.
+				res = append(res, AffectedVersions{
+					VulnID:    vuln.GetId(),
+					Ecosystem: "GIT",
+					Name:      normalizeRepo(repoURL),
+					Versions:  []string{},
+				})
+			} else {
+				for _, chunk := range chunkedVersions {
+					res = append(res, AffectedVersions{
+						VulnID:    vuln.GetId(),
+						Ecosystem: "GIT",
+						Name:      normalizeRepo(repoURL),
+						Versions:  chunk,
+					})
+				}
+			}
 		}
 	}
 

--- a/go/internal/database/datastore/affected_versions_test.go
+++ b/go/internal/database/datastore/affected_versions_test.go
@@ -2,6 +2,7 @@ package datastore
 
 import (
 	"cmp"
+	"fmt"
 	"testing"
 
 	gocmp "github.com/google/go-cmp/cmp"
@@ -269,6 +270,94 @@ func TestComputeAffectedVersions_GitAndSemverWithoutPackage(t *testing.T) {
 	}
 
 	if diff := gocmp.Diff(want, got, cmpopts.EquateEmpty()); diff != "" {
+		t.Errorf("computeAffectedVersions mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestComputeAffectedVersions_Chunking(t *testing.T) {
+	// Generate 2500 versions: 1.0.0 through 1.0.2499
+	// This will be split into 3 chunks: [0..999], [1000..1999], [2000..2499]
+	versions := make([]string, 0, 2500)
+	for i := range 2500 {
+		versions = append(versions, fmt.Sprintf("1.0.%d", i))
+	}
+
+	vuln := &osvschema.Vulnerability{
+		Id: "CHUNK-TEST-1",
+		Affected: []*osvschema.Affected{
+			{
+				Package: &osvschema.Package{
+					Name:      "testchunk",
+					Ecosystem: "npm",
+				},
+				Versions: versions,
+				Ranges: []*osvschema.Range{
+					{
+						Type: osvschema.Range_GIT,
+						Repo: "https://github.com/test/chunk",
+					},
+				},
+			},
+		},
+	}
+
+	got := computeAffectedVersions(vuln)
+
+	want := []AffectedVersions{
+		{
+			VulnID:    "CHUNK-TEST-1",
+			Ecosystem: "npm",
+			Name:      "testchunk",
+			Versions:  versions[:1000],
+			CoarseMin: "00:00000001.00000000.00000000",
+			CoarseMax: "00:00000001.00000000.00000999",
+		},
+		{
+			VulnID:    "CHUNK-TEST-1",
+			Ecosystem: "npm",
+			Name:      "testchunk",
+			Versions:  versions[1000:2000],
+			CoarseMin: "00:00000001.00000000.00001000",
+			CoarseMax: "00:00000001.00000000.00001999",
+		},
+		{
+			VulnID:    "CHUNK-TEST-1",
+			Ecosystem: "npm",
+			Name:      "testchunk",
+			Versions:  versions[2000:],
+			CoarseMin: "00:00000001.00000000.00002000",
+			CoarseMax: "00:00000001.00000000.00002499",
+		},
+		{
+			VulnID:    "CHUNK-TEST-1",
+			Ecosystem: "GIT",
+			Name:      "github.com/test/chunk",
+			Versions:  versions[:1000],
+		},
+		{
+			VulnID:    "CHUNK-TEST-1",
+			Ecosystem: "GIT",
+			Name:      "github.com/test/chunk",
+			Versions:  versions[1000:2000],
+		},
+		{
+			VulnID:    "CHUNK-TEST-1",
+			Ecosystem: "GIT",
+			Name:      "github.com/test/chunk",
+			Versions:  versions[2000:],
+		},
+	}
+
+	sortOpt := cmpopts.SortSlices(func(a, b AffectedVersions) bool {
+		return cmp.Or(
+			cmp.Compare(a.Ecosystem, b.Ecosystem),
+			cmp.Compare(len(a.Versions), len(b.Versions)),
+			cmp.Compare(a.CoarseMin, b.CoarseMin),
+			cmp.Compare(a.CoarseMax, b.CoarseMax),
+		) < 0
+	})
+
+	if diff := gocmp.Diff(want, got, cmpopts.EquateEmpty(), sortOpt); diff != "" {
 		t.Errorf("computeAffectedVersions mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
Fixes #5806
Some CVEs have repos with *a lot* of tags (e.g. https://github.com/jupyterlab/jupyterlab has over 48,000). Datastore has limits on entity sizes, and indexes per entity that we seem to be running in to.

Add logic to chunk the `AffectedVersions` versions into multiple entities of 1000 to hopefully allow datastore to store these (it's still in a single transaction, and I'm not sure if it will be too many entities in one transaction or not)