### PR TITLE
fix(datastore): keep unbounded coarse window when SortEvents fails

### DIFF
--- a/go/internal/database/datastore/affected_versions.go
+++ b/go/internal/database/datastore/affected_versions.go
@@ -84,8 +84,16 @@ func computeAffectedVersions(vuln *osvschema.Vulnerability) []AffectedVersions {
 				}
 			}
 
+			// SortEvents returns an error when it had to fall back to a
+			// lexicographic order (any event version failed Parse/Compare).
+			// Positional coarse_min/coarse_max derivation is only valid under a
+			// semantic sort, so on error keep the unbounded window (same
+			// fail-open stance as the Python _get_coarse_min_max ValueError path).
+			eventsSortedOK := false
 			if exists {
-				_ = osvutil.SortEvents(eHelper, events)
+				if err := osvutil.SortEvents(eHelper, events); err == nil {
+					eventsSortedOK = true
+				}
 			}
 
 			var rangeEvents []AffectedEvent
@@ -96,7 +104,7 @@ func computeAffectedVersions(vuln *osvschema.Vulnerability) []AffectedVersions {
 			coarseMin := minCoarseVersion
 			coarseMax := maxCoarseVersion
 
-			if exists {
+			if exists && eventsSortedOK {
 				for _, ev := range rangeEvents {
 					if ev.Type == "introduced" {
 						if cm, err := eHelper.Coarse(ev.Value); err == nil {

--- a/go/internal/database/datastore/affected_versions_test.go
+++ b/go/internal/database/datastore/affected_versions_test.go
@@ -272,3 +272,45 @@ func TestComputeAffectedVersions_GitAndSemverWithoutPackage(t *testing.T) {
 		t.Errorf("computeAffectedVersions mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestComputeAffectedVersions_SortEventsErrorKeepsUnboundedCoarse(t *testing.T) {
+	// Packagist rejects versions containing '#', which forces SortEvents into its
+	// lexicographic fallback. Under that order the events sort as:
+	//   1.0, 1.0#bad, 20.0, 30.0, 9.0
+	// so a positional coarse_max taken from the last event becomes coarse(9.0)
+	// and the Datastore pre-filter excludes the semantically affected version 25.0.
+	// On SortEvents error we must keep the unbounded coarse window instead.
+	vuln := &osvschema.Vulnerability{
+		Id: "TEST-SORT-ERR",
+		Affected: []*osvschema.Affected{
+			{
+				Package: &osvschema.Package{
+					Name:      "vendor/pkg",
+					Ecosystem: "Packagist",
+				},
+				Ranges: []*osvschema.Range{
+					{
+						Type: osvschema.Range_ECOSYSTEM,
+						Events: []*osvschema.Event{
+							{Introduced: "1.0"},
+							{Fixed: "9.0"},
+							{Introduced: "20.0"},
+							{Fixed: "30.0"},
+							{Introduced: "1.0#bad"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := computeAffectedVersions(vuln)
+	if len(got) == 0 {
+		t.Fatal("expected at least one AffectedVersions row")
+	}
+	row := got[0]
+	if row.CoarseMin != minCoarseVersion || row.CoarseMax != maxCoarseVersion {
+		t.Fatalf("want unbounded coarse window on SortEvents error, got min=%q max=%q (events=%v)",
+			row.CoarseMin, row.CoarseMax, row.Events)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the coarse-window narrowing described in https://github.com/google/osv.dev/issues/5824.

`computeAffectedVersions` discarded `SortEvents` errors and still derived `coarse_min`/`coarse_max` from positional assumptions that only hold under a semantic sort. On lexicographic fallback, that can exclude genuinely affected versions from the Datastore pre-filter.

On `SortEvents` error, leave the unbounded coarse window (same fail-open stance as the Python `_get_coarse_min_max` `ValueError` path).

## Test plan

- [x] `go test ./internal/database/datastore/ -run TestComputeAffectedVersions`
- [x] New regression: Packagist range with `1.0#bad` keeps unbounded coarse bounds

## Process

Opened as **draft** pending issue assignment per CONTRIBUTING. Please assign #5824 and I will mark ready (or feel free to take the patch).

## AI assistance

This contribution was AI-assisted. I read and followed `AGENTS.md` / `CONTRIBUTING.md`.

<!-- AI-PR -->


Made with [Cursor](https://cursor.com)