### PR TITLE
refactor(go-website): connect list page to database

### DIFF
--- a/gcp/website/frontend3/src/go/templates/list.html
+++ b/gcp/website/frontend3/src/go/templates/list.html
@@ -73,7 +73,7 @@
         </div>
       </div>
       <div role="rowgroup" class="vuln-table-rows mdc-data-table__content">
-        <turbo-frame id="vulnerability-table-page{{ .Page }}" data-turbo-action="advance" target="_top">
+        <turbo-frame id="vulnerability-table-page{{ if .CurrentAfter }}-{{ .CurrentAfter }}{{ end }}" data-turbo-action="advance" target="_top">
           {{ range .Vulnerabilities }}
           <div role="row" class="vuln-table-row mdc-data-table__row">
             <span role="cell" class="vuln-table-cell mdc-data-table__cell">
@@ -122,15 +122,11 @@
           {{ if eq (len .Vulnerabilities) 0 }}
           <span class="no-results">No results (check our <a href="https://google.github.io/osv.dev/faq/">FAQ</a> if this is unexpected)</span>
           {{ end }}
-          {{ if lt .Page .TotalPages }}
-          <turbo-frame id="vulnerability-table-page{{ add .Page 1 }}" data-turbo-action="advance" target="_top" class="next-page-frame">
+          {{ if .NextAfter }}
+          <turbo-frame id="vulnerability-table-page-{{ .NextAfter }}" data-turbo-action="advance" target="_top" class="next-page-frame">
             <div class="next-page-container">
-              <a class="next-page-button link-button" data-turbo-frame="_self" href="/list?page={{ add .Page 1 }}{{ if $.Query }}&q={{ $.EncodedQuery }}{{ end }}{{ if $.SelectedEcosystem }}&ecosystem={{ $.EncodedEcosystem }}{{ end }}">
+              <a class="next-page-button link-button" data-turbo-frame="_self" href="/list?after={{ .NextAfter }}{{ if $.Query }}&q={{ $.Query }}{{ end }}{{ if $.SelectedEcosystem }}&ecosystem={{ $.SelectedEcosystem }}{{ end }}">
                 <span>Load more...</span>
-                {{ $pagesLeft := sub $.TotalPages $.Page }}
-                {{ if le $pagesLeft 3 }}
-                <span style="margin-left: 5px">({{ $pagesLeft }} page{{ if gt $pagesLeft 1 }}s{{ end }} left)</span>
-                {{ end }}
               </a>
               <md-circular-progress class="next-page-indicator" indeterminate density="-4" aria-label="Page loading progress"></md-circular-progress>
             </div>

--- a/go/cmd/website/main.go
+++ b/go/cmd/website/main.go
@@ -99,6 +99,7 @@ func run() error {
 		}),
 		Relations:  db.NewRelationsStore(dbClient),
 		SourceRepo: db.NewSourceRepositoryStore(dbClient),
+		VulnSearch: db.NewVulnerabilitySearchStore(dbClient),
 	}
 
 	apiURL := os.Getenv("OSV_API_URL")

--- a/go/internal/database/datastore/vulnerability_search.go
+++ b/go/internal/database/datastore/vulnerability_search.go
@@ -1,0 +1,361 @@
+package datastore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"cloud.google.com/go/datastore"
+	"github.com/google/osv.dev/go/internal/models"
+	"github.com/ossf/osv-schema/bindings/go/osvschema"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/api/iterator"
+)
+
+type VulnerabilitySearchStore struct {
+	client *datastore.Client
+
+	mu           sync.RWMutex
+	cachedCounts []models.EcosystemCount
+	lastFetched  time.Time
+	isRefreshing bool
+}
+
+var _ models.VulnerabilitySearchStore = (*VulnerabilitySearchStore)(nil)
+
+func NewVulnerabilitySearchStore(client *datastore.Client) *VulnerabilitySearchStore {
+	store := &VulnerabilitySearchStore{client: client}
+	// Warm up ecosystem counts in the background so initial HTTP requests don't block
+	go func() {
+		_, _ = store.refreshEcosystemCounts(context.Background())
+	}()
+
+	return store
+}
+
+func (lv *ListedVulnerability) toModel(key *datastore.Key) *models.ListedVulnerability {
+	id := ""
+	if key != nil {
+		id = key.Name
+	} else if lv.Key != nil {
+		id = lv.Key.Name
+	}
+
+	pkgs := make([]models.Package, 0, len(lv.Packages))
+	for _, p := range lv.Packages {
+		if strings.Contains(p, "/") {
+			// This is quite hacky, but there's not much point fixing it here if we want to migrate away from datastore.
+			// We joined the ecosystem name with the package name in datastore (because that's how it's rendered
+			// on the website), but this makes changing the format here difficult. Un-join them here to get
+			// joined back up on the website frontend side (these should remain separate in a postgres migration).
+			eco, name, _ := strings.Cut(p, "/")
+			// Check if this actually was a url (and thus a repo)
+			cut, _, _ := strings.Cut(eco, ":") // an ecosystem name can legitimately have a dot after the colon for the repository URL
+			if strings.Contains(cut, ".") && eco != "crates.io" {
+				pkgs = append(pkgs, models.Package{Repo: p})
+			} else {
+				// Regular ecosystem/name
+				pkgs = append(pkgs, models.Package{
+					Package: &osvschema.Package{
+						Ecosystem: eco,
+						Name:      name,
+					},
+				})
+			}
+		} else {
+			pkgs = append(pkgs, models.Package{
+				Package: &osvschema.Package{
+					Name: p,
+				},
+			})
+		}
+	}
+
+	severities := make([]*osvschema.Severity, 0, len(lv.Severities))
+	for _, s := range lv.Severities {
+		var sevType osvschema.Severity_Type
+		if val, ok := osvschema.Severity_Type_value[s.Type]; ok {
+			sevType = osvschema.Severity_Type(val)
+		}
+		severities = append(severities, &osvschema.Severity{
+			Type:  sevType,
+			Score: s.Score,
+		})
+	}
+
+	return &models.ListedVulnerability{
+		ID:         id,
+		Published:  lv.Published,
+		Packages:   pkgs,
+		Summary:    lv.Summary,
+		IsFixed:    lv.IsFixed,
+		Severities: severities,
+	}
+}
+
+func (s *VulnerabilitySearchStore) Search(ctx context.Context, query models.VulnerabilitySearchQuery) (*models.VulnerabilitySearchResult, error) {
+	pageSize := query.PageSize
+	if pageSize <= 0 {
+		pageSize = 16
+	}
+
+	searchString := strings.ToLower(strings.TrimSpace(query.Query))
+
+	q := datastore.NewQuery("ListedVulnerability")
+	if searchString != "" && len(searchString) <= 300 {
+		q = q.FilterField("search_indices", "=", searchString)
+	}
+	if query.Ecosystem != "" {
+		q = q.FilterField("ecosystems", "=", query.Ecosystem)
+	}
+	q = q.Order("-published").Order("__key__")
+
+	var items []*models.ListedVulnerability
+	var nextAfterTime time.Time
+	var nextAfterID string
+
+	afterTime := query.AfterTime.Truncate(time.Second)
+
+	if !afterTime.IsZero() {
+		// Keyset pagination using AfterTime and AfterID
+		q = q.FilterField("published", "<=", afterTime)
+		it := s.client.Run(ctx, q)
+
+		for {
+			var lv ListedVulnerability
+			key, err := it.Next(&lv)
+			if errors.Is(err, iterator.Done) {
+				break
+			}
+			if err != nil {
+				return nil, fmt.Errorf("failed to iterate listed vulnerabilities: %w", err)
+			}
+
+			// Skip entities at the boundary timestamp that were already seen
+			if lv.Published.Truncate(time.Second).Equal(afterTime) && key.Name <= query.AfterID {
+				continue
+			}
+
+			items = append(items, lv.toModel(key))
+			if len(items) == pageSize {
+				// Check if there is another entity after this page
+				var peekLv ListedVulnerability
+				_, peekErr := it.Next(&peekLv)
+				if peekErr == nil {
+					nextAfterTime = lv.Published.Truncate(time.Second)
+					nextAfterID = key.Name
+				}
+
+				break
+			}
+		}
+	} else if query.Page > 1 {
+		// Legacy offset pagination fallback
+		offset := (query.Page - 1) * pageSize
+		q = q.Offset(offset).Limit(pageSize + 1)
+		var entities []ListedVulnerability
+		keys, err := s.client.GetAll(ctx, q, &entities)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch listed vulnerabilities: %w", err)
+		}
+		hasMore := len(entities) > pageSize
+		if hasMore {
+			entities = entities[:pageSize]
+		}
+		for i, e := range entities {
+			items = append(items, e.toModel(keys[i]))
+		}
+		if hasMore && len(items) > 0 {
+			lastIdx := len(entities) - 1
+			nextAfterTime = entities[lastIdx].Published.Truncate(time.Second)
+			nextAfterID = keys[lastIdx].Name
+		}
+	} else {
+		// First page
+		q = q.Limit(pageSize + 1)
+		var entities []ListedVulnerability
+		keys, err := s.client.GetAll(ctx, q, &entities)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch listed vulnerabilities: %w", err)
+		}
+		hasMore := len(entities) > pageSize
+		if hasMore {
+			entities = entities[:pageSize]
+		}
+		for i, e := range entities {
+			items = append(items, e.toModel(keys[i]))
+		}
+		if hasMore && len(items) > 0 {
+			lastIdx := len(entities) - 1
+			nextAfterTime = entities[lastIdx].Published.Truncate(time.Second)
+			nextAfterID = keys[lastIdx].Name
+		}
+	}
+
+	// Exact ID match prioritization on page 1
+	if query.AfterTime.IsZero() && query.Page <= 1 && searchString != "" && len(items) > 1 {
+		for i, v := range items {
+			if strings.EqualFold(v.ID, query.Query) {
+				if i > 0 {
+					match := items[i]
+					copy(items[1:i+1], items[0:i])
+					items[0] = match
+				}
+
+				break
+			}
+		}
+	}
+
+	return &models.VulnerabilitySearchResult{
+		Vulnerabilities: items,
+		NextAfterTime:   nextAfterTime,
+		NextAfterID:     nextAfterID,
+	}, nil
+}
+
+func (s *VulnerabilitySearchStore) Autocomplete(ctx context.Context, prefix string, limit int) ([]string, error) {
+	prefix = strings.ToLower(strings.TrimSpace(prefix))
+	if prefix == "" || len(prefix) > 300 {
+		return []string{}, nil
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+
+	q := datastore.NewQuery("ListedVulnerability").
+		FilterField("autocomplete_tags", ">=", prefix).
+		FilterField("autocomplete_tags", "<", prefix+"\ufffd").
+		Order("autocomplete_tags").
+		Project("autocomplete_tags").
+		Limit(limit * 5)
+
+	var entities []ListedVulnerability
+	if _, err := s.client.GetAll(ctx, q, &entities); err != nil {
+		return nil, fmt.Errorf("failed to query autocomplete tags: %w", err)
+	}
+
+	tagSet := make(map[string]struct{})
+	for _, e := range entities {
+		for _, tag := range e.AutocompleteTags {
+			if strings.HasPrefix(strings.ToLower(tag), prefix) {
+				tagSet[strings.ToUpper(tag)] = struct{}{}
+			}
+		}
+	}
+
+	suggestions := make([]string, 0, len(tagSet))
+	for tag := range tagSet {
+		suggestions = append(suggestions, tag)
+	}
+	slices.Sort(suggestions)
+
+	if len(suggestions) > limit {
+		suggestions = suggestions[:limit]
+	}
+
+	return suggestions, nil
+}
+
+func (s *VulnerabilitySearchStore) EcosystemCounts(ctx context.Context) ([]models.EcosystemCount, error) {
+	s.mu.RLock()
+	cached := s.cachedCounts
+	age := time.Since(s.lastFetched)
+	s.mu.RUnlock()
+
+	// 1. Fresh cache: return immediately (< 0.001 ms)
+	if len(cached) > 0 && age < 30*time.Minute {
+		return cached, nil
+	}
+
+	// 2. Stale cache: return stale data immediately and refresh asynchronously in the background
+	if len(cached) > 0 {
+		s.mu.Lock()
+		if !s.isRefreshing {
+			s.isRefreshing = true
+			bgCtx := context.WithoutCancel(ctx)
+			go func() {
+				defer func() {
+					s.mu.Lock()
+					s.isRefreshing = false
+					s.mu.Unlock()
+				}()
+				_, _ = s.refreshEcosystemCounts(bgCtx)
+			}()
+		}
+		s.mu.Unlock()
+
+		return cached, nil
+	}
+
+	// 3. Cold start fallback: fetch synchronously
+	return s.refreshEcosystemCounts(ctx)
+}
+
+func (s *VulnerabilitySearchStore) refreshEcosystemCounts(ctx context.Context) ([]models.EcosystemCount, error) {
+	q := datastore.NewQuery("ListedVulnerability").
+		Project("ecosystems").
+		Distinct()
+
+	var entities []ListedVulnerability
+	if _, err := s.client.GetAll(ctx, q, &entities); err != nil {
+		return nil, fmt.Errorf("failed to get distinct ecosystems: %w", err)
+	}
+
+	ecoSet := make(map[string]struct{})
+	for _, e := range entities {
+		for _, eco := range e.Ecosystems {
+			if strings.Contains(eco, ":") || eco == "[EMPTY]" || eco == "" {
+				continue
+			}
+			ecoSet[eco] = struct{}{}
+		}
+	}
+
+	ecosystems := make([]string, 0, len(ecoSet))
+	for eco := range ecoSet {
+		ecosystems = append(ecosystems, eco)
+	}
+	slices.Sort(ecosystems)
+
+	counts := make([]models.EcosystemCount, len(ecosystems))
+	g, gCtx := errgroup.WithContext(ctx)
+
+	for i, eco := range ecosystems {
+		g.Go(func() error {
+			countQ := datastore.NewQuery("ListedVulnerability").FilterField("ecosystems", "=", eco)
+			c, err := s.client.Count(gCtx, countQ)
+			if err != nil {
+				return fmt.Errorf("failed to count ecosystem %q: %w", eco, err)
+			}
+			counts[i] = models.EcosystemCount{
+				Name:  eco,
+				Count: c,
+			}
+
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	result := make([]models.EcosystemCount, 0, len(counts))
+	for _, c := range counts {
+		if c.Count > 0 {
+			result = append(result, c)
+		}
+	}
+
+	s.mu.Lock()
+	s.cachedCounts = result
+	s.lastFetched = time.Now()
+	s.mu.Unlock()
+
+	return result, nil
+}

--- a/go/internal/database/datastore/vulnerability_search.go
+++ b/go/internal/database/datastore/vulnerability_search.go
@@ -11,6 +11,7 @@ import (
 
 	"cloud.google.com/go/datastore"
 	"github.com/google/osv.dev/go/internal/models"
+	"github.com/google/osv.dev/go/logger"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/iterator"
@@ -31,7 +32,9 @@ func NewVulnerabilitySearchStore(client *datastore.Client) *VulnerabilitySearchS
 	store := &VulnerabilitySearchStore{client: client}
 	// Warm up ecosystem counts in the background so initial HTTP requests don't block
 	go func() {
-		_, _ = store.refreshEcosystemCounts(context.Background())
+		if _, err := store.refreshEcosystemCounts(context.Background()); err != nil {
+			logger.Error("failed to warm up ecosystem counts in background", "error", err)
+		}
 	}()
 
 	return store
@@ -104,9 +107,12 @@ func (s *VulnerabilitySearchStore) Search(ctx context.Context, query models.Vuln
 	}
 
 	searchString := strings.ToLower(strings.TrimSpace(query.Query))
+	if len(searchString) > 300 {
+		return &models.VulnerabilitySearchResult{}, nil
+	}
 
 	q := datastore.NewQuery("ListedVulnerability")
-	if searchString != "" && len(searchString) <= 300 {
+	if searchString != "" {
 		q = q.FilterField("search_indices", "=", searchString)
 	}
 	if query.Ecosystem != "" {
@@ -118,7 +124,7 @@ func (s *VulnerabilitySearchStore) Search(ctx context.Context, query models.Vuln
 	var nextAfterTime time.Time
 	var nextAfterID string
 
-	afterTime := query.AfterTime.Truncate(time.Second)
+	afterTime := query.AfterTime.Truncate(time.Microsecond)
 
 	if !afterTime.IsZero() {
 		// Keyset pagination using AfterTime and AfterID
@@ -136,7 +142,7 @@ func (s *VulnerabilitySearchStore) Search(ctx context.Context, query models.Vuln
 			}
 
 			// Skip entities at the boundary timestamp that were already seen
-			if lv.Published.Truncate(time.Second).Equal(afterTime) && key.Name <= query.AfterID {
+			if lv.Published.Truncate(time.Microsecond).Equal(afterTime) && key.Name <= query.AfterID {
 				continue
 			}
 
@@ -146,36 +152,19 @@ func (s *VulnerabilitySearchStore) Search(ctx context.Context, query models.Vuln
 				var peekLv ListedVulnerability
 				_, peekErr := it.Next(&peekLv)
 				if peekErr == nil {
-					nextAfterTime = lv.Published.Truncate(time.Second)
+					nextAfterTime = lv.Published.Truncate(time.Microsecond)
 					nextAfterID = key.Name
 				}
 
 				break
 			}
 		}
-	} else if query.Page > 1 {
-		// Legacy offset pagination fallback
-		offset := (query.Page - 1) * pageSize
-		q = q.Offset(offset).Limit(pageSize + 1)
-		var entities []ListedVulnerability
-		keys, err := s.client.GetAll(ctx, q, &entities)
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch listed vulnerabilities: %w", err)
-		}
-		hasMore := len(entities) > pageSize
-		if hasMore {
-			entities = entities[:pageSize]
-		}
-		for i, e := range entities {
-			items = append(items, e.toModel(keys[i]))
-		}
-		if hasMore && len(items) > 0 {
-			lastIdx := len(entities) - 1
-			nextAfterTime = entities[lastIdx].Published.Truncate(time.Second)
-			nextAfterID = keys[lastIdx].Name
-		}
 	} else {
-		// First page
+		// First page or legacy offset pagination fallback
+		if query.Page > 1 {
+			offset := (query.Page - 1) * pageSize
+			q = q.Offset(offset)
+		}
 		q = q.Limit(pageSize + 1)
 		var entities []ListedVulnerability
 		keys, err := s.client.GetAll(ctx, q, &entities)
@@ -191,7 +180,7 @@ func (s *VulnerabilitySearchStore) Search(ctx context.Context, query models.Vuln
 		}
 		if hasMore && len(items) > 0 {
 			lastIdx := len(entities) - 1
-			nextAfterTime = entities[lastIdx].Published.Truncate(time.Second)
+			nextAfterTime = entities[lastIdx].Published.Truncate(time.Microsecond)
 			nextAfterID = keys[lastIdx].Name
 		}
 	}
@@ -284,7 +273,9 @@ func (s *VulnerabilitySearchStore) EcosystemCounts(ctx context.Context) ([]model
 					s.isRefreshing = false
 					s.mu.Unlock()
 				}()
-				_, _ = s.refreshEcosystemCounts(bgCtx)
+				if _, err := s.refreshEcosystemCounts(bgCtx); err != nil {
+					logger.Error("failed to refresh ecosystem counts in background", "error", err)
+				}
 			}()
 		}
 		s.mu.Unlock()

--- a/go/internal/database/datastore/vulnerability_search_test.go
+++ b/go/internal/database/datastore/vulnerability_search_test.go
@@ -1,0 +1,328 @@
+package datastore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/datastore"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/osv.dev/go/internal/models"
+	"github.com/google/osv.dev/go/testutils"
+)
+
+func TestVulnerabilitySearchStore_Search(t *testing.T) {
+	ctx := context.Background()
+	dsClient := testutils.MustNewDatastoreClientForTesting(t)
+	store := NewVulnerabilitySearchStore(dsClient)
+
+	baseTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	// Create test ListedVulnerability entities
+	vulns := []struct {
+		id   string
+		vuln ListedVulnerability
+	}{
+		{
+			id: "GHSA-1",
+			vuln: ListedVulnerability{
+				Published:        baseTime.Add(3 * time.Hour),
+				Ecosystems:       []string{"PyPI"},
+				Packages:         []string{"PyPI/requests"},
+				Summary:          "Critical vuln in requests",
+				IsFixed:          true,
+				Severities:       []Severity{{Type: "CVSS_V3", Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}},
+				AutocompleteTags: []string{"ghsa-1", "requests"},
+				SearchIndices:    []string{"ghsa-1", "requests", "pypi"},
+			},
+		},
+		{
+			id: "GHSA-2",
+			vuln: ListedVulnerability{
+				Published:        baseTime.Add(2 * time.Hour),
+				Ecosystems:       []string{"Go"},
+				Packages:         []string{"Go/golang.org/x/net"},
+				Summary:          "DOS in golang net",
+				IsFixed:          false,
+				Severities:       []Severity{{Type: "CVSS_V3", Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"}},
+				AutocompleteTags: []string{"ghsa-2", "golang.org/x/net"},
+				SearchIndices:    []string{"ghsa-2", "golang.org/x/net", "go"},
+			},
+		},
+		{
+			id: "GHSA-3A",
+			vuln: ListedVulnerability{
+				Published:        baseTime.Add(1 * time.Hour),
+				Ecosystems:       []string{"PyPI"},
+				Packages:         []string{"PyPI/flask"},
+				Summary:          "Flask vulnerability A",
+				IsFixed:          true,
+				AutocompleteTags: []string{"ghsa-3a", "flask"},
+				SearchIndices:    []string{"ghsa-3a", "flask", "pypi"},
+			},
+		},
+		{
+			id: "GHSA-3B",
+			vuln: ListedVulnerability{
+				Published:        baseTime.Add(1 * time.Hour), // Same timestamp as 3A
+				Ecosystems:       []string{"PyPI"},
+				Packages:         []string{"PyPI/django"},
+				Summary:          "Django vulnerability B",
+				IsFixed:          true,
+				AutocompleteTags: []string{"ghsa-3b", "django"},
+				SearchIndices:    []string{"ghsa-3b", "django", "pypi"},
+			},
+		},
+		{
+			id: "GHSA-4",
+			vuln: ListedVulnerability{
+				Published:        baseTime,
+				Ecosystems:       []string{"npm"},
+				Packages:         []string{"github.com/expressjs/express"},
+				Summary:          "Express vulnerability",
+				IsFixed:          true,
+				AutocompleteTags: []string{"ghsa-4", "express"},
+				SearchIndices:    []string{"ghsa-4", "express", "npm"},
+			},
+		},
+	}
+
+	keys := make([]*datastore.Key, len(vulns))
+	entities := make([]ListedVulnerability, len(vulns))
+	for i, v := range vulns {
+		keys[i] = datastore.NameKey("ListedVulnerability", v.id, nil)
+		entities[i] = v.vuln
+	}
+
+	if _, err := dsClient.PutMulti(ctx, keys, entities); err != nil {
+		t.Fatalf("Failed to put test entities: %v", err)
+	}
+
+	t.Run("All vulnerabilities page 1", func(t *testing.T) {
+		res, err := store.Search(ctx, models.VulnerabilitySearchQuery{
+			PageSize: 2,
+		})
+		if err != nil {
+			t.Fatalf("Search failed: %v", err)
+		}
+		if len(res.Vulnerabilities) != 2 {
+			t.Fatalf("Got %d items, want 2", len(res.Vulnerabilities))
+		}
+		if res.Vulnerabilities[0].ID != "GHSA-1" || res.Vulnerabilities[1].ID != "GHSA-2" {
+			t.Errorf("Unexpected items: %v, %v", res.Vulnerabilities[0].ID, res.Vulnerabilities[1].ID)
+		}
+		if res.NextAfterTime.IsZero() || res.NextAfterID != "GHSA-2" {
+			t.Errorf("NextAfter = (%v, %v), want (GHSA-2 time, GHSA-2)", res.NextAfterTime, res.NextAfterID)
+		}
+	})
+
+	t.Run("Keyset pagination across identical timestamps", func(t *testing.T) {
+		// Page 2 starting after GHSA-2
+		res2, err := store.Search(ctx, models.VulnerabilitySearchQuery{
+			PageSize:  2,
+			AfterTime: baseTime.Add(2 * time.Hour),
+			AfterID:   "GHSA-2",
+		})
+		if err != nil {
+			t.Fatalf("Search page 2 failed: %v", err)
+		}
+		if len(res2.Vulnerabilities) != 2 {
+			t.Fatalf("Page 2 items = %d, want 2", len(res2.Vulnerabilities))
+		}
+		if res2.Vulnerabilities[0].ID != "GHSA-3A" || res2.Vulnerabilities[1].ID != "GHSA-3B" {
+			t.Errorf("Unexpected page 2 items: %v, %v", res2.Vulnerabilities[0].ID, res2.Vulnerabilities[1].ID)
+		}
+
+		// Page 3 starting after GHSA-3B
+		res3, err := store.Search(ctx, models.VulnerabilitySearchQuery{
+			PageSize:  2,
+			AfterTime: baseTime.Add(1 * time.Hour),
+			AfterID:   "GHSA-3B",
+		})
+		if err != nil {
+			t.Fatalf("Search page 3 failed: %v", err)
+		}
+		if len(res3.Vulnerabilities) != 1 {
+			t.Fatalf("Page 3 items = %d, want 1", len(res3.Vulnerabilities))
+		}
+		if res3.Vulnerabilities[0].ID != "GHSA-4" {
+			t.Errorf("Unexpected page 3 item: %v", res3.Vulnerabilities[0].ID)
+		}
+		if !res3.NextAfterTime.IsZero() {
+			t.Errorf("NextAfterTime should be zero on last page, got %v", res3.NextAfterTime)
+		}
+	})
+
+	t.Run("Ecosystem filter", func(t *testing.T) {
+		res, err := store.Search(ctx, models.VulnerabilitySearchQuery{
+			Ecosystem: "PyPI",
+			PageSize:  10,
+		})
+		if err != nil {
+			t.Fatalf("Search failed: %v", err)
+		}
+		if len(res.Vulnerabilities) != 3 {
+			t.Fatalf("Got %d items, want 3", len(res.Vulnerabilities))
+		}
+		for _, v := range res.Vulnerabilities {
+			if v.Packages[0].Package.GetEcosystem() != "PyPI" {
+				t.Errorf("Expected PyPI package, got %v", v.Packages[0])
+			}
+		}
+	})
+
+	t.Run("Search query string", func(t *testing.T) {
+		res, err := store.Search(ctx, models.VulnerabilitySearchQuery{
+			Query:    "requests",
+			PageSize: 10,
+		})
+		if err != nil {
+			t.Fatalf("Search failed: %v", err)
+		}
+		if len(res.Vulnerabilities) != 1 || res.Vulnerabilities[0].ID != "GHSA-1" {
+			t.Errorf("Unexpected result: %v", res.Vulnerabilities)
+		}
+	})
+
+	t.Run("Exact ID match prioritization on page 1", func(t *testing.T) {
+		res, err := store.Search(ctx, models.VulnerabilitySearchQuery{
+			Query:    "ghsa-3b",
+			PageSize: 10,
+		})
+		if err != nil {
+			t.Fatalf("Search failed: %v", err)
+		}
+		if len(res.Vulnerabilities) == 0 || res.Vulnerabilities[0].ID != "GHSA-3B" {
+			t.Errorf("Expected GHSA-3B first, got %v", res.Vulnerabilities)
+		}
+	})
+}
+
+func TestVulnerabilitySearchStore_Autocomplete(t *testing.T) {
+	ctx := context.Background()
+	dsClient := testutils.MustNewDatastoreClientForTesting(t)
+	store := NewVulnerabilitySearchStore(dsClient)
+
+	vulns := []struct {
+		id   string
+		vuln ListedVulnerability
+	}{
+		{
+			id: "GHSA-100",
+			vuln: ListedVulnerability{
+				AutocompleteTags: []string{"requests", "request-promise", "req"},
+			},
+		},
+		{
+			id: "GHSA-200",
+			vuln: ListedVulnerability{
+				AutocompleteTags: []string{"requests", "req-fetch"},
+			},
+		},
+		{
+			id: "GHSA-300",
+			vuln: ListedVulnerability{
+				AutocompleteTags: []string{"django"},
+			},
+		},
+	}
+
+	keys := make([]*datastore.Key, len(vulns))
+	entities := make([]ListedVulnerability, len(vulns))
+	for i, v := range vulns {
+		keys[i] = datastore.NameKey("ListedVulnerability", v.id, nil)
+		entities[i] = v.vuln
+	}
+
+	if _, err := dsClient.PutMulti(ctx, keys, entities); err != nil {
+		t.Fatalf("Failed to put test entities: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		prefix  string
+		limit   int
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:   "Prefix req",
+			prefix: "req",
+			limit:  10,
+			want:   []string{"REQ", "REQ-FETCH", "REQUEST-PROMISE", "REQUESTS"},
+		},
+		{
+			name:   "Prefix requests with limit",
+			prefix: "requests",
+			limit:  1,
+			want:   []string{"REQUESTS"},
+		},
+		{
+			name:   "Empty prefix",
+			prefix: "",
+			limit:  10,
+			want:   []string{},
+		},
+		{
+			name:   "No match",
+			prefix: "zebra",
+			limit:  10,
+			want:   []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := store.Autocomplete(ctx, tt.prefix, tt.limit)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Autocomplete(%q) error = %v, wantErr %v", tt.prefix, err, tt.wantErr)
+			}
+			if diff := cmp.Diff(tt.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Autocomplete(%q) mismatch (-want +got):\n%s", tt.prefix, diff)
+			}
+		})
+	}
+}
+
+func TestVulnerabilitySearchStore_EcosystemCounts(t *testing.T) {
+	ctx := context.Background()
+	dsClient := testutils.MustNewDatastoreClientForTesting(t)
+	store := NewVulnerabilitySearchStore(dsClient)
+
+	vulns := []struct {
+		id   string
+		vuln ListedVulnerability
+	}{
+		{id: "V1", vuln: ListedVulnerability{Ecosystems: []string{"PyPI", "Debian"}, SearchIndices: []string{"requests", "pypi", "debian"}}},
+		{id: "V2", vuln: ListedVulnerability{Ecosystems: []string{"PyPI"}, SearchIndices: []string{"requests", "pypi"}}},
+		{id: "V3", vuln: ListedVulnerability{Ecosystems: []string{"Go"}, SearchIndices: []string{"golang.org/x/net", "go"}}},
+		{id: "V4", vuln: ListedVulnerability{Ecosystems: []string{"Debian:11"}, SearchIndices: []string{"debian:11"}}}, // Variant should be ignored
+	}
+
+	keys := make([]*datastore.Key, len(vulns))
+	entities := make([]ListedVulnerability, len(vulns))
+	for i, v := range vulns {
+		keys[i] = datastore.NameKey("ListedVulnerability", v.id, nil)
+		entities[i] = v.vuln
+	}
+
+	if _, err := dsClient.PutMulti(ctx, keys, entities); err != nil {
+		t.Fatalf("Failed to put test entities: %v", err)
+	}
+
+	got, err := store.EcosystemCounts(ctx)
+	if err != nil {
+		t.Fatalf("EcosystemCounts failed: %v", err)
+	}
+
+	want := []models.EcosystemCount{
+		{Name: "Debian", Count: 1},
+		{Name: "Go", Count: 1},
+		{Name: "PyPI", Count: 2},
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("EcosystemCounts mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/go/internal/models/vulnerability.go
+++ b/go/internal/models/vulnerability.go
@@ -24,16 +24,6 @@ type Package struct {
 	Repo    string
 }
 
-// ListedVulnerability represents a vulnerability entry used for rendering the website list page.
-type ListedVulnerability struct {
-	ID         string
-	Published  time.Time
-	Packages   []Package
-	Summary    string
-	IsFixed    bool
-	Severities []*osvschema.Severity
-}
-
 // WriteRequest bundles everything needed to perform a permanent update to an OSV record.
 type WriteRequest struct {
 	ID              string

--- a/go/internal/models/vulnerability_search.go
+++ b/go/internal/models/vulnerability_search.go
@@ -1,0 +1,71 @@
+// Package models contains the domain types for the OSV database.
+package models
+
+import (
+	"context"
+	"time"
+
+	"github.com/ossf/osv-schema/bindings/go/osvschema"
+)
+
+// ListedVulnerability represents a vulnerability entry used for rendering the website list page.
+type ListedVulnerability struct {
+	ID         string
+	Published  time.Time
+	Packages   []Package
+	Summary    string
+	IsFixed    bool
+	Severities []*osvschema.Severity
+}
+
+// EcosystemCount represents an ecosystem filter option and its vulnerability count.
+type EcosystemCount struct {
+	Name  string
+	Count int
+}
+
+// VulnerabilitySearchQuery defines search, filter, and pagination parameters.
+type VulnerabilitySearchQuery struct {
+	Query     string    // Search query (e.g. package name, repository, vuln ID)
+	Ecosystem string    // Optional ecosystem filter
+	PageSize  int       // Number of items per page
+	AfterTime time.Time // Published timestamp cutoff (descending)
+	AfterID   string    // Tie-breaker vulnerability ID for identical timestamps
+	Page      int       // Optional legacy 1-based page number
+}
+
+// VulnerabilitySearchResult represents the result of a vulnerability search query.
+type VulnerabilitySearchResult struct {
+	Vulnerabilities []*ListedVulnerability
+	NextAfterTime   time.Time // Zero time if there are no more results
+	NextAfterID     string
+}
+
+// VulnerabilitySearchStore defines the interface for vulnerability search, autocomplete, and aggregate counts.
+type VulnerabilitySearchStore interface {
+	// Search queries vulnerabilities with optional text query, ecosystem filter, and pagination.
+	Search(ctx context.Context, query VulnerabilitySearchQuery) (*VulnerabilitySearchResult, error)
+
+	// Autocomplete returns search suggestions for a given query prefix.
+	Autocomplete(ctx context.Context, prefix string, limit int) ([]string, error)
+
+	// EcosystemCounts returns vulnerability counts grouped by ecosystem.
+	EcosystemCounts(ctx context.Context) ([]EcosystemCount, error)
+}
+
+// UnimplementedVulnerabilitySearchStore provides a default unimplemented stub for VulnerabilitySearchStore.
+type UnimplementedVulnerabilitySearchStore struct{}
+
+var _ VulnerabilitySearchStore = UnimplementedVulnerabilitySearchStore{}
+
+func (s UnimplementedVulnerabilitySearchStore) Search(_ context.Context, _ VulnerabilitySearchQuery) (*VulnerabilitySearchResult, error) {
+	panic("not implemented")
+}
+
+func (s UnimplementedVulnerabilitySearchStore) Autocomplete(_ context.Context, _ string, _ int) ([]string, error) {
+	panic("not implemented")
+}
+
+func (s UnimplementedVulnerabilitySearchStore) EcosystemCounts(_ context.Context) ([]EcosystemCount, error) {
+	panic("not implemented")
+}

--- a/go/internal/website/list.go
+++ b/go/internal/website/list.go
@@ -49,9 +49,9 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
 	if afterStr != "" {
 		timeStr, id, found := strings.Cut(afterStr, "_")
 		if found {
-			sec, err := strconv.ParseInt(timeStr, 10, 64)
+			usec, err := strconv.ParseInt(timeStr, 10, 64)
 			if err == nil {
-				afterTime = time.Unix(sec, 0)
+				afterTime = time.UnixMicro(usec)
 				afterID = id
 			} else {
 				logger.ErrorContext(r.Context(), "failed to parse after_time", "after_time", afterStr)
@@ -86,7 +86,7 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
 			vulns[i] = ListedVulnerabilityDisplay(*v)
 		}
 		if !result.NextAfterTime.IsZero() {
-			nextAfter = fmt.Sprintf("%d_%s", result.NextAfterTime.Unix(), result.NextAfterID)
+			nextAfter = fmt.Sprintf("%d_%s", result.NextAfterTime.UnixMicro(), result.NextAfterID)
 		}
 
 		return nil

--- a/go/internal/website/list.go
+++ b/go/internal/website/list.go
@@ -1,13 +1,15 @@
 package website
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/google/osv.dev/go/internal/models"
-	"github.com/ossf/osv-schema/bindings/go/osvschema"
+	"github.com/google/osv.dev/go/logger"
+	"golang.org/x/sync/errgroup"
 )
 
 const vulnsPerPage = 16
@@ -21,12 +23,14 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
 	q := strings.TrimSpace(r.URL.Query().Get("q"))
 	ecosystem := r.URL.Query().Get("ecosystem")
 	pageStr := r.URL.Query().Get("page")
+	afterStr := r.URL.Query().Get("after")
 	isTurboFrame := r.Header.Get("Turbo-Frame") != ""
 
 	// Redirect full-page requests (non-Turbo-Frame) that contain a page parameter back to canonical URL
-	if !isTurboFrame && pageStr != "" {
+	if !isTurboFrame && (pageStr != "" || afterStr != "") {
 		queryVals := r.URL.Query()
 		queryVals.Del("page")
+		queryVals.Del("after")
 		targetURL := "/list"
 		if encoded := queryVals.Encode(); encoded != "" {
 			targetURL += "?" + encoded
@@ -40,62 +44,77 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
 	if p, err := strconv.Atoi(pageStr); err == nil && p > 0 {
 		page = p
 	}
-
-	// Stub mock data for development
-	mockVulns := []ListedVulnerabilityDisplay{
-		{
-			ID:        "GHSA-1234-5678-90ab",
-			Published: time.Now().Add(-24 * time.Hour),
-			Packages: []models.Package{
-				{Package: &osvschema.Package{Ecosystem: "PyPI", Name: "requests"}},
-				{Package: &osvschema.Package{Ecosystem: "PyPI", Name: "urllib3"}},
-			},
-			Summary: "Critical remote code execution in `requests`",
-			IsFixed: true,
-			Severities: []*osvschema.Severity{
-				{Type: osvschema.Severity_CVSS_V3, Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"},
-			},
-		},
-		{
-			ID:        "CVE-2024-9999",
-			Published: time.Now().Add(-48 * time.Hour),
-			Packages: []models.Package{
-				{Package: &osvschema.Package{Ecosystem: "Go", Name: "golang.org/x/net"}},
-				{Repo: "https://github.com/golang/net"},
-			},
-			Summary: "Denial of service in HTTP/2 handler",
-			IsFixed: false,
-			Severities: []*osvschema.Severity{
-				{Type: osvschema.Severity_CVSS_V3, Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N"},
-			},
-		},
+	var afterTime time.Time
+	var afterID string
+	if afterStr != "" {
+		timeStr, id, found := strings.Cut(afterStr, "_")
+		if found {
+			sec, err := strconv.ParseInt(timeStr, 10, 64)
+			if err == nil {
+				afterTime = time.Unix(sec, 0)
+				afterID = id
+			} else {
+				logger.ErrorContext(r.Context(), "failed to parse after_time", "after_time", afterStr)
+			}
+		} else {
+			logger.ErrorContext(r.Context(), "failed to parse after_time", "after_time", afterStr)
+		}
+	}
+	if page > 1 {
+		logger.WarnContext(r.Context(), "search is using legacy pagination")
 	}
 
-	mockEcosystemCounts := []EcosystemCount{
-		{Name: "PyPI", Count: 1420},
-		{Name: "Go", Count: 850},
-		{Name: "npm", Count: 3200},
-		{Name: "Maven", Count: 1100},
-		{Name: "A Very Long Ecosystem Name", Count: 1111111},
-		{Name: "A Very *Very* Long Ecosystem Name (comes with snacks!)", Count: 1111111},
-		{Name: "Evil PyPI", Count: 1420},
-		{Name: "Evil Go", Count: 850},
-		{Name: "Good npm", Count: 3200},
-		{Name: "Evil Maven", Count: 1100},
+	g, ctx := errgroup.WithContext(r.Context())
+
+	var vulns []ListedVulnerabilityDisplay
+	var nextAfter string
+	g.Go(func() error {
+		result, err := s.stores.VulnSearch.Search(ctx, models.VulnerabilitySearchQuery{
+			Query:     q,
+			Ecosystem: ecosystem,
+			AfterTime: afterTime,
+			AfterID:   afterID,
+			PageSize:  vulnsPerPage,
+			Page:      page,
+		})
+		if err != nil {
+			return err
+		}
+
+		vulns = make([]ListedVulnerabilityDisplay, len(result.Vulnerabilities))
+		for i, v := range result.Vulnerabilities {
+			vulns[i] = ListedVulnerabilityDisplay(*v)
+		}
+		if !result.NextAfterTime.IsZero() {
+			nextAfter = fmt.Sprintf("%d_%s", result.NextAfterTime.Unix(), result.NextAfterID)
+		}
+
+		return nil
+	})
+
+	var ecoCounts []EcosystemCount
+	if !isTurboFrame {
+		// Only need to do this for the first page load, not subsequent page loads using the Turbo frame.
+		g.Go(func() error {
+			counts, err := s.stores.VulnSearch.EcosystemCounts(ctx)
+			if err != nil {
+				return err
+			}
+			ecoCounts = counts
+
+			return nil
+		})
 	}
 
-	totalEcosystemCount := 0
-	for _, eco := range mockEcosystemCounts {
-		totalEcosystemCount += eco.Count
+	if err := g.Wait(); err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+
+		return
 	}
 
-	now := time.Now()
-	vulns := make([]ListedVulnerabilityDisplay, 0, vulnsPerPage)
-	for i := range vulnsPerPage {
-		idx := (page-1)*vulnsPerPage + i
-		item := mockVulns[i%len(mockVulns)]
-		item.Published = now.Add(-time.Duration(idx*3) * time.Hour)
-		vulns = append(vulns, item)
+	totalEcoCounts := 0
+	for _, c := range ecoCounts {
+		totalEcoCounts += c.Count
 	}
 
 	pageTitle := "Vulnerability Database - OSV"
@@ -111,10 +130,10 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
 		},
 		Query:               q,
 		SelectedEcosystem:   ecosystem,
-		Page:                page,
-		TotalPages:          5,
-		EcosystemCounts:     mockEcosystemCounts,
-		TotalEcosystemCount: totalEcosystemCount,
+		CurrentAfter:        afterStr,
+		NextAfter:           nextAfter,
+		EcosystemCounts:     ecoCounts,
+		TotalEcosystemCount: totalEcoCounts,
 		Vulnerabilities:     vulns,
 	}
 

--- a/go/internal/website/list_models.go
+++ b/go/internal/website/list_models.go
@@ -2,7 +2,6 @@ package website
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
 	"time"
 
@@ -11,10 +10,7 @@ import (
 )
 
 // EcosystemCount represents an ecosystem filter option and its vulnerability count.
-type EcosystemCount struct {
-	Name  string
-	Count int
-}
+type EcosystemCount = models.EcosystemCount
 
 // ListedVulnerabilityDisplay wraps models.ListedVulnerability with website presentation methods.
 type ListedVulnerabilityDisplay models.ListedVulnerability
@@ -160,19 +156,9 @@ type ListPageData struct {
 
 	Query               string
 	SelectedEcosystem   string
-	Page                int
-	TotalPages          int
+	CurrentAfter        string
+	NextAfter           string
 	EcosystemCounts     []EcosystemCount
 	TotalEcosystemCount int
 	Vulnerabilities     []ListedVulnerabilityDisplay
-}
-
-// EncodedQuery returns the URL query-escaped search query string.
-func (d ListPageData) EncodedQuery() string {
-	return url.QueryEscape(d.Query)
-}
-
-// EncodedEcosystem returns the URL query-escaped ecosystem filter string.
-func (d ListPageData) EncodedEcosystem() string {
-	return url.QueryEscape(d.SelectedEcosystem)
 }

--- a/go/internal/website/list_models_test.go
+++ b/go/internal/website/list_models_test.go
@@ -147,23 +147,6 @@ func TestPrimarySeverity_Ranking(t *testing.T) {
 	}
 }
 
-func TestEncodedQueryAndEcosystem(t *testing.T) {
-	t.Parallel()
-
-	data := ListPageData{
-		Query:             "requests & urllib3",
-		SelectedEcosystem: "C++",
-	}
-
-	if got, want := data.EncodedQuery(), "requests+%26+urllib3"; got != want {
-		t.Errorf("EncodedQuery() = %q, want %q", got, want)
-	}
-
-	if got, want := data.EncodedEcosystem(), "C%2B%2B"; got != want {
-		t.Errorf("EncodedEcosystem() = %q, want %q", got, want)
-	}
-}
-
 func TestDisplayPackages(t *testing.T) {
 	t.Parallel()
 

--- a/go/internal/website/search.go
+++ b/go/internal/website/search.go
@@ -1,19 +1,37 @@
 package website
 
 import (
-	"fmt"
+	"encoding/json"
 	"net/http"
+
+	"github.com/google/osv.dev/go/logger"
 )
+
+const maxSearchSuggestions = 10
+
+type searchSuggestionsResponse struct {
+	Suggestions []string `json:"suggestions"`
+}
 
 // handleSearchSuggestions handles auto-complete search suggestions querying Datastore models.
 // Query parameters:
 //   - q: search query string / prefix
-//   - ecosystem: optional ecosystem filter
 func (s *Server) handleSearchSuggestions(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query().Get("q")
-	ecosystem := r.URL.Query().Get("ecosystem")
+	suggestions, err := s.stores.VulnSearch.Autocomplete(r.Context(), q, maxSearchSuggestions)
+	if err != nil {
+		logger.ErrorContext(r.Context(), "failed to get search suggestions", "error", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 
-	// TODO: Perform prefix / search matching on Datastore vulnerability indices
+		return
+	}
+
+	if suggestions == nil {
+		suggestions = []string{}
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	http.Error(w, fmt.Sprintf(`{"error": "Search suggestions handler stub", "q": %q, "ecosystem": %q}`, q, ecosystem), http.StatusNotImplemented)
+	if err := json.NewEncoder(w).Encode(searchSuggestionsResponse{Suggestions: suggestions}); err != nil {
+		logger.ErrorContext(r.Context(), "failed to encode search suggestions", "error", err)
+	}
 }

--- a/go/internal/website/server.go
+++ b/go/internal/website/server.go
@@ -32,6 +32,7 @@ type Stores struct {
 	Vuln       models.VulnerabilityStore
 	Relations  models.RelationsStore
 	SourceRepo models.SourceRepositoryStore
+	VulnSearch models.VulnerabilitySearchStore
 }
 
 // Server handles website routing and HTTP requests.
@@ -83,6 +84,9 @@ func NewServer(cfg Config) (*Server, error) {
 	if cfg.Stores.SourceRepo == nil {
 		return nil, errors.New("Stores.SourceRepo is required")
 	}
+	if cfg.Stores.VulnSearch == nil {
+		return nil, errors.New("Stores.VulnSearch is required")
+	}
 
 	if cfg.APIURL == "" {
 		cfg.APIURL = "api.osv.dev"
@@ -124,6 +128,7 @@ func loggingMiddleware(next http.Handler) http.Handler {
 		logger.InfoContext(r.Context(), "HTTP Request",
 			slog.String("method", r.Method),
 			slog.String("path", r.URL.Path),
+			slog.String("query", r.URL.RawQuery),
 			slog.Int("status", rw.statusCode),
 			slog.Duration("duration", time.Since(start)),
 			slog.Int64("bytes", rw.bytesWritten),

--- a/go/internal/website/server_test.go
+++ b/go/internal/website/server_test.go
@@ -82,6 +82,22 @@ func (m mockSourceRepoStore) All(_ context.Context) iter.Seq2[*models.SourceRepo
 	return func(_ func(*models.SourceRepository, error) bool) {}
 }
 
+type mockVulnSearchStore struct {
+	models.UnimplementedVulnerabilitySearchStore
+}
+
+func (m mockVulnSearchStore) Search(_ context.Context, _ models.VulnerabilitySearchQuery) (*models.VulnerabilitySearchResult, error) {
+	return &models.VulnerabilitySearchResult{}, nil
+}
+
+func (m mockVulnSearchStore) Autocomplete(_ context.Context, _ string, _ int) ([]string, error) {
+	return nil, nil
+}
+
+func (m mockVulnSearchStore) EcosystemCounts(_ context.Context) ([]models.EcosystemCount, error) {
+	return nil, nil
+}
+
 func newTestServer(t *testing.T, cfg website.Config) *website.Server {
 	t.Helper()
 	if cfg.StaticFS == nil {
@@ -102,6 +118,9 @@ func newTestServer(t *testing.T, cfg website.Config) *website.Server {
 	if cfg.Stores.SourceRepo == nil {
 		cfg.Stores.SourceRepo = mockSourceRepoStore{}
 	}
+	if cfg.Stores.VulnSearch == nil {
+		cfg.Stores.VulnSearch = mockVulnSearchStore{}
+	}
 	srv, err := website.NewServer(cfg)
 	if err != nil {
 		t.Fatalf("failed creating test server: %v", err)
@@ -120,6 +139,7 @@ func TestNewServer_NilConfig(t *testing.T) {
 			Vuln:       mockVulnStore{},
 			Relations:  mockRelationsStore{},
 			SourceRepo: mockSourceRepoStore{},
+			VulnSearch: mockVulnSearchStore{},
 		},
 	}
 
@@ -155,6 +175,12 @@ func TestNewServer_NilConfig(t *testing.T) {
 	noSourceRepo.Stores.SourceRepo = nil
 	if _, err := website.NewServer(noSourceRepo); err == nil {
 		t.Errorf("expected error when Stores.SourceRepo is nil, got nil")
+	}
+
+	noVulnSearch := validConfig
+	noVulnSearch.Stores.VulnSearch = nil
+	if _, err := website.NewServer(noVulnSearch); err == nil {
+		t.Errorf("expected error when Stores.VulnSearch is nil, got nil")
 	}
 }
 

--- a/go/internal/website/static.go
+++ b/go/internal/website/static.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+
+	"github.com/google/osv.dev/go/logger"
 )
 
 // RenderNotFound renders the standard 404 Not Found page.
@@ -59,15 +61,20 @@ func computeEcosystemDisplays(counts map[string]int) []EcosystemDisplay {
 	return displays
 }
 
-func (s *Server) getEcosystemCounts(_ context.Context) map[string]int {
-	// Stub for ecosystem count fetch (Datastore or cache integration)
-	return map[string]int{
-		"PyPI": 23174,
-		"npm":  222222,
-		"Go":   8010,
-		"GIT":  943411,
-		"Pub":  11,
+func (s *Server) getEcosystemCounts(ctx context.Context) map[string]int {
+	res, err := s.stores.VulnSearch.EcosystemCounts(ctx)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to get ecosystem counts", "error", err)
+
+		return map[string]int{}
 	}
+
+	counts := make(map[string]int, len(res))
+	for _, eco := range res {
+		counts[eco.Name] = eco.Count
+	}
+
+	return counts
 }
 
 func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Connect the list/search page to Datastore.
- Made a new VulnerabilitySearchStore to provide needed methods for ecosystem counts, search results, and autocomplete.
  - have not connected Redis to the ecosystem counts, so these take a long time to populate (but they are locally cached). Is done in follow-up PR (next in stack)
- Changed how the next-page logic works to use a `after=timestamp_ID` instead of a page number - page numbers require re-iterating through all previous results in the database to arrive at the next page, which becomes very inefficient later pages. Swapping to a timestamp/id lets us use the database more correctly.
  - Maintained `page=N` functionality (with a warning log) so we can see if people have been manually scraping our website

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>