### PR TITLE
refactor(go-website): implement the linter page in go

### DIFF
--- a/go/cmd/website/main.go
+++ b/go/cmd/website/main.go
@@ -18,6 +18,7 @@ import (
 	"cloud.google.com/go/datastore"
 	"cloud.google.com/go/storage"
 	db "github.com/google/osv.dev/go/internal/database/datastore"
+	"github.com/google/osv.dev/go/internal/gcs"
 	"github.com/google/osv.dev/go/internal/website"
 	"github.com/google/osv.dev/go/logger"
 	"github.com/google/osv.dev/go/osv/clients"
@@ -94,6 +95,11 @@ func run() error {
 		return errors.New("OSV_VULNERABILITIES_BUCKET environment variable is not set")
 	}
 
+	linterBucket := os.Getenv("OSV_LINTER_BUCKET")
+	if linterBucket == "" {
+		linterBucket = "osv-test-public-import-logs"
+	}
+
 	var redisClient redis.Cmdable
 	if redisHost := os.Getenv("REDISHOST"); redisHost != "" {
 		redisPort := os.Getenv("REDISPORT")
@@ -119,6 +125,7 @@ func run() error {
 		Relations:  db.NewRelationsStore(dbClient),
 		SourceRepo: db.NewSourceRepositoryStore(dbClient),
 		VulnSearch: db.NewVulnerabilitySearchStore(dbClient, redisClient),
+		Linter:     gcs.NewLinterStore(gcsClient.Bucket(linterBucket), "linter-result/"),
 	}
 
 	apiURL := os.Getenv("OSV_API_URL")

--- a/go/internal/gcs/linter.go
+++ b/go/internal/gcs/linter.go
@@ -69,7 +69,7 @@ func (s *LinterStore) ListSources(ctx context.Context) ([]string, error) {
 
 // GetFindings downloads the result.json findings file for the specified source.
 func (s *LinterStore) GetFindings(ctx context.Context, source string) ([]byte, error) {
-	if source == "" || strings.Contains(source, "/") || strings.Contains(source, "..") {
+	if source == "" || source == "." || strings.Contains(source, "/") || strings.Contains(source, "..") {
 		return nil, models.ErrNotFound
 	}
 

--- a/go/internal/gcs/linter.go
+++ b/go/internal/gcs/linter.go
@@ -1,0 +1,92 @@
+package gcs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path"
+	"slices"
+	"strings"
+
+	"cloud.google.com/go/storage"
+	"github.com/google/osv.dev/go/internal/models"
+	"google.golang.org/api/iterator"
+)
+
+// LinterStore implements models.LinterStore backed by a Google Cloud Storage bucket.
+type LinterStore struct {
+	bucket *storage.BucketHandle
+	prefix string
+}
+
+var _ models.LinterStore = (*LinterStore)(nil)
+
+// NewLinterStore creates a new GCS-backed LinterStore.
+func NewLinterStore(bucket *storage.BucketHandle, prefix string) *LinterStore {
+	if prefix == "" {
+		prefix = "linter-result/"
+	}
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+
+	return &LinterStore{
+		bucket: bucket,
+		prefix: prefix,
+	}
+}
+
+// ListSources lists all source directories with linter findings under the prefix.
+func (s *LinterStore) ListSources(ctx context.Context) ([]string, error) {
+	it := s.bucket.Objects(ctx, &storage.Query{
+		Prefix:    s.prefix,
+		Delimiter: "/",
+	})
+
+	var sources []string
+	for {
+		attrs, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to list linter sources: %w", err)
+		}
+		if attrs.Prefix != "" {
+			src := strings.TrimPrefix(attrs.Prefix, s.prefix)
+			src = strings.TrimSuffix(src, "/")
+			if src != "" {
+				sources = append(sources, src)
+			}
+		}
+	}
+
+	slices.Sort(sources)
+
+	return sources, nil
+}
+
+// GetFindings downloads the result.json findings file for the specified source.
+func (s *LinterStore) GetFindings(ctx context.Context, source string) ([]byte, error) {
+	if source == "" || strings.Contains(source, "/") || strings.Contains(source, "..") {
+		return nil, models.ErrNotFound
+	}
+
+	objPath := path.Join(s.prefix, source, "result.json")
+	r, err := s.bucket.Object(objPath).NewReader(ctx)
+	if errors.Is(err, storage.ErrObjectNotExist) {
+		return nil, models.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to open linter findings for %q: %w", source, err)
+	}
+	defer r.Close()
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read linter findings for %q: %w", source, err)
+	}
+
+	return data, nil
+}

--- a/go/internal/gcs/linter_test.go
+++ b/go/internal/gcs/linter_test.go
@@ -27,7 +27,7 @@ func TestGetFindings_InvalidSource(t *testing.T) {
 	t.Parallel()
 
 	s := gcs.NewLinterStore(nil, "")
-	invalidSources := []string{"", "../etc/passwd", "a/b", "..", "/root"}
+	invalidSources := []string{"", ".", "../etc/passwd", "a/b", "..", "/root"}
 
 	for _, src := range invalidSources {
 		_, err := s.GetFindings(context.Background(), src)

--- a/go/internal/gcs/linter_test.go
+++ b/go/internal/gcs/linter_test.go
@@ -1,0 +1,38 @@
+package gcs_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/osv.dev/go/internal/gcs"
+	"github.com/google/osv.dev/go/internal/models"
+)
+
+func TestNewLinterStore(t *testing.T) {
+	t.Parallel()
+
+	s := gcs.NewLinterStore(nil, "")
+	if s == nil {
+		t.Fatal("expected non-nil LinterStore")
+	}
+
+	sWithPrefix := gcs.NewLinterStore(nil, "custom-prefix")
+	if sWithPrefix == nil {
+		t.Fatal("expected non-nil LinterStore")
+	}
+}
+
+func TestGetFindings_InvalidSource(t *testing.T) {
+	t.Parallel()
+
+	s := gcs.NewLinterStore(nil, "")
+	invalidSources := []string{"", "../etc/passwd", "a/b", "..", "/root"}
+
+	for _, src := range invalidSources {
+		_, err := s.GetFindings(context.Background(), src)
+		if !errors.Is(err, models.ErrNotFound) {
+			t.Errorf("expected ErrNotFound for source %q, got %v", src, err)
+		}
+	}
+}

--- a/go/internal/models/linter.go
+++ b/go/internal/models/linter.go
@@ -1,0 +1,25 @@
+package models
+
+import "context"
+
+// LinterStore defines the interface for accessing linter findings from storage.
+type LinterStore interface {
+	// ListSources returns the list of source repository names that have linter results.
+	ListSources(ctx context.Context) ([]string, error)
+
+	// GetFindings returns the raw JSON findings for a specific source repository.
+	GetFindings(ctx context.Context, source string) ([]byte, error)
+}
+
+// UnimplementedLinterStore provides a default unimplemented stub for LinterStore.
+type UnimplementedLinterStore struct{}
+
+var _ LinterStore = UnimplementedLinterStore{}
+
+func (UnimplementedLinterStore) ListSources(_ context.Context) ([]string, error) {
+	panic("not implemented")
+}
+
+func (UnimplementedLinterStore) GetFindings(_ context.Context, _ string) ([]byte, error) {
+	panic("not implemented")
+}

--- a/go/internal/website/linter.go
+++ b/go/internal/website/linter.go
@@ -2,11 +2,40 @@ package website
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
+	"strings"
+
+	"github.com/google/osv.dev/go/internal/models"
+	"github.com/google/osv.dev/go/logger"
 )
+
+func (s *Server) redirectLinterToTest(w http.ResponseWriter, r *http.Request) bool {
+	host := strings.ToLower(r.Host)
+	if colonIdx := strings.IndexByte(host, ':'); colonIdx != -1 {
+		host = host[:colonIdx]
+	}
+
+	if host == "osv.dev" {
+		http.Redirect(w, r, "https://test.osv.dev"+r.URL.RequestURI(), http.StatusFound)
+
+		return true
+	}
+	if host == "api.osv.dev" {
+		http.Redirect(w, r, "https://api.test.osv.dev"+r.URL.RequestURI(), http.StatusFound)
+
+		return true
+	}
+
+	return false
+}
 
 // handleLinterPage handles serving the linter findings UI page.
 func (s *Server) handleLinterPage(w http.ResponseWriter, r *http.Request) {
+	if s.redirectLinterToTest(w, r) {
+		return
+	}
+
 	data := LinterPageData{
 		BasePageData: BasePageData{
 			ActiveSection: "linter",
@@ -17,15 +46,35 @@ func (s *Server) handleLinterPage(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleLinterSources handles listing sources that have linter findings from GCS.
-func (s *Server) handleLinterSources(w http.ResponseWriter, _ *http.Request) {
-	// TODO: List prefixes in GCS bucket osv-test-public-import-logs under linter-result/
+func (s *Server) handleLinterSources(w http.ResponseWriter, r *http.Request) {
+	if s.redirectLinterToTest(w, r) {
+		return
+	}
+
+	sources, err := s.stores.Linter.ListSources(r.Context())
+	if err != nil {
+		logger.ErrorContext(r.Context(), "failed to list linter sources", "error", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+
+		return
+	}
+
+	if sources == nil {
+		sources = []string{}
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	//nolint:errchkjson
-	_ = json.NewEncoder(w).Encode([]string{"ghsa", "cve-osv", "malicious-packages"})
+	if err := json.NewEncoder(w).Encode(sources); err != nil {
+		logger.ErrorContext(r.Context(), "failed to encode linter sources", "error", err)
+	}
 }
 
 // handleLinterFindings handles fetching linter findings JSON for a specific source from GCS.
 func (s *Server) handleLinterFindings(w http.ResponseWriter, r *http.Request) {
+	if s.redirectLinterToTest(w, r) {
+		return
+	}
+
 	source := r.PathValue("source")
 	if source == "" {
 		http.NotFound(w, r)
@@ -33,12 +82,21 @@ func (s *Server) handleLinterFindings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: Download linter-result/<source>/result.json from GCS bucket
+	findings, err := s.stores.Linter.GetFindings(r.Context(), source)
+	if errors.Is(err, models.ErrNotFound) {
+		http.NotFound(w, r)
+
+		return
+	}
+	if err != nil {
+		logger.ErrorContext(r.Context(), "failed to get linter findings", "source", source, "error", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	//nolint:errchkjson
-	_ = json.NewEncoder(w).Encode(map[string][]map[string]string{
-		"path/OSV-1234-5678.json": {{
-			"Code":    "SCH:001",
-			"Message": "record is bad",
-		}}})
+	if _, err := w.Write(findings); err != nil {
+		logger.ErrorContext(r.Context(), "failed to write linter findings", "source", source, "error", err)
+	}
 }

--- a/go/internal/website/server.go
+++ b/go/internal/website/server.go
@@ -33,6 +33,7 @@ type Stores struct {
 	Relations  models.RelationsStore
 	SourceRepo models.SourceRepositoryStore
 	VulnSearch models.VulnerabilitySearchStore
+	Linter     models.LinterStore
 }
 
 // Server handles website routing and HTTP requests.
@@ -86,6 +87,9 @@ func NewServer(cfg Config) (*Server, error) {
 	}
 	if cfg.Stores.VulnSearch == nil {
 		return nil, errors.New("Stores.VulnSearch is required")
+	}
+	if cfg.Stores.Linter == nil {
+		return nil, errors.New("Stores.Linter is required")
 	}
 
 	if cfg.APIURL == "" {

--- a/go/internal/website/server_test.go
+++ b/go/internal/website/server_test.go
@@ -98,12 +98,29 @@ func (m mockVulnSearchStore) EcosystemCounts(_ context.Context) ([]models.Ecosys
 	return nil, nil
 }
 
+type mockLinterStore struct {
+	models.UnimplementedLinterStore
+}
+
+func (m mockLinterStore) ListSources(_ context.Context) ([]string, error) {
+	return []string{"cve-osv", "ghsa"}, nil
+}
+
+func (m mockLinterStore) GetFindings(_ context.Context, source string) ([]byte, error) {
+	if source == "ghsa" {
+		return []byte(`{"findings":[]}`), nil
+	}
+
+	return nil, models.ErrNotFound
+}
+
 func newTestServer(t *testing.T, cfg website.Config) *website.Server {
 	t.Helper()
 	if cfg.StaticFS == nil {
 		cfg.StaticFS = fstest.MapFS{
-			"go/base.html": &fstest.MapFile{Data: []byte(`<html>{{ block "content" . }}{{ end }}</html>`)},
-			"go/404.html":  &fstest.MapFile{Data: []byte(`{{ define "content" }}404{{ end }}`)},
+			"go/base.html":   &fstest.MapFile{Data: []byte(`<html>{{ block "content" . }}{{ end }}</html>`)},
+			"go/404.html":    &fstest.MapFile{Data: []byte(`{{ define "content" }}404{{ end }}`)},
+			"go/linter.html": &fstest.MapFile{Data: []byte(`{{ define "content" }}linter{{ end }}`)},
 		}
 	}
 	if cfg.DocsFS == nil {
@@ -120,6 +137,9 @@ func newTestServer(t *testing.T, cfg website.Config) *website.Server {
 	}
 	if cfg.Stores.VulnSearch == nil {
 		cfg.Stores.VulnSearch = mockVulnSearchStore{}
+	}
+	if cfg.Stores.Linter == nil {
+		cfg.Stores.Linter = mockLinterStore{}
 	}
 	srv, err := website.NewServer(cfg)
 	if err != nil {
@@ -140,6 +160,7 @@ func TestNewServer_NilConfig(t *testing.T) {
 			Relations:  mockRelationsStore{},
 			SourceRepo: mockSourceRepoStore{},
 			VulnSearch: mockVulnSearchStore{},
+			Linter:     mockLinterStore{},
 		},
 	}
 
@@ -181,6 +202,12 @@ func TestNewServer_NilConfig(t *testing.T) {
 	noVulnSearch.Stores.VulnSearch = nil
 	if _, err := website.NewServer(noVulnSearch); err == nil {
 		t.Errorf("expected error when Stores.VulnSearch is nil, got nil")
+	}
+
+	noLinter := validConfig
+	noLinter.Stores.Linter = nil
+	if _, err := website.NewServer(noLinter); err == nil {
+		t.Errorf("expected error when Stores.Linter is nil, got nil")
 	}
 }
 
@@ -712,4 +739,98 @@ func TestEndpointRegistration(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLinterEndpoints(t *testing.T) {
+	t.Parallel()
+
+	srv := newTestServer(t, website.Config{})
+
+	t.Run("GET /linter renders successfully", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/linter", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200 OK, got %d", rec.Code)
+		}
+	})
+
+	t.Run("GET /linter on osv.dev redirects to test.osv.dev", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/linter", nil)
+		req.Host = "OSV.DEV:443"
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusFound {
+			t.Errorf("expected status 302 Found, got %d", rec.Code)
+		}
+		if loc := rec.Header().Get("Location"); loc != "https://test.osv.dev/linter" {
+			t.Errorf("expected Location 'https://test.osv.dev/linter', got %q", loc)
+		}
+	})
+
+	t.Run("GET /linter-findings returns sources JSON", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/linter-findings", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200 OK, got %d", rec.Code)
+		}
+		if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %q", ct)
+		}
+		expectedBody := "[\"cve-osv\",\"ghsa\"]\n"
+		if rec.Body.String() != expectedBody {
+			t.Errorf("expected body %q, got %q", expectedBody, rec.Body.String())
+		}
+	})
+
+	t.Run("GET /linter-findings on osv.dev redirects to test.osv.dev", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/linter-findings", nil)
+		req.Host = "osv.dev"
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusFound {
+			t.Errorf("expected status 302 Found, got %d", rec.Code)
+		}
+		if loc := rec.Header().Get("Location"); loc != "https://test.osv.dev/linter-findings" {
+			t.Errorf("expected Location 'https://test.osv.dev/linter-findings', got %q", loc)
+		}
+	})
+
+	t.Run("GET /linter-findings/{source} returns findings JSON", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/linter-findings/ghsa", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200 OK, got %d", rec.Code)
+		}
+		if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %q", ct)
+		}
+		expectedBody := `{"findings":[]}`
+		if rec.Body.String() != expectedBody {
+			t.Errorf("expected body %q, got %q", expectedBody, rec.Body.String())
+		}
+	})
+
+	t.Run("GET /linter-findings/{source} on unknown source returns 404", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/linter-findings/unknown-source", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("expected status 404 Not Found, got %d", rec.Code)
+		}
+	})
 }


### PR DESCRIPTION
Did all the Database logic for getting the osv linter results webpage to work in go.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>