### PR TITLE
refactor(go-website): Implement auth & triage page

### DIFF
--- a/go/cmd/website/main.go
+++ b/go/cmd/website/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -117,6 +118,10 @@ func run() error {
 		redisClient = rdb
 	}
 
+	bypassOAuth := strings.EqualFold(os.Getenv("BYPASS_OAUTH_FOR_LOCAL_DEV"), "true") ||
+		os.Getenv("BYPASS_OAUTH_FOR_LOCAL_DEV") == "1" ||
+		strings.EqualFold(os.Getenv("BYPASS_OAUTH_FOR_LOCAL_DEV"), "t")
+
 	stores := website.Stores{
 		Vuln: db.NewVulnerabilityStore(db.VulnStoreConfig{
 			Client: dbClient,
@@ -126,6 +131,7 @@ func run() error {
 		SourceRepo: db.NewSourceRepositoryStore(dbClient),
 		VulnSearch: db.NewVulnerabilitySearchStore(dbClient, redisClient),
 		Linter:     gcs.NewLinterStore(gcsClient.Bucket(linterBucket), "linter-result/"),
+		Triage:     gcs.NewTriageStore(gcsClient),
 	}
 
 	apiURL := os.Getenv("OSV_API_URL")
@@ -136,11 +142,25 @@ func run() error {
 		apiURL = "api.osv.dev"
 	}
 
+	secretKey := os.Getenv("SESSION_SECRET_KEY")
+	if secretKey == "" {
+		secretKey = os.Getenv("FLASK_SECRET_KEY")
+	}
+	if secretKey == "" {
+		secretKey = os.Getenv("SECRET_KEY")
+	}
+
 	srv, err := website.NewServer(website.Config{
 		StaticFS: staticFiles,
 		DocsFS:   docsFiles,
 		Stores:   stores,
 		APIURL:   apiURL,
+		Auth: website.AuthConfig{
+			ClientID:     os.Getenv("GOOGLE_OAUTH_CLIENT_ID"),
+			ClientSecret: os.Getenv("GOOGLE_OAUTH_CLIENT_SECRET"),
+			SecretKey:    secretKey,
+			BypassOAuth:  bypassOAuth,
+		},
 	})
 	if err != nil {
 		logger.ErrorContext(ctx, "Failed to create website server", slog.Any("error", err))

--- a/go/cmd/website/main.go
+++ b/go/cmd/website/main.go
@@ -149,6 +149,9 @@ func run() error {
 	if secretKey == "" {
 		secretKey = os.Getenv("SECRET_KEY")
 	}
+	if secretKey == "" && !bypassOAuth {
+		logger.WarnContext(ctx, "SESSION_SECRET_KEY environment variable is not set, authentication will not work")
+	}
 
 	srv, err := website.NewServer(website.Config{
 		StaticFS: staticFiles,

--- a/go/go.mod
+++ b/go/go.mod
@@ -35,6 +35,7 @@ require (
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.22.0
 	golang.org/x/text v0.40.0
 	google.golang.org/api v0.287.1
@@ -117,7 +118,6 @@ require (
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
 	golang.org/x/net v0.57.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto v0.0.0-20260519071638-aa98bba5eb94 // indirect

--- a/go/internal/gcs/triage.go
+++ b/go/internal/gcs/triage.go
@@ -1,0 +1,117 @@
+package gcs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/google/osv.dev/go/internal/models"
+)
+
+var cveIDRegex = regexp.MustCompile(`^(?i)CVE-(\d{4})-(\d+)$`)
+
+type sourceConfig struct {
+	Bucket       string
+	PathTemplate string
+}
+
+var gcsSources = map[string]sourceConfig{
+	"test-nvd":          {Bucket: "osv-test-cve-osv-conversion", PathTemplate: "nvd-osv/%s.json"},
+	"test-cve5":         {Bucket: "osv-test-cve-osv-conversion", PathTemplate: "cve5/%s.json"},
+	"test-osv":          {Bucket: "osv-test-cve-osv-conversion", PathTemplate: "osv-output/%s.json"},
+	"test-nvd-metrics":  {Bucket: "osv-test-cve-osv-conversion", PathTemplate: "nvd-osv/%s.metrics.json"},
+	"test-cve5-metrics": {Bucket: "osv-test-cve-osv-conversion", PathTemplate: "cve5/%s.metrics.json"},
+	"prod-nvd":          {Bucket: "cve-osv-conversion", PathTemplate: "nvd-osv/%s.json"},
+	"prod-cve5":         {Bucket: "cve-osv-conversion", PathTemplate: "cve5/%s.json"},
+	"prod-osv":          {Bucket: "cve-osv-conversion", PathTemplate: "osv-output/%s.json"},
+	"prod-nvd-metrics":  {Bucket: "cve-osv-conversion", PathTemplate: "nvd-osv/%s.metrics.json"},
+	"prod-cve5-metrics": {Bucket: "cve-osv-conversion", PathTemplate: "cve5/%s.metrics.json"},
+}
+
+// TriageStore implements models.TriageStore for reading CVE data from GCS and upstream APIs.
+type TriageStore struct {
+	client     *storage.Client
+	httpClient *http.Client
+}
+
+var _ models.TriageStore = (*TriageStore)(nil)
+
+// NewTriageStore creates a new TriageStore.
+func NewTriageStore(client *storage.Client) *TriageStore {
+	return &TriageStore{
+		client: client,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+// GetFile retrieves the raw JSON content for a given source and CVE ID.
+func (s *TriageStore) GetFile(ctx context.Context, source, cveID string) ([]byte, error) {
+	cveID = strings.ToUpper(cveID)
+	matches := cveIDRegex.FindStringSubmatch(cveID)
+	if len(matches) < 3 {
+		return nil, fmt.Errorf("invalid CVE ID format: %s", cveID)
+	}
+
+	// Handle GCS sources
+	if cfg, ok := gcsSources[source]; ok {
+		if s.client == nil {
+			return nil, errors.New("storage client is not configured")
+		}
+		path := fmt.Sprintf(cfg.PathTemplate, cveID)
+		r, err := s.client.Bucket(cfg.Bucket).Object(path).NewReader(ctx)
+		if errors.Is(err, storage.ErrObjectNotExist) {
+			return nil, models.ErrNotFound
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to read from GCS (%s): %w", source, err)
+		}
+		defer r.Close()
+
+		return io.ReadAll(r)
+	}
+
+	// Handle external API sources
+	var url string
+	switch source {
+	case "cve":
+		year := matches[1]
+		seq := matches[2]
+		seqPrefix := "0"
+		if len(seq) > 3 {
+			seqPrefix = seq[:len(seq)-3]
+		}
+		url = fmt.Sprintf("https://raw.githubusercontent.com/CVEProject/cvelistV5/refs/heads/main/cves/%s/%sxxx/%s.json", year, seqPrefix, cveID)
+	case "nvd":
+		url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=" + cveID
+	default:
+		return nil, fmt.Errorf("invalid source: %s", source)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch from external API (%s): %w", source, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, models.ErrNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("external API returned status %d", resp.StatusCode)
+	}
+
+	return io.ReadAll(resp.Body)
+}

--- a/go/internal/gcs/triage.go
+++ b/go/internal/gcs/triage.go
@@ -14,6 +14,10 @@ import (
 	"github.com/google/osv.dev/go/internal/models"
 )
 
+const (
+	maxResponseSize = 10 * 1024 * 1024 // 10 MB
+)
+
 var cveIDRegex = regexp.MustCompile(`^(?i)CVE-(\d{4})-(\d+)$`)
 
 type sourceConfig struct {
@@ -57,7 +61,7 @@ func (s *TriageStore) GetFile(ctx context.Context, source, cveID string) ([]byte
 	cveID = strings.ToUpper(cveID)
 	matches := cveIDRegex.FindStringSubmatch(cveID)
 	if len(matches) < 3 {
-		return nil, fmt.Errorf("invalid CVE ID format: %s", cveID)
+		return nil, fmt.Errorf("%w: invalid CVE ID format: %s", models.ErrInvalidArgument, cveID)
 	}
 
 	// Handle GCS sources
@@ -92,7 +96,7 @@ func (s *TriageStore) GetFile(ctx context.Context, source, cveID string) ([]byte
 	case "nvd":
 		url = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=" + cveID
 	default:
-		return nil, fmt.Errorf("invalid source: %s", source)
+		return nil, fmt.Errorf("%w: invalid source: %s", models.ErrInvalidArgument, source)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -113,5 +117,5 @@ func (s *TriageStore) GetFile(ctx context.Context, source, cveID string) ([]byte
 		return nil, fmt.Errorf("external API returned status %d", resp.StatusCode)
 	}
 
-	return io.ReadAll(resp.Body)
+	return io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
 }

--- a/go/internal/gcs/triage_test.go
+++ b/go/internal/gcs/triage_test.go
@@ -1,0 +1,52 @@
+package gcs_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/osv.dev/go/internal/gcs"
+	"github.com/google/osv.dev/go/internal/models"
+)
+
+func TestNewTriageStore(t *testing.T) {
+	t.Parallel()
+
+	s := gcs.NewTriageStore(nil)
+	if s == nil {
+		t.Fatal("expected non-nil TriageStore")
+	}
+}
+
+func TestTriageStore_GetFile_InvalidArgument(t *testing.T) {
+	t.Parallel()
+
+	s := gcs.NewTriageStore(nil)
+
+	tests := []struct {
+		name   string
+		source string
+		cveID  string
+	}{
+		{
+			name:   "invalid cve format",
+			source: "cve",
+			cveID:  "INVALID-CVE",
+		},
+		{
+			name:   "invalid source",
+			source: "unknown-source",
+			cveID:  "CVE-2024-1234",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := s.GetFile(context.Background(), tc.source, tc.cveID)
+			if !errors.Is(err, models.ErrInvalidArgument) {
+				t.Errorf("expected ErrInvalidArgument, got %v", err)
+			}
+		})
+	}
+}

--- a/go/internal/models/errors.go
+++ b/go/internal/models/errors.go
@@ -4,3 +4,6 @@ import "errors"
 
 // ErrNotFound indicates that a requested entity was not found.
 var ErrNotFound = errors.New("not found")
+
+// ErrInvalidArgument indicates that an argument provided to a function or method is invalid.
+var ErrInvalidArgument = errors.New("invalid argument")

--- a/go/internal/models/triage.go
+++ b/go/internal/models/triage.go
@@ -1,0 +1,18 @@
+package models
+
+import "context"
+
+// TriageStore defines the interface for fetching CVE conversion data and external records for triage.
+type TriageStore interface {
+	// GetFile retrieves the raw JSON content for a given source and CVE ID.
+	GetFile(ctx context.Context, source, cveID string) ([]byte, error)
+}
+
+// UnimplementedTriageStore provides a default unimplemented stub for TriageStore.
+type UnimplementedTriageStore struct{}
+
+var _ TriageStore = UnimplementedTriageStore{}
+
+func (UnimplementedTriageStore) GetFile(_ context.Context, _, _ string) ([]byte, error) {
+	panic("not implemented")
+}

--- a/go/internal/website/auth.go
+++ b/go/internal/website/auth.go
@@ -4,6 +4,7 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -252,7 +253,7 @@ func (s *Server) handleAuthCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	queryState := r.URL.Query().Get("state")
-	if queryState == "" || queryState != statePayload.State {
+	if subtle.ConstantTimeCompare([]byte(queryState), []byte(statePayload.State)) != 1 {
 		s.renderJSON(w, r, http.StatusBadRequest, map[string]string{
 			"error": "Invalid state parameter",
 		})

--- a/go/internal/website/auth.go
+++ b/go/internal/website/auth.go
@@ -1,34 +1,332 @@
 package website
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"time"
+
+	"github.com/google/osv.dev/go/logger"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/idtoken"
 )
 
-// handleLogin handles initiating Google OAuth authentication login flow.
-// Query parameters:
-//   - redirect: optional post-login redirect destination
-func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
-	redirectURI := r.URL.Query().Get("redirect")
+const (
+	sessionCookieName    = "osv_session"
+	oauthStateCookieName = "osv_oauth_state"
+	sessionDuration      = 7 * 24 * time.Hour
+	oauthStateDuration   = 10 * time.Minute
+)
 
-	// TODO: Redirect user to Google OAuth authorization endpoint
-	http.Error(w, fmt.Sprintf("OAuth login handler stub (redirect=%q)", redirectURI), http.StatusNotImplemented)
+// AuthConfig contains Google OAuth2 configuration.
+type AuthConfig struct {
+	ClientID     string
+	ClientSecret string
+	SecretKey    string
+	BypassOAuth  bool
+}
+
+type sessionPayload struct {
+	Email     string `json:"email,omitempty"`
+	State     string `json:"state,omitempty"`
+	ExpiresAt int64  `json:"exp"`
+}
+
+func (s *Server) encryptCookie(payload sessionPayload) (string, error) {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+
+	block, err := aes.NewCipher(s.secretKey)
+	if err != nil {
+		return "", err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+
+	ciphertext := gcm.Seal(nonce, nonce, data, nil)
+
+	return base64.RawURLEncoding.EncodeToString(ciphertext), nil
+}
+
+func (s *Server) decryptCookie(cookieVal string) (*sessionPayload, error) {
+	data, err := base64.RawURLEncoding.DecodeString(cookieVal)
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := aes.NewCipher(s.secretKey)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(data) < nonceSize {
+		return nil, errors.New("cookie too short")
+	}
+
+	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var payload sessionPayload
+	if err := json.Unmarshal(plaintext, &payload); err != nil {
+		return nil, err
+	}
+
+	if time.Now().Unix() > payload.ExpiresAt {
+		return nil, errors.New("cookie expired")
+	}
+
+	return &payload, nil
+}
+
+func (s *Server) setEncryptedCookie(w http.ResponseWriter, name string, payload sessionPayload, duration time.Duration) error {
+	encoded, err := s.encryptCookie(payload)
+	if err != nil {
+		return err
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    encoded,
+		Path:     "/",
+		MaxAge:   int(duration.Seconds()),
+		Expires:  time.Now().Add(duration),
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	return nil
+}
+
+func (s *Server) clearCookie(w http.ResponseWriter, name string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		Expires:  time.Unix(0, 0),
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func (s *Server) oauthConfig(r *http.Request) *oauth2.Config {
+	scheme := "http"
+	if r.Header.Get("X-Forwarded-Proto") == "https" || r.TLS != nil {
+		scheme = "https"
+	}
+	redirectURI := fmt.Sprintf("%s://%s/auth/callback", scheme, r.Host)
+
+	return &oauth2.Config{
+		ClientID:     s.config.Auth.ClientID,
+		ClientSecret: s.config.Auth.ClientSecret,
+		Endpoint:     google.Endpoint,
+		RedirectURL:  redirectURI,
+		Scopes:       []string{"openid", "email", "profile"},
+	}
+}
+
+func (s *Server) requireGoogleAccount(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if s.config.Auth.BypassOAuth {
+			next(w, r)
+
+			return
+		}
+
+		cookie, err := r.Cookie(sessionCookieName)
+		if err != nil || cookie.Value == "" {
+			http.Redirect(w, r, "/login", http.StatusFound)
+
+			return
+		}
+
+		payload, err := s.decryptCookie(cookie.Value)
+		if err != nil || payload.Email == "" {
+			http.Redirect(w, r, "/login", http.StatusFound)
+
+			return
+		}
+
+		next(w, r)
+	}
+}
+
+// handleLogin handles initiating Google OAuth authentication login flow.
+func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
+	if s.config.Auth.BypassOAuth {
+		if err := s.setEncryptedCookie(w, sessionCookieName, sessionPayload{
+			Email:     "dev@google.com",
+			ExpiresAt: time.Now().Add(sessionDuration).Unix(),
+		}, sessionDuration); err != nil {
+			logger.ErrorContext(r.Context(), "failed to set session cookie", "error", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+
+			return
+		}
+
+		http.Redirect(w, r, "/triage", http.StatusFound)
+
+		return
+	}
+
+	if s.config.Auth.ClientID == "" || s.config.Auth.ClientSecret == "" {
+		s.renderJSON(w, r, http.StatusInternalServerError, map[string]string{
+			"error": "OAuth credentials not configured. Set GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET env vars or enable BYPASS_OAUTH_FOR_LOCAL_DEV.",
+		})
+
+		return
+	}
+
+	stateBytes := make([]byte, 16)
+	if _, err := io.ReadFull(rand.Reader, stateBytes); err != nil {
+		logger.ErrorContext(r.Context(), "failed to generate oauth state", "error", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+
+		return
+	}
+	state := hex.EncodeToString(stateBytes)
+
+	if err := s.setEncryptedCookie(w, oauthStateCookieName, sessionPayload{
+		State:     state,
+		ExpiresAt: time.Now().Add(oauthStateDuration).Unix(),
+	}, oauthStateDuration); err != nil {
+		logger.ErrorContext(r.Context(), "failed to set oauth state cookie", "error", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+
+		return
+	}
+
+	conf := s.oauthConfig(r)
+	http.Redirect(w, r, conf.AuthCodeURL(state, oauth2.AccessTypeOffline), http.StatusFound)
 }
 
 // handleAuthCallback handles processing OAuth callback tokens.
-// Query parameters:
-//   - code: authorization code from OAuth provider
-//   - state: CSRF protection state token
 func (s *Server) handleAuthCallback(w http.ResponseWriter, r *http.Request) {
-	code := r.URL.Query().Get("code")
-	state := r.URL.Query().Get("state")
+	cookie, err := r.Cookie(oauthStateCookieName)
+	if err != nil || cookie.Value == "" {
+		s.renderJSON(w, r, http.StatusBadRequest, map[string]string{
+			"error": "Invalid state parameter",
+		})
 
-	// TODO: Exchange code for session token and store in cookie
-	http.Error(w, fmt.Sprintf("OAuth callback handler stub (code=%q, state=%q)", code, state), http.StatusNotImplemented)
+		return
+	}
+
+	s.clearCookie(w, oauthStateCookieName)
+
+	statePayload, err := s.decryptCookie(cookie.Value)
+	if err != nil || statePayload.State == "" {
+		s.renderJSON(w, r, http.StatusBadRequest, map[string]string{
+			"error": "Invalid state parameter",
+		})
+
+		return
+	}
+
+	queryState := r.URL.Query().Get("state")
+	if queryState == "" || queryState != statePayload.State {
+		s.renderJSON(w, r, http.StatusBadRequest, map[string]string{
+			"error": "Invalid state parameter",
+		})
+
+		return
+	}
+
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		s.renderJSON(w, r, http.StatusBadRequest, map[string]string{
+			"error": "Missing code parameter",
+		})
+
+		return
+	}
+
+	conf := s.oauthConfig(r)
+	token, err := conf.Exchange(r.Context(), code)
+	if err != nil {
+		logger.ErrorContext(r.Context(), "failed to exchange oauth code", "error", err)
+		s.renderJSON(w, r, http.StatusBadRequest, map[string]string{
+			"error": "Failed to obtain ID token. Maybe credentials mismatch or invalid code.",
+		})
+
+		return
+	}
+
+	rawIDToken, ok := token.Extra("id_token").(string)
+	if !ok || rawIDToken == "" {
+		s.renderJSON(w, r, http.StatusBadRequest, map[string]string{
+			"error": "Missing ID token in token response",
+		})
+
+		return
+	}
+
+	payload, err := idtoken.Validate(r.Context(), rawIDToken, s.config.Auth.ClientID)
+	if err != nil {
+		logger.ErrorContext(r.Context(), "invalid oauth id token", "error", err)
+		s.renderJSON(w, r, http.StatusBadRequest, map[string]string{
+			"error": "Invalid token",
+		})
+
+		return
+	}
+
+	email, _ := payload.Claims["email"].(string)
+	if email == "" {
+		s.renderJSON(w, r, http.StatusBadRequest, map[string]string{
+			"error": "Token missing email claim",
+		})
+
+		return
+	}
+
+	if err := s.setEncryptedCookie(w, sessionCookieName, sessionPayload{
+		Email:     email,
+		ExpiresAt: time.Now().Add(sessionDuration).Unix(),
+	}, sessionDuration); err != nil {
+		logger.ErrorContext(r.Context(), "failed to set session cookie", "error", err)
+		s.renderJSON(w, r, http.StatusInternalServerError, map[string]string{
+			"error": "Failed to set session",
+		})
+
+		return
+	}
+
+	http.Redirect(w, r, "/triage", http.StatusFound)
 }
 
 // handleLogout handles logging out user and clearing authentication session cookies.
-func (s *Server) handleLogout(w http.ResponseWriter, _ *http.Request) {
-	// TODO: Clear authentication cookie and redirect user
-	http.Error(w, "OAuth logout handler stub", http.StatusNotImplemented)
+func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
+	s.clearCookie(w, sessionCookieName)
+	s.clearCookie(w, oauthStateCookieName)
+
+	http.Redirect(w, r, "/triage", http.StatusFound)
 }

--- a/go/internal/website/server.go
+++ b/go/internal/website/server.go
@@ -3,6 +3,7 @@ package website
 
 import (
 	"bytes"
+	"crypto/hkdf"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/json"
@@ -108,8 +109,11 @@ func NewServer(cfg Config) (*Server, error) {
 
 	var secretKey []byte
 	if cfg.Auth.SecretKey != "" {
-		hash := sha256.Sum256([]byte(cfg.Auth.SecretKey))
-		secretKey = hash[:]
+		var err error
+		secretKey, err = hkdf.Key(sha256.New, []byte(cfg.Auth.SecretKey), nil, "osv-cookie-encryption", 32)
+		if err != nil {
+			return nil, fmt.Errorf("failed to derive secret key: %w", err)
+		}
 	} else {
 		secretKey = make([]byte, 32)
 		if _, err := io.ReadFull(rand.Reader, secretKey); err != nil {

--- a/go/internal/website/server.go
+++ b/go/internal/website/server.go
@@ -3,8 +3,13 @@ package website
 
 import (
 	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"html/template"
+	"io"
 	"io/fs"
 	"log/slog"
 	"net/http"
@@ -26,6 +31,7 @@ type Config struct {
 	TemplateDir string
 	Stores      Stores
 	APIURL      string
+	Auth        AuthConfig
 }
 
 type Stores struct {
@@ -34,15 +40,16 @@ type Stores struct {
 	SourceRepo models.SourceRepositoryStore
 	VulnSearch models.VulnerabilitySearchStore
 	Linter     models.LinterStore
+	Triage     models.TriageStore
 }
 
 // Server handles website routing and HTTP requests.
 type Server struct {
-	config  Config
-	mux     *http.ServeMux
-	handler http.Handler
-
-	stores Stores
+	config    Config
+	mux       *http.ServeMux
+	handler   http.Handler
+	stores    Stores
+	secretKey []byte
 }
 
 type responseLogger struct {
@@ -91,15 +98,30 @@ func NewServer(cfg Config) (*Server, error) {
 	if cfg.Stores.Linter == nil {
 		return nil, errors.New("Stores.Linter is required")
 	}
+	if cfg.Stores.Triage == nil {
+		return nil, errors.New("Stores.Triage is required")
+	}
 
 	if cfg.APIURL == "" {
 		cfg.APIURL = "api.osv.dev"
 	}
 
+	var secretKey []byte
+	if cfg.Auth.SecretKey != "" {
+		hash := sha256.Sum256([]byte(cfg.Auth.SecretKey))
+		secretKey = hash[:]
+	} else {
+		secretKey = make([]byte, 32)
+		if _, err := io.ReadFull(rand.Reader, secretKey); err != nil {
+			return nil, fmt.Errorf("failed to generate secret key: %w", err)
+		}
+	}
+
 	s := &Server{
-		config: cfg,
-		mux:    http.NewServeMux(),
-		stores: cfg.Stores,
+		config:    cfg,
+		mux:       http.NewServeMux(),
+		stores:    cfg.Stores,
+		secretKey: secretKey,
 	}
 	s.registerRoutes()
 
@@ -204,10 +226,10 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /linter-findings/", s.handleLinterSources)
 	s.mux.HandleFunc("GET /linter-findings/{source}", s.handleLinterFindings)
 
-	// Triage workflow
-	// TODO: auth stuff
-	s.mux.HandleFunc("GET /triage", s.handleTriagePage)
-	s.mux.HandleFunc("/triage/proxy", s.handleTriageProxy)
+	// Triage workflow (protected by Google OAuth account authentication)
+	s.mux.HandleFunc("GET /triage", s.requireGoogleAccount(s.handleTriagePage))
+	s.mux.HandleFunc("GET /triage/", s.requireGoogleAccount(s.handleTriagePage))
+	s.mux.HandleFunc("GET /triage/proxy", s.requireGoogleAccount(s.handleTriageProxy))
 
 	// Google OAuth authentication
 	s.mux.HandleFunc("GET /login", s.handleLogin)
@@ -272,4 +294,12 @@ func (s *Server) render(w http.ResponseWriter, r *http.Request, pageFile string,
 
 func (s *Server) renderStandalone(w http.ResponseWriter, r *http.Request, pageFile string, status int, data any) {
 	s.renderTemplates(w, r, status, data, pageFile)
+}
+
+func (s *Server) renderJSON(w http.ResponseWriter, r *http.Request, status int, data any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		logger.ErrorContext(r.Context(), "failed to encode JSON response", "error", err)
+	}
 }

--- a/go/internal/website/server_test.go
+++ b/go/internal/website/server_test.go
@@ -114,6 +114,18 @@ func (m mockLinterStore) GetFindings(_ context.Context, source string) ([]byte, 
 	return nil, models.ErrNotFound
 }
 
+type mockTriageStore struct {
+	models.UnimplementedTriageStore
+}
+
+func (m mockTriageStore) GetFile(_ context.Context, source, cveID string) ([]byte, error) {
+	if cveID == "CVE-2024-1234" && (source == "test-nvd" || source == "cve") {
+		return []byte(`{"id":"CVE-2024-1234"}`), nil
+	}
+
+	return nil, models.ErrNotFound
+}
+
 func newTestServer(t *testing.T, cfg website.Config) *website.Server {
 	t.Helper()
 	if cfg.StaticFS == nil {
@@ -121,6 +133,7 @@ func newTestServer(t *testing.T, cfg website.Config) *website.Server {
 			"go/base.html":   &fstest.MapFile{Data: []byte(`<html>{{ block "content" . }}{{ end }}</html>`)},
 			"go/404.html":    &fstest.MapFile{Data: []byte(`{{ define "content" }}404{{ end }}`)},
 			"go/linter.html": &fstest.MapFile{Data: []byte(`{{ define "content" }}linter{{ end }}`)},
+			"go/triage.html": &fstest.MapFile{Data: []byte(`{{ define "content" }}triage{{ end }}`)},
 		}
 	}
 	if cfg.DocsFS == nil {
@@ -140,6 +153,12 @@ func newTestServer(t *testing.T, cfg website.Config) *website.Server {
 	}
 	if cfg.Stores.Linter == nil {
 		cfg.Stores.Linter = mockLinterStore{}
+	}
+	if cfg.Stores.Triage == nil {
+		cfg.Stores.Triage = mockTriageStore{}
+	}
+	if !cfg.Auth.BypassOAuth && cfg.Auth.ClientID == "" && cfg.Auth.ClientSecret == "" {
+		cfg.Auth.BypassOAuth = true
 	}
 	srv, err := website.NewServer(cfg)
 	if err != nil {
@@ -161,6 +180,7 @@ func TestNewServer_NilConfig(t *testing.T) {
 			SourceRepo: mockSourceRepoStore{},
 			VulnSearch: mockVulnSearchStore{},
 			Linter:     mockLinterStore{},
+			Triage:     mockTriageStore{},
 		},
 	}
 
@@ -208,6 +228,12 @@ func TestNewServer_NilConfig(t *testing.T) {
 	noLinter.Stores.Linter = nil
 	if _, err := website.NewServer(noLinter); err == nil {
 		t.Errorf("expected error when Stores.Linter is nil, got nil")
+	}
+
+	noTriage := validConfig
+	noTriage.Stores.Triage = nil
+	if _, err := website.NewServer(noTriage); err == nil {
+		t.Errorf("expected error when Stores.Triage is nil, got nil")
 	}
 }
 
@@ -712,33 +738,289 @@ func TestVulnerabilityJSON(t *testing.T) {
 	})
 }
 
-func TestEndpointRegistration(t *testing.T) {
+func TestAuthEndpoints(t *testing.T) {
 	t.Parallel()
 
-	srv := newTestServer(t, website.Config{})
-
-	endpoints := []struct {
-		method string
-		path   string
-	}{
-		{http.MethodPost, "/triage/proxy"},
-		{http.MethodGet, "/login"},
-		{http.MethodGet, "/auth/callback"},
-		{http.MethodGet, "/logout"},
-	}
-
-	for _, ep := range endpoints {
-		t.Run(ep.method+" "+ep.path, func(t *testing.T) {
-			t.Parallel()
-			req := httptest.NewRequest(ep.method, ep.path, nil)
-			rec := httptest.NewRecorder()
-			srv.ServeHTTP(rec, req)
-
-			if rec.Code != http.StatusNotImplemented {
-				t.Errorf("expected status 501 Not Implemented, got %d", rec.Code)
-			}
+	t.Run("GET /login with BypassOAuth sets cookie and redirects to /triage", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer(t, website.Config{
+			Auth: website.AuthConfig{
+				BypassOAuth: true,
+			},
 		})
-	}
+		req := httptest.NewRequest(http.MethodGet, "/login", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusFound {
+			t.Errorf("expected status 302 Found, got %d", rec.Code)
+		}
+		if loc := rec.Header().Get("Location"); loc != "/triage" {
+			t.Errorf("expected Location '/triage', got %q", loc)
+		}
+		cookies := rec.Result().Cookies()
+		if len(cookies) == 0 || cookies[0].Name != "osv_session" {
+			t.Errorf("expected session cookie to be set")
+		}
+	})
+
+	t.Run("GET /login without credentials returns 500 JSON", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer(t, website.Config{
+			Auth: website.AuthConfig{
+				ClientID: "missing-client-secret",
+			},
+		})
+		req := httptest.NewRequest(http.MethodGet, "/login", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusInternalServerError {
+			t.Errorf("expected status 500, got %d", rec.Code)
+		}
+	})
+
+	t.Run("GET /login with credentials redirects to Google OAuth and sets state cookie", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer(t, website.Config{
+			Auth: website.AuthConfig{
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+			},
+		})
+		req := httptest.NewRequest(http.MethodGet, "/login", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusFound {
+			t.Errorf("expected status 302 Found, got %d", rec.Code)
+		}
+		loc := rec.Header().Get("Location")
+		if !strings.HasPrefix(loc, "https://accounts.google.com/o/oauth2/auth") && !strings.HasPrefix(loc, "https://accounts.google.com/o/oauth2/v2/auth") {
+			t.Errorf("expected Location to start with Google auth URL, got %q", loc)
+		}
+		cookies := rec.Result().Cookies()
+		var stateCookie *http.Cookie
+		for _, c := range cookies {
+			if c.Name == "osv_oauth_state" {
+				stateCookie = c
+				break
+			}
+		}
+		if stateCookie == nil || stateCookie.Value == "" {
+			t.Errorf("expected osv_oauth_state cookie to be set")
+		}
+	})
+
+	t.Run("GET /auth/callback with mismatched state returns 400", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer(t, website.Config{})
+		req := httptest.NewRequest(http.MethodGet, "/auth/callback?state=invalid-state", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected status 400 Bad Request, got %d", rec.Code)
+		}
+	})
+
+	t.Run("GET /logout clears session cookie and redirects", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer(t, website.Config{})
+		req := httptest.NewRequest(http.MethodGet, "/logout", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusFound {
+			t.Errorf("expected status 302 Found, got %d", rec.Code)
+		}
+		if loc := rec.Header().Get("Location"); loc != "/triage" {
+			t.Errorf("expected Location '/triage', got %q", loc)
+		}
+		cookies := rec.Result().Cookies()
+		for _, c := range cookies {
+			if c.Name == "osv_session" && c.MaxAge != -1 {
+				t.Errorf("expected osv_session cookie to be cleared (MaxAge=-1), got %d", c.MaxAge)
+			}
+		}
+	})
+}
+
+func TestTriageEndpoints(t *testing.T) {
+	t.Parallel()
+
+	t.Run("GET /triage without auth redirects to /login", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer(t, website.Config{
+			Auth: website.AuthConfig{
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+			},
+		})
+		req := httptest.NewRequest(http.MethodGet, "/triage", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusFound {
+			t.Errorf("expected status 302 Found, got %d", rec.Code)
+		}
+		if loc := rec.Header().Get("Location"); loc != "/login" {
+			t.Errorf("expected Location '/login', got %q", loc)
+		}
+	})
+
+	t.Run("GET /triage with valid session cookie renders 200 OK", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer(t, website.Config{
+			Auth: website.AuthConfig{
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+				SecretKey:    "test-secret-key-12345",
+			},
+		})
+
+		// First log in with bypass to get a valid session cookie
+		bypassSrv := newTestServer(t, website.Config{
+			Auth: website.AuthConfig{
+				BypassOAuth: true,
+				SecretKey:   "test-secret-key-12345",
+			},
+		})
+		loginReq := httptest.NewRequest(http.MethodGet, "/login", nil)
+		loginRec := httptest.NewRecorder()
+		bypassSrv.ServeHTTP(loginRec, loginReq)
+
+		cookies := loginRec.Result().Cookies()
+		var sessionCookie *http.Cookie
+		for _, c := range cookies {
+			if c.Name == "osv_session" {
+				sessionCookie = c
+				break
+			}
+		}
+		if sessionCookie == nil {
+			t.Fatalf("expected session cookie from login")
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/triage", nil)
+		req.AddCookie(sessionCookie)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200 OK with valid cookie, got %d", rec.Code)
+		}
+	})
+
+	t.Run("GET /triage with invalid session cookie redirects to /login", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer(t, website.Config{
+			Auth: website.AuthConfig{
+				ClientID:     "test-client-id",
+				ClientSecret: "test-client-secret",
+			},
+		})
+		req := httptest.NewRequest(http.MethodGet, "/triage", nil)
+		req.AddCookie(&http.Cookie{
+			Name:  "osv_session",
+			Value: "tampered-or-invalid-cookie",
+		})
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusFound {
+			t.Errorf("expected status 302 Found, got %d", rec.Code)
+		}
+		if loc := rec.Header().Get("Location"); loc != "/login" {
+			t.Errorf("expected Location '/login', got %q", loc)
+		}
+	})
+
+	t.Run("GET /triage with BypassOAuth renders 200 OK", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer(t, website.Config{
+			Auth: website.AuthConfig{
+				BypassOAuth: true,
+			},
+		})
+		req := httptest.NewRequest(http.MethodGet, "/triage", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200 OK, got %d", rec.Code)
+		}
+	})
+
+	t.Run("GET /triage/proxy fetches file successfully", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer(t, website.Config{
+			Auth: website.AuthConfig{
+				BypassOAuth: true,
+			},
+		})
+		req := httptest.NewRequest(http.MethodGet, "/triage/proxy?source=test-nvd&id=CVE-2024-1234", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status 200 OK, got %d", rec.Code)
+		}
+		if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %q", ct)
+		}
+		if rec.Body.String() != `{"id":"CVE-2024-1234"}` {
+			t.Errorf("unexpected response body: %s", rec.Body.String())
+		}
+	})
+
+	t.Run("GET /triage/proxy with missing params returns 400", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer(t, website.Config{
+			Auth: website.AuthConfig{
+				BypassOAuth: true,
+			},
+		})
+		req := httptest.NewRequest(http.MethodGet, "/triage/proxy", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected status 400 Bad Request, got %d", rec.Code)
+		}
+	})
+
+	t.Run("GET /triage/proxy with invalid CVE ID format returns 400", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer(t, website.Config{
+			Auth: website.AuthConfig{
+				BypassOAuth: true,
+			},
+		})
+		req := httptest.NewRequest(http.MethodGet, "/triage/proxy?source=test-nvd&id=INVALID", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected status 400 Bad Request, got %d", rec.Code)
+		}
+	})
+
+	t.Run("GET /triage/proxy with non-existent CVE returns 404", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer(t, website.Config{
+			Auth: website.AuthConfig{
+				BypassOAuth: true,
+			},
+		})
+		req := httptest.NewRequest(http.MethodGet, "/triage/proxy?source=test-nvd&id=CVE-2024-9999", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("expected status 404 Not Found, got %d", rec.Code)
+		}
+	})
 }
 
 func TestLinterEndpoints(t *testing.T) {

--- a/go/internal/website/server_test.go
+++ b/go/internal/website/server_test.go
@@ -119,6 +119,9 @@ type mockTriageStore struct {
 }
 
 func (m mockTriageStore) GetFile(_ context.Context, source, cveID string) ([]byte, error) {
+	if source == "invalid-source" {
+		return nil, models.ErrInvalidArgument
+	}
 	if cveID == "CVE-2024-1234" && (source == "test-nvd" || source == "cve") {
 		return []byte(`{"id":"CVE-2024-1234"}`), nil
 	}
@@ -998,6 +1001,22 @@ func TestTriageEndpoints(t *testing.T) {
 			},
 		})
 		req := httptest.NewRequest(http.MethodGet, "/triage/proxy?source=test-nvd&id=INVALID", nil)
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("expected status 400 Bad Request, got %d", rec.Code)
+		}
+	})
+
+	t.Run("GET /triage/proxy with invalid source returns 400", func(t *testing.T) {
+		t.Parallel()
+		srv := newTestServer(t, website.Config{
+			Auth: website.AuthConfig{
+				BypassOAuth: true,
+			},
+		})
+		req := httptest.NewRequest(http.MethodGet, "/triage/proxy?source=invalid-source&id=CVE-2024-1234", nil)
 		rec := httptest.NewRecorder()
 		srv.ServeHTTP(rec, req)
 

--- a/go/internal/website/triage.go
+++ b/go/internal/website/triage.go
@@ -45,6 +45,13 @@ func (s *Server) handleTriageProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data, err := s.stores.Triage.GetFile(r.Context(), source, vulnID)
+	if errors.Is(err, models.ErrInvalidArgument) {
+		s.renderJSON(w, r, http.StatusBadRequest, map[string]string{
+			"error": "Invalid source",
+		})
+
+		return
+	}
 	if errors.Is(err, models.ErrNotFound) {
 		s.renderJSON(w, r, http.StatusNotFound, map[string]string{
 			"error": "File not found",

--- a/go/internal/website/triage.go
+++ b/go/internal/website/triage.go
@@ -1,8 +1,15 @@
 package website
 
 import (
+	"errors"
 	"net/http"
+	"regexp"
+
+	"github.com/google/osv.dev/go/internal/models"
+	"github.com/google/osv.dev/go/logger"
 )
+
+var cveIDRegex = regexp.MustCompile(`^(?i)CVE-\d{4}-\d+$`)
 
 // handleTriagePage handles serving the vulnerability triage UI page.
 func (s *Server) handleTriagePage(w http.ResponseWriter, r *http.Request) {
@@ -16,8 +23,46 @@ func (s *Server) handleTriagePage(w http.ResponseWriter, r *http.Request) {
 	s.render(w, r, "triage.html", http.StatusOK, data)
 }
 
-// handleTriageProxy handles proxying triage workflow actions.
-func (s *Server) handleTriageProxy(w http.ResponseWriter, _ *http.Request) {
-	// TODO: Proxy triage submission to backend service
-	http.Error(w, "Triage proxy handler stub", http.StatusNotImplemented)
+// handleTriageProxy handles proxying triage workflow actions from GCS buckets or external APIs.
+func (s *Server) handleTriageProxy(w http.ResponseWriter, r *http.Request) {
+	source := r.URL.Query().Get("source")
+	vulnID := r.URL.Query().Get("id")
+
+	if source == "" || vulnID == "" {
+		s.renderJSON(w, r, http.StatusBadRequest, map[string]string{
+			"error": "Missing source or id parameters",
+		})
+
+		return
+	}
+
+	if !cveIDRegex.MatchString(vulnID) {
+		s.renderJSON(w, r, http.StatusBadRequest, map[string]string{
+			"error": "Invalid ID format",
+		})
+
+		return
+	}
+
+	data, err := s.stores.Triage.GetFile(r.Context(), source, vulnID)
+	if errors.Is(err, models.ErrNotFound) {
+		s.renderJSON(w, r, http.StatusNotFound, map[string]string{
+			"error": "File not found",
+		})
+
+		return
+	}
+	if err != nil {
+		logger.ErrorContext(r.Context(), "failed to fetch triage file", "source", source, "id", vulnID, "error", err)
+		s.renderJSON(w, r, http.StatusInternalServerError, map[string]string{
+			"error": "Internal server error",
+		})
+
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(data); err != nil {
+		logger.ErrorContext(r.Context(), "failed to write triage file response", "source", source, "id", vulnID, "error", err)
+	}
 }


### PR DESCRIPTION
Implemented the google login page & cookies & connections needed for the triage page.

Auth stuff implements AES-256-GCM (instead of Flask's unencrypted signed cookies) to store the auth session client-side. I was thinking of using [scs](https://pkg.go.dev/github.com/alexedwards/scs/v2), but that is server side (would need to connect to redis), and I'd rather keep it similar to Flask's client-side stuff.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>