### PR TITLE
refactor(go-website): Start deploying the new Go website implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,12 +169,15 @@ Many tests use expected outputs saved directly in the source tree:
   make run-website-devserver
   ```
   - Mock vulnerability records are located in [`go/cmd/website-devserver/testdata/`](go/cmd/website-devserver/testdata/). Add or edit `.json` records and `.meta.yaml` companion files to immediately see changes on page refresh.
-- **Python Website with Datastore Emulator (Legacy)**:
-  Run the legacy Python website server against a local Datastore emulator:
+- **Run against Cloud Datastore**:
+  Run the Go website server against production Datastore:
   ```bash
-  make run-website-emulator
+  make run-website
   ```
-  - Add custom mock testcases inside [`gcp/website/testdata/osv/`](gcp/website/testdata/osv/).
+  Or against staging Datastore:
+  ```bash
+  make run-website-staging
+  ```
 
 ### Local API Server Development (Go-native)
 - To run the public OSV API server locally using the native Go implementation alongside the ESPv2 proxy (which transcodes HTTP/JSON REST requests to gRPC):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,16 +186,15 @@ make run-website
 
 #### Running a local UI instance
 
-For contributors without access to the GCP project, you can use the website emulator which does
-not require Google Cloud project access. This emulator uses a local datastore
-and loads data from a local directory.
+For contributors without access to the GCP project, you can use the website devserver which does
+not require Google Cloud project access or a Datastore emulator. It serves the Go website using a live flat mock dataset with hot reloading.
 
 ```shell
-make run-website-emulator
+make run-website-devserver
 ```
 
-You can add testcase records to `gcp/website/testdata/osv/` to test odd cases.
-See [gcp/website/testdata/osv/README.md](gcp/website/testdata/osv/README.md)
+Mock vulnerability records are located in `go/cmd/website-devserver/testdata/`.
+See [go/cmd/website-devserver/testdata/README.md](go/cmd/website-devserver/testdata/README.md)
 for more information on the format of these records.
 
 ### Linting and formatting

--- a/Makefile
+++ b/Makefile
@@ -77,19 +77,10 @@ build-website-frontend:
 	cd website/frontend3 && pnpm install && pnpm run build
 	cd website/blog && hugo --buildFuture -d ../dist/static/blog
 
-run-website: build-website-frontend ## Run local Python website against prod Datastore
-	cd gcp/website && $(install-cmd) && GOOGLE_CLOUD_PROJECT=oss-vdb OSV_VULNERABILITIES_BUCKET=osv-vulnerabilities $(run-cmd) python main.py
-
-run-website-staging: build-website-frontend
-	cd gcp/website && $(install-cmd) && GOOGLE_CLOUD_PROJECT=oss-vdb-test OSV_VULNERABILITIES_BUCKET=osv-test-vulnerabilities $(run-cmd) python main.py
-
-run-website-emulator: build-website-frontend ## Run local Python website against emulator
-	cd gcp/website && $(install-cmd) && DATASTORE_EMULATOR_PORT=5002 $(run-cmd) python frontend_emulator.py
-
-run-go-website: build-website-frontend ## Run local Go website against prod Datastore
+run-website: build-website-frontend ## Run local Go website against prod Datastore
 	cd go && GOOGLE_CLOUD_PROJECT=oss-vdb OSV_VULNERABILITIES_BUCKET=osv-vulnerabilities go run ./cmd/website -static-dir ../website/dist -docs-dir ../docs
 
-run-go-website-staging: build-website-frontend
+run-website-staging: build-website-frontend
 	cd go && GOOGLE_CLOUD_PROJECT=oss-vdb-test OSV_VULNERABILITIES_BUCKET=osv-test-vulnerabilities go run ./cmd/website -static-dir ../website/dist -docs-dir ../docs
 
 run-website-devserver: build-website-frontend ## Run local Go website development server against local mock dataset
@@ -100,7 +91,7 @@ stage-website-assets: build-website-frontend
 	cp -r website/dist/* go/cmd/website/dist/
 	cp docs/osv_service_v1.swagger.json go/cmd/website/docs/
 
-run-go-website-prod: stage-website-assets
+run-website-prod: stage-website-assets
 	cd go && GOOGLE_CLOUD_PROJECT=oss-vdb OSV_VULNERABILITIES_BUCKET=osv-vulnerabilities go run -tags embedstatic ./cmd/website
 
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ consists of:
 | `gcp/datastore` | The datastore index file (`index.yaml`) |
 | `gcp/functions` | The Cloud Function for publishing PyPI vulnerabilities (maintained, but not developed) |
 | `gcp/indexer`   | The determine version `indexer` |
-| `gcp/website`   | The backend of the osv.dev web interface, with the frontend in `frontend3` <br /> Blog posts (in `blog`) |
+| `gcp/website`   | Frontend assets for the osv.dev website (in `frontend3`) and blog posts (in `blog`) |
 | `gcp/workers/`  | Python workers (`vanir_signatures` and `oss_fuzz_worker`) |
-| `go/`           | Go module for shared libraries and commands (`cmd/api`, `cmd/importer`, `cmd/worker`, `cmd/exporter`, `cmd/recoverer`, `cmd/relations`, etc.) |
+| `go/`           | Go module for shared libraries and commands (`cmd/api`, `cmd/website`, `cmd/importer`, `cmd/worker`, `cmd/exporter`, `cmd/recoverer`, `cmd/relations`, etc.) |
 | `osv/`          | The core OSV Python library, used in basically all Python services <br /> OSV ecosystem package versioning helpers in `ecosystems/` <br /> Datastore model definitions in `models.py` |
 | `tools/`        | Misc scripts/tools, mostly intended for development (datastore stuff, linting) <br /> The `indexer-api-caller` for indexer calling |
 | `vulnfeeds/`    | Go module for (mostly) the NVD CVE conversion <br /> The Alpine feed converter (`cmd/alpine`) <br /> The Debian feed converter (`tools/debian`, which is written in Python) |

--- a/deployment/build-and-stage.yaml
+++ b/deployment/build-and-stage.yaml
@@ -445,6 +445,25 @@ steps:
   args: ['push', '--all-tags', 'gcr.io/oss-vdb/nvd-cve-osv']
   waitFor: ['build-nvd-cve-osv', 'cloud-build-queue']
 
+# Build website frontend assets
+- name: 'node:24.18'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    corepack enable pnpm
+    pnpm install --frozen-lockfile --ignore-scripts
+    pnpm run build:prod
+  dir: 'gcp/website/frontend3'
+  id: 'build-frontend3'
+  waitFor: ['setup']
+
+- name: 'gcr.io/oss-vdb/ci'
+  args: ['hugo', '--buildFuture', '-d', '../dist/static/blog']
+  dir: 'gcp/website/blog'
+  id: 'build-hugo'
+  waitFor: ['setup']
+
 # Build/push Website image
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'bash'
@@ -454,9 +473,14 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: ['buildx', 'build', '--load', '--build-arg', 'BUILDKIT_INLINE_CACHE=1',
          '-t', 'gcr.io/oss-vdb/osv-website:latest', '-t', 'gcr.io/oss-vdb/osv-website:$COMMIT_SHA',
-         '-f', 'gcp/website/Dockerfile', '--cache-from', 'gcr.io/oss-vdb/osv-website:latest', '--pull', '.']
+         '--target', 'website',
+         '--build-context', 'bindings=../bindings',
+         '--build-context', 'website-dist=../gcp/website/dist',
+         '--build-context', 'docs=../docs',
+         '-f', 'Dockerfile', '--cache-from', 'gcr.io/oss-vdb/osv-website:latest', '--pull', '.']
+  dir: 'go'
   id: 'build-website'
-  waitFor: ['pull-website', 'build-first-package-finder']
+  waitFor: ['pull-website', 'build-frontend3', 'build-hugo', 'build-first-package-finder']
   volumes:
   - name: 'docker-config'
     path: '/root/.docker'

--- a/deployment/clouddeploy/osv-website/run-prod.yaml
+++ b/deployment/clouddeploy/osv-website/run-prod.yaml
@@ -14,6 +14,10 @@ spec:
         env:
         - name: OSV_VULNERABILITIES_BUCKET
           value: 'osv-vulnerabilities'
+        - name: OSV_LINTER_BUCKET
+          value: 'osv-public-import-logs'
+        - name: OSV_API_URL
+          value: 'api.osv.dev'
         - name: REDISHOST
           value: '10.85.52.228'
         - name: REDISPORT

--- a/deployment/clouddeploy/osv-website/run-staging.yaml
+++ b/deployment/clouddeploy/osv-website/run-staging.yaml
@@ -14,6 +14,10 @@ spec:
         env:
         - name: OSV_VULNERABILITIES_BUCKET
           value: 'osv-test-vulnerabilities'
+        - name: OSV_LINTER_BUCKET
+          value: 'osv-test-public-import-logs'
+        - name: OSV_API_URL
+          value: 'api.test.osv.dev'
         - name: REDISHOST
           value: '10.189.34.180'
         - name: REDISPORT
@@ -28,7 +32,7 @@ spec:
             secretKeyRef:
               name: google-oauth-client-secret
               key: 'latest'
-        - name: FLASK_SECRET_KEY
+        - name: SESSION_SECRET_KEY
           valueFrom:
             secretKeyRef:
               name: flask-secret-key

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -21,9 +21,10 @@
 # 
 #   cd go
 #   docker build -t osv/importer --target importer --build-context bindings=../bindings -f Dockerfile .
+#   docker build -t osv/website --target website --build-context bindings=../bindings --build-context website-dist=../website/dist --build-context docs=../docs -f Dockerfile .
 # 
 # Select which service to build using the --target flag (e.g. importer, worker, exporter, 
-# relations, recordchecker, generatesitemap, custommetrics, gitter, first_package_finder, api, recoverer).
+# relations, recordchecker, generatesitemap, custommetrics, gitter, first_package_finder, api, recoverer, website).
 # ====================================================================================
 
 # ========================================================
@@ -158,3 +159,13 @@ FROM gcr.io/distroless/static-debian12@sha256:a9fcaedd4c9b59e12dd65d954f0b5044f1
 COPY --from=recoverer-build /app/recoverer /
 ENTRYPOINT ["/recoverer"]
 
+# Target: Website
+# ========================================================
+FROM builder AS website-build
+COPY --from=website-dist . /workspace/go/cmd/website/dist/
+COPY --from=docs osv_service_v1.swagger.json /workspace/go/cmd/website/docs/
+RUN CGO_ENABLED=0 go build -tags embedstatic -o /app/website ./cmd/website/
+
+FROM gcr.io/distroless/static-debian12@sha256:a9fcaedd4c9b59e12dd65d954f0b5044f19b0647a8a3712e77205df9e7b102cd AS website
+COPY --from=website-build /app/website /
+ENTRYPOINT ["/website"]


### PR DESCRIPTION
- Modify `build-and-stage.yaml` (and the go `Dockerfile`) to build website from Go
- Update the Cloud Run configs to have new required environment variables
- Remove python website targets from `Makefile`
- update various documentation to refer to the new Go website

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>