### PR TITLE
test(vanir): capture expected error logs in `test_process_batch_failure`

### DIFF
--- a/gcp/workers/vanir_signatures/vanir_signatures_test.py
+++ b/gcp/workers/vanir_signatures/vanir_signatures_test.py
@@ -216,12 +216,14 @@ class VanirSignaturesTest(unittest.TestCase):
     vuln_entity.put()
     initial_modified = vuln_entity.modified
 
-    result, failed_ids = vanir_signatures.process_batch([vuln_id],
-                                                        'fake_git_working_dir')
+    with self.assertLogs(level='ERROR') as cm:
+      result, failed_ids = vanir_signatures.process_batch(
+          [vuln_id], 'fake_git_working_dir')
 
     # Result should be 0 because upload failed
     self.assertEqual(result, 0)
     self.assertEqual(failed_ids, [vuln_id])
+    self.assertTrue(any('Failed upload for VULN-1' in log for log in cm.output))
 
     # Verify Datastore was NOT updated
     updated_vuln = osv.Vulnerability.get_by_id(vuln_id, use_cache=False)


### PR DESCRIPTION
`test_process_batch_failure` tests GCS upload error handling by simulating an exception, however `vanir_signatures.process_batch` calls `logging.exception()` and an expected traceback was sent to `stderr` in CI and appearing as a test failure.

- Wrap `process_batch()` in `self.assertLogs(level='ERROR')` to capture the log output.
- Assert that `Failed upload for VULN-1` is recorded.
- Suppress misleading error tracebacks.
