### PR TITLE
fix(gitter): no bash and better repo path handling

### DIFF
--- a/go/cmd/gitter/gitter.go
+++ b/go/cmd/gitter/gitter.go
@@ -295,6 +295,7 @@ func getRepoDirName(repoURL string) string {
 	base := path.Base(repoURL)
 	base = filepath.Base(base)
 	base = strings.TrimSuffix(base, ".git")
+	base = url.QueryEscape(base)
 	hash := sha256.Sum256([]byte(repoURL))
 
 	return fmt.Sprintf("%s-%s", base, hex.EncodeToString(hash[:]))

--- a/go/cmd/gitter/gitter_test.go
+++ b/go/cmd/gitter/gitter_test.go
@@ -24,6 +24,8 @@ func TestGetRepoDirName(t *testing.T) {
 		{"https://github.com/google/osv.dev.git", "osv.dev"},
 		{"https://github.com/google/osv.dev", "osv.dev"},
 		{"https://gitlab.com/gitlab-org/gitlab.git", "gitlab"},
+		{"http://some-domain.com/special_char-!@#$%^&*().,><;:?.git", "special_char-%21%40%23%24%25%5E%26%2A%28%29.%2C%3E%3C%3B%3A%3F"},
+		{"http://some-domain.com/repo with spaces.git", "repo+with+spaces"},
 	}
 
 	for _, tt := range tests {
@@ -115,6 +117,18 @@ func TestPrepareURL(t *testing.T) {
 		{
 			name:      "Unsupported protocol file://",
 			url:       "file://this-is-invalid",
+			expected:  "",
+			expectErr: true,
+		},
+		{
+			name:      "URL with newline control character",
+			url:       "https://github.com/google/osv.dev\n.git",
+			expected:  "",
+			expectErr: true,
+		},
+		{
+			name:      "URL with null byte control character",
+			url:       "https://github.com/google/osv.dev\x00.git",
 			expected:  "",
 			expectErr: true,
 		},

--- a/go/cmd/gitter/repository.go
+++ b/go/cmd/gitter/repository.go
@@ -983,7 +983,7 @@ func (r *Repository) GetLocalTags(ctx context.Context) (map[string]SHA1, error) 
 
 // GetRemoteTags uses git ls-remote to get tags from remote git repository
 func (r *Repository) GetRemoteTags(ctx context.Context) (map[string]SHA1, error) {
-	cmd := prepareCmd(ctx, "", []string{"GIT_TERMINAL_PROMPT=0"}, "git", "ls-remote", "--tags", "--quiet", r.URL)
+	cmd := prepareCmd(ctx, "", []string{"GIT_TERMINAL_PROMPT=0"}, "git", "ls-remote", "--tags", "--quiet", "--", r.URL)
 
 	return r.runAndParseTags(ctx, cmd)
 }

--- a/go/cmd/gitter/repository.go
+++ b/go/cmd/gitter/repository.go
@@ -184,10 +184,10 @@ func (r *Repository) buildCommitGraph(ctx context.Context, cache *pb.RepositoryC
 	// Safeguard for early returns / context cancellation
 	defer tmpFile.Close()
 
-	// `git log --all --full-history --sparse --format=%H%x09%P%x09%D > git-log.out`
+	// `git log --all --full-history --sparse --format=%H%x09%P%x09%D`
 	// --all: all branches
 	// --full-history + --sparse: full-history alone still prunes TREESAME commit so we combine that with --sparse to actually get the full history of a repository
-	// Redirecting to a file is faster than using stdout pipe and git binary's own --output flag.
+	// This is faster than git binary's own --output flag.
 	cmd := prepareCmd(ctx, r.repoPath, nil, "git", "log", "--all", "--full-history", "--sparse", "--format="+gitLogFormat)
 	cmd.Stdout = tmpFile
 	var stderr bytes.Buffer
@@ -197,6 +197,7 @@ func (r *Repository) buildCommitGraph(ctx context.Context, cache *pb.RepositoryC
 			logger.WarnContext(ctx, "Command cancelled", slog.String("cmd", "git log"), slog.Any("err", ctx.Err()))
 			return nil, fmt.Errorf("command git log cancelled: %w", ctx.Err())
 		}
+
 		return nil, fmt.Errorf("failed to run git log: %w, stderr: %s", err, stderr.String())
 	}
 	_ = tmpFile.Close()

--- a/go/cmd/gitter/repository.go
+++ b/go/cmd/gitter/repository.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/hex"
 	"errors"
@@ -180,15 +181,25 @@ func (r *Repository) buildCommitGraph(ctx context.Context, cache *pb.RepositoryC
 		return nil, fmt.Errorf("failed to create temp file: %w", err)
 	}
 	defer os.Remove(tmpFile.Name())
+	// Safeguard for early returns / context cancellation
+	defer tmpFile.Close()
 
 	// `git log --all --full-history --sparse --format=%H%x09%P%x09%D > git-log.out`
 	// --all: all branches
 	// --full-history + --sparse: full-history alone still prunes TREESAME commit so we combine that with --sparse to actually get the full history of a repository
-	// We are also running via bash because redirecting to file is faster than using stdout pipe and git binary's own --output flag
-	err = runCmd(ctx, r.repoPath, nil, "bash", "-c", "git log --all --full-history --sparse --format="+gitLogFormat+" > "+tmpFile.Name())
-	if err != nil {
-		return nil, fmt.Errorf("failed to run git log: %w", err)
+	// Redirecting to a file is faster than using stdout pipe and git binary's own --output flag.
+	cmd := prepareCmd(ctx, r.repoPath, nil, "git", "log", "--all", "--full-history", "--sparse", "--format="+gitLogFormat)
+	cmd.Stdout = tmpFile
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			logger.WarnContext(ctx, "Command cancelled", slog.String("cmd", "git log"), slog.Any("err", ctx.Err()))
+			return nil, fmt.Errorf("command git log cancelled: %w", ctx.Err())
+		}
+		return nil, fmt.Errorf("failed to run git log: %w, stderr: %s", err, stderr.String())
 	}
+	_ = tmpFile.Close()
 
 	// Read git log output
 	file, err := os.Open(tmpFile.Name())

--- a/go/cmd/gitter/repository.go
+++ b/go/cmd/gitter/repository.go
@@ -187,7 +187,7 @@ func (r *Repository) buildCommitGraph(ctx context.Context, cache *pb.RepositoryC
 	// `git log --all --full-history --sparse --format=%H%x09%P%x09%D`
 	// --all: all branches
 	// --full-history + --sparse: full-history alone still prunes TREESAME commit so we combine that with --sparse to actually get the full history of a repository
-	// This is faster than git binary's own --output flag.
+	// Redirecting to a file is faster than git binary's own --output flag or streaming into memory.
 	cmd := prepareCmd(ctx, r.repoPath, nil, "git", "log", "--all", "--full-history", "--sparse", "--format="+gitLogFormat)
 	cmd.Stdout = tmpFile
 	var stderr bytes.Buffer


### PR DESCRIPTION
Cleans up how gitter runs git commands and sanitizes repo_url from input:
- Runs `git log` directly in Go instead of calling through `bash`. 
- Escapes special characters from repoURL before creating directory for clone.
- Standardize  use of `--` separator before URLs in git commands.