### PR TITLE
chore: remove unused local ssd mounts and clean up importer disk config

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/core/importer-deleter.yaml
+++ b/deployment/clouddeploy/gke-workers/base/core/importer-deleter.yaml
@@ -19,18 +19,11 @@ spec:
               env:
                 - name: DEFAULT_TASK_POOL
                   value: "default"
-              volumeMounts:
-                - mountPath: "/work"
-                  name: "ssd"
               resources:
                 requests:
                   cpu: "1"
                   memory: "10G"
                 limits:
-                  cpu: "1"
+                  cpu: "2"
                   memory: "11G"
           restartPolicy: Never
-          volumes:
-            - name: "ssd"
-              hostPath:
-                path: "/mnt/disks/ssd0"

--- a/deployment/clouddeploy/gke-workers/base/core/importer-reconciler.yaml
+++ b/deployment/clouddeploy/gke-workers/base/core/importer-reconciler.yaml
@@ -34,35 +34,3 @@ spec:
                 cpu: "3"
                 memory: "11G"
           restartPolicy: Never
-          volumes:
-            - name: git-cache
-              persistentVolumeClaim:
-                claimName: importer-reconciler-git-cache-pvc
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: importer-reconciler-git-cache-pv
-spec:
-  storageClassName: ""
-  capacity:
-    storage: 200Gi
-  accessModes:
-    - ReadWriteOnce
-  csi:
-    driver: pd.csi.storage.gke.io
-    volumeHandle: projects/oss-vdb/zones/us-central1-f/disks/importer-reconciler-git-cache
-    fsType: ext4
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: importer-reconciler-git-cache-pvc
-spec:
-  storageClassName: ""
-  volumeName: importer-reconciler-git-cache-pv
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 200Gi

--- a/deployment/clouddeploy/gke-workers/base/core/importer-reconciler.yaml
+++ b/deployment/clouddeploy/gke-workers/base/core/importer-reconciler.yaml
@@ -17,9 +17,6 @@ spec:
             image: importer
             imagePullPolicy: Always
             args: ["--reconcile=true"]
-            volumeMounts:
-              - mountPath: "/work"
-                name: git-cache
             env:
               - name: GITTER_HOST
                 value: http://gitter-service:8888
@@ -31,10 +28,10 @@ spec:
                 value: "reimport"
             resources:
               requests:
-                cpu: "1"
+                cpu: "2"
                 memory: "10G"
               limits:
-                cpu: "2"
+                cpu: "3"
                 memory: "11G"
           restartPolicy: Never
           volumes:

--- a/deployment/clouddeploy/gke-workers/base/core/importer.yaml
+++ b/deployment/clouddeploy/gke-workers/base/core/importer.yaml
@@ -12,17 +12,10 @@ spec:
     spec:
       template:
         spec:
-          tolerations:
-          - key: workloadType
-            operator: Equal
-            value: importer-pool
           containers:
           - name: importer
             image: importer
             imagePullPolicy: Always
-            volumeMounts:
-              - mountPath: "/work"
-                name: "ssd"
             env:
               - name: GITTER_HOST
                 value: http://gitter-service:8888
@@ -36,15 +29,9 @@ spec:
                 value: "reimport"
             resources:
               requests:
-                cpu: "1"
+                cpu: "3"
                 memory: "24G"
               limits:
-                cpu: "2"
-                memory: "32G"
-          nodeSelector:
-            cloud.google.com/gke-nodepool: importer-pool
+                cpu: "4"
+                memory: "29G"
           restartPolicy: Never
-          volumes:
-            - name: "ssd"
-              hostPath:
-                path: "/mnt/disks/ssd0"

--- a/deployment/clouddeploy/gke-workers/base/feeds/alpine-cve-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/base/feeds/alpine-cve-convert.yaml
@@ -29,7 +29,3 @@ spec:
                 cpu: "4"
                 memory: "16G"
           restartPolicy: Never
-          volumes:
-            - name: "ssd"
-              hostPath:
-                path: "/mnt/disks/ssd0"

--- a/deployment/clouddeploy/gke-workers/base/feeds/combine-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/feeds/combine-to-osv.yaml
@@ -32,7 +32,3 @@ spec:
           nodeSelector:
             cloud.google.com/gke-nodepool: highend
           restartPolicy: Never # on the assumption that the next scheduled run is soon enough
-          volumes:
-            - name: "ssd"
-              hostPath:
-                path: "/mnt/disks/ssd0"

--- a/deployment/clouddeploy/gke-workers/base/feeds/cpe-repo-gen.yaml
+++ b/deployment/clouddeploy/gke-workers/base/feeds/cpe-repo-gen.yaml
@@ -28,7 +28,3 @@ spec:
               - name: WORK_DIR
                 value: /scratch
           restartPolicy: Never
-          volumes:
-            - name: "ssd"
-              hostPath:
-                path: "/mnt/disks/ssd0"

--- a/deployment/clouddeploy/gke-workers/base/feeds/cve5-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/feeds/cve5-to-osv.yaml
@@ -32,7 +32,3 @@ spec:
           - key: workloadType
             operator: Equal
             value: highend
-          volumes:
-            - name: "ssd"
-              hostPath:
-                path: "/mnt/disks/ssd0"

--- a/deployment/clouddeploy/gke-workers/base/feeds/debian-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/base/feeds/debian-convert.yaml
@@ -17,9 +17,6 @@ spec:
           - name: debian-convert
             image: debian-convert
             imagePullPolicy: Always
-            volumeMounts:
-              - mountPath: "/work"
-                name: "ssd"
             resources:
               requests:
                 cpu: "1"
@@ -28,7 +25,3 @@ spec:
                 cpu: "1"
                 memory: "2G"
           restartPolicy: Never
-          volumes:
-            - name: "ssd"
-              hostPath:
-                path: "/mnt/disks/ssd0"

--- a/deployment/clouddeploy/gke-workers/base/feeds/debian-copyright-mirror.yaml
+++ b/deployment/clouddeploy/gke-workers/base/feeds/debian-copyright-mirror.yaml
@@ -28,7 +28,3 @@ spec:
               - name: WORK_DIR
                 value: /scratch
           restartPolicy: Never
-          volumes:
-            - name: "ssd"
-              hostPath:
-                path: "/mnt/disks/ssd0"

--- a/deployment/clouddeploy/gke-workers/base/feeds/debian-cve-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/base/feeds/debian-cve-convert.yaml
@@ -38,7 +38,3 @@ spec:
                 cpu: "4"
                 memory: "16G"
           restartPolicy: Never
-          volumes:
-            - name: "ssd"
-              hostPath:
-                path: "/mnt/disks/ssd0"

--- a/deployment/clouddeploy/gke-workers/base/feeds/debian-first-version.yaml
+++ b/deployment/clouddeploy/gke-workers/base/feeds/debian-first-version.yaml
@@ -17,9 +17,6 @@ spec:
           - name: debian-first-version
             image: run_first_package_finder
             imagePullPolicy: Always
-            volumeMounts:
-              - mountPath: "/work"
-                name: "ssd"
             resources:
               requests:
                 cpu: "1"
@@ -28,7 +25,3 @@ spec:
                 cpu: "1"
                 memory: "2G"
           restartPolicy: OnFailure
-          volumes:
-            - name: "ssd"
-              hostPath:
-                path: "/mnt/disks/ssd0"

--- a/deployment/clouddeploy/gke-workers/base/feeds/nvd-cve-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/feeds/nvd-cve-osv.yaml
@@ -38,7 +38,3 @@ spec:
               - name: GITTER_HOST
                 value: http://gitter-service:8888
           restartPolicy: Never
-          volumes:
-            - name: "ssd"
-              hostPath:
-                path: "/mnt/disks/ssd0"

--- a/deployment/clouddeploy/gke-workers/base/feeds/nvd-mirror.yaml
+++ b/deployment/clouddeploy/gke-workers/base/feeds/nvd-mirror.yaml
@@ -35,7 +35,3 @@ spec:
           nodeSelector:
             cloud.google.com/gke-nodepool: highend
           restartPolicy: Never
-          volumes:
-            - name: "ssd"
-              hostPath:
-                path: "/mnt/disks/ssd0"

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/importer-reconciler.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/importer-reconciler.yaml
@@ -15,13 +15,3 @@ spec:
             - name: OSV_VULNERABILITIES_BUCKET
               value: osv-test-vulnerabilities
             args: ["--reconcile=true"]
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: importer-reconciler-git-cache-pv
-spec:
-  csi:
-    driver: pd.csi.storage.gke.io
-    volumeHandle: projects/oss-vdb-test/zones/us-central1-f/disks/importer-reconciler-git-cache
-    fsType: ext4

--- a/deployment/clouddeploy/gke-workers/environments/private/importer-reconciler.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/private/importer-reconciler.yaml
@@ -19,13 +19,3 @@ spec:
             - name: REIMPORT_TASK_POOL
               value: "default"
             args: ["--reconcile=true"]
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: importer-reconciler-git-cache-pv
-spec:
-  csi:
-    driver: pd.csi.storage.gke.io
-    volumeHandle: projects/private-osv/zones/us-central1-f/disks/importer-reconciler-git-cache
-    fsType: ext4

--- a/deployment/terraform/environments/private-osv/main.tf
+++ b/deployment/terraform/environments/private-osv/main.tf
@@ -15,8 +15,6 @@ module "osv_pipeline" {
   cluster_master_cidr                        = "172.16.0.80/28"
   gitter_disk_name                           = "gitter-disk"
   gitter_disk_size_gb                        = 6144
-  importer_reconciler_git_cache_disk_name    = "importer-reconciler-git-cache"
-  importer_reconciler_git_cache_size_gb      = 200
   subnet_name                                = "osv-subnet"
   subnet_cidr                                = "10.45.80.0/22"
   router_name                                = "osv-router"

--- a/deployment/terraform/modules/osv/workers_gke.tf
+++ b/deployment/terraform/modules/osv/workers_gke.tf
@@ -185,19 +185,3 @@ resource "google_compute_disk" "gitter_disk" {
     ]
   }
 }
-
-# Hyperdisk for Importer Reconciler
-resource "google_compute_disk" "importer_reconciler_git_cache" {
-  project = var.project_id
-  name    = "importer-reconciler-git-cache"
-  type    = "hyperdisk-balanced"
-  zone    = google_container_cluster.workers.location
-  size    = 200
-
-  lifecycle {
-    ignore_changes = [
-      type,
-      snapshot,
-    ]
-  }
-}

--- a/deployment/terraform/modules/osv/workers_gke.tf
+++ b/deployment/terraform/modules/osv/workers_gke.tf
@@ -118,41 +118,6 @@ resource "google_container_node_pool" "highend" {
   }
 }
 
-resource "google_container_node_pool" "importer_pool" {
-  project    = var.project_id
-  name       = "importer-pool"
-  cluster    = google_container_cluster.workers.name
-  location   = google_container_cluster.workers.location
-  node_count = 1
-
-  lifecycle {
-    # Terraform doesn't automatically know to recreate node pools when the cluster is recreated.
-    # A bit redundant since the cluster has prevent_destroy = true.
-    replace_triggered_by = [
-      google_container_cluster.workers.id,
-    ]
-  }
-
-  node_config {
-    machine_type    = "n2-highmem-4"
-    disk_type       = "pd-ssd"
-    disk_size_gb    = 64
-    local_ssd_count = 1
-
-    oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
-
-    labels = {
-      workloadType = "importer-pool"
-    }
-
-    taint {
-      effect = "NO_EXECUTE"
-      key    = "workloadType"
-      value  = "importer-pool"
-    }
-  }
-}
-
 resource "google_container_node_pool" "worker_pool_temp" {
   count    = var.project_id == "oss-vdb-test" ? 1 : 0
   project  = var.project_id

--- a/deployment/terraform/modules/osv_pipeline/gke.tf
+++ b/deployment/terraform/modules/osv_pipeline/gke.tf
@@ -163,12 +163,3 @@ resource "google_compute_disk" "gitter_disk" {
   zone    = google_container_cluster.workers.location
   size    = var.gitter_disk_size_gb
 }
-
-# SSD for Importer Reconciler Git Cache
-resource "google_compute_disk" "importer_reconciler_git_cache" {
-  project = var.project_id
-  name    = var.importer_reconciler_git_cache_disk_name
-  type    = "hyperdisk-balanced"
-  zone    = google_container_cluster.workers.location
-  size    = var.importer_reconciler_git_cache_size_gb
-}

--- a/deployment/terraform/modules/osv_pipeline/gke.tf
+++ b/deployment/terraform/modules/osv_pipeline/gke.tf
@@ -117,41 +117,6 @@ resource "google_container_node_pool" "highend" {
   }
 }
 
-resource "google_container_node_pool" "importer_pool" {
-  project    = var.project_id
-  name       = "importer-pool"
-  cluster    = google_container_cluster.workers.name
-  location   = google_container_cluster.workers.location
-  node_count = 1
-
-  lifecycle {
-    # Terraform doesn't automatically know to recreate node pools when the cluster is recreated.
-    replace_triggered_by = [
-      google_container_cluster.workers.id,
-    ]
-  }
-
-  node_config {
-    service_account = google_service_account.worker_sa.email
-    machine_type    = "n2-highmem-4"
-    disk_type       = "pd-ssd"
-    disk_size_gb    = 64
-    local_ssd_count = 1
-
-    oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
-
-    labels = {
-      workloadType = "importer-pool"
-    }
-
-    taint {
-      effect = "NO_EXECUTE"
-      key    = "workloadType"
-      value  = "importer-pool"
-    }
-  }
-}
-
 resource "google_container_node_pool" "worker_pool" {
   project  = var.project_id
   name     = "worker-pool"

--- a/deployment/terraform/modules/osv_pipeline/variables.tf
+++ b/deployment/terraform/modules/osv_pipeline/variables.tf
@@ -96,18 +96,6 @@ variable "gitter_disk_size_gb" {
   default     = 6144 # 6TiB
 }
 
-variable "importer_reconciler_git_cache_disk_name" {
-  type        = string
-  description = "The name of the persistent SSD disk for the importer reconciler git cache."
-  default     = "importer-reconciler-git-cache"
-}
-
-variable "importer_reconciler_git_cache_size_gb" {
-  type        = number
-  description = "The size in GiB of the persistent SSD disk used by the importer reconciler git cache."
-  default     = 200
-}
-
 # Networking
 variable "subnet_name" {
   type        = string

--- a/go/cmd/importer/main.go
+++ b/go/cmd/importer/main.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strconv"
 	"syscall"
 	"time"
@@ -39,7 +38,6 @@ func main() {
 	runDelete := flag.Bool("delete", false, "Bypass importing and propagate record deletions from source to Datastore")
 	runReconcile := flag.Bool("reconcile", false, "Analyze sources and trigger an import if the source modified date is newer than the database record")
 	deleteThresholdPct := flag.Float64("delete-threshold-pct", 10.0, "More than this percent of records for a given source being deleted triggers an error")
-	workDir := flag.String("work-dir", "/work", "Work directory for git repos")
 	numWorkers := flag.Int("num-workers", 50, "Number of workers to use for importing")
 	maxCowardEntriesToShow := flag.Int("max-coward-entries-to-show", 250, "Maximum number of entries to show when cowardly refusing to delete missing records")
 	dryRun := flag.Bool("dry-run", false, "Do not send anything to the message bus if true")
@@ -70,7 +68,6 @@ func main() {
 		NumWorkers:             *numWorkers,
 		DefaultTaskPool:        defaultTaskPool,
 		ReimportTaskPool:       reimportTaskPool,
-		GitWorkDir:             filepath.Join(*workDir, "sources"),
 		SampleRate:             vulnerabilitySampleRate(),
 		DryRun:                 *dryRun,
 	}

--- a/go/internal/importer/importer.go
+++ b/go/internal/importer/importer.go
@@ -50,7 +50,6 @@ type Config struct {
 	Publisher          clients.Publisher
 	GCSProvider        clients.CloudStorageProvider
 	HTTPClient         *http.Client
-	GitWorkDir         string
 	GitterClient       gitter.Client
 
 	StrictValidation       bool


### PR DESCRIPTION
- Move importer to default pool, remove importer-pool.
- Increase core count now that go can make use of it.
- Reduce memory limit to under what the machine can actually give.
- Remove unused ssd assignments, remove unused mounts (all of them), remove unused disks. 
- Ignore everything in oss-fuzz.

agy