### PR TITLE
fix: add --load and docker-config volume to recoverer build

### DIFF
--- a/deployment/build-and-stage.yaml
+++ b/deployment/build-and-stage.yaml
@@ -256,10 +256,13 @@ steps:
   id: 'pull-recoverer'
   waitFor: ['setup']
 - name: gcr.io/cloud-builders/docker
-  args: ['buildx', 'build', '-t', 'gcr.io/oss-vdb/recoverer:latest', '-t', 'gcr.io/oss-vdb/recoverer:$COMMIT_SHA', '--target', 'recoverer', '--build-context', 'bindings=../bindings', '-f', 'Dockerfile', '--cache-from', 'gcr.io/oss-vdb/recoverer:latest', '--pull', '.']
+  args: ['buildx', 'build', '--load', '-t', 'gcr.io/oss-vdb/recoverer:latest', '-t', 'gcr.io/oss-vdb/recoverer:$COMMIT_SHA', '--target', 'recoverer', '--build-context', 'bindings=../bindings', '-f', 'Dockerfile', '--cache-from', 'gcr.io/oss-vdb/recoverer:latest', '--pull', '.']
   dir: 'go'
   id: 'build-recoverer'
   waitFor: ['pull-recoverer', 'build-osv-server']
+  volumes:
+  - name: 'docker-config'
+    path: '/root/.docker'
 - name: gcr.io/cloud-builders/docker
   args: ['push', '--all-tags', 'gcr.io/oss-vdb/recoverer']
   waitFor: ['build-recoverer', 'cloud-build-queue']


### PR DESCRIPTION
Hope this is the last try for https://github.com/google/osv.dev/issues/5692...

In #5877, `recoverer` was migrated to Go and added as a `buildx build` step in `deployment/build-and-stage.yaml`. However, it was missing `--load` and the shared `docker-config` volume introduced in #5881. As a result, the built image was retained inside the `osv-builder` container and never loaded into the host Docker daemon's image store.
