### PR TITLE
fix(terraform): add some missing IAM perms for the GKE indexer and staging

### DIFF
--- a/deployment/terraform/environments/oss-vdb-test/main.tf
+++ b/deployment/terraform/environments/oss-vdb-test/main.tf
@@ -59,6 +59,9 @@ module "osv_test" {
   website_domain = "test.osv.dev"
   api_url        = "api.test.osv.dev"
   esp_version    = "2.55.3"
+
+  indexer_configs_bucket = "osv-test-indexer-configs"
+  indexer_repos_bucket   = "osv-test-indexer-repos"
 }
 
 module "k8s_cron_alert" {

--- a/deployment/terraform/environments/oss-vdb/main.tf
+++ b/deployment/terraform/environments/oss-vdb/main.tf
@@ -61,6 +61,9 @@ module "osv" {
   website_domain = "osv.dev"
   api_url        = "api.osv.dev"
   esp_version    = "2.55.3"
+
+  indexer_configs_bucket = "osv-indexer-configs"
+  indexer_repos_bucket   = "osv-indexer-repos"
 }
 
 module "oss_fuzz" {

--- a/deployment/terraform/modules/osv/variables.tf
+++ b/deployment/terraform/modules/osv/variables.tf
@@ -59,3 +59,27 @@ variable "worker_service_account_email" {
   default     = ""
 }
 
+variable "indexer_configs_bucket" {
+  type        = string
+  description = "Name of bucket storing indexer configuration."
+  default     = ""
+}
+
+variable "indexer_repos_bucket" {
+  type        = string
+  description = "Name of bucket storing indexer repository data."
+  default     = ""
+}
+
+variable "indexer_topic" {
+  type        = string
+  description = "Name of indexer Pub/Sub topic."
+  default     = "indexer-work"
+}
+
+variable "indexer_subscription" {
+  type        = string
+  description = "Name of indexer Pub/Sub subscription."
+  default     = "indexer-work-sub"
+}
+

--- a/deployment/terraform/modules/osv/worker_iam.tf
+++ b/deployment/terraform/modules/osv/worker_iam.tf
@@ -42,3 +42,33 @@ resource "google_pubsub_topic_iam_member" "worker_pypi_bridge_publisher" {
   role    = "roles/pubsub.publisher"
   member  = "serviceAccount:${var.worker_service_account_email}"
 }
+
+resource "google_storage_bucket_iam_member" "worker_indexer_configs" {
+  count  = var.worker_service_account_email != "" && var.indexer_configs_bucket != "" ? 1 : 0
+  bucket = var.indexer_configs_bucket
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${var.worker_service_account_email}"
+}
+
+resource "google_storage_bucket_iam_member" "worker_indexer_repos" {
+  count  = var.worker_service_account_email != "" && var.indexer_repos_bucket != "" ? 1 : 0
+  bucket = var.indexer_repos_bucket
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${var.worker_service_account_email}"
+}
+
+resource "google_pubsub_topic_iam_member" "worker_indexer_work_publisher" {
+  count   = var.worker_service_account_email != "" && var.indexer_topic != "" ? 1 : 0
+  project = var.project_id
+  topic   = var.indexer_topic
+  role    = "roles/pubsub.publisher"
+  member  = "serviceAccount:${var.worker_service_account_email}"
+}
+
+resource "google_pubsub_subscription_iam_member" "worker_indexer_work_subscriber" {
+  count        = var.worker_service_account_email != "" && var.indexer_subscription != "" ? 1 : 0
+  project      = var.project_id
+  subscription = var.indexer_subscription
+  role         = "roles/pubsub.subscriber"
+  member       = "serviceAccount:${var.worker_service_account_email}"
+}

--- a/deployment/terraform/modules/osv_pipeline/iam.tf
+++ b/deployment/terraform/modules/osv_pipeline/iam.tf
@@ -31,7 +31,8 @@ resource "google_project_iam_member" "worker_node_roles" {
     "roles/container.defaultNodeServiceAccount",
     "roles/monitoring.metricWriter",
     "roles/monitoring.viewer",
-    "roles/cloudtrace.agent"
+    "roles/cloudtrace.agent",
+    "roles/artifactregistry.reader"
   ])
 
   project = var.project_id


### PR DESCRIPTION
I don't recall *why* the indexer buckets/pubsub aren't in Terraform, but the worker service account needs permissions for them.

Also, the staging artifact registry is not public, but the staging API tester image is hosted there, so add artifact registry read perms to the worker service account too.