### PR TITLE
perf(deploy): rightsize vulnfeed workload resources and move to default pool

### DIFF
--- a/deployment/clouddeploy/gke-workers/base/feeds/alpine-cve-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/base/feeds/alpine-cve-convert.yaml
@@ -13,10 +13,6 @@ spec:
       activeDeadlineSeconds: 3600
       template:
         spec:
-          tolerations:
-          - key: workloadType
-            operator: Equal
-            value: highend
           containers:
           - name: alpine-cve-convert
             image: alpine-cve-convert

--- a/deployment/clouddeploy/gke-workers/base/feeds/combine-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/feeds/combine-to-osv.yaml
@@ -14,21 +14,15 @@ spec:
       activeDeadlineSeconds: 7200
       template:
         spec:
-          tolerations:
-          - key: workloadType
-            operator: Equal
-            value: highend
           containers:
           - name: combine-to-osv
             image: combine-to-osv
             imagePullPolicy: Always
             resources:
               requests:
-                cpu: "30"
-                memory: "16G"
+                cpu: "4"
+                memory: "4G"
               limits:
-                cpu: "30"
-                memory: "24G"
-          nodeSelector:
-            cloud.google.com/gke-nodepool: highend
+                cpu: "7"
+                memory: "8G"
           restartPolicy: Never # on the assumption that the next scheduled run is soon enough

--- a/deployment/clouddeploy/gke-workers/base/feeds/cve5-to-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/feeds/cve5-to-osv.yaml
@@ -19,16 +19,12 @@ spec:
             imagePullPolicy: Always
             resources:
               requests:
-                cpu: "8"
-                memory: "64G"
+                cpu: "2"
+                memory: "4G"
               limits:
-                cpu: "12"
-                memory: "96G"
+                cpu: "3"
+                memory: "8G"
             env:
               - name: GITTER_HOST
                 value: http://gitter-service:8888
           restartPolicy: Never
-          tolerations:
-          - key: workloadType
-            operator: Equal
-            value: highend

--- a/deployment/clouddeploy/gke-workers/base/feeds/debian-cve-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/base/feeds/debian-cve-convert.yaml
@@ -29,8 +29,8 @@ spec:
             resources:
               requests:
                 cpu: "2"
-                memory: "16G"
+                memory: "8G"
               limits:
                 cpu: "4"
-                memory: "16G"
+                memory: "12G"
           restartPolicy: Never

--- a/deployment/clouddeploy/gke-workers/base/feeds/debian-cve-convert.yaml
+++ b/deployment/clouddeploy/gke-workers/base/feeds/debian-cve-convert.yaml
@@ -13,10 +13,6 @@ spec:
       activeDeadlineSeconds: 3600
       template:
         spec:
-          tolerations:
-          - key: workloadType
-            operator: Equal
-            value: highend
           containers:
           - name: debian-cve-convert
             image: debian-cve-convert

--- a/deployment/clouddeploy/gke-workers/base/feeds/nvd-cve-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/feeds/nvd-cve-osv.yaml
@@ -19,11 +19,11 @@ spec:
             imagePullPolicy: Always
             resources:
               requests:
-                cpu: "4"
+                cpu: "2"
                 memory: "8G"
               limits:
-                cpu: "7"
-                memory: "16G"
+                cpu: "4"
+                memory: "12G"
             env:
               - name: WORK_DIR
                 value: /tmp

--- a/deployment/clouddeploy/gke-workers/base/feeds/nvd-cve-osv.yaml
+++ b/deployment/clouddeploy/gke-workers/base/feeds/nvd-cve-osv.yaml
@@ -13,22 +13,16 @@ spec:
       activeDeadlineSeconds: 86400
       template:
         spec:
-          tolerations:
-          - key: workloadType
-            operator: Equal
-            value: highend
-          nodeSelector:
-            cloud.google.com/gke-nodepool: highend
           containers:
           - name: nvd-cve-osv
             image: nvd-cve-osv
             imagePullPolicy: Always
             resources:
               requests:
-                cpu: "8"
+                cpu: "4"
                 memory: "8G"
               limits:
-                cpu: "8"
+                cpu: "7"
                 memory: "16G"
             env:
               - name: WORK_DIR

--- a/deployment/clouddeploy/gke-workers/base/feeds/nvd-mirror.yaml
+++ b/deployment/clouddeploy/gke-workers/base/feeds/nvd-mirror.yaml
@@ -14,10 +14,6 @@ spec:
       activeDeadlineSeconds: 7200
       template:
         spec:
-          tolerations:
-          - key: workloadType
-            operator: Equal
-            value: highend
           containers:
           - name: nvd-mirror
             args:
@@ -27,11 +23,9 @@ spec:
             imagePullPolicy: Always
             resources:
               requests:
-                cpu: "30"
-                memory: "192G"
+                cpu: "1"
+                memory: "1G"
               limits:
-                cpu: "30"
-                memory: "192G"
-          nodeSelector:
-            cloud.google.com/gke-nodepool: highend
+                cpu: "2"
+                memory: "2G"
           restartPolicy: Never


### PR DESCRIPTION
Rightsizes resource allocations for several feed jobs and moves them from the `highend` node pool (`n4-highmem-32`, 32 vCPUs / 256 GB RAM) to `default-pool` (`n4-standard-8`, 8 vCPUs / ~30 GB allocatable RAM).

### Rationale

* **`nvd-mirror`**: 30 CPU / 192 GB was a legacy allocation from the older Python script. The Go binary directly streams dumps to GCS, using ~44 MB peak RSS (~0.38 GiB in Cloud Monitoring) and ~12s total CPU time.
* **`combine-to-osv`**: 30 CPU / 24 GB was added for legacy batch speedups. The job is network I/O-bound with peak memory of ~0.5–1.1 GiB.
* **`cve5-to-osv`**: 64–96 GB was allocated to prevent OOMs when files were staged locally on tmpfs. The Go converter now streams directly to GCS via worker pools, with peak memory around ~4.4 GiB.
* **`alpine-cve-convert`, `debian-cve-convert`, `nvd-cve-osv`**: Peak memory usage ranges from ~5 to ~13.3 GiB, which comfortably fits within the ~30 GB allocatable RAM of `default-pool` nodes.

### Summary of Changes

| Workload | Previous (Req / Lim) | New (Req / Lim) | Previous Pool | New Pool | 7-Day Peak Memory |
| :--- | :--- | :--- | :--- | :--- | :--- |
| **`nvd-mirror`** | 30 / 30 CPU, 192G / 192G | **1 / 2 CPU, 1G / 2G** | `highend` | **`default-pool`** | ~0.38 GiB |
| **`combine-to-osv`** | 30 / 30 CPU, 16G / 24G | **4 / 7 CPU, 4G / 8G** | `highend` | **`default-pool`** | ~1.07 GiB |
| **`cve5-to-osv`** | 8 / 12 CPU, 64G / 96G | **2 / 3 CPU, 4G / 8G** | `highend` | **`default-pool`** | ~4.35 GiB |
| **`alpine-cve-convert`** | 2 / 4 CPU, 16G / 16G | **2 / 4 CPU, 16G / 16G** | `highend` | **`default-pool`** | ~13.32 GiB |
| **`debian-cve-convert`** | 2 / 4 CPU, 16G / 16G | **2 / 4 CPU, 8G / 12G** | `highend` | **`default-pool`** | ~5.48 GiB |
| **`nvd-cve-osv`** | 8 / 8 CPU, 8G / 16G | **2 / 4 CPU, 8G / 12G** | `highend` | **`default-pool`** | ~6.27 GiB |

### Verification
* Validated all Kustomize overlays across `oss-vdb`, `oss-vdb-test`, and `private` environments (`kubectl kustomize`).
* Verified peak memory against 7-day Google Cloud Monitoring metrics (`kubernetes.io/container/memory/used_bytes`).

<!-- AI-PR -->