### PR TITLE
refactor(infra): begin moving GKE to us-west2

### DIFF
--- a/deployment/terraform/environments/private-osv/main.tf
+++ b/deployment/terraform/environments/private-osv/main.tf
@@ -19,6 +19,9 @@ module "osv_pipeline" {
   subnet_cidr                                = "10.45.80.0/22"
   router_name                                = "osv-router"
   nat_name                                   = "osv-nat-config"
+
+  default_pool_res_size = 1
+  highend_pool_res_size = 1
 }
 
 

--- a/deployment/terraform/modules/osv_pipeline/gke.tf
+++ b/deployment/terraform/modules/osv_pipeline/gke.tf
@@ -140,6 +140,9 @@ resource "google_compute_reservation" "default_pool_res" {
   project = var.project_id
   name    = "n4-standard-8-res"
   zone    = "us-west2-b" # google_container_cluster.workers.location
+  reservation_sharing_policy {
+    service_share_type = "ALLOW_ALL"
+  }
   specific_reservation {
     count = var.default_pool_res_size
     instance_properties {
@@ -152,6 +155,9 @@ resource "google_compute_reservation" "highend_pool_res" {
   project = var.project_id
   name    = "n4-highmem-32-res"
   zone    = "us-west2-b" # google_container_cluster.workers.location
+  reservation_sharing_policy {
+    service_share_type = "ALLOW_ALL"
+  }
   specific_reservation {
     count = var.highend_pool_res_size
     instance_properties {

--- a/deployment/terraform/modules/osv_pipeline/gke.tf
+++ b/deployment/terraform/modules/osv_pipeline/gke.tf
@@ -134,3 +134,28 @@ resource "google_compute_disk" "gitter_disk" {
     ]
   }
 }
+
+# Reservations for N4 VMs so our infra can keep running in case of capacity issues
+resource "google_compute_reservation" "default_pool_res" {
+  project = var.project_id
+  name    = "n4-standard-8-res"
+  zone    = "us-west2-b" # google_container_cluster.workers.location
+  specific_reservation {
+    count = var.default_pool_res_size
+    instance_properties {
+      machine_type = "n4-standard-8"
+    }
+  }
+}
+
+resource "google_compute_reservation" "highend_pool_res" {
+  project = var.project_id
+  name    = "n4-highmem-32-res"
+  zone    = "us-west2-b" # google_container_cluster.workers.location
+  specific_reservation {
+    count = var.highend_pool_res_size
+    instance_properties {
+      machine_type = "n4-highmem-32"
+    }
+  }
+}

--- a/deployment/terraform/modules/osv_pipeline/variables.tf
+++ b/deployment/terraform/modules/osv_pipeline/variables.tf
@@ -78,6 +78,18 @@ variable "cluster_location" {
   default     = "us-central1-f"
 }
 
+variable "default_pool_res_size" {
+  type        = number
+  description = "Number of N4 VMs to reserve for the default pool."
+  default     = 3
+}
+
+variable "highend_pool_res_size" {
+  type        = number
+  description = "Number of N4 VMs to reserve for the highend pool."
+  default     = 2
+}
+
 variable "cluster_master_cidr" {
   type        = string
   description = "The private /28 IP range to allocate for the GKE master control plane peering."

--- a/deployment/terraform/modules/osv_pipeline/wild_west.tf
+++ b/deployment/terraform/modules/osv_pipeline/wild_west.tf
@@ -1,15 +1,18 @@
-# GKE "workers" cluster and node pools
+# Temporary resource to facilitate migrating ckuster to us-west2
 
-resource "google_container_cluster" "workers" {
+
+
+
+resource "google_container_cluster" "workers_west" {
   project    = var.project_id
   name       = var.cluster_name
-  location   = var.cluster_location
-  subnetwork = google_compute_subnetwork.my_subnet_0.self_link
+  location   = "us-west2-b"
+  subnetwork = google_compute_subnetwork.my_subnet_west.self_link
 
   private_cluster_config {
     enable_private_endpoint = false
     enable_private_nodes    = true
-    master_ipv4_cidr_block  = var.cluster_master_cidr
+    master_ipv4_cidr_block  = "172.16.0.64/28"
   }
 
   # We need to define this for private clusters, but all fields are optional.
@@ -44,17 +47,17 @@ resource "google_container_cluster" "workers" {
   }
 }
 
-resource "google_container_node_pool" "default_pool" {
+resource "google_container_node_pool" "default_pool_west" {
   project        = var.project_id
   name           = "default-pool"
-  cluster        = google_container_cluster.workers.name
-  location       = google_container_cluster.workers.location
-  node_locations = var.node_pool_node_locations
+  cluster        = google_container_cluster.workers_west.name
+  location       = google_container_cluster.workers_west.location
+  node_locations = ["us-west2-a", "us-west2-b", "us-west2-c"]
 
   lifecycle {
     # Terraform doesn't automatically know to recreate node pools when the cluster is recreated.
     replace_triggered_by = [
-      google_container_cluster.workers.id,
+      google_container_cluster.workers_west.id,
     ]
   }
 
@@ -75,19 +78,19 @@ resource "google_container_node_pool" "default_pool" {
   }
 }
 
-resource "google_container_node_pool" "highend" {
+resource "google_container_node_pool" "highend_west" {
   project        = var.project_id
   name           = "highend"
-  cluster        = google_container_cluster.workers.name
-  location       = google_container_cluster.workers.location
-  node_locations = var.node_pool_node_locations
+  cluster        = google_container_cluster.workers_west.name
+  location       = google_container_cluster.workers_west.location
+  node_locations = ["us-west2-a", "us-west2-b", "us-west2-c"]
   # For using the ephemeral storage local ssd config
   provider = google-beta
 
   lifecycle {
     # Terraform doesn't automatically know to recreate node pools when the cluster is recreated.
     replace_triggered_by = [
-      google_container_cluster.workers.id,
+      google_container_cluster.workers_west.id,
     ]
   }
 
@@ -120,11 +123,11 @@ resource "google_container_node_pool" "highend" {
 }
 
 # 6TiB SSD disk used by the gitter caching service
-resource "google_compute_disk" "gitter_disk" {
+resource "google_compute_disk" "gitter_disk_west" {
   project = var.project_id
   name    = var.gitter_disk_name
   type    = "hyperdisk-balanced"
-  zone    = google_container_cluster.workers.location
+  zone    = google_container_cluster.workers_west.location
   size    = var.gitter_disk_size_gb
 
   lifecycle {
@@ -132,5 +135,50 @@ resource "google_compute_disk" "gitter_disk" {
       type,
       snapshot,
     ]
+  }
+}
+
+
+resource "google_compute_subnetwork" "my_subnet_west" {
+  project                  = var.project_id
+  name                     = var.subnet_name
+  network                  = "default"
+  ip_cidr_range            = "10.44.0.0/20"
+  private_ip_google_access = true
+  region                   = "us-west2"
+
+  lifecycle {
+    ignore_changes = [
+      description,
+    ]
+  }
+}
+
+# Cloud Router
+# Required to route traffic for GKE nodes running on private IPs.
+resource "google_compute_router" "router_west" {
+  project = var.project_id
+  name    = var.router_name
+  network = "default"
+  region  = "us-west2"
+}
+
+resource "google_compute_router_nat" "nat_config_west" {
+  project                             = var.project_id
+  name                                = var.nat_name
+  router                              = google_compute_router.router_west.name
+  source_subnetwork_ip_ranges_to_nat  = "LIST_OF_SUBNETWORKS"
+  nat_ip_allocate_option              = "AUTO_ONLY"
+  region                              = google_compute_router.router_west.region
+  enable_endpoint_independent_mapping = false
+
+  subnetwork {
+    name                    = google_compute_subnetwork.my_subnet_west.id
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+
+  log_config {
+    enable = false
+    filter = "ALL"
   }
 }


### PR DESCRIPTION
N4 machine availability is causing us grief in us-central, us-west2 seems to have better availability, so let's start moving our stuff there.

This PR just sets up an additional cluster in the west region. We still need to, after this:
- Fix the new gitter disk snapshot
- Fix Cloud Deploy to deploy to this new cluster
- Terraform move all the old resourses to the new ones after changing the location (and delete these temporary resources)