### PR TITLE
refactor(infra): move test instance Cloud Deploy stuff to us-west2

### DIFF
--- a/deployment/clouddeploy/gke-indexer/clouddeploy.yaml
+++ b/deployment/clouddeploy/gke-indexer/clouddeploy.yaml
@@ -17,7 +17,7 @@ metadata:
   name: staging-indexer
 description: oss-vdb-test worker cluster
 gke:
-  cluster: projects/oss-vdb-test/locations/us-central1-f/clusters/workers
+  cluster: projects/oss-vdb-test/locations/us-west2-b/clusters/workers
 executionConfigs:
 - usages:
   - RENDER

--- a/deployment/clouddeploy/gke-workers/clouddeploy.yaml
+++ b/deployment/clouddeploy/gke-workers/clouddeploy.yaml
@@ -19,7 +19,7 @@ metadata:
   name: staging-workers
 description: oss-vdb-test worker cluster
 gke:
-  cluster: projects/oss-vdb-test/locations/us-central1-f/clusters/workers
+  cluster: projects/oss-vdb-test/locations/us-west2-b/clusters/workers
 executionConfigs:
 - usages:
   - RENDER

--- a/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/gitter.yaml
+++ b/deployment/clouddeploy/gke-workers/environments/oss-vdb-test/gitter.yaml
@@ -24,5 +24,5 @@ metadata:
 spec:
   csi:
     driver: pd.csi.storage.gke.io
-    volumeHandle: projects/oss-vdb-test/zones/us-central1-f/disks/gitter-disk
+    volumeHandle: projects/oss-vdb-test/zones/us-west2-b/disks/gitter-disk
     fsType: ext4

--- a/deployment/terraform/modules/osv_pipeline/wild_west.tf
+++ b/deployment/terraform/modules/osv_pipeline/wild_west.tf
@@ -124,11 +124,12 @@ resource "google_container_node_pool" "highend_west" {
 
 # 6TiB SSD disk used by the gitter caching service
 resource "google_compute_disk" "gitter_disk_west" {
-  project = var.project_id
-  name    = var.gitter_disk_name
-  type    = "hyperdisk-balanced"
-  zone    = google_container_cluster.workers_west.location
-  size    = var.gitter_disk_size_gb
+  project  = var.project_id
+  name     = var.gitter_disk_name
+  type     = "hyperdisk-balanced"
+  zone     = google_container_cluster.workers_west.location
+  size     = var.gitter_disk_size_gb
+  snapshot = "instant-snapshot-transfer-to-west-full"
 
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
This is just for the test instance for now (and needs to be manually applied to Cloud Deploy).

Also, add the snapshot to the gitter disk so we don't lose all our data