### PR TITLE
refactor(infra): move prod & private to us-west2-c

### DIFF
--- a/deployment/clouddeploy/gke-indexer/clouddeploy.yaml
+++ b/deployment/clouddeploy/gke-indexer/clouddeploy.yaml
@@ -31,7 +31,7 @@ metadata:
   name: production-indexer
 description: oss-vdb worker cluster
 gke:
-  cluster: projects/oss-vdb/locations/us-central1-f/clusters/workers
+  cluster: projects/oss-vdb/locations/us-west2-c/clusters/workers
 executionConfigs:
 - usages:
   - RENDER

--- a/deployment/clouddeploy/gke-workers/clouddeploy.yaml
+++ b/deployment/clouddeploy/gke-workers/clouddeploy.yaml
@@ -33,7 +33,7 @@ metadata:
   name: production-workers
 description: oss-vdb worker cluster
 gke:
-  cluster: projects/oss-vdb/locations/us-central1-f/clusters/workers
+  cluster: projects/oss-vdb/locations/us-west2-c/clusters/workers
 executionConfigs:
 - usages:
   - RENDER
@@ -47,7 +47,7 @@ metadata:
   name: private-workers
 description: Private OSV worker cluster
 gke:
-  cluster: projects/private-osv/locations/us-central1-f/clusters/workers
+  cluster: projects/private-osv/locations/us-west2-c/clusters/workers
 executionConfigs:
 - usages:
   - RENDER

--- a/deployment/terraform/environments/oss-vdb-test/main.tf
+++ b/deployment/terraform/environments/oss-vdb-test/main.tf
@@ -39,6 +39,8 @@ module "osv_pipeline" {
     "reimport",
     "cves",
   ]
+
+  reservation_location = "us-west2-b"
 }
 
 module "osv_test" {

--- a/deployment/terraform/modules/osv_pipeline/gke.tf
+++ b/deployment/terraform/modules/osv_pipeline/gke.tf
@@ -139,7 +139,7 @@ resource "google_compute_disk" "gitter_disk" {
 resource "google_compute_reservation" "default_pool_res" {
   project = var.project_id
   name    = "n4-standard-8-res"
-  zone    = "us-west2-b" # google_container_cluster.workers.location
+  zone    = var.reservation_location
   reservation_sharing_policy {
     service_share_type = "ALLOW_ALL"
   }
@@ -154,7 +154,7 @@ resource "google_compute_reservation" "default_pool_res" {
 resource "google_compute_reservation" "highend_pool_res" {
   project = var.project_id
   name    = "n4-highmem-32-res"
-  zone    = "us-west2-b" # google_container_cluster.workers.location
+  zone    = var.reservation_location
   reservation_sharing_policy {
     service_share_type = "ALLOW_ALL"
   }

--- a/deployment/terraform/modules/osv_pipeline/variables.tf
+++ b/deployment/terraform/modules/osv_pipeline/variables.tf
@@ -90,6 +90,12 @@ variable "highend_pool_res_size" {
   default     = 2
 }
 
+variable "reservation_location" {
+  type        = string
+  description = "Location for compute pool reservations."
+  default     = "us-west2-c"
+}
+
 variable "cluster_master_cidr" {
   type        = string
   description = "The private /28 IP range to allocate for the GKE master control plane peering."

--- a/deployment/terraform/modules/osv_pipeline/wild_west.tf
+++ b/deployment/terraform/modules/osv_pipeline/wild_west.tf
@@ -6,7 +6,7 @@
 resource "google_container_cluster" "workers_west" {
   project    = var.project_id
   name       = var.cluster_name
-  location   = "us-west2-b"
+  location   = var.reservation_location
   subnetwork = google_compute_subnetwork.my_subnet_west.self_link
 
   private_cluster_config {


### PR DESCRIPTION
Couldn't manage to reserve resources on `us-west2-b` on the prod instance, but did manage it with `us-west2-c`, so that's where we're going (staging can stay on `us-west2-b`).