### PR TITLE
docs: add CVE Lite CLI to third-party tools and integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ to consult the [OpenSSF's Concise Guide for Evaluating Open Source Software](htt
 to determine suitability for your use. Some popular third party tools are:
 
 - [Cortex XSOAR](https://github.com/demisto/content)
+- [CVE Lite CLI](https://github.com/OWASP/cve-lite-cli)
 - [dep-scan](https://github.com/AppThreat/dep-scan)
 - [Dependency-Track](https://github.com/DependencyTrack/dependency-track)
 - [GUAC](https://github.com/guacsec/guac)


### PR DESCRIPTION
Add [CVE Lite CLI](https://github.com/OWASP/cve-lite-cli) to the list of third-party tools that use OSV.

CVE Lite CLI is an OWASP Lab Project - a fast, developer-first dependency vulnerability scanner for JavaScript and TypeScript projects. It queries the OSV API to match lockfile dependencies against known advisories across npm, pnpm, Yarn, and Bun.

It uses OSV as its primary data source and provides actionable remediation guidance on top of the OSV findings (fix-version validation, parent-aware transitive upgrade paths, SARIF output for GitHub Code Scanning).

GitHub: https://github.com/OWASP/cve-lite-cli
npm: https://www.npmjs.com/package/cve-lite-cli
