### PR TITLE
perf(exporter): parallelize ZIP generation using klauspost/compress/zip

### DIFF
--- a/go/cmd/exporter/exporter_test.go
+++ b/go/cmd/exporter/exporter_test.go
@@ -231,3 +231,52 @@ func TestExporterPipeline_EndToEnd(t *testing.T) {
 		t.Errorf("unexpected vanir content: %s", string(vanirBytes))
 	}
 }
+
+func TestMarshalToJSON_IsCompact(t *testing.T) {
+	time1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	vuln := &osvschema.Vulnerability{
+		SchemaVersion: "1.6.0",
+		Id:            "OSV-2026-1234",
+		Modified:      timestamppb.New(time1),
+		Published:     timestamppb.New(time1),
+		Summary:       "A test vulnerability summary",
+		Details:       "Detailed description with some text\nand a newline inside the string field.",
+		Affected: []*osvschema.Affected{
+			{
+				Package: &osvschema.Package{
+					Ecosystem: "PyPI",
+					Name:      "test-pkg",
+				},
+				Ranges: []*osvschema.Range{
+					{
+						Type: osvschema.Range_ECOSYSTEM,
+						Events: []*osvschema.Event{
+							{Introduced: "0"},
+							{Fixed: "1.0.0"},
+						},
+					},
+				},
+				DatabaseSpecific: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"custom_key": structpb.NewStringValue("custom_val"),
+					},
+				},
+			},
+		},
+	}
+
+	got, err := marshalToJSON(vuln)
+	if err != nil {
+		t.Fatalf("marshalToJSON failed: %v", err)
+	}
+
+	// Verify that the output is byte-for-byte identical to json.Compact
+	var compacted bytes.Buffer
+	if err := json.Compact(&compacted, got); err != nil {
+		t.Fatalf("json.Compact failed on marshalToJSON output: %v", err)
+	}
+
+	if !bytes.Equal(got, compacted.Bytes()) {
+		t.Errorf("marshalToJSON output is not compact.\nGot:       %s\nCompacted: %s", string(got), compacted.String())
+	}
+}

--- a/go/cmd/exporter/worker.go
+++ b/go/cmd/exporter/worker.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"archive/zip"
 	"bytes"
 	"cmp"
 	"context"
@@ -18,6 +17,7 @@ import (
 	"time"
 
 	"github.com/google/osv.dev/go/logger"
+	kzip "github.com/klauspost/compress/zip"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
 	"go.opentelemetry.io/otel"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -176,7 +176,7 @@ func marshalToJSON(vuln *osvschema.Vulnerability) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Compact the JSON, making output (more) stable.
+	// Compact the JSON, removing extra spaces emitted by protojson.
 	var out bytes.Buffer
 	if err := json.Compact(&out, b); err != nil {
 		return nil, err
@@ -244,12 +244,12 @@ func writeZIP(ctx context.Context, path string, allVulns []vulnMeta, outCh chan<
 	}
 	defer tmpZip.Close()
 
-	wr := zip.NewWriter(tmpZip)
+	wr := kzip.NewWriter(tmpZip)
 	for _, vuln := range allVulns {
-		w, err := wr.CreateHeader(&zip.FileHeader{
+		w, err := wr.CreateHeader(&kzip.FileHeader{
 			Name:     vuln.id + ".json",
 			Modified: vuln.modified,
-			Method:   zip.Deflate,
+			Method:   kzip.Deflate,
 		})
 		if err != nil {
 			logger.ErrorContext(ctx, "failed to create vuln json in zip file", slog.String("id", vuln.id), slog.Any("err", err))


### PR DESCRIPTION
Accelerates exporter runtime by:
1. Using github.com/klauspost/compress/zip for multi-core parallel Deflate compression of all.zip and ecosystem ZIP archives.
  1. We already use this guys zstd package, so no new module deps.
2. Adding `TestMarshalToJSON_IsCompact` asserting `marshalToJSON` outputs canonical compact JSON (verifying whitespace removal by `json.Compact`).

agy