### PR TITLE
fix(infra): make highend pool mono-zonal

### DIFF
--- a/deployment/terraform/modules/osv_pipeline/gke.tf
+++ b/deployment/terraform/modules/osv_pipeline/gke.tf
@@ -50,8 +50,8 @@ resource "google_container_cluster" "workers" {
       "DAEMONSET",
       "DEPLOYMENT",
       "STATEFULSET",
-      "KUBELET",
-      "CADVISOR"
+      "CADVISOR",
+      "KUBELET"
     ]
 
     managed_prometheus {
@@ -92,11 +92,10 @@ resource "google_container_node_pool" "default_pool" {
 }
 
 resource "google_container_node_pool" "highend" {
-  project        = var.project_id
-  name           = "highend"
-  cluster        = google_container_cluster.workers.name
-  location       = google_container_cluster.workers.location
-  node_locations = var.node_pool_node_locations
+  project  = var.project_id
+  name     = "highend"
+  cluster  = google_container_cluster.workers.name
+  location = google_container_cluster.workers.location
   # For using the ephemeral storage local ssd config
   provider = google-beta
 


### PR DESCRIPTION
Since the gitter disk is only on one zone, if the gitter job attempts to be scheduled on the wrong highend zone, it fails to start.
Make the highend pool only on one zone, so we don't run into this problem.