### PR TITLE
chore(sources): update chainguard source to v3 feed URL

### DIFF
--- a/source.yaml
+++ b/source.yaml
@@ -141,7 +141,7 @@
 
 - name: 'chainguard'
   versions_from_repo: False
-  rest_api_url: 'https://packages.cgr.dev/chainguard/osv/all.json'
+  rest_api_url: 'https://advisories.cgr.dev/chainguard/v3/osv/all.json'
   type: 2
   ignore_patterns: ['^(?!CGA-).*$']  # NOTE: Not currently supported for REST sources
   directory_path: 'chainguard/osv'
@@ -150,10 +150,10 @@
   db_prefix: ['CGA-']
   accepted_ecosystems: ['Chainguard', 'Wolfi']
   ignore_git: True
-  link: 'https://packages.cgr.dev/chainguard/osv/'
+  link: 'https://advisories.cgr.dev/chainguard/v3/osv/'
   human_link: 'https://images.chainguard.dev/security/{{ BUG_ID }}'
   editable: False
-  strict_validation: False
+  strict_validation: True
 
 - name: 'cleanstart'
   versions_from_repo: False


### PR DESCRIPTION
Point the Chainguard entry in `source.yaml` at the new Chainguard OSV
v3 feed, as was previously already done in source_test.yaml. See:
- https://github.com/google/osv.dev/pull/5606

Chainguard v3 feed docs are in:
- https://github.com/chainguard-dev/vulnerability-scanner-support/blob/main/docs/osv_v3_feed.md

This has had a few weeks of testing now in the test instance, and behaviour observed there is the desired behaviour for the CGA- entries.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@chainguard.dev>