### PR TITLE
perf(exporter): add -cleanup-scratch-dir flag and pre-compress for CreateRaw ZIP generation

### DIFF
--- a/go/cmd/exporter/downloader.go
+++ b/go/cmd/exporter/downloader.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"bytes"
+	"compress/flate"
 	"context"
+	"hash/crc32"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -15,10 +18,23 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+var flateWriterPool = sync.Pool{
+	New: func() any {
+		fw, _ := flate.NewWriter(ioDiscard{}, flate.DefaultCompression)
+		return fw
+	},
+}
+
+type ioDiscard struct{}
+
+func (ioDiscard) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
 // downloadThenProcessor is a worker that receives GCS object handles from inCh, downloads
 // the raw protobuf data, unmarshals it into a Vulnerability, marshals it to compact
-// JSON, saves it to scratch disk, queues individual JSON uploads, and sends the
-// metadata to routerCh.
+// JSON, saves pre-compressed Deflate data to scratch disk, queues individual JSON uploads,
+// and sends the metadata to routerCh.
 func downloadThenProcessor(ctx context.Context, cancel context.CancelFunc, client clients.CloudStorage, scratchDir string, inCh <-chan string, routerCh chan<- processedVuln, writeCh chan<- writeMsg, wg *sync.WaitGroup) {
 	defer wg.Done()
 	for path := range inCh {
@@ -49,9 +65,32 @@ func downloadThenProcessor(ctx context.Context, cancel context.CancelFunc, clien
 			continue
 		}
 
-		// Cache to local scratch disk for later ZIP generation.
-		localPath := filepath.Join(scratchDir, vuln.GetId()+".json")
-		if err := os.WriteFile(localPath, b, 0600); err != nil {
+		// Pre-compress using Deflate for zero-copy CreateRaw ZIP generation.
+		var compBuf bytes.Buffer
+		fw := flateWriterPool.Get().(*flate.Writer)
+		fw.Reset(&compBuf)
+		if _, err := fw.Write(b); err != nil {
+			flateWriterPool.Put(fw)
+			logger.ErrorContext(ctx, "failed to compress vulnerability json", slog.String("id", vuln.GetId()), slog.Any("err", err))
+			cancel()
+
+			return
+		}
+		if err := fw.Close(); err != nil {
+			flateWriterPool.Put(fw)
+			logger.ErrorContext(ctx, "failed to close flate writer", slog.String("id", vuln.GetId()), slog.Any("err", err))
+			cancel()
+
+			return
+		}
+		flateWriterPool.Put(fw)
+
+		compressedBytes := compBuf.Bytes()
+		crc := crc32.ChecksumIEEE(b)
+
+		// Cache pre-compressed Deflate payload to local scratch disk.
+		localPath := filepath.Join(scratchDir, vuln.GetId()+".deflate")
+		if err := os.WriteFile(localPath, compressedBytes, 0600); err != nil {
 			logger.ErrorContext(ctx, "failed to write cached vulnerability to disk", slog.String("id", vuln.GetId()), slog.Any("err", err))
 			// Cancel the exporter context if writing to the scratch disk fails (e.g. disk full)
 			// to fail fast rather than producing incomplete archives later.
@@ -101,8 +140,11 @@ func downloadThenProcessor(ctx context.Context, cancel context.CancelFunc, clien
 		select {
 		case routerCh <- processedVuln{
 			meta: vulnMeta{
-				id:       vuln.GetId(),
-				modified: vuln.GetModified().AsTime(),
+				id:         vuln.GetId(),
+				modified:   vuln.GetModified().AsTime(),
+				crc32:      crc,
+				uncompSize: uint64(len(b)),
+				compSize:   uint64(len(compressedBytes)),
 			},
 			ecosystems: ecoNames,
 			hasVanir:   hasVanir,

--- a/go/cmd/exporter/downloader.go
+++ b/go/cmd/exporter/downloader.go
@@ -5,6 +5,7 @@ import (
 	"compress/flate"
 	"context"
 	"hash/crc32"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -20,15 +21,9 @@ import (
 
 var flateWriterPool = sync.Pool{
 	New: func() any {
-		fw, _ := flate.NewWriter(ioDiscard{}, flate.DefaultCompression)
+		fw, _ := flate.NewWriter(io.Discard, flate.DefaultCompression)
 		return fw
 	},
-}
-
-type ioDiscard struct{}
-
-func (ioDiscard) Write(p []byte) (int, error) {
-	return len(p), nil
 }
 
 // downloadThenProcessor is a worker that receives GCS object handles from inCh, downloads

--- a/go/cmd/exporter/exporter.go
+++ b/go/cmd/exporter/exporter.go
@@ -45,6 +45,7 @@ func main() {
 	numWorkers := flag.Int("workers", 1000, "The total number of concurrent workers to use for downloading from GCS and writing the output.")
 	breakdownPrefixesStr := flag.String("breakdown-prefixes", "", "Comma-separated list of prefix breakdowns for parallel GCS object listing.")
 	scratchDirFlag := flag.String("scratch-dir", defaultScratchDir, "Directory to stage temporary JSON and zip files.")
+	cleanUpScratchDir := flag.Bool("cleanup-scratch-dir", false, "Whether to delete the temporary scratch directory on exit. Defaults to false.")
 
 	flag.Parse()
 
@@ -56,13 +57,16 @@ func main() {
 	if err != nil {
 		logger.FatalContext(ctx, "failed to create temp directory in scratch dir", slog.String("dir", scratchDir), slog.Any("err", err))
 	}
-	defer os.RemoveAll(scratchDir)
+	if *cleanUpScratchDir {
+		defer os.RemoveAll(scratchDir)
+	}
 
 	logger.InfoContext(ctx, "exporter starting",
 		slog.String("bucket", *outBucketName),
 		slog.String("osv-vulns-bucket", *vulnBucketName),
 		slog.Bool("upload-to-gcs", *uploadToGCS),
 		slog.Int("workers", *numWorkers),
+		slog.Bool("cleanup-scratch-dir", *cleanUpScratchDir),
 		slog.String("breakdown-prefixes", *breakdownPrefixesStr),
 		slog.String("scratch-dir", scratchDir))
 

--- a/go/cmd/exporter/exporter_test.go
+++ b/go/cmd/exporter/exporter_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/csv"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -185,6 +186,22 @@ func TestExporterPipeline_EndToEnd(t *testing.T) {
 	zipNames := make([]string, 0, len(zipReader.File))
 	for _, f := range zipReader.File {
 		zipNames = append(zipNames, f.Name)
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("failed to open zip entry %s: %v", f.Name, err)
+		}
+		entryBytes, err := io.ReadAll(rc)
+		_ = rc.Close()
+		if err != nil {
+			t.Fatalf("failed to read/decompress zip entry %s: %v", f.Name, err)
+		}
+		var parsed map[string]any
+		if err := json.Unmarshal(entryBytes, &parsed); err != nil {
+			t.Fatalf("failed to parse JSON from zip entry %s: %v", f.Name, err)
+		}
+		if parsed["id"] != f.Name[:len(f.Name)-len(".json")] {
+			t.Errorf("expected id %s in %s, got %v", f.Name[:len(f.Name)-len(".json")], f.Name, parsed["id"])
+		}
 	}
 	if len(zipNames) != 2 {
 		t.Errorf("expected 2 files in all.zip, got %v", zipNames)

--- a/go/cmd/exporter/worker.go
+++ b/go/cmd/exporter/worker.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"archive/zip"
 	"bytes"
 	"cmp"
+	"compress/flate"
 	"context"
 	"encoding/csv"
 	"encoding/json"
@@ -17,7 +19,6 @@ import (
 	"time"
 
 	"github.com/google/osv.dev/go/logger"
-	kzip "github.com/klauspost/compress/zip"
 	"github.com/ossf/osv-schema/bindings/go/osvschema"
 	"go.opentelemetry.io/otel"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -31,10 +32,13 @@ const (
 	ecosystemsFilename  = "ecosystems.txt"
 )
 
-// vulnMeta holds the ID and modified time for a vulnerability.
+// vulnMeta holds the ID, modified time, CRC32, and pre-compression sizes for a vulnerability.
 type vulnMeta struct {
-	id       string
-	modified time.Time
+	id         string
+	modified   time.Time
+	crc32      uint32
+	uncompSize uint64
+	compSize   uint64
 }
 
 // csvEntry holds the modified time and the relative entry path.
@@ -230,7 +234,7 @@ func writeModifiedIDCSV(ctx context.Context, path string, csvData []csvEntry, ou
 	write(ctx, path, buf.Bytes(), "text/csv", outCh)
 }
 
-// writeZIP constructs and writes a zip file by streaming from local files to a temporary zip file.
+// writeZIP constructs and writes a zip file by streaming pre-compressed local files via CreateRaw.
 func writeZIP(ctx context.Context, path string, allVulns []vulnMeta, outCh chan<- writeMsg, scratchDir string) {
 	logger.InfoContext(ctx, "constructing zip file", slog.String("path", path))
 	slices.SortFunc(allVulns, func(a, b vulnMeta) int {
@@ -244,25 +248,28 @@ func writeZIP(ctx context.Context, path string, allVulns []vulnMeta, outCh chan<
 	}
 	defer tmpZip.Close()
 
-	wr := kzip.NewWriter(tmpZip)
+	wr := zip.NewWriter(tmpZip)
 	for _, vuln := range allVulns {
-		w, err := wr.CreateHeader(&kzip.FileHeader{
-			Name:     vuln.id + ".json",
-			Modified: vuln.modified,
-			Method:   kzip.Deflate,
+		w, err := wr.CreateRaw(&zip.FileHeader{
+			Name:               vuln.id + ".json",
+			Modified:           vuln.modified,
+			Method:             zip.Deflate,
+			CRC32:              vuln.crc32,
+			CompressedSize64:   vuln.compSize,
+			UncompressedSize64: vuln.uncompSize,
 		})
 		if err != nil {
-			logger.ErrorContext(ctx, "failed to create vuln json in zip file", slog.String("id", vuln.id), slog.Any("err", err))
+			logger.ErrorContext(ctx, "failed to create raw vuln in zip file", slog.String("id", vuln.id), slog.Any("err", err))
 			continue
 		}
-		localPath := filepath.Join(scratchDir, vuln.id+".json")
+		localPath := filepath.Join(scratchDir, vuln.id+".deflate")
 		f, err := os.Open(localPath)
 		if err != nil {
-			logger.ErrorContext(ctx, "failed to open local vuln json file", slog.String("path", localPath), slog.Any("err", err))
+			logger.ErrorContext(ctx, "failed to open local vuln deflate file", slog.String("path", localPath), slog.Any("err", err))
 			continue
 		}
 		if _, err := io.Copy(w, f); err != nil {
-			logger.ErrorContext(ctx, "failed to write vuln json in zip file", slog.String("id", vuln.id), slog.Any("err", err))
+			logger.ErrorContext(ctx, "failed to write vuln deflate data to zip file", slog.String("id", vuln.id), slog.Any("err", err))
 		}
 		f.Close()
 	}
@@ -283,10 +290,18 @@ func writeVanir(ctx context.Context, vanirVulnIDs []string, outCh chan<- writeMs
 
 	vulns := make([]json.RawMessage, 0, len(vanirVulnIDs))
 	for _, id := range vanirVulnIDs {
-		localPath := filepath.Join(scratchDir, id+".json")
-		data, err := os.ReadFile(localPath)
+		localPath := filepath.Join(scratchDir, id+".deflate")
+		f, err := os.Open(localPath)
 		if err != nil {
-			logger.ErrorContext(ctx, "failed to read local vuln file for vanir", slog.String("id", id), slog.Any("err", err))
+			logger.ErrorContext(ctx, "failed to open local vuln file for vanir", slog.String("id", id), slog.Any("err", err))
+			continue
+		}
+		fr := flate.NewReader(f)
+		data, err := io.ReadAll(fr)
+		_ = fr.Close()
+		_ = f.Close()
+		if err != nil {
+			logger.ErrorContext(ctx, "failed to decompress local vuln file for vanir", slog.String("id", id), slog.Any("err", err))
 			continue
 		}
 		vulns = append(vulns, data)


### PR DESCRIPTION
Accelerates exporter performance and container lifecycle by:
1. Adding the `-cleanup-scratch-dir` flag (defaulting to `false`), avoiding synchronous 1.8M file `os.RemoveAll` deletion on container exit in Kubernetes where emptyDir volumes are automatically cleaned up.
2. Pre-compressing Deflate payloads in `downloadThenProcessor` using a pooled `flate.Writer` and caching `<id>.deflate` files to scratch disk.
3. Using `zip.Writer.CreateRaw` in `writeZIP` to stream pre-compressed payloads directly into `all.zip` and ecosystem ZIP archives, eliminating 3.6M redundant runtime compressions.

Benchmarks are looking pretty good.

agy