### PR TITLE
fix(go-website): minor fixes

### DIFF
--- a/go/cmd/website/main.go
+++ b/go/cmd/website/main.go
@@ -153,11 +153,18 @@ func run() error {
 		logger.WarnContext(ctx, "SESSION_SECRET_KEY environment variable is not set, authentication will not work")
 	}
 
+	const (
+		readTimeout    = 15 * time.Second
+		writeTimeout   = 60 * time.Second
+		requestTimeout = writeTimeout - 2*time.Second
+	)
+
 	srv, err := website.NewServer(website.Config{
-		StaticFS: staticFiles,
-		DocsFS:   docsFiles,
-		Stores:   stores,
-		APIURL:   apiURL,
+		StaticFS:       staticFiles,
+		DocsFS:         docsFiles,
+		Stores:         stores,
+		APIURL:         apiURL,
+		RequestTimeout: requestTimeout,
 		Auth: website.AuthConfig{
 			ClientID:     os.Getenv("GOOGLE_OAUTH_CLIENT_ID"),
 			ClientSecret: os.Getenv("GOOGLE_OAUTH_CLIENT_SECRET"),
@@ -174,8 +181,8 @@ func run() error {
 	httpServer := &http.Server{
 		Addr:         fmt.Sprintf(":%d", *port),
 		Handler:      srv,
-		ReadTimeout:  15 * time.Second,
-		WriteTimeout: 15 * time.Second,
+		ReadTimeout:  readTimeout,
+		WriteTimeout: writeTimeout,
 		IdleTimeout:  60 * time.Second,
 	}
 

--- a/go/internal/database/datastore/relations.go
+++ b/go/internal/database/datastore/relations.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"slices"
 
 	"cloud.google.com/go/datastore"
 	"github.com/google/osv.dev/go/internal/models"
+	"github.com/google/osv.dev/go/logger"
 )
 
 type RelationsStore struct {
@@ -106,11 +108,23 @@ func (s *RelationsStore) GetUpstreamHierarchy(ctx context.Context, id string) (*
 	}
 
 	var rawHierarchy map[string][]string
-	if err := json.Unmarshal(upstreamGroup.UpstreamHierarchy, &rawHierarchy); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal upstream hierarchy JSON: %w", err)
+	if err = json.Unmarshal(upstreamGroup.UpstreamHierarchy, &rawHierarchy); err == nil {
+		return ComputeUpstreamHierarchy(id, rawHierarchy)
+	}
+	// For some reason, a few upstream hierarchy JSON blobs are strings containing JSON
+	// e.g. it contains literally "{\"CVE-123\": [\"CVE-124\"]}" (outer quotes included).
+	// Attempt to unmarshal it into a string, then into the map
+	var str string
+	err2 := json.Unmarshal(upstreamGroup.UpstreamHierarchy, &str)
+	if err2 == nil {
+		err3 := json.Unmarshal([]byte(str), &rawHierarchy)
+		if err3 == nil {
+			logger.WarnContext(ctx, "double unmarshal needed for upstream hierarchy", slog.String("id", id))
+			return ComputeUpstreamHierarchy(id, rawHierarchy)
+		}
 	}
 
-	return ComputeUpstreamHierarchy(id, rawHierarchy)
+	return nil, fmt.Errorf("failed to unmarshal upstream hierarchy JSON: %w", err)
 }
 
 func (s *RelationsStore) GetDownstreamHierarchy(ctx context.Context, id string) (*models.Hierarchy, error) {

--- a/go/internal/database/datastore/relations_test.go
+++ b/go/internal/database/datastore/relations_test.go
@@ -474,6 +474,46 @@ func TestRelationsStore_GetUpstreamHierarchy(t *testing.T) {
 		t.Errorf("GetUpstreamHierarchy() mismatch (-want +got):\n%s", diff)
 	}
 
+	// Double-encoded JSON string (JSON object serialized inside a JSON string)
+	upstreamGroupDouble := UpstreamGroup{
+		VulnID:            "VULN-2",
+		UpstreamIDs:       []string{"ROOT-2"},
+		UpstreamHierarchy: []byte(`"{\"VULN-2\": [\"ROOT-2\"]}"`),
+		Modified:          time.Now().Truncate(time.Second),
+	}
+	if _, err := dsClient.Put(ctx, datastore.IncompleteKey("UpstreamGroup", nil), &upstreamGroupDouble); err != nil {
+		t.Fatalf("Failed to setup double-encoded test data: %v", err)
+	}
+
+	gotDouble, err := store.GetUpstreamHierarchy(ctx, "VULN-2")
+	if err != nil {
+		t.Fatalf("GetUpstreamHierarchy() double-encoded unexpected error: %v", err)
+	}
+	wantDouble := &models.Hierarchy{
+		Roots: []string{"ROOT-2"},
+		Graph: map[string][]string{
+			"ROOT-2": {"VULN-2"},
+		},
+	}
+	if diff := cmp.Diff(wantDouble, gotDouble); diff != "" {
+		t.Errorf("GetUpstreamHierarchy() double-encoded mismatch (-want +got):\n%s", diff)
+	}
+
+	// Invalid JSON should return an error
+	upstreamGroupInvalid := UpstreamGroup{
+		VulnID:            "VULN-INVALID",
+		UpstreamIDs:       []string{"ROOT-3"},
+		UpstreamHierarchy: []byte(`"not-json-content"`),
+		Modified:          time.Now().Truncate(time.Second),
+	}
+	if _, err := dsClient.Put(ctx, datastore.IncompleteKey("UpstreamGroup", nil), &upstreamGroupInvalid); err != nil {
+		t.Fatalf("Failed to setup invalid JSON test data: %v", err)
+	}
+
+	if _, err := store.GetUpstreamHierarchy(ctx, "VULN-INVALID"); err == nil {
+		t.Errorf("expected error for invalid upstream hierarchy JSON, got nil")
+	}
+
 	// Missing entity should return ErrNotFound
 	missing, err := store.GetUpstreamHierarchy(ctx, "NON-EXISTENT")
 	if !errors.Is(err, models.ErrNotFound) || missing != nil {

--- a/go/internal/database/datastore/vulnerability_search_test.go
+++ b/go/internal/database/datastore/vulnerability_search_test.go
@@ -290,7 +290,6 @@ func TestVulnerabilitySearchStore_Autocomplete(t *testing.T) {
 func TestVulnerabilitySearchStore_EcosystemCounts(t *testing.T) {
 	ctx := context.Background()
 	dsClient := testutils.MustNewDatastoreClientForTesting(t)
-	store := NewVulnerabilitySearchStore(dsClient, nil)
 
 	vulns := []struct {
 		id   string
@@ -313,6 +312,7 @@ func TestVulnerabilitySearchStore_EcosystemCounts(t *testing.T) {
 		t.Fatalf("Failed to put test entities: %v", err)
 	}
 
+	store := NewVulnerabilitySearchStore(dsClient, nil)
 	got, err := store.EcosystemCounts(ctx)
 	if err != nil {
 		t.Fatalf("EcosystemCounts failed: %v", err)

--- a/go/internal/website/list.go
+++ b/go/internal/website/list.go
@@ -3,6 +3,7 @@ package website
 import (
 	"fmt"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -101,6 +102,9 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
 				return err
 			}
 			ecoCounts = counts
+			slices.SortFunc(ecoCounts, func(a, b models.EcosystemCount) int {
+				return strings.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name))
+			})
 
 			return nil
 		})

--- a/go/internal/website/server.go
+++ b/go/internal/website/server.go
@@ -27,12 +27,13 @@ const goVanityMetadata = `<meta name="go-import" content="osv.dev git https://gi
 
 // Config holds configuration options for the website server.
 type Config struct {
-	StaticFS    fs.FS
-	DocsFS      fs.FS
-	TemplateDir string
-	Stores      Stores
-	APIURL      string
-	Auth        AuthConfig
+	StaticFS       fs.FS
+	DocsFS         fs.FS
+	TemplateDir    string
+	Stores         Stores
+	APIURL         string
+	Auth           AuthConfig
+	RequestTimeout time.Duration
 }
 
 type Stores struct {
@@ -129,8 +130,12 @@ func NewServer(cfg Config) (*Server, error) {
 	}
 	s.registerRoutes()
 
-	// Middlewares: 404 Fallback -> Logging (if local/dev) -> ServeMux
+	// Middlewares: 404 Fallback -> Timeout (if set) -> Logging (if local/dev) -> ServeMux
 	h := s.notFoundMiddleware(s.mux)
+
+	if cfg.RequestTimeout > 0 {
+		h = http.TimeoutHandler(h, cfg.RequestTimeout, "Request timed out")
+	}
 
 	// Skip HTTP access logging in Cloud Run production to avoid duplicating Cloud Run infrastructure logs.
 	if os.Getenv("K_SERVICE") == "" {

--- a/go/internal/website/server_test.go
+++ b/go/internal/website/server_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"github.com/google/osv.dev/go/internal/models"
 	"github.com/google/osv.dev/go/internal/website"
@@ -1134,4 +1135,43 @@ func TestLinterEndpoints(t *testing.T) {
 			t.Errorf("expected status 404 Not Found, got %d", rec.Code)
 		}
 	})
+}
+
+type slowVulnStore struct {
+	mockVulnStore
+
+	delay time.Duration
+}
+
+func (s slowVulnStore) GetWithMetadata(ctx context.Context, id string) (*osvschema.Vulnerability, *models.VulnSourceRef, error) {
+	select {
+	case <-time.After(s.delay):
+		return s.mockVulnStore.GetWithMetadata(ctx, id)
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	}
+}
+
+func TestServer_RequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	cfg := website.Config{
+		RequestTimeout: 20 * time.Millisecond,
+		Stores: website.Stores{
+			Vuln: slowVulnStore{delay: 100 * time.Millisecond},
+		},
+	}
+	srv := newTestServer(t, cfg)
+
+	req := httptest.NewRequest(http.MethodGet, "/vulnerability/TEST-VULN", nil)
+	rec := httptest.NewRecorder()
+
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503 Service Unavailable, got %d", rec.Code)
+	}
+	if body := rec.Body.String(); body != "Request timed out" {
+		t.Errorf("expected body 'Request timed out', got %q", body)
+	}
 }

--- a/go/internal/website/vulnerability.go
+++ b/go/internal/website/vulnerability.go
@@ -114,7 +114,7 @@ func (s *Server) handleVulnerabilityDetails(w http.ResponseWriter, r *http.Reque
 
 	// Collect all the vuln IDs mentioned by this vuln to check the database (in parallel) for existence.
 	candidateIDs := make(map[string]struct{})
-	knownIDs := make(map[string]bool)
+	knownIDs := make(map[string]struct{})
 	for _, id := range vuln.GetAliases() {
 		candidateIDs[id] = struct{}{}
 	}
@@ -137,9 +137,11 @@ func (s *Server) handleVulnerabilityDetails(w http.ResponseWriter, r *http.Reque
 		// However, something being in downstream implies it must be in the database,
 		// so we don't need to check for existence of >10k downstreams.
 		for k, children := range downstreamHierarchy.Graph {
-			knownIDs[k] = true
+			knownIDs[k] = struct{}{}
+			delete(candidateIDs, k)
 			for _, c := range children {
-				knownIDs[c] = true
+				knownIDs[c] = struct{}{}
+				delete(candidateIDs, c)
 			}
 		}
 	}
@@ -155,7 +157,7 @@ func (s *Server) handleVulnerabilityDetails(w http.ResponseWriter, r *http.Reque
 			}
 			if known {
 				mu.Lock()
-				knownIDs[id] = true
+				knownIDs[id] = struct{}{}
 				mu.Unlock()
 			}
 

--- a/go/internal/website/vulnerability.go
+++ b/go/internal/website/vulnerability.go
@@ -114,6 +114,7 @@ func (s *Server) handleVulnerabilityDetails(w http.ResponseWriter, r *http.Reque
 
 	// Collect all the vuln IDs mentioned by this vuln to check the database (in parallel) for existence.
 	candidateIDs := make(map[string]struct{})
+	knownIDs := make(map[string]bool)
 	for _, id := range vuln.GetAliases() {
 		candidateIDs[id] = struct{}{}
 	}
@@ -132,16 +133,18 @@ func (s *Server) handleVulnerabilityDetails(w http.ResponseWriter, r *http.Reque
 		}
 	}
 	if downstreamHierarchy != nil {
+		// Downstream hierarchy can be HUGE.
+		// However, something being in downstream implies it must be in the database,
+		// so we don't need to check for existence of >10k downstreams.
 		for k, children := range downstreamHierarchy.Graph {
-			candidateIDs[k] = struct{}{}
+			knownIDs[k] = true
 			for _, c := range children {
-				candidateIDs[c] = struct{}{}
+				knownIDs[c] = true
 			}
 		}
 	}
 
 	var mu sync.Mutex
-	knownIDs := make(map[string]bool)
 	g, ctx := errgroup.WithContext(r.Context())
 	g.SetLimit(20) // some vulns can have lots of related/alias/upstream/downstream
 	for id := range candidateIDs {

--- a/go/internal/website/vulnerability_helpers.go
+++ b/go/internal/website/vulnerability_helpers.go
@@ -111,7 +111,7 @@ func ParseDatabaseSpecificKVs(s *structpb.Struct) []DatabaseSpecificKV {
 }
 
 // ConstructHierarchyHTML formats a models.Hierarchy into a template.HTML tree string.
-func ConstructHierarchyHTML(targetID string, hierarchy *models.Hierarchy, knownIDs map[string]bool) template.HTML {
+func ConstructHierarchyHTML(targetID string, hierarchy *models.Hierarchy, knownIDs map[string]struct{}) template.HTML {
 	if hierarchy == nil || len(hierarchy.Roots) == 0 {
 		return ""
 	}
@@ -131,7 +131,7 @@ func ConstructHierarchyHTML(targetID string, hierarchy *models.Hierarchy, knownI
 
 		if vulnID != targetID {
 			escapedID := template.HTMLEscapeString(vulnID)
-			if knownIDs[vulnID] {
+			if _, known := knownIDs[vulnID]; known {
 				sb.WriteString(fmt.Sprintf(`<li><a href="/vulnerability/%s">%s</a></li>`, escapedID, escapedID))
 			} else {
 				sb.WriteString(fmt.Sprintf("<li>%s</li>", escapedID))

--- a/go/internal/website/vulnerability_models.go
+++ b/go/internal/website/vulnerability_models.go
@@ -82,7 +82,7 @@ type VulnerabilityPageData struct {
 	APIURL              string
 	HumanSourceLink     string
 	SourceLink          string
-	KnownIDs            map[string]bool
+	KnownIDs            map[string]struct{}
 	UpstreamHierarchy   template.HTML
 	DownstreamHierarchy template.HTML
 }

--- a/go/internal/website/vulnerability_view.go
+++ b/go/internal/website/vulnerability_view.go
@@ -114,7 +114,9 @@ func (v VulnerabilityPageData) IsKnownID(id string) bool {
 		return false
 	}
 
-	return v.KnownIDs[id]
+	_, known := v.KnownIDs[id]
+
+	return known
 }
 
 // ShouldCollapse returns true if the affected packages list should collapse into grouped accordions.


### PR DESCRIPTION
A couple of fixes for the go website
- Sort the ecosystem names on the `/list` page alphabetically and case-insensitively
- Handle weird double-marshalled upstream hierarchies that can be found in the Datastore
- Don't check for existence of downstream vulns in the website - the fact they exist in the database implies that they should exist
- Cancel the request's context when the `writeTimeout` has been exceeded (so we don't waste time on work that can't be sent). And increase the `writeTimeout` to 60s
- Also, adjusted one of the tests to hopefully be less flaky (I think there was a race condition where ecosystem counts were being cached at the same time the entities were being written to the datastore emulator)