### PR TITLE
fix(lint): nolint but make it actually work

### DIFF
--- a/go/cmd/staging_api_test/generator.go
+++ b/go/cmd/staging_api_test/generator.go
@@ -288,11 +288,9 @@ func newHTTPClient() *http.Client {
 }
 
 // executeRequest sends an HTTP request and updates stats.
-//
-//nolint:gosec // G704: Staging API load testing client
 func executeRequest(ctx context.Context, client *http.Client, req *http.Request, stats *GeneratorStats) {
 	req = req.WithContext(ctx)
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) // #nosec G704: Staging API load testing client
 	if err != nil {
 		if ctx.Err() == nil {
 			logger.Warn("Failed to send HTTP request",


### PR DESCRIPTION
nolint:gosec and nolintlint are fighting so we're switching to the gosec native ignore pattern.
Seems like our lint workflow only intermittently report the nolintlint error, which is why #5959 was fine.