### PR TITLE
fix(alpine): do not derive introduced from an unrelated NVD CPE branch

### DIFF
--- a/vulnfeeds/cmd/converters/alpine/main.go
+++ b/vulnfeeds/cmd/converters/alpine/main.go
@@ -202,7 +202,7 @@ func generateAlpineOSV(allAlpineSecDb map[string][]VersionAndPkg, allCVEs map[mo
 				continue
 			}
 
-			introduced := findIntroducedVersion(cve.CVE, verPkg.Pkg)
+			introduced := findIntroducedVersion(cve.CVE, verPkg.Pkg, verPkg.Ver)
 			pkgInfo := vulns.PackageInfo{
 				PkgName: verPkg.Pkg,
 				VersionInfo: models.VersionInfo{
@@ -259,27 +259,88 @@ func cpeMatchesAlpinePackage(parsed *models.CPEString, alpinePkg string) bool {
 }
 
 // findIntroducedVersion searches NVD CPE configurations for the introduced
-// version corresponding to the given Alpine package. Returns "0" if no
-// VersionStartIncluding match is found.
-func findIntroducedVersion(cve models.NVDCVE, alpinePkg string) string {
+// version corresponding to the given Alpine package, on the branch fixed at
+// fixedVersion. A CVE's CPE configuration can describe several independently
+// vulnerable branches (e.g. fixed separately in 5.26.x and 5.28.x), so a
+// candidate is only used when it sorts before fixedVersion; otherwise it
+// belongs to an unrelated branch and pairing it with fixedVersion would
+// produce an inverted, unsatisfiable range. When several candidates qualify,
+// the one closest to fixedVersion is used. Returns "0" if no match qualifies.
+func findIntroducedVersion(cve models.NVDCVE, alpinePkg string, fixedVersion string) string {
+	introduced := ""
 	for _, config := range cve.Configurations {
 		for _, node := range config.Nodes {
 			for _, match := range node.CPEMatch {
 				if !match.Vulnerable || match.VersionStartIncluding == nil {
 					continue
 				}
+				candidate := *match.VersionStartIncluding
+				if !versionLess(candidate, fixedVersion) {
+					continue
+				}
 				parsed, err := conversion.ParseCPE(match.Criteria)
 				if err != nil {
 					continue
 				}
-				if cpeMatchesAlpinePackage(parsed, alpinePkg) {
-					return *match.VersionStartIncluding
+				if !cpeMatchesAlpinePackage(parsed, alpinePkg) {
+					continue
+				}
+				if introduced == "" || versionLess(introduced, candidate) {
+					introduced = candidate
 				}
 			}
 		}
 	}
 
-	return "0"
+	if introduced == "" {
+		return "0"
+	}
+
+	return introduced
+}
+
+// versionLess reports whether a sorts before b, comparing dot-separated
+// numeric components in order and treating missing trailing components as 0.
+// It is intentionally approximate, ignoring any non-numeric suffix on a
+// component (e.g. Alpine's "-r0" revision, or the "a" in "1.0.2a"), since it
+// is only used to sanity-check that a candidate introduced version precedes
+// a fixed version rather than to order versions precisely.
+func versionLess(a, b string) bool {
+	aParts := numericVersionComponents(a)
+	bParts := numericVersionComponents(b)
+	for i := 0; i < len(aParts) || i < len(bParts); i++ {
+		var av, bv int
+		if i < len(aParts) {
+			av = aParts[i]
+		}
+		if i < len(bParts) {
+			bv = bParts[i]
+		}
+		if av != bv {
+			return av < bv
+		}
+	}
+
+	return false
+}
+
+// numericVersionComponents splits a version string on '.' and parses the
+// leading digits of each component, stopping at the first non-digit rune.
+func numericVersionComponents(version string) []int {
+	fields := strings.Split(version, ".")
+	components := make([]int, len(fields))
+	for i, field := range fields {
+		n := 0
+		for _, c := range field {
+			if c < '0' || c > '9' {
+				break
+			}
+			n = n*10 + int(c-'0')
+		}
+		components[i] = n
+	}
+
+	return components
 }
 
 // downloadAlpine downloads Alpine SecDB data from their API

--- a/vulnfeeds/cmd/converters/alpine/main_test.go
+++ b/vulnfeeds/cmd/converters/alpine/main_test.go
@@ -68,16 +68,18 @@ func TestFindIntroducedVersion(t *testing.T) {
 	const pillowCPE = "cpe:2.3:a:python-pillow:pillow:*:*:*:*:*:python:*:*"
 
 	tests := []struct {
-		name      string
-		cve       models.NVDCVE
-		alpinePkg string
-		want      string
+		name         string
+		cve          models.NVDCVE
+		alpinePkg    string
+		fixedVersion string
+		want         string
 	}{
 		{
-			name:      "no configurations",
-			cve:       models.NVDCVE{},
-			alpinePkg: "xz",
-			want:      "0",
+			name:         "no configurations",
+			cve:          models.NVDCVE{},
+			alpinePkg:    "xz",
+			fixedVersion: "5.6.1-r0",
+			want:         "0",
 		},
 		{
 			name: "match with VersionStartIncluding",
@@ -92,8 +94,9 @@ func TestFindIntroducedVersion(t *testing.T) {
 					}},
 				}},
 			},
-			alpinePkg: "xz",
-			want:      "5.6.0",
+			alpinePkg:    "xz",
+			fixedVersion: "5.6.1-r0",
+			want:         "5.6.0",
 		},
 		{
 			name: "non-vulnerable CPE skipped",
@@ -108,8 +111,9 @@ func TestFindIntroducedVersion(t *testing.T) {
 					}},
 				}},
 			},
-			alpinePkg: "xz",
-			want:      "0",
+			alpinePkg:    "xz",
+			fixedVersion: "5.6.1-r0",
+			want:         "0",
 		},
 		{
 			name: "VersionStartIncluding nil returns 0",
@@ -123,8 +127,9 @@ func TestFindIntroducedVersion(t *testing.T) {
 					}},
 				}},
 			},
-			alpinePkg: "xz",
-			want:      "0",
+			alpinePkg:    "xz",
+			fixedVersion: "5.6.1-r0",
+			want:         "0",
 		},
 		{
 			// Known gap: VersionStartExcluding is not handled; falls back to "0".
@@ -140,8 +145,9 @@ func TestFindIntroducedVersion(t *testing.T) {
 					}},
 				}},
 			},
-			alpinePkg: "xz",
-			want:      "0",
+			alpinePkg:    "xz",
+			fixedVersion: "5.6.1-r0",
+			want:         "0",
 		},
 		{
 			name: "invalid CPE criteria skipped",
@@ -156,8 +162,9 @@ func TestFindIntroducedVersion(t *testing.T) {
 					}},
 				}},
 			},
-			alpinePkg: "xz",
-			want:      "0",
+			alpinePkg:    "xz",
+			fixedVersion: "5.6.1-r0",
+			want:         "0",
 		},
 		{
 			name: "match found in second node",
@@ -181,8 +188,9 @@ func TestFindIntroducedVersion(t *testing.T) {
 					},
 				}},
 			},
-			alpinePkg: "foo",
-			want:      "1.0.0",
+			alpinePkg:    "foo",
+			fixedVersion: "1.2.0-r0",
+			want:         "1.0.0",
 		},
 		{
 			name: "python package prefix match",
@@ -197,11 +205,14 @@ func TestFindIntroducedVersion(t *testing.T) {
 					}},
 				}},
 			},
-			alpinePkg: "py3-pillow",
-			want:      "9.0.0",
+			alpinePkg:    "py3-pillow",
+			fixedVersion: "9.1.0-r0",
+			want:         "9.0.0",
 		},
 		{
-			name: "first match wins when multiple CPEs match",
+			// Among multiple qualifying candidates, the one closest to (just
+			// below) the fixed version is preferred as the tightest bound.
+			name: "closest qualifying match wins when multiple CPEs match",
 			cve: models.NVDCVE{
 				Configurations: []models.Config{{
 					Nodes: []models.Node{{
@@ -220,16 +231,73 @@ func TestFindIntroducedVersion(t *testing.T) {
 					}},
 				}},
 			},
-			alpinePkg: "xz",
-			want:      "5.0.0",
+			alpinePkg:    "xz",
+			fixedVersion: "5.6.1-r0",
+			want:         "5.6.0",
+		},
+		{
+			// Regression test for https://github.com/google/osv.dev/issues/5634:
+			// NVD's CPE configuration for perl CVE-2018-18311 describes two
+			// independently fixed branches (< 5.26.3 and [5.28.0, 5.28.1)).
+			// Alpine's secfix is 5.26.3-r0, on the first branch, so the
+			// 5.28.0 VersionStartIncluding from the unrelated second branch
+			// must not be used as introduced: it would invert the range.
+			name: "unrelated higher branch is not used as introduced",
+			cve: models.NVDCVE{
+				Configurations: []models.Config{{
+					Nodes: []models.Node{{
+						CPEMatch: []models.CPEMatch{
+							{
+								Criteria:            "cpe:2.3:a:perl:perl:*:*:*:*:*:*:*:*",
+								Vulnerable:          true,
+								VersionEndExcluding: new("5.26.3"),
+							},
+							{
+								Criteria:              "cpe:2.3:a:perl:perl:*:*:*:*:*:*:*:*",
+								Vulnerable:            true,
+								VersionStartIncluding: new("5.28.0"),
+								VersionEndExcluding:   new("5.28.1"),
+							},
+						},
+					}},
+				}},
+			},
+			alpinePkg:    "perl",
+			fixedVersion: "5.26.3-r0",
+			want:         "0",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := findIntroducedVersion(tc.cve, tc.alpinePkg)
+			got := findIntroducedVersion(tc.cve, tc.alpinePkg, tc.fixedVersion)
 			if got != tc.want {
-				t.Errorf("findIntroducedVersion(..., %q) = %q, want %q", tc.alpinePkg, got, tc.want)
+				t.Errorf("findIntroducedVersion(..., %q, %q) = %q, want %q", tc.alpinePkg, tc.fixedVersion, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestVersionLess(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want bool
+	}{
+		{"5.28.0", "5.26.3-r0", false},
+		{"0", "5.26.3-r0", true},
+		{"5.0.0", "5.6.1-r0", true},
+		{"5.6.0", "5.6.1-r0", true},
+		{"5.6.1", "5.6.1-r0", false},
+		{"1.0.2", "1.0.2a", false},
+		{"9.0.0", "9.1.0-r0", true},
+		{"1.2.0", "1.2.0-r0", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.a+"_vs_"+tc.b, func(t *testing.T) {
+			got := versionLess(tc.a, tc.b)
+			if got != tc.want {
+				t.Errorf("versionLess(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
findIntroducedVersion picked the first CPE match with a versionStartIncluding, regardless of which vulnerable branch it described. When a CVE was fixed independently on multiple branches (e.g. perl CVE-2018-18311, fixed at 5.26.3 and separately at 5.28.1), this could pair an introduced version from one branch with the Alpine secfix from a different, unrelated branch, producing an inverted and unsatisfiable range (introduced > fixed). Scanners then treated every higher version as affected, causing false positives long after the real fix.

Only use a candidate introduced version when it sorts before the Alpine fixed version, picking the closest qualifying one and falling back to "0" otherwise.

Fixes #5634 