### PR TITLE
fix(website): display per-package severity

### DIFF
--- a/go/internal/website/vulnerability_view.go
+++ b/go/internal/website/vulnerability_view.go
@@ -150,12 +150,14 @@ func (v VulnerabilityPageData) Severities() []SeverityDisplay {
 		return nil
 	}
 
-	severities := v.Vulnerability.GetSeverity()
+	return severityDisplays(v.Vulnerability.GetSeverity(), v.Vulnerability.GetId())
+}
+
+func severityDisplays(severities []*osvschema.Severity, id string) []SeverityDisplay {
 	if len(severities) == 0 {
 		return nil
 	}
 
-	id := v.Vulnerability.GetId()
 	displays := make([]SeverityDisplay, 0, len(severities))
 	for _, sev := range severities {
 		source := ""
@@ -364,6 +366,7 @@ func (v VulnerabilityPageData) AffectedPackages() []AffectedPackageDisplay {
 			PackagePurl:           pkgPurl,
 			HasPackage:            hasPkg,
 			IsLastPackage:         i == len(affectedList)-1,
+			Severities:            severityDisplays(aff.GetSeverity(), v.Vulnerability.GetId()),
 			Ranges:                ranges,
 			VersionGroups:         versionGroups,
 			EcosystemSpecificJSON: FormatProtoStruct(aff.GetEcosystemSpecific()),

--- a/go/internal/website/vulnerability_view_test.go
+++ b/go/internal/website/vulnerability_view_test.go
@@ -96,6 +96,21 @@ func TestSeverities(t *testing.T) {
 	}
 }
 
+func TestAffectedPackagesSeverities(t *testing.T) {
+	pageData := VulnerabilityPageData{
+		Vulnerability: &osvschema.Vulnerability{
+			Affected: []*osvschema.Affected{{
+				Severity: []*osvschema.Severity{{Type: osvschema.Severity_CVSS_V3, Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}},
+			}},
+		},
+	}
+
+	sevs := pageData.AffectedPackages()[0].Severities
+	if len(sevs) != 1 || sevs[0].Level != "critical" {
+		t.Errorf("Severities = %+v, want one critical entry", sevs)
+	}
+}
+
 func TestDepsDevURL(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
Small follow-up to the Go website migration. The per-package severity section on vulnerability pages was hidden because `Severities` was not populated for each affected package. The section was already rendered in the template. 

This reuses the existing severity conversion for each `affected[]` entry.

Before/After on `BIT-activemq-2026-33227`:

<img width="1054" height="370" alt="before" src="https://github.com/user-attachments/assets/cea882a1-d960-4f62-8ca6-420e610b9d4c" />

<img width="1006" height="410" alt="after" src="https://github.com/user-attachments/assets/b4f2537f-7e25-49eb-8a99-3ee2fd9b21eb" />

