### PR TITLE
fix(importer): close REST response body on HTTP error

### DIFF
--- a/go/internal/importer/rest.go
+++ b/go/internal/importer/rest.go
@@ -39,6 +39,7 @@ func (r restSourceRecord) Open(ctx context.Context) (io.ReadCloser, error) {
 	}
 
 	if resp.StatusCode >= http.StatusBadRequest {
+		resp.Body.Close()
 		return nil, fmt.Errorf("failed to fetch REST API: %d %s for %s", resp.StatusCode, resp.Status, u)
 	}
 

--- a/go/internal/importer/rest_test.go
+++ b/go/internal/importer/rest_test.go
@@ -4,11 +4,28 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/osv.dev/go/internal/models"
 )
+
+type trackingReadCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (r *trackingReadCloser) Close() error {
+	r.closed = true
+	return nil
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestRestSourceRecord_Open(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -37,6 +54,28 @@ func TestRestSourceRecord_Open(t *testing.T) {
 
 	if string(data) != "data" {
 		t.Errorf("Expected 'data', got '%s'", string(data))
+	}
+}
+
+func TestRestSourceRecord_OpenClosesBodyOnHTTPError(t *testing.T) {
+	body := &trackingReadCloser{Reader: strings.NewReader("error")}
+	record := restSourceRecord{
+		cl: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Status:     "500 Internal Server Error",
+				Body:       body,
+			}, nil
+		})},
+		urlBase: "https://example.com",
+		urlPath: "/test",
+	}
+
+	if _, err := record.Open(t.Context()); err == nil {
+		t.Fatal("Open succeeded, want HTTP error")
+	}
+	if !body.closed {
+		t.Error("response body was not closed")
 	}
 }
 

--- a/go/internal/importer/rest_test.go
+++ b/go/internal/importer/rest_test.go
@@ -13,6 +13,7 @@ import (
 
 type trackingReadCloser struct {
 	io.Reader
+
 	closed bool
 }
 


### PR DESCRIPTION
## Overview

Close the REST source response body before returning an HTTP status error from `restSourceRecord.Open`.

Fixes #5985

## Details

`Open` returns `resp.Body` to callers on success, but previously returned early on 4xx/5xx responses without closing it. This closes the body on the error path and adds a regression test using a tracking `ReadCloser`.

## Testing

- `go test -v ./internal/importer -run 'TestRestSourceRecord_Open'`
- `go test ./internal/importer`
- `git diff --check`

AI-assisted contribution: I used an AI coding agent during investigation and implementation. I reviewed the final diff and ran the verification listed above. I am responsible for the submitted change and follow-up.

<!-- AI-PR -->