### PR TITLE
feat(gitter): New endpoint for commit history and patch extraction

### DIFF
--- a/go/cmd/gitter/errors.go
+++ b/go/cmd/gitter/errors.go
@@ -156,8 +156,17 @@ func isRefNotFoundError(err error) bool {
 	return errContainsAny(err,
 		"not found or invalid",
 		"failed to resolve target ref",
+		"failed to resolve target branch",
 		"failed to run git rev-parse",
 		"ref cannot be empty",
+	)
+}
+
+// isCommitNotAncestorError returns true if last_scan_commit is not found in the repository or is not an ancestor of HEAD.
+func isCommitNotAncestorError(err error) bool {
+	return errContainsAny(err,
+		"not an ancestor",
+		"failed to resolve last_scan_commit",
 	)
 }
 

--- a/go/cmd/gitter/git.go
+++ b/go/cmd/gitter/git.go
@@ -42,8 +42,8 @@ func prepareCmd(ctx context.Context, dir string, env []string, name string, args
 }
 
 // runCmd executes a command with context cancellation handled by sending SIGINT.
-// It logs cancellation errors separately as requested.
-func runCmd(ctx context.Context, dir string, env []string, name string, args ...string) error {
+// It logs cancellation errors separately as requested
+func runCmd(ctx context.Context, dir string, env []string, name string, args ...string) ([]byte, error) {
 	cmd := prepareCmd(ctx, dir, env, name, args...)
 	out, err := cmd.CombinedOutput()
 
@@ -51,10 +51,10 @@ func runCmd(ctx context.Context, dir string, env []string, name string, args ...
 		if ctx.Err() != nil {
 			// Log separately if cancelled
 			logger.DebugContext(ctx, "Command cancelled", slog.String("cmd", name), slog.Any("err", ctx.Err()))
-			return fmt.Errorf("command %s cancelled: %w", name, ctx.Err())
+			return out, fmt.Errorf("command %s cancelled: %w", name, ctx.Err())
 		}
 
-		return fmt.Errorf("command %s failed: %w, output: %s", name, err, out)
+		return out, fmt.Errorf("command %s failed: %w, output: %s", name, err, out)
 	}
 
 	logger.DebugContext(ctx, "Git command executed",
@@ -63,12 +63,13 @@ func runCmd(ctx context.Context, dir string, env []string, name string, args ...
 		slog.String("output", string(out)),
 	)
 
-	return nil
+	return out, nil
 }
 
 // cloneRepo clones a git repository into repoPath.
 func cloneRepo(ctx context.Context, repoURL string, repoPath string) error {
-	return runCmd(ctx, "", []string{"GIT_TERMINAL_PROMPT=0"}, "git", "clone", "--", repoURL, repoPath)
+	_, err := runCmd(ctx, "", []string{"GIT_TERMINAL_PROMPT=0"}, "git", "clone", "--", repoURL, repoPath)
+	return err
 }
 
 // Attempt to recover from git fetch errors
@@ -82,7 +83,7 @@ func attemptGitRecovery(ctx context.Context, repoPath string, err error) bool {
 	// We can try removing stale remote-tracking branches and retry
 	if isRefConflictError(err) {
 		logger.WarnContext(ctx, "Ref conflict detected, running git remote prune origin")
-		if err := runCmd(ctx, repoPath, nil, "git", "remote", "prune", "origin"); err != nil {
+		if _, err := runCmd(ctx, repoPath, nil, "git", "remote", "prune", "origin"); err != nil {
 			logger.WarnContext(ctx, "Failed to prune origin", slog.Any("err", err))
 			return false
 		}
@@ -101,13 +102,13 @@ func attemptGitRecovery(ctx context.Context, repoPath string, err error) bool {
 
 // fetchRepo fetches remote origin and updates origin/HEAD to the remote's default branch
 func fetchRepo(ctx context.Context, repoPath string) error {
-	err := runCmd(ctx, repoPath, nil, "git", "fetch", "origin")
+	_, err := runCmd(ctx, repoPath, nil, "git", "fetch", "origin")
 	if err != nil {
 		return fmt.Errorf("git fetch failed: %w", err)
 	}
 
 	// Make sure origin/HEAD points to the latest default branch from remotes
-	err = runCmd(ctx, repoPath, nil, "git", "remote", "set-head", "origin", "--auto")
+	_, err = runCmd(ctx, repoPath, nil, "git", "remote", "set-head", "origin", "--auto")
 	if err != nil {
 		logger.WarnContext(ctx, "git remote set-head failed", slog.Any("err", err))
 	}
@@ -297,14 +298,14 @@ func ArchiveRepo(ctx context.Context, repoURL string) ([]byte, error) {
 		startArchive := time.Now()
 
 		// Reset working tree to origin/HEAD before creating archive
-		if err := runCmd(ctx, repoPath, nil, "git", "reset", "--hard", "origin/HEAD"); err != nil {
+		if _, err := runCmd(ctx, repoPath, nil, "git", "reset", "--hard", "origin/HEAD"); err != nil {
 			return nil, fmt.Errorf("git reset failed: %w", err)
 		}
 
 		// Archive
 		// tar --zstd -cf <archivePath> -C "<gitStorePath>/<repoDirName>" .
 		// using -C to archive the relative path so it unzips nicely
-		err := runCmd(ctx, "", nil, "tar", "--zstd", "-cf", archivePath, "-C", filepath.Join(gitStorePath, repoDirName), ".")
+		_, err := runCmd(ctx, "", nil, "tar", "--zstd", "-cf", archivePath, "-C", filepath.Join(gitStorePath, repoDirName), ".")
 		if err != nil {
 			return nil, fmt.Errorf("tar zstd failed: %w", err)
 		}

--- a/go/cmd/gitter/git_test.go
+++ b/go/cmd/gitter/git_test.go
@@ -47,14 +47,14 @@ func TestRefreshRepo_DontRecloneOnRemoteError(t *testing.T) {
 	if err := os.MkdirAll(repoPath, 0755); err != nil {
 		t.Fatalf("failed to create repo dir: %v", err)
 	}
-	if err := runCmd(ctx, repoPath, nil, "git", "init"); err != nil {
+	if _, err := runCmd(ctx, repoPath, nil, "git", "init"); err != nil {
 		t.Fatalf("git init failed: %v", err)
 	}
 	// Configure dummy git user
-	_ = runCmd(ctx, repoPath, nil, "git", "config", "user.name", "Test")
-	_ = runCmd(ctx, repoPath, nil, "git", "config", "user.email", "test@example.com")
+	_, _ = runCmd(ctx, repoPath, nil, "git", "config", "user.name", "Test")
+	_, _ = runCmd(ctx, repoPath, nil, "git", "config", "user.email", "test@example.com")
 	// Add remote origin pointing to an unreachable port (connection refused)
-	if err := runCmd(ctx, repoPath, nil, "git", "remote", "add", "origin", "https://127.0.0.1:59999/repo.git"); err != nil {
+	if _, err := runCmd(ctx, repoPath, nil, "git", "remote", "add", "origin", "https://127.0.0.1:59999/repo.git"); err != nil {
 		t.Fatalf("git remote add failed: %v", err)
 	}
 
@@ -63,10 +63,10 @@ func TestRefreshRepo_DontRecloneOnRemoteError(t *testing.T) {
 	if err := os.WriteFile(dummyFile, []byte("hello"), 0600); err != nil {
 		t.Fatalf("write file failed: %v", err)
 	}
-	if err := runCmd(ctx, repoPath, nil, "git", "add", "dummy.txt"); err != nil {
+	if _, err := runCmd(ctx, repoPath, nil, "git", "add", "dummy.txt"); err != nil {
 		t.Fatalf("git add failed: %v", err)
 	}
-	if err := runCmd(ctx, repoPath, nil, "git", "commit", "-m", "initial commit"); err != nil {
+	if _, err := runCmd(ctx, repoPath, nil, "git", "commit", "-m", "initial commit"); err != nil {
 		t.Fatalf("git commit failed: %v", err)
 	}
 

--- a/go/cmd/gitter/gitter.go
+++ b/go/cmd/gitter/gitter.go
@@ -1023,7 +1023,7 @@ func commitDiffsHandler(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	resolvedBranch, headCommit, commits, err := repo.ListCommits(ctx, branch, lastScanCommit, lastScanTime, body.GetNewestFirst())
+	resolvedBranch, headCommit, commits, err := repo.ListCommits(ctx, branch, lastScanCommit, lastScanTime, body.GetNewestFirst(), body.GetIncludePaths(), body.GetExcludePaths())
 	if err != nil {
 		// Distinguish missing refs - 404 Not Found (e.g. the commit hash is not a valid ancestor of HEAD - likely from git amend)
 		// From generic issues - 500
@@ -1050,11 +1050,12 @@ func commitDiffsHandler(w http.ResponseWriter, req *http.Request) {
 			})
 		}
 		pbCommits = append(pbCommits, &pb.CommitDiff{
-			Commit:       c.Commit,
-			Timestamp:    timestamppb.New(c.Timestamp),
-			Message:      c.Message,
-			Patch:        c.Patch,
-			FilesChanged: filesChanged,
+			Commit:         c.Commit,
+			Timestamp:      timestamppb.New(c.Timestamp),
+			Message:        c.Message,
+			Patch:          c.Patch,
+			FilesChanged:   filesChanged,
+			PatchTruncated: c.PatchTruncated,
 		})
 	}
 

--- a/go/cmd/gitter/gitter.go
+++ b/go/cmd/gitter/gitter.go
@@ -33,6 +33,7 @@ import (
 	"golang.org/x/sync/singleflight"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pb "github.com/google/osv.dev/go/internal/gitter/pb/repository"
 )
@@ -56,6 +57,7 @@ var endpointHandlers = map[string]http.HandlerFunc{
 	"POST /affected-commits": affectedCommitsHandler,
 	"POST /file-diffs":       fileDiffsHandler,
 	"POST /file-content":     fileContentHandler,
+	"POST /commit-diffs":     commitDiffsHandler,
 }
 
 var (
@@ -963,5 +965,111 @@ func fileContentHandler(w http.ResponseWriter, req *http.Request) {
 		logger.ErrorContext(ctx, "Error writing file content response", slog.Any("error", err))
 		statusCode = http.StatusInternalServerError
 		http.Error(w, fmt.Sprintf("Error writing file content response: %v", err), statusCode)
+	}
+}
+
+func commitDiffsHandler(w http.ResponseWriter, req *http.Request) {
+	start := time.Now()
+	statusCode := http.StatusOK
+	ctx := req.Context()
+	defer func() { logRequestCompletion(ctx, "/commit-diffs", start, statusCode) }()
+
+	body := &pb.CommitDiffsRequest{}
+	if err := unmarshalRequest(req, body); err != nil {
+		statusCode = http.StatusBadRequest
+		http.Error(w, fmt.Sprintf("Error unmarshaling request: %v", err), statusCode)
+
+		return
+	}
+
+	repoURL, err := prepareURL(req, body.GetUrl())
+	if err != nil {
+		statusCode = http.StatusBadRequest
+		http.Error(w, err.Error(), statusCode)
+
+		return
+	}
+
+	lastScanCommit := strings.TrimSpace(body.GetLastScanCommit())
+	branch := strings.TrimSpace(body.GetBranch())
+	var lastScanTime time.Time
+	if body.GetLastScanTime() != nil {
+		lastScanTime = body.GetLastScanTime().AsTime()
+	}
+
+	// Require at least one boundary (last_scan_commit or last_scan_time).
+	if lastScanCommit == "" && lastScanTime.IsZero() {
+		statusCode = http.StatusBadRequest
+		http.Error(w, "missing last_scan_commit and last_scan_time (must provide at least one)", statusCode)
+
+		return
+	}
+
+	ctx = context.WithValue(ctx, urlKey, repoURL)
+	logger.DebugContext(ctx, "Received request: /commit-diffs",
+		slog.String("last_scan_commit", lastScanCommit),
+		slog.String("branch", branch),
+		slog.Time("last_scan_time", lastScanTime),
+		slog.Bool("newest_first", body.GetNewestFirst()),
+	)
+
+	// Always force update to get latest commits from the remote
+	repo, err := SyncRepoOnDisk(ctx, repoURL, FetchOptions{ForceUpdate: true, SkipReqConcurrencySemaphore: false})
+	if err != nil {
+		statusCode = errorToHTTPStatusCode(err)
+		cacheInvalidRepo(repoURL, statusCode)
+		http.Error(w, fmt.Sprintf("Error getting repo: %v", err), statusCode)
+
+		return
+	}
+
+	resolvedBranch, headCommit, commits, err := repo.ListCommits(ctx, branch, lastScanCommit, lastScanTime, body.GetNewestFirst())
+	if err != nil {
+		// Distinguish missing refs - 404 Not Found (e.g. the commit hash is not a valid ancestor of HEAD - likely from git amend)
+		// From generic issues - 500
+		if isRefNotFoundError(err) || isCommitNotAncestorError(err) {
+			statusCode = http.StatusNotFound
+			http.Error(w, fmt.Sprintf("Commit or branch not found: %v", err), statusCode)
+
+			return
+		}
+		logger.ErrorContext(ctx, "Error listing commits", slog.Any("error", err))
+		statusCode = http.StatusInternalServerError
+		http.Error(w, fmt.Sprintf("Error listing commits: %v", err), statusCode)
+
+		return
+	}
+
+	pbCommits := make([]*pb.CommitDiff, 0, len(commits))
+	for _, c := range commits {
+		filesChanged := make([]*pb.FileChange, 0, len(c.FilesChanged))
+		for _, f := range c.FilesChanged {
+			filesChanged = append(filesChanged, &pb.FileChange{
+				FromPath: f.From,
+				ToPath:   f.To,
+			})
+		}
+		pbCommits = append(pbCommits, &pb.CommitDiff{
+			Commit:       c.Commit,
+			Timestamp:    timestamppb.New(c.Timestamp),
+			Message:      c.Message,
+			Patch:        c.Patch,
+			FilesChanged: filesChanged,
+		})
+	}
+
+	resp := &pb.CommitDiffsResponse{
+		Url:        body.GetUrl(),
+		Branch:     resolvedBranch,
+		HeadCommit: headCommit,
+		//nolint:gosec // G115: len(commits) should safely fit in int32 (max is 2.14 billion)
+		NumCommits: int32(len(commits)),
+		Commits:    pbCommits,
+	}
+
+	if err := writeResponse(w, req, resp); err != nil {
+		logger.ErrorContext(ctx, "Error writing commit diffs response", slog.Any("error", err))
+		statusCode = http.StatusInternalServerError
+		http.Error(w, fmt.Sprintf("Error writing commit diffs response: %v", err), statusCode)
 	}
 }

--- a/go/cmd/gitter/gitter_test.go
+++ b/go/cmd/gitter/gitter_test.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestGetRepoDirName(t *testing.T) {
@@ -766,6 +767,185 @@ func TestFileContentHandler(t *testing.T) {
 				if diff := cmp.Diff(tt.expectedResponse, resp, protocmp.Transform()); diff != "" {
 					t.Errorf("fileContentHandler returned wrong response: -want +got:\n%s", diff)
 				}
+			}
+		})
+	}
+}
+
+func TestCommitDiffsHandler(t *testing.T) {
+	setupTest(t)
+
+	tests := []struct {
+		name         string
+		reqBody      *pb.CommitDiffsRequest
+		rawBody      []byte
+		contentType  string
+		expectedCode int
+		verifyResp   func(t *testing.T, resp *pb.CommitDiffsResponse)
+	}{
+		{
+			name: "Missing repo URL",
+			reqBody: &pb.CommitDiffsRequest{
+				LastScanCommit: "1234567890123456789012345678901234567890",
+			},
+			contentType:  "application/json",
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name: "Missing both last_scan_commit and last_scan_time",
+			reqBody: &pb.CommitDiffsRequest{
+				Url: "https://github.com/oliverchang/osv-test.git",
+			},
+			contentType:  "application/json",
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name: "Forbidden or non-existent repo",
+			reqBody: &pb.CommitDiffsRequest{
+				Url:            "https://github.com/google/this-repo-does-not-exist-12345.git",
+				LastScanCommit: "ff8cc32ba60ad9cbb3b23f0a82aad96ebe9ff76b",
+			},
+			contentType:  "application/json",
+			expectedCode: http.StatusForbidden,
+		},
+		{
+			name: "Query commits with JSON",
+			reqBody: &pb.CommitDiffsRequest{
+				Url:            "https://github.com/oliverchang/osv-test.git",
+				LastScanCommit: "b1c95a196f22d06fcf80df8c6691cd113d8fefff",
+			},
+			contentType:  "application/json",
+			expectedCode: http.StatusOK,
+			verifyResp: func(t *testing.T, resp *pb.CommitDiffsResponse) {
+				t.Helper()
+				if resp.GetHeadCommit() != "b9b3fd4732695b83c3068b7b6a14bb372ec31f98" {
+					t.Errorf("unexpected head commit: %s", resp.GetHeadCommit())
+				}
+				if resp.GetNumCommits() != 2 || len(resp.GetCommits()) != 2 {
+					t.Fatalf("expected 2 commits, got %d", resp.GetNumCommits())
+				}
+				// Default order is oldest first, so the latest commit (HEAD) is the second commit
+				c := resp.GetCommits()[1]
+				if c.GetCommit() != "b9b3fd4732695b83c3068b7b6a14bb372ec31f98" {
+					t.Errorf("unexpected commit sha: %s", c.GetCommit())
+				}
+				if c.GetPatch() == "" {
+					t.Errorf("expected non-empty patch")
+				}
+				if len(c.GetFilesChanged()) == 0 {
+					t.Errorf("expected non-empty files changed")
+				}
+			},
+		},
+		{
+			name: "Query commits with Protobuf wire format",
+			reqBody: &pb.CommitDiffsRequest{
+				Url:            "https://github.com/oliverchang/osv-test.git",
+				LastScanCommit: "b1c95a196f22d06fcf80df8c6691cd113d8fefff",
+				NewestFirst:    true,
+			},
+			contentType:  "application/x-protobuf",
+			expectedCode: http.StatusOK,
+			verifyResp: func(t *testing.T, resp *pb.CommitDiffsResponse) {
+				t.Helper()
+				if resp.GetHeadCommit() != "b9b3fd4732695b83c3068b7b6a14bb372ec31f98" {
+					t.Errorf("unexpected head commit: %s", resp.GetHeadCommit())
+				}
+				if resp.GetNumCommits() != 2 || len(resp.GetCommits()) != 2 {
+					t.Fatalf("expected 2 commits, got %d", resp.GetNumCommits())
+				}
+				// Newest first, so first commit is HEAD
+				c := resp.GetCommits()[0]
+				if c.GetCommit() != "b9b3fd4732695b83c3068b7b6a14bb372ec31f98" {
+					t.Errorf("unexpected commit sha: %s", c.GetCommit())
+				}
+			},
+		},
+		{
+			name: "Query commits using last_scan_time only",
+			reqBody: &pb.CommitDiffsRequest{
+				Url:          "https://github.com/oliverchang/osv-test.git",
+				LastScanTime: timestamppb.New(time.Unix(1, 0)),
+			},
+			contentType:  "application/json",
+			expectedCode: http.StatusOK,
+			verifyResp: func(t *testing.T, resp *pb.CommitDiffsResponse) {
+				t.Helper()
+				if resp.GetNumCommits() == 0 {
+					t.Errorf("expected non-empty commits")
+				}
+			},
+		},
+		{
+			name: "Non-existent branch name",
+			reqBody: &pb.CommitDiffsRequest{
+				Url:            "https://github.com/oliverchang/osv-test.git",
+				Branch:         "non-existent-branch-12345",
+				LastScanCommit: "b1c95a196f22d06fcf80df8c6691cd113d8fefff",
+			},
+			contentType:  "application/json",
+			expectedCode: http.StatusNotFound,
+		},
+		{
+			name: "Invalid last_scan_commit without last_scan_time",
+			reqBody: &pb.CommitDiffsRequest{
+				Url:            "https://github.com/oliverchang/osv-test.git",
+				LastScanCommit: "invalidhash123456",
+			},
+			contentType:  "application/json",
+			expectedCode: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var bodyBytes []byte
+			if tt.rawBody != nil {
+				bodyBytes = tt.rawBody
+			} else if tt.reqBody != nil {
+				var err error
+				if tt.contentType == "application/json" {
+					bodyBytes, err = protojson.Marshal(tt.reqBody)
+				} else {
+					bodyBytes, err = proto.Marshal(tt.reqBody)
+				}
+				if err != nil {
+					t.Fatalf("failed to marshal request: %v", err)
+				}
+			}
+
+			req, err := http.NewRequest(http.MethodPost, "/commit-diffs", bytes.NewReader(bodyBytes))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tt.contentType != "" {
+				req.Header.Set("Content-Type", tt.contentType)
+			}
+
+			rr := httptest.NewRecorder()
+			commitDiffsHandler(rr, req)
+
+			// Non-existent repos on github may return 403 or 502 depending on network latency/timeouts
+			if tt.name == "Forbidden or non-existent repo" {
+				if rr.Code != http.StatusForbidden && rr.Code != http.StatusBadGateway {
+					t.Errorf("commitDiffsHandler returned wrong status code: got %v want 403 or 502", rr.Code)
+				}
+			} else if status := rr.Code; status != tt.expectedCode {
+				t.Errorf("commitDiffsHandler returned wrong status code: got %v want %v", status, tt.expectedCode)
+			}
+
+			if tt.verifyResp != nil && rr.Code == http.StatusOK {
+				resp := &pb.CommitDiffsResponse{}
+				var err error
+				if tt.contentType == "application/json" {
+					err = protojson.Unmarshal(rr.Body.Bytes(), resp)
+				} else {
+					err = proto.Unmarshal(rr.Body.Bytes(), resp)
+				}
+				if err != nil {
+					t.Fatalf("failed to unmarshal response: %v", err)
+				}
+				tt.verifyResp(t, resp)
 			}
 		})
 	}

--- a/go/cmd/gitter/repository.go
+++ b/go/cmd/gitter/repository.go
@@ -1030,13 +1030,18 @@ type FileChange struct {
 	To   string
 }
 
+// DefaultMaxCommitPatchBytes is the default maximum size (5 MB) allowed for an individual commit's unified patch diff.
+// If a commit's patch exceeds this size, the patch is truncated to prevent excessive memory consumption.
+const DefaultMaxCommitPatchBytes = 5 * 1024 * 1024
+
 // CommitDiff represents a commit and its changes on a repository.
 type CommitDiff struct {
-	Commit       string
-	Timestamp    time.Time
-	Message      string
-	Patch        string
-	FilesChanged []*FileChange
+	Commit         string
+	Timestamp      time.Time
+	Message        string
+	Patch          string
+	FilesChanged   []*FileChange
+	PatchTruncated bool
 }
 
 // resolveCommit resolves a branch or (abbreviated) commit SHA to its raw 20-byte SHA-1.
@@ -1223,7 +1228,8 @@ func (r *Repository) GetFileContent(ctx context.Context, ref, path string) ([]by
 }
 
 // ListCommits returns commits on targetBranch since lastScanCommit (or the lastScanTime timestamp).
-func (r *Repository) ListCommits(ctx context.Context, targetBranch, lastScanCommit string, lastScanTime time.Time, newestFirst bool) (string, string, []*CommitDiff, error) {
+// Optional includePaths and excludePaths to apply Git pathspec filtering.
+func (r *Repository) ListCommits(ctx context.Context, targetBranch, lastScanCommit string, lastScanTime time.Time, newestFirst bool, includePaths, excludePaths []string) (string, string, []*CommitDiff, error) {
 	repoLock := GetRepoLock(r.URL)
 	repoLock.RLock()
 	defer repoLock.RUnlock()
@@ -1233,6 +1239,8 @@ func (r *Repository) ListCommits(ctx context.Context, targetBranch, lastScanComm
 		slog.String("last_scan_commit", lastScanCommit),
 		slog.Time("last_scan_time", lastScanTime),
 		slog.Bool("newest_first", newestFirst),
+		slog.Any("include_paths", includePaths),
+		slog.Any("exclude_paths", excludePaths),
 	)
 	start := time.Now()
 
@@ -1288,9 +1296,9 @@ func (r *Repository) ListCommits(ctx context.Context, targetBranch, lastScanComm
 
 	// Step 3: Execute `git log` to extract commit metadata, file status changes, and code diffs.
 	// Command syntax:
-	// `git log [--since=<time>] --format=%x1e---COMMIT-METADATA---%n%H%n%ct%n%B%x00---COMMIT-DIFF---%n --raw -p -M --no-color [--reverse] <range> --`
+	// `git log [--since=<time>] --format=%x1e---COMMIT-METADATA---%n%H%n%ct%n%B%x00---COMMIT-DIFF---%n --raw -p -M --no-color [--reverse] <range> -- <pathspecs...>`
 	// Flags breakdown:
-	// --format: see comment for the const for details
+	// --format: see comment for const gitLogCommitDiffsFormat for details
 	// --raw: output status and file paths (A|C|D|M|R|T) for parsing via parseNameStatusLine
 	// -p: output unified diff patch for each commit
 	// -M: detect renames and copies
@@ -1320,8 +1328,26 @@ func (r *Repository) ListCommits(ctx context.Context, targetBranch, lastScanComm
 		args = append(args, toCommit)
 	}
 
-	// End of flags --
+	// End of flags
 	args = append(args, "--")
+
+	for _, inc := range includePaths {
+		inc = strings.TrimSpace(inc)
+		if inc != "" {
+			args = append(args, inc)
+		}
+	}
+
+	for _, exc := range excludePaths {
+		exc = strings.TrimSpace(exc)
+		if exc != "" {
+			if strings.HasPrefix(exc, ":(exclude)") || strings.HasPrefix(exc, ":!") {
+				args = append(args, exc)
+			} else {
+				args = append(args, ":(exclude)"+exc)
+			}
+		}
+	}
 
 	out, err := runCmd(ctx, r.repoPath, nil, "git", args...)
 	if err != nil {
@@ -1329,7 +1355,7 @@ func (r *Repository) ListCommits(ctx context.Context, targetBranch, lastScanComm
 	}
 
 	// Parse git log output into structured CommitDiff objects
-	commits := parseCommitsLog(ctx, out)
+	commits := parseCommitsLog(ctx, out, DefaultMaxCommitPatchBytes)
 
 	logger.DebugContext(ctx, "Commits listing completed",
 		slog.Int("commits_count", len(commits)),
@@ -1340,7 +1366,11 @@ func (r *Repository) ListCommits(ctx context.Context, targetBranch, lastScanComm
 }
 
 // parseCommitsLog parses git log output into a slice of CommitDiff.
-func parseCommitsLog(ctx context.Context, output []byte) []*CommitDiff {
+func parseCommitsLog(ctx context.Context, output []byte, maxPatchBytes int) []*CommitDiff {
+	if maxPatchBytes <= 0 {
+		maxPatchBytes = DefaultMaxCommitPatchBytes
+	}
+
 	records := bytes.Split(output, []byte(commitMetadataMarker))
 	commits := make([]*CommitDiff, 0, len(records))
 
@@ -1378,42 +1408,62 @@ func parseCommitsLog(ctx context.Context, output []byte) []*CommitDiff {
 			msg = string(bytes.TrimSpace(metaLines[2]))
 		}
 
-		// diffContent contains two sections from git log output:
+		// diffContent contains two sequential sections from git log output:
 		// 1. File diff status entries (each line starts with ":") parsed into FileChange objects.
 		// 2. Unified diff patches (beginning with "diff --")
-		lines := strings.Split(string(diffContent), "\n")
+		//
+		// Instead of splitting the entire diffContent with strings.Split (which allocates arrays of string pointers
+		// and copies for every single line in large diffs), we scan line-by-line using bytes.IndexByte to locate status
+		// lines, and then slice the remaining unified patch block in a single zero-allocation operation.
 		var filesChanged []*FileChange
-		var patchLines []string
-		inPatch := false
+		var patch string
+		var patchTruncated bool
 
-		for _, line := range lines {
-			switch {
-			case inPatch:
-				// Already in patch section, just keep appending.
-				patchLines = append(patchLines, line)
-			case strings.HasPrefix(line, "diff --"):
-				// Start of patch section
-				inPatch = true
-				patchLines = append(patchLines, line)
-			case strings.HasPrefix(line, ":"):
-				// Each line is one raw file diff entry
-				change, err := parseRawDiffLine(line)
+		pos := 0
+		for pos < len(diffContent) {
+			nextNL := bytes.IndexByte(diffContent[pos:], '\n')
+			var line []byte
+			lineStart := pos
+
+			if nextNL == -1 {
+				line = diffContent[pos:]
+				pos = len(diffContent)
+			} else {
+				line = diffContent[pos : pos+nextNL]
+				pos += nextNL + 1
+			}
+
+			if bytes.HasPrefix(line, []byte(":")) {
+				// Section 1: Raw file diff (1 per line)
+				change, err := parseRawDiffLine(string(line))
 				if err != nil {
-					logger.WarnContext(ctx, "Failed to parse raw diff line", slog.String("line", line), slog.Any("error", err))
+					logger.WarnContext(ctx, "Failed to parse raw diff line", slog.String("line", string(line)), slog.Any("error", err))
 					continue
 				}
 				filesChanged = append(filesChanged, change)
+			} else if bytes.HasPrefix(line, []byte("diff --")) {
+				// Section 2: First line of the unified diff patch reached.
+				// Everything from lineStart to the end of diffContent belongs to the unified diff patch.
+				patchBytes := diffContent[lineStart:]
+				if len(patchBytes) > maxPatchBytes {
+					// Truncate the patch if it exceeds maxPatchBytes.
+					patch = string(patchBytes[:maxPatchBytes]) + fmt.Sprintf("\n\n[Diff truncated: exceeded max patch size of %d bytes]", maxPatchBytes)
+					patchTruncated = true
+				} else {
+					patch = strings.TrimSpace(string(patchBytes))
+				}
+
+				break
 			}
 		}
 
-		patch := strings.TrimSpace(strings.Join(patchLines, "\n"))
-
 		commits = append(commits, &CommitDiff{
-			Commit:       hash,
-			Timestamp:    time.Unix(timestampSec, 0).UTC(),
-			Message:      msg,
-			Patch:        patch,
-			FilesChanged: filesChanged,
+			Commit:         hash,
+			Timestamp:      time.Unix(timestampSec, 0).UTC(),
+			Message:        msg,
+			Patch:          patch,
+			FilesChanged:   filesChanged,
+			PatchTruncated: patchTruncated,
 		})
 	}
 

--- a/go/cmd/gitter/repository.go
+++ b/go/cmd/gitter/repository.go
@@ -55,9 +55,27 @@ type Repository struct {
 	rootCommits []int
 }
 
-// %H commit hash; %P parent hashes; %D:refs (tab delimited)
-// We use \x09 (tab) as delimiter because it is disallowed in git refs and won't appear in hashes
-const gitLogFormat = "%H%x09%P%x09%D"
+const (
+	// gitLogGraphFormat formats commits for building the commit graph and patch IDs:
+	// %H commit hash; %P parent hashes; %D:refs (tab delimited)
+	// We use \x09 (tab) as delimiter because it is disallowed in git refs and won't appear in hashes
+	gitLogGraphFormat = "%H%x09%P%x09%D"
+
+	commitMetadataTag = "---COMMIT-METADATA---"
+	commitDiffTag     = "---COMMIT-DIFF---"
+
+	// gitLogCommitDiffsFormat formats commit records for ListCommits:
+	// Format goes like this:
+	// %x1e (record separator) ---COMMIT-METADATA---
+	// Metadata: %H (hash); %ct (commit timestamp); %B (raw commit message body)
+	// %x00 (NUL byte) ---COMMIT-DIFF---
+	// The file diffs output
+	gitLogCommitDiffsFormat = "%x1e" + commitMetadataTag + "%n%H%n%ct%n%B%x00" + commitDiffTag + "%n"
+
+	// Delimiters for metadata/diff extraction in ListCommits.
+	commitMetadataMarker = "\x1e" + commitMetadataTag + "\n"
+	commitDiffMarker     = "\x00" + commitDiffTag + "\n"
+)
 
 // Number of workers for patch ID calculation
 var workers = 16
@@ -188,7 +206,7 @@ func (r *Repository) buildCommitGraph(ctx context.Context, cache *pb.RepositoryC
 	// --all: all branches
 	// --full-history + --sparse: full-history alone still prunes TREESAME commit so we combine that with --sparse to actually get the full history of a repository
 	// Redirecting to a file is faster than git binary's own --output flag or streaming into memory.
-	cmd := prepareCmd(ctx, r.repoPath, nil, "git", "log", "--all", "--full-history", "--sparse", "--format="+gitLogFormat)
+	cmd := prepareCmd(ctx, r.repoPath, nil, "git", "log", "--all", "--full-history", "--sparse", "--format="+gitLogGraphFormat)
 	cmd.Stdout = tmpFile
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -1012,15 +1030,23 @@ type FileChange struct {
 	To   string
 }
 
+// CommitDiff represents a commit and its changes on a repository.
+type CommitDiff struct {
+	Commit       string
+	Timestamp    time.Time
+	Message      string
+	Patch        string
+	FilesChanged []*FileChange
+}
+
 // resolveCommit resolves a branch or (abbreviated) commit SHA to its raw 20-byte SHA-1.
 func (r *Repository) resolveCommit(ctx context.Context, ref string) (string, error) {
 	if strings.TrimSpace(ref) == "" {
 		return "", errors.New("ref cannot be empty")
 	}
-	cmd := prepareCmd(ctx, r.repoPath, nil, "git", "rev-parse", "--verify", "--quiet", ref+"^{commit}")
-	out, err := cmd.CombinedOutput()
+	out, err := runCmd(ctx, r.repoPath, nil, "git", "rev-parse", "--verify", "--quiet", ref+"^{commit}")
 	if err != nil {
-		return "", fmt.Errorf("failed to run git rev-parse on %q: %w, output: %s", ref, err, out)
+		return "", fmt.Errorf("failed to run git rev-parse on %q: %w", ref, err)
 	}
 
 	return strings.TrimSpace(string(out)), nil
@@ -1194,4 +1220,216 @@ func (r *Repository) GetFileContent(ctx context.Context, ref, path string) ([]by
 	}
 
 	return out, nil
+}
+
+// ListCommits returns commits on targetBranch since lastScanCommit (or the lastScanTime timestamp).
+func (r *Repository) ListCommits(ctx context.Context, targetBranch, lastScanCommit string, lastScanTime time.Time, newestFirst bool) (string, string, []*CommitDiff, error) {
+	repoLock := GetRepoLock(r.URL)
+	repoLock.RLock()
+	defer repoLock.RUnlock()
+
+	logger.DebugContext(ctx, "Starting commits listing",
+		slog.String("target_branch", targetBranch),
+		slog.String("last_scan_commit", lastScanCommit),
+		slog.Time("last_scan_time", lastScanTime),
+		slog.Bool("newest_first", newestFirst),
+	)
+	start := time.Now()
+
+	// Step 1: Resolve the target branch name and HEAD commit SHA.
+	var ref string
+	var resolvedBranch string
+	if targetBranch == "" {
+		// If targetBranch is empty, default to origin/HEAD, but still need to find the actual branch name
+		ref = "origin/HEAD"
+		if out, err := runCmd(ctx, r.repoPath, nil, "git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"); err == nil {
+			resolvedBranch = strings.TrimPrefix(strings.TrimSpace(string(out)), "origin/")
+		}
+	} else {
+		resolvedBranch = targetBranch
+		if strings.HasPrefix(targetBranch, "origin/") {
+			ref = targetBranch
+		} else {
+			ref = "origin/" + targetBranch
+		}
+	}
+
+	toCommit, err := r.resolveCommit(ctx, ref)
+	if err != nil {
+		// Fallback for local test fixtures without origin/
+		toCommit, err = r.resolveCommit(ctx, targetBranch)
+		if err != nil {
+			return "", "", nil, fmt.Errorf("failed to resolve target branch %q: %w", targetBranch, err)
+		}
+	}
+
+	// Step 2: Validate lastScanCommit
+	var fromCommit string
+	if lastScanCommit != "" {
+		if lastScanCommit == toCommit || strings.HasPrefix(toCommit, lastScanCommit) {
+			// No new commits exist, return early.
+			return resolvedBranch, toCommit, []*CommitDiff{}, nil
+		}
+		// Validates last scan commit is an ancestor of the target HEAD commit
+		_, err := runCmd(ctx, r.repoPath, nil, "git", "merge-base", "--is-ancestor", lastScanCommit, toCommit)
+		if err == nil {
+			fromCommit = lastScanCommit
+		} else {
+			// Fall back to last scan time
+			if lastScanTime.IsZero() {
+				return "", "", nil, fmt.Errorf("last_scan_commit %s is not an ancestor of HEAD commit %s and last_scan_time is not provided", lastScanCommit, toCommit)
+			}
+			logger.WarnContext(ctx, "last_scan_commit is not an ancestor of HEAD, falling back to last_scan_time",
+				slog.String("last_scan_commit", lastScanCommit),
+				slog.Time("last_scan_time", lastScanTime),
+			)
+		}
+	}
+
+	// Step 3: Execute `git log` to extract commit metadata, file status changes, and code diffs.
+	// Command syntax:
+	// `git log [--since=<time>] --format=%x1e---COMMIT-METADATA---%n%H%n%ct%n%B%x00---COMMIT-DIFF---%n --raw -p -M --no-color [--reverse] <range> --`
+	// Flags breakdown:
+	// --format: see comment for the const for details
+	// --raw: output status and file paths (A|C|D|M|R|T) for parsing via parseNameStatusLine
+	// -p: output unified diff patch for each commit
+	// -M: detect renames and copies
+	// --no-color: plain-text diffs without ANSI escape codes
+	// --reverse: return commits in chronological order (oldest to newest) when newest_first is false
+	// TODO: Depending on the actual needs we might want to use one of the --diff-merges options, but let's not over-complicate things for now
+	args := []string{
+		"log",
+		"--format=" + gitLogCommitDiffsFormat,
+		"--raw",
+		"-p",
+		"-M",
+		"--no-color",
+	}
+
+	if !newestFirst {
+		args = append(args, "--reverse")
+	}
+
+	if fromCommit != "" {
+		args = append(args, fromCommit+".."+toCommit)
+	} else {
+		// Only add --since filter if revision range is not available
+		if !lastScanTime.IsZero() {
+			args = append(args, "--since="+lastScanTime.Format(time.RFC3339))
+		}
+		args = append(args, toCommit)
+	}
+
+	// End of flags --
+	args = append(args, "--")
+
+	out, err := runCmd(ctx, r.repoPath, nil, "git", args...)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("git log failed: %w", err)
+	}
+
+	// Parse git log output into structured CommitDiff objects
+	commits := parseCommitsLog(ctx, out)
+
+	logger.DebugContext(ctx, "Commits listing completed",
+		slog.Int("commits_count", len(commits)),
+		slog.Duration("duration", time.Since(start)),
+	)
+
+	return resolvedBranch, toCommit, commits, nil
+}
+
+// parseCommitsLog parses git log output into a slice of CommitDiff.
+func parseCommitsLog(ctx context.Context, output []byte) []*CommitDiff {
+	records := bytes.Split(output, []byte(commitMetadataMarker))
+	commits := make([]*CommitDiff, 0, len(records))
+
+	for _, r := range records {
+		r = bytes.TrimSpace(r)
+		if len(r) == 0 {
+			continue
+		}
+
+		parts := bytes.SplitN(r, []byte(commitDiffMarker), 2)
+		if len(parts) < 2 {
+			logger.WarnContext(ctx, "Malformed commit record in git log output")
+			continue
+		}
+
+		meta := bytes.TrimSpace(parts[0])
+		diffContent := parts[1]
+
+		// Split into 3 parts: [0] = Commit SHA, [1] = Commit Timestamp, [2] = Commit message (if exist).
+		metaLines := bytes.SplitN(meta, []byte("\n"), 3)
+		if len(metaLines) < 2 {
+			logger.WarnContext(ctx, "Malformed metadata in git log output")
+			continue
+		}
+
+		hash := string(metaLines[0])
+		timestampSec, err := strconv.ParseInt(string(metaLines[1]), 10, 64)
+		if err != nil {
+			logger.WarnContext(ctx, "Invalid timestamp in git log output", slog.Any("error", err))
+			continue
+		}
+
+		var msg string
+		if len(metaLines) == 3 {
+			msg = string(bytes.TrimSpace(metaLines[2]))
+		}
+
+		// diffContent contains two sections from git log output:
+		// 1. File diff status entries (each line starts with ":") parsed into FileChange objects.
+		// 2. Unified diff patches (beginning with "diff --")
+		lines := strings.Split(string(diffContent), "\n")
+		var filesChanged []*FileChange
+		var patchLines []string
+		inPatch := false
+
+		for _, line := range lines {
+			switch {
+			case inPatch:
+				// Already in patch section, just keep appending.
+				patchLines = append(patchLines, line)
+			case strings.HasPrefix(line, "diff --"):
+				// Start of patch section
+				inPatch = true
+				patchLines = append(patchLines, line)
+			case strings.HasPrefix(line, ":"):
+				// Each line is one raw file diff entry
+				change, err := parseRawDiffLine(line)
+				if err != nil {
+					logger.WarnContext(ctx, "Failed to parse raw diff line", slog.String("line", line), slog.Any("error", err))
+					continue
+				}
+				filesChanged = append(filesChanged, change)
+			}
+		}
+
+		patch := strings.TrimSpace(strings.Join(patchLines, "\n"))
+
+		commits = append(commits, &CommitDiff{
+			Commit:       hash,
+			Timestamp:    time.Unix(timestampSec, 0).UTC(),
+			Message:      msg,
+			Patch:        patch,
+			FilesChanged: filesChanged,
+		})
+	}
+
+	return commits
+}
+
+// parseRawDiffLine parses a single raw diff line from git log --raw:
+// Format: 	:<src-mode> <dst-mode> <src-sha> <dst-sha> <status>\t<path>[\t<dst-path>]
+// Example: :100644 100644 5be4a4a 0000000 R86 file1 file3
+// Ref: https://git-scm.com/docs/git-diff#_raw_output_format
+// We are only interested in the last part <status>\t<path>[\t<dst-path>] which is always the last field when separated by space
+func parseRawDiffLine(line string) (*FileChange, error) {
+	fields := strings.SplitN(line, " ", 5)
+	if len(fields) < 5 {
+		return nil, fmt.Errorf("invalid raw diff line format: %q", line)
+	}
+
+	return parseNameStatusLine(fields[4])
 }

--- a/go/cmd/gitter/repository_test.go
+++ b/go/cmd/gitter/repository_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -1893,6 +1894,160 @@ func TestResolveCommit(t *testing.T) {
 				if tt.wantSha != "" && got != tt.wantSha {
 					t.Errorf("ResolveCommit(%q) got %q, want %q", tt.ref, got, tt.wantSha)
 				}
+			}
+		})
+	}
+}
+
+func TestListCommits(t *testing.T) {
+	url := setupFileDiffsTestRepo(t, "git://test-repo-list-commits.git")
+	repoPath := filepath.Join(gitStorePath, getRepoDirName(url))
+	r := NewRepository(url)
+	ctx := context.WithValue(t.Context(), urlKey, repoPath)
+
+	commit1, err := r.resolveCommit(ctx, "v1.0.0")
+	if err != nil {
+		t.Fatalf("resolve commit v1.0.0: %v", err)
+	}
+	commit2, err := r.resolveCommit(ctx, "v2.0.0")
+	if err != nil {
+		t.Fatalf("resolve commit v2.0.0: %v", err)
+	}
+
+	tests := []struct {
+		name             string
+		targetBranch     string
+		lastScanCommit   string
+		lastScanTime     time.Time
+		newestFirst      bool
+		wantBranch       string
+		wantHead         string
+		wantCommitsCount int
+		wantErr          bool
+		check            func(t *testing.T, commits []*CommitDiff)
+	}{
+		{
+			name:             "Default branch resolution and range query",
+			targetBranch:     "",
+			lastScanTime:     time.Unix(1, 0),
+			wantBranch:       "main",
+			wantHead:         commit1,
+			wantCommitsCount: 1,
+			check: func(t *testing.T, commits []*CommitDiff) {
+				t.Helper()
+				if commits[0].Commit != commit1 {
+					t.Errorf("expected commit %q, got %q", commit1, commits[0].Commit)
+				}
+			},
+		},
+		{
+			name:             "Specific branch with lastScanCommit",
+			targetBranch:     "feature-branch",
+			lastScanCommit:   commit1,
+			wantBranch:       "feature-branch",
+			wantHead:         commit2,
+			wantCommitsCount: 1,
+			check: func(t *testing.T, commits []*CommitDiff) {
+				t.Helper()
+				c := commits[0]
+				if c.Commit != commit2 {
+					t.Errorf("expected commit %q, got %q", commit2, c.Commit)
+				}
+				if !strings.Contains(c.Message, "commit 2: feature changes") {
+					t.Errorf("unexpected message: %q", c.Message)
+				}
+				if len(c.FilesChanged) == 0 {
+					t.Errorf("expected files changed, got 0")
+				}
+				if c.Patch == "" {
+					t.Errorf("expected non-empty patch")
+				}
+			},
+		},
+		{
+			name:             "Zero commits when lastScanCommit equals HEAD",
+			targetBranch:     "feature-branch",
+			lastScanCommit:   commit2,
+			wantBranch:       "feature-branch",
+			wantHead:         commit2,
+			wantCommitsCount: 0,
+		},
+		{
+			name:             "Empty boundaries queries full branch history",
+			targetBranch:     "feature-branch",
+			wantBranch:       "feature-branch",
+			wantHead:         commit2,
+			wantCommitsCount: 2,
+		},
+		{
+			name:           "Non-ancestor without lastScanTime returns error",
+			targetBranch:   "main",
+			lastScanCommit: commit2,
+			wantErr:        true,
+		},
+		{
+			name:             "Non-ancestor with lastScanTime falls back to lastScanTime",
+			targetBranch:     "main",
+			lastScanCommit:   commit2,
+			lastScanTime:     time.Unix(1, 0),
+			wantBranch:       "main",
+			wantHead:         commit1,
+			wantCommitsCount: 1,
+		},
+		{
+			name:             "Ordering chronological (default oldest first)",
+			targetBranch:     "feature-branch",
+			lastScanTime:     time.Unix(1, 0),
+			newestFirst:      false,
+			wantBranch:       "feature-branch",
+			wantHead:         commit2,
+			wantCommitsCount: 2,
+			check: func(t *testing.T, commits []*CommitDiff) {
+				t.Helper()
+				if commits[0].Commit != commit1 || commits[1].Commit != commit2 {
+					t.Errorf("expected chronological order [commit1, commit2], got [%s, %s]",
+						commits[0].Commit, commits[1].Commit)
+				}
+			},
+		},
+		{
+			name:             "Ordering newest_first",
+			targetBranch:     "feature-branch",
+			lastScanTime:     time.Unix(1, 0),
+			newestFirst:      true,
+			wantBranch:       "feature-branch",
+			wantHead:         commit2,
+			wantCommitsCount: 2,
+			check: func(t *testing.T, commits []*CommitDiff) {
+				t.Helper()
+				if commits[0].Commit != commit2 || commits[1].Commit != commit1 {
+					t.Errorf("expected reverse chronological order [commit2, commit1], got [%s, %s]",
+						commits[0].Commit, commits[1].Commit)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			branch, head, commits, err := r.ListCommits(ctx, tt.targetBranch, tt.lastScanCommit, tt.lastScanTime, tt.newestFirst)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ListCommits() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if branch != tt.wantBranch {
+				t.Errorf("branch = %q, want %q", branch, tt.wantBranch)
+			}
+			if head != tt.wantHead {
+				t.Errorf("head = %q, want %q", head, tt.wantHead)
+			}
+			if len(commits) != tt.wantCommitsCount {
+				t.Fatalf("len(commits) = %d, want %d", len(commits), tt.wantCommitsCount)
+			}
+			if tt.check != nil {
+				tt.check(t, commits)
 			}
 		})
 	}

--- a/go/cmd/gitter/repository_test.go
+++ b/go/cmd/gitter/repository_test.go
@@ -1920,6 +1920,8 @@ func TestListCommits(t *testing.T) {
 		lastScanCommit   string
 		lastScanTime     time.Time
 		newestFirst      bool
+		includePaths     []string
+		excludePaths     []string
 		wantBranch       string
 		wantHead         string
 		wantCommitsCount int
@@ -2026,11 +2028,46 @@ func TestListCommits(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:             "Path filtering with include_paths",
+			targetBranch:     "feature-branch",
+			lastScanCommit:   commit1,
+			includePaths:     []string{"modified_file.txt"},
+			wantBranch:       "feature-branch",
+			wantHead:         commit2,
+			wantCommitsCount: 1,
+			check: func(t *testing.T, commits []*CommitDiff) {
+				t.Helper()
+				if len(commits[0].FilesChanged) != 1 {
+					t.Fatalf("expected exactly 1 file changed, got %d", len(commits[0].FilesChanged))
+				}
+				if commits[0].FilesChanged[0].To != "modified_file.txt" {
+					t.Errorf("expected modified_file.txt, got %q", commits[0].FilesChanged[0].To)
+				}
+			},
+		},
+		{
+			name:             "Path filtering with exclude_paths",
+			targetBranch:     "feature-branch",
+			lastScanCommit:   commit1,
+			excludePaths:     []string{"modified_file.txt"},
+			wantBranch:       "feature-branch",
+			wantHead:         commit2,
+			wantCommitsCount: 1,
+			check: func(t *testing.T, commits []*CommitDiff) {
+				t.Helper()
+				for _, fc := range commits[0].FilesChanged {
+					if fc.To == "modified_file.txt" || fc.From == "modified_file.txt" {
+						t.Errorf("expected modified_file.txt to be excluded, but found it in files changed")
+					}
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			branch, head, commits, err := r.ListCommits(ctx, tt.targetBranch, tt.lastScanCommit, tt.lastScanTime, tt.newestFirst)
+			branch, head, commits, err := r.ListCommits(ctx, tt.targetBranch, tt.lastScanCommit, tt.lastScanTime, tt.newestFirst, tt.includePaths, tt.excludePaths)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("ListCommits() error = %v, wantErr = %v", err, tt.wantErr)
 			}
@@ -2050,5 +2087,42 @@ func TestListCommits(t *testing.T) {
 				tt.check(t, commits)
 			}
 		})
+	}
+}
+
+func TestParseCommitsLogPatchTruncation(t *testing.T) {
+	ctx := t.Context()
+	sampleLog := []byte("\x1e---COMMIT-METADATA---\n" +
+		"abcd1234abcd1234abcd1234abcd1234abcd1234\n" +
+		"1700000000\n" +
+		"feat: add large dataset\n" +
+		"\x00---COMMIT-DIFF---\n" +
+		":100644 100644 5be4a4a 0000000 M\tlarge_file.txt\n" +
+		"diff --git a/large_file.txt b/large_file.txt\n" +
+		"--- a/large_file.txt\n" +
+		"+++ b/large_file.txt\n" +
+		"@@ -1,3 +1,3 @@\n" +
+		"+Line 1: this is a huge patch hunk\n" +
+		"+Line 2: another line of data\n" +
+		"+Line 3: yet another line of data\n")
+
+	// Parse with a tiny limit (20 bytes) to force truncation for testing
+	commits := parseCommitsLog(ctx, sampleLog, 20)
+	if len(commits) != 1 {
+		t.Fatalf("expected 1 commit, got %d", len(commits))
+	}
+
+	c := commits[0]
+	if c.Commit != "abcd1234abcd1234abcd1234abcd1234abcd1234" {
+		t.Errorf("unexpected commit hash: %s", c.Commit)
+	}
+	if len(c.FilesChanged) != 1 || c.FilesChanged[0].To != "large_file.txt" {
+		t.Errorf("FilesChanged was lost or corrupted: %+v", c.FilesChanged)
+	}
+	if !c.PatchTruncated {
+		t.Errorf("expected PatchTruncated to be true")
+	}
+	if !strings.Contains(c.Patch, "[Diff truncated: exceeded max patch size of 20 bytes]") {
+		t.Errorf("expected truncation notice in patch, got: %s", c.Patch)
 	}
 }

--- a/go/internal/gitter/pb/repository/repository.pb.go
+++ b/go/internal/gitter/pb/repository/repository.pb.go
@@ -853,14 +853,15 @@ func (x *FileContentResponse) GetContent() []byte {
 }
 
 type CommitDiff struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Commit        string                 `protobuf:"bytes,1,opt,name=commit,proto3" json:"commit,omitempty"`
-	Timestamp     *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
-	Message       string                 `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
-	Patch         string                 `protobuf:"bytes,4,opt,name=patch,proto3" json:"patch,omitempty"`
-	FilesChanged  []*FileChange          `protobuf:"bytes,5,rep,name=files_changed,json=filesChanged,proto3" json:"files_changed,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Commit         string                 `protobuf:"bytes,1,opt,name=commit,proto3" json:"commit,omitempty"`
+	Timestamp      *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	Message        string                 `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
+	Patch          string                 `protobuf:"bytes,4,opt,name=patch,proto3" json:"patch,omitempty"`
+	FilesChanged   []*FileChange          `protobuf:"bytes,5,rep,name=files_changed,json=filesChanged,proto3" json:"files_changed,omitempty"`
+	PatchTruncated bool                   `protobuf:"varint,6,opt,name=patch_truncated,json=patchTruncated,proto3" json:"patch_truncated,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *CommitDiff) Reset() {
@@ -928,6 +929,13 @@ func (x *CommitDiff) GetFilesChanged() []*FileChange {
 	return nil
 }
 
+func (x *CommitDiff) GetPatchTruncated() bool {
+	if x != nil {
+		return x.PatchTruncated
+	}
+	return false
+}
+
 type CommitDiffsRequest struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	Url            string                 `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
@@ -935,6 +943,8 @@ type CommitDiffsRequest struct {
 	LastScanCommit string                 `protobuf:"bytes,3,opt,name=last_scan_commit,json=lastScanCommit,proto3" json:"last_scan_commit,omitempty"` // Optional, SHA of last scanned commit, preferred over last_scan_time when provided
 	LastScanTime   *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=last_scan_time,json=lastScanTime,proto3" json:"last_scan_time,omitempty"`       // Optional, timestamp of last scan. Used as fallback if last_scan_commit is not provided or is no longer on the branch.
 	NewestFirst    bool                   `protobuf:"varint,5,opt,name=newest_first,json=newestFirst,proto3" json:"newest_first,omitempty"`           // Optional, if true, newest commits first. Defaults to false (chronological order).
+	IncludePaths   []string               `protobuf:"bytes,6,rep,name=include_paths,json=includePaths,proto3" json:"include_paths,omitempty"`         // Optional, paths/globs to include in diffs
+	ExcludePaths   []string               `protobuf:"bytes,7,rep,name=exclude_paths,json=excludePaths,proto3" json:"exclude_paths,omitempty"`         // Optional, paths/globs to exclude from diffs
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -1002,6 +1012,20 @@ func (x *CommitDiffsRequest) GetNewestFirst() bool {
 		return x.NewestFirst
 	}
 	return false
+}
+
+func (x *CommitDiffsRequest) GetIncludePaths() []string {
+	if x != nil {
+		return x.IncludePaths
+	}
+	return nil
+}
+
+func (x *CommitDiffsRequest) GetExcludePaths() []string {
+	if x != nil {
+		return x.ExcludePaths
+	}
+	return nil
 }
 
 type CommitDiffsResponse struct {
@@ -1134,20 +1158,23 @@ const file_internal_gitter_pb_repository_repository_proto_rawDesc = "" +
 	"\x06commit\x18\x02 \x01(\tR\x06commit\x12\x12\n" +
 	"\x04path\x18\x03 \x01(\tR\x04path\"/\n" +
 	"\x13FileContentResponse\x12\x18\n" +
-	"\acontent\x18\x01 \x01(\fR\acontent\"\xc7\x01\n" +
+	"\acontent\x18\x01 \x01(\fR\acontent\"\xf0\x01\n" +
 	"\n" +
 	"CommitDiff\x12\x16\n" +
 	"\x06commit\x18\x01 \x01(\tR\x06commit\x128\n" +
 	"\ttimestamp\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12\x18\n" +
 	"\amessage\x18\x03 \x01(\tR\amessage\x12\x14\n" +
 	"\x05patch\x18\x04 \x01(\tR\x05patch\x127\n" +
-	"\rfiles_changed\x18\x05 \x03(\v2\x12.gitter.FileChangeR\ffilesChanged\"\xcd\x01\n" +
+	"\rfiles_changed\x18\x05 \x03(\v2\x12.gitter.FileChangeR\ffilesChanged\x12'\n" +
+	"\x0fpatch_truncated\x18\x06 \x01(\bR\x0epatchTruncated\"\x97\x02\n" +
 	"\x12CommitDiffsRequest\x12\x10\n" +
 	"\x03url\x18\x01 \x01(\tR\x03url\x12\x16\n" +
 	"\x06branch\x18\x02 \x01(\tR\x06branch\x12(\n" +
 	"\x10last_scan_commit\x18\x03 \x01(\tR\x0elastScanCommit\x12@\n" +
 	"\x0elast_scan_time\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\flastScanTime\x12!\n" +
-	"\fnewest_first\x18\x05 \x01(\bR\vnewestFirst\"\xaf\x01\n" +
+	"\fnewest_first\x18\x05 \x01(\bR\vnewestFirst\x12#\n" +
+	"\rinclude_paths\x18\x06 \x03(\tR\fincludePaths\x12#\n" +
+	"\rexclude_paths\x18\a \x03(\tR\fexcludePaths\"\xaf\x01\n" +
 	"\x13CommitDiffsResponse\x12\x10\n" +
 	"\x03url\x18\x01 \x01(\tR\x03url\x12\x16\n" +
 	"\x06branch\x18\x02 \x01(\tR\x06branch\x12\x1f\n" +

--- a/go/internal/gitter/pb/repository/repository.pb.go
+++ b/go/internal/gitter/pb/repository/repository.pb.go
@@ -2,13 +2,14 @@
 // versions:
 // 	protoc-gen-go v1.36.11
 // 	protoc        v3.21.12
-// source: repository.proto
+// source: internal/gitter/pb/repository/repository.proto
 
 package repository
 
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -57,11 +58,11 @@ func (x EventType) String() string {
 }
 
 func (EventType) Descriptor() protoreflect.EnumDescriptor {
-	return file_repository_proto_enumTypes[0].Descriptor()
+	return file_internal_gitter_pb_repository_repository_proto_enumTypes[0].Descriptor()
 }
 
 func (EventType) Type() protoreflect.EnumType {
-	return &file_repository_proto_enumTypes[0]
+	return &file_internal_gitter_pb_repository_repository_proto_enumTypes[0]
 }
 
 func (x EventType) Number() protoreflect.EnumNumber {
@@ -70,7 +71,7 @@ func (x EventType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use EventType.Descriptor instead.
 func (EventType) EnumDescriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{0}
+	return file_internal_gitter_pb_repository_repository_proto_rawDescGZIP(), []int{0}
 }
 
 type CommitDetail struct {
@@ -83,7 +84,7 @@ type CommitDetail struct {
 
 func (x *CommitDetail) Reset() {
 	*x = CommitDetail{}
-	mi := &file_repository_proto_msgTypes[0]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -95,7 +96,7 @@ func (x *CommitDetail) String() string {
 func (*CommitDetail) ProtoMessage() {}
 
 func (x *CommitDetail) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[0]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -108,7 +109,7 @@ func (x *CommitDetail) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CommitDetail.ProtoReflect.Descriptor instead.
 func (*CommitDetail) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{0}
+	return file_internal_gitter_pb_repository_repository_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *CommitDetail) GetHash() []byte {
@@ -136,7 +137,7 @@ type RepositoryCache struct {
 
 func (x *RepositoryCache) Reset() {
 	*x = RepositoryCache{}
-	mi := &file_repository_proto_msgTypes[1]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -148,7 +149,7 @@ func (x *RepositoryCache) String() string {
 func (*RepositoryCache) ProtoMessage() {}
 
 func (x *RepositoryCache) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[1]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -161,7 +162,7 @@ func (x *RepositoryCache) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RepositoryCache.ProtoReflect.Descriptor instead.
 func (*RepositoryCache) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{1}
+	return file_internal_gitter_pb_repository_repository_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *RepositoryCache) GetCommits() []*CommitDetail {
@@ -180,7 +181,7 @@ type Commit struct {
 
 func (x *Commit) Reset() {
 	*x = Commit{}
-	mi := &file_repository_proto_msgTypes[2]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -192,7 +193,7 @@ func (x *Commit) String() string {
 func (*Commit) ProtoMessage() {}
 
 func (x *Commit) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[2]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -205,7 +206,7 @@ func (x *Commit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Commit.ProtoReflect.Descriptor instead.
 func (*Commit) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{2}
+	return file_internal_gitter_pb_repository_repository_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *Commit) GetHash() []byte {
@@ -225,7 +226,7 @@ type Ref struct {
 
 func (x *Ref) Reset() {
 	*x = Ref{}
-	mi := &file_repository_proto_msgTypes[3]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -237,7 +238,7 @@ func (x *Ref) String() string {
 func (*Ref) ProtoMessage() {}
 
 func (x *Ref) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[3]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -250,7 +251,7 @@ func (x *Ref) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Ref.ProtoReflect.Descriptor instead.
 func (*Ref) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{3}
+	return file_internal_gitter_pb_repository_repository_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *Ref) GetLabel() string {
@@ -278,7 +279,7 @@ type AffectedCommitsResponse struct {
 
 func (x *AffectedCommitsResponse) Reset() {
 	*x = AffectedCommitsResponse{}
-	mi := &file_repository_proto_msgTypes[4]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -290,7 +291,7 @@ func (x *AffectedCommitsResponse) String() string {
 func (*AffectedCommitsResponse) ProtoMessage() {}
 
 func (x *AffectedCommitsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[4]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -303,7 +304,7 @@ func (x *AffectedCommitsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AffectedCommitsResponse.ProtoReflect.Descriptor instead.
 func (*AffectedCommitsResponse) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{4}
+	return file_internal_gitter_pb_repository_repository_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *AffectedCommitsResponse) GetCommits() []*Commit {
@@ -336,7 +337,7 @@ type TagsResponse struct {
 
 func (x *TagsResponse) Reset() {
 	*x = TagsResponse{}
-	mi := &file_repository_proto_msgTypes[5]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -348,7 +349,7 @@ func (x *TagsResponse) String() string {
 func (*TagsResponse) ProtoMessage() {}
 
 func (x *TagsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[5]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -361,7 +362,7 @@ func (x *TagsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TagsResponse.ProtoReflect.Descriptor instead.
 func (*TagsResponse) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{5}
+	return file_internal_gitter_pb_repository_repository_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *TagsResponse) GetTags() []*Ref {
@@ -381,7 +382,7 @@ type Event struct {
 
 func (x *Event) Reset() {
 	*x = Event{}
-	mi := &file_repository_proto_msgTypes[6]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -393,7 +394,7 @@ func (x *Event) String() string {
 func (*Event) ProtoMessage() {}
 
 func (x *Event) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[6]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -406,7 +407,7 @@ func (x *Event) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Event.ProtoReflect.Descriptor instead.
 func (*Event) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{6}
+	return file_internal_gitter_pb_repository_repository_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *Event) GetEventType() EventType {
@@ -434,7 +435,7 @@ type CacheRequest struct {
 
 func (x *CacheRequest) Reset() {
 	*x = CacheRequest{}
-	mi := &file_repository_proto_msgTypes[7]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -446,7 +447,7 @@ func (x *CacheRequest) String() string {
 func (*CacheRequest) ProtoMessage() {}
 
 func (x *CacheRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[7]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -459,7 +460,7 @@ func (x *CacheRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CacheRequest.ProtoReflect.Descriptor instead.
 func (*CacheRequest) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{7}
+	return file_internal_gitter_pb_repository_repository_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *CacheRequest) GetUrl() string {
@@ -499,7 +500,7 @@ type AffectedCommitsRequest struct {
 
 func (x *AffectedCommitsRequest) Reset() {
 	*x = AffectedCommitsRequest{}
-	mi := &file_repository_proto_msgTypes[8]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -511,7 +512,7 @@ func (x *AffectedCommitsRequest) String() string {
 func (*AffectedCommitsRequest) ProtoMessage() {}
 
 func (x *AffectedCommitsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[8]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -524,7 +525,7 @@ func (x *AffectedCommitsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AffectedCommitsRequest.ProtoReflect.Descriptor instead.
 func (*AffectedCommitsRequest) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{8}
+	return file_internal_gitter_pb_repository_repository_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *AffectedCommitsRequest) GetUrl() string {
@@ -593,7 +594,7 @@ type FileChange struct {
 
 func (x *FileChange) Reset() {
 	*x = FileChange{}
-	mi := &file_repository_proto_msgTypes[9]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -605,7 +606,7 @@ func (x *FileChange) String() string {
 func (*FileChange) ProtoMessage() {}
 
 func (x *FileChange) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[9]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -618,7 +619,7 @@ func (x *FileChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FileChange.ProtoReflect.Descriptor instead.
 func (*FileChange) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{9}
+	return file_internal_gitter_pb_repository_repository_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *FileChange) GetFromPath() string {
@@ -646,7 +647,7 @@ type FileDiffsRequest struct {
 
 func (x *FileDiffsRequest) Reset() {
 	*x = FileDiffsRequest{}
-	mi := &file_repository_proto_msgTypes[10]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -658,7 +659,7 @@ func (x *FileDiffsRequest) String() string {
 func (*FileDiffsRequest) ProtoMessage() {}
 
 func (x *FileDiffsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[10]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -671,7 +672,7 @@ func (x *FileDiffsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FileDiffsRequest.ProtoReflect.Descriptor instead.
 func (*FileDiffsRequest) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{10}
+	return file_internal_gitter_pb_repository_repository_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *FileDiffsRequest) GetUrl() string {
@@ -705,7 +706,7 @@ type FileDiffsResponse struct {
 
 func (x *FileDiffsResponse) Reset() {
 	*x = FileDiffsResponse{}
-	mi := &file_repository_proto_msgTypes[11]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -717,7 +718,7 @@ func (x *FileDiffsResponse) String() string {
 func (*FileDiffsResponse) ProtoMessage() {}
 
 func (x *FileDiffsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[11]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -730,7 +731,7 @@ func (x *FileDiffsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FileDiffsResponse.ProtoReflect.Descriptor instead.
 func (*FileDiffsResponse) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{11}
+	return file_internal_gitter_pb_repository_repository_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *FileDiffsResponse) GetLatestCommit() string {
@@ -758,7 +759,7 @@ type FileContentRequest struct {
 
 func (x *FileContentRequest) Reset() {
 	*x = FileContentRequest{}
-	mi := &file_repository_proto_msgTypes[12]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -770,7 +771,7 @@ func (x *FileContentRequest) String() string {
 func (*FileContentRequest) ProtoMessage() {}
 
 func (x *FileContentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[12]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -783,7 +784,7 @@ func (x *FileContentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FileContentRequest.ProtoReflect.Descriptor instead.
 func (*FileContentRequest) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{12}
+	return file_internal_gitter_pb_repository_repository_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *FileContentRequest) GetUrl() string {
@@ -816,7 +817,7 @@ type FileContentResponse struct {
 
 func (x *FileContentResponse) Reset() {
 	*x = FileContentResponse{}
-	mi := &file_repository_proto_msgTypes[13]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -828,7 +829,7 @@ func (x *FileContentResponse) String() string {
 func (*FileContentResponse) ProtoMessage() {}
 
 func (x *FileContentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_repository_proto_msgTypes[13]
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -841,7 +842,7 @@ func (x *FileContentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FileContentResponse.ProtoReflect.Descriptor instead.
 func (*FileContentResponse) Descriptor() ([]byte, []int) {
-	return file_repository_proto_rawDescGZIP(), []int{13}
+	return file_internal_gitter_pb_repository_repository_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *FileContentResponse) GetContent() []byte {
@@ -851,11 +852,239 @@ func (x *FileContentResponse) GetContent() []byte {
 	return nil
 }
 
-var File_repository_proto protoreflect.FileDescriptor
+type CommitDiff struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Commit        string                 `protobuf:"bytes,1,opt,name=commit,proto3" json:"commit,omitempty"`
+	Timestamp     *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	Message       string                 `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
+	Patch         string                 `protobuf:"bytes,4,opt,name=patch,proto3" json:"patch,omitempty"`
+	FilesChanged  []*FileChange          `protobuf:"bytes,5,rep,name=files_changed,json=filesChanged,proto3" json:"files_changed,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
 
-const file_repository_proto_rawDesc = "" +
+func (x *CommitDiff) Reset() {
+	*x = CommitDiff{}
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CommitDiff) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CommitDiff) ProtoMessage() {}
+
+func (x *CommitDiff) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CommitDiff.ProtoReflect.Descriptor instead.
+func (*CommitDiff) Descriptor() ([]byte, []int) {
+	return file_internal_gitter_pb_repository_repository_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *CommitDiff) GetCommit() string {
+	if x != nil {
+		return x.Commit
+	}
+	return ""
+}
+
+func (x *CommitDiff) GetTimestamp() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Timestamp
+	}
+	return nil
+}
+
+func (x *CommitDiff) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *CommitDiff) GetPatch() string {
+	if x != nil {
+		return x.Patch
+	}
+	return ""
+}
+
+func (x *CommitDiff) GetFilesChanged() []*FileChange {
+	if x != nil {
+		return x.FilesChanged
+	}
+	return nil
+}
+
+type CommitDiffsRequest struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Url            string                 `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
+	Branch         string                 `protobuf:"bytes,2,opt,name=branch,proto3" json:"branch,omitempty"`                                         // Optional, defaults to remote default branch (origin/HEAD)
+	LastScanCommit string                 `protobuf:"bytes,3,opt,name=last_scan_commit,json=lastScanCommit,proto3" json:"last_scan_commit,omitempty"` // Optional, SHA of last scanned commit, preferred over last_scan_time when provided
+	LastScanTime   *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=last_scan_time,json=lastScanTime,proto3" json:"last_scan_time,omitempty"`       // Optional, timestamp of last scan. Used as fallback if last_scan_commit is not provided or is no longer on the branch.
+	NewestFirst    bool                   `protobuf:"varint,5,opt,name=newest_first,json=newestFirst,proto3" json:"newest_first,omitempty"`           // Optional, if true, newest commits first. Defaults to false (chronological order).
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *CommitDiffsRequest) Reset() {
+	*x = CommitDiffsRequest{}
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CommitDiffsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CommitDiffsRequest) ProtoMessage() {}
+
+func (x *CommitDiffsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CommitDiffsRequest.ProtoReflect.Descriptor instead.
+func (*CommitDiffsRequest) Descriptor() ([]byte, []int) {
+	return file_internal_gitter_pb_repository_repository_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *CommitDiffsRequest) GetUrl() string {
+	if x != nil {
+		return x.Url
+	}
+	return ""
+}
+
+func (x *CommitDiffsRequest) GetBranch() string {
+	if x != nil {
+		return x.Branch
+	}
+	return ""
+}
+
+func (x *CommitDiffsRequest) GetLastScanCommit() string {
+	if x != nil {
+		return x.LastScanCommit
+	}
+	return ""
+}
+
+func (x *CommitDiffsRequest) GetLastScanTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastScanTime
+	}
+	return nil
+}
+
+func (x *CommitDiffsRequest) GetNewestFirst() bool {
+	if x != nil {
+		return x.NewestFirst
+	}
+	return false
+}
+
+type CommitDiffsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Url           string                 `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
+	Branch        string                 `protobuf:"bytes,2,opt,name=branch,proto3" json:"branch,omitempty"`
+	HeadCommit    string                 `protobuf:"bytes,3,opt,name=head_commit,json=headCommit,proto3" json:"head_commit,omitempty"`
+	NumCommits    int32                  `protobuf:"varint,4,opt,name=num_commits,json=numCommits,proto3" json:"num_commits,omitempty"`
+	Commits       []*CommitDiff          `protobuf:"bytes,5,rep,name=commits,proto3" json:"commits,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CommitDiffsResponse) Reset() {
+	*x = CommitDiffsResponse{}
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CommitDiffsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CommitDiffsResponse) ProtoMessage() {}
+
+func (x *CommitDiffsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_gitter_pb_repository_repository_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CommitDiffsResponse.ProtoReflect.Descriptor instead.
+func (*CommitDiffsResponse) Descriptor() ([]byte, []int) {
+	return file_internal_gitter_pb_repository_repository_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *CommitDiffsResponse) GetUrl() string {
+	if x != nil {
+		return x.Url
+	}
+	return ""
+}
+
+func (x *CommitDiffsResponse) GetBranch() string {
+	if x != nil {
+		return x.Branch
+	}
+	return ""
+}
+
+func (x *CommitDiffsResponse) GetHeadCommit() string {
+	if x != nil {
+		return x.HeadCommit
+	}
+	return ""
+}
+
+func (x *CommitDiffsResponse) GetNumCommits() int32 {
+	if x != nil {
+		return x.NumCommits
+	}
+	return 0
+}
+
+func (x *CommitDiffsResponse) GetCommits() []*CommitDiff {
+	if x != nil {
+		return x.Commits
+	}
+	return nil
+}
+
+var File_internal_gitter_pb_repository_repository_proto protoreflect.FileDescriptor
+
+const file_internal_gitter_pb_repository_repository_proto_rawDesc = "" +
 	"\n" +
-	"\x10repository.proto\x12\x06gitter\"=\n" +
+	".internal/gitter/pb/repository/repository.proto\x12\x06gitter\x1a\x1fgoogle/protobuf/timestamp.proto\"=\n" +
 	"\fCommitDetail\x12\x12\n" +
 	"\x04hash\x18\x01 \x01(\fR\x04hash\x12\x19\n" +
 	"\bpatch_id\x18\x02 \x01(\fR\apatchId\"A\n" +
@@ -905,7 +1134,28 @@ const file_repository_proto_rawDesc = "" +
 	"\x06commit\x18\x02 \x01(\tR\x06commit\x12\x12\n" +
 	"\x04path\x18\x03 \x01(\tR\x04path\"/\n" +
 	"\x13FileContentResponse\x12\x18\n" +
-	"\acontent\x18\x01 \x01(\fR\acontent*D\n" +
+	"\acontent\x18\x01 \x01(\fR\acontent\"\xc7\x01\n" +
+	"\n" +
+	"CommitDiff\x12\x16\n" +
+	"\x06commit\x18\x01 \x01(\tR\x06commit\x128\n" +
+	"\ttimestamp\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12\x18\n" +
+	"\amessage\x18\x03 \x01(\tR\amessage\x12\x14\n" +
+	"\x05patch\x18\x04 \x01(\tR\x05patch\x127\n" +
+	"\rfiles_changed\x18\x05 \x03(\v2\x12.gitter.FileChangeR\ffilesChanged\"\xcd\x01\n" +
+	"\x12CommitDiffsRequest\x12\x10\n" +
+	"\x03url\x18\x01 \x01(\tR\x03url\x12\x16\n" +
+	"\x06branch\x18\x02 \x01(\tR\x06branch\x12(\n" +
+	"\x10last_scan_commit\x18\x03 \x01(\tR\x0elastScanCommit\x12@\n" +
+	"\x0elast_scan_time\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\flastScanTime\x12!\n" +
+	"\fnewest_first\x18\x05 \x01(\bR\vnewestFirst\"\xaf\x01\n" +
+	"\x13CommitDiffsResponse\x12\x10\n" +
+	"\x03url\x18\x01 \x01(\tR\x03url\x12\x16\n" +
+	"\x06branch\x18\x02 \x01(\tR\x06branch\x12\x1f\n" +
+	"\vhead_commit\x18\x03 \x01(\tR\n" +
+	"headCommit\x12\x1f\n" +
+	"\vnum_commits\x18\x04 \x01(\x05R\n" +
+	"numCommits\x12,\n" +
+	"\acommits\x18\x05 \x03(\v2\x12.gitter.CommitDiffR\acommits*D\n" +
 	"\tEventType\x12\x0e\n" +
 	"\n" +
 	"INTRODUCED\x10\x00\x12\t\n" +
@@ -914,20 +1164,20 @@ const file_repository_proto_rawDesc = "" +
 	"\x05LIMIT\x10\x03B\x0eZ\f./repositoryb\x06proto3"
 
 var (
-	file_repository_proto_rawDescOnce sync.Once
-	file_repository_proto_rawDescData []byte
+	file_internal_gitter_pb_repository_repository_proto_rawDescOnce sync.Once
+	file_internal_gitter_pb_repository_repository_proto_rawDescData []byte
 )
 
-func file_repository_proto_rawDescGZIP() []byte {
-	file_repository_proto_rawDescOnce.Do(func() {
-		file_repository_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_repository_proto_rawDesc), len(file_repository_proto_rawDesc)))
+func file_internal_gitter_pb_repository_repository_proto_rawDescGZIP() []byte {
+	file_internal_gitter_pb_repository_repository_proto_rawDescOnce.Do(func() {
+		file_internal_gitter_pb_repository_repository_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_internal_gitter_pb_repository_repository_proto_rawDesc), len(file_internal_gitter_pb_repository_repository_proto_rawDesc)))
 	})
-	return file_repository_proto_rawDescData
+	return file_internal_gitter_pb_repository_repository_proto_rawDescData
 }
 
-var file_repository_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_repository_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
-var file_repository_proto_goTypes = []any{
+var file_internal_gitter_pb_repository_repository_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_internal_gitter_pb_repository_repository_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_internal_gitter_pb_repository_repository_proto_goTypes = []any{
 	(EventType)(0),                  // 0: gitter.EventType
 	(*CommitDetail)(nil),            // 1: gitter.CommitDetail
 	(*RepositoryCache)(nil),         // 2: gitter.RepositoryCache
@@ -943,8 +1193,12 @@ var file_repository_proto_goTypes = []any{
 	(*FileDiffsResponse)(nil),       // 12: gitter.FileDiffsResponse
 	(*FileContentRequest)(nil),      // 13: gitter.FileContentRequest
 	(*FileContentResponse)(nil),     // 14: gitter.FileContentResponse
+	(*CommitDiff)(nil),              // 15: gitter.CommitDiff
+	(*CommitDiffsRequest)(nil),      // 16: gitter.CommitDiffsRequest
+	(*CommitDiffsResponse)(nil),     // 17: gitter.CommitDiffsResponse
+	(*timestamppb.Timestamp)(nil),   // 18: google.protobuf.Timestamp
 }
-var file_repository_proto_depIdxs = []int32{
+var file_internal_gitter_pb_repository_repository_proto_depIdxs = []int32{
 	1,  // 0: gitter.RepositoryCache.commits:type_name -> gitter.CommitDetail
 	3,  // 1: gitter.AffectedCommitsResponse.commits:type_name -> gitter.Commit
 	4,  // 2: gitter.AffectedCommitsResponse.tags:type_name -> gitter.Ref
@@ -953,34 +1207,38 @@ var file_repository_proto_depIdxs = []int32{
 	0,  // 5: gitter.Event.event_type:type_name -> gitter.EventType
 	7,  // 6: gitter.AffectedCommitsRequest.events:type_name -> gitter.Event
 	10, // 7: gitter.FileDiffsResponse.changes:type_name -> gitter.FileChange
-	8,  // [8:8] is the sub-list for method output_type
-	8,  // [8:8] is the sub-list for method input_type
-	8,  // [8:8] is the sub-list for extension type_name
-	8,  // [8:8] is the sub-list for extension extendee
-	0,  // [0:8] is the sub-list for field type_name
+	18, // 8: gitter.CommitDiff.timestamp:type_name -> google.protobuf.Timestamp
+	10, // 9: gitter.CommitDiff.files_changed:type_name -> gitter.FileChange
+	18, // 10: gitter.CommitDiffsRequest.last_scan_time:type_name -> google.protobuf.Timestamp
+	15, // 11: gitter.CommitDiffsResponse.commits:type_name -> gitter.CommitDiff
+	12, // [12:12] is the sub-list for method output_type
+	12, // [12:12] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
-func init() { file_repository_proto_init() }
-func file_repository_proto_init() {
-	if File_repository_proto != nil {
+func init() { file_internal_gitter_pb_repository_repository_proto_init() }
+func file_internal_gitter_pb_repository_repository_proto_init() {
+	if File_internal_gitter_pb_repository_repository_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_repository_proto_rawDesc), len(file_repository_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internal_gitter_pb_repository_repository_proto_rawDesc), len(file_internal_gitter_pb_repository_repository_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   14,
+			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_repository_proto_goTypes,
-		DependencyIndexes: file_repository_proto_depIdxs,
-		EnumInfos:         file_repository_proto_enumTypes,
-		MessageInfos:      file_repository_proto_msgTypes,
+		GoTypes:           file_internal_gitter_pb_repository_repository_proto_goTypes,
+		DependencyIndexes: file_internal_gitter_pb_repository_repository_proto_depIdxs,
+		EnumInfos:         file_internal_gitter_pb_repository_repository_proto_enumTypes,
+		MessageInfos:      file_internal_gitter_pb_repository_repository_proto_msgTypes,
 	}.Build()
-	File_repository_proto = out.File
-	file_repository_proto_goTypes = nil
-	file_repository_proto_depIdxs = nil
+	File_internal_gitter_pb_repository_repository_proto = out.File
+	file_internal_gitter_pb_repository_repository_proto_goTypes = nil
+	file_internal_gitter_pb_repository_repository_proto_depIdxs = nil
 }

--- a/go/internal/gitter/pb/repository/repository.proto
+++ b/go/internal/gitter/pb/repository/repository.proto
@@ -97,6 +97,7 @@ message CommitDiff {
     string message = 3;
     string patch = 4;
     repeated FileChange files_changed = 5;
+    bool patch_truncated = 6;
 }
 
 message CommitDiffsRequest {
@@ -105,6 +106,8 @@ message CommitDiffsRequest {
     string last_scan_commit = 3;                  // Optional, SHA of last scanned commit, preferred over last_scan_time when provided
     google.protobuf.Timestamp last_scan_time = 4; // Optional, timestamp of last scan. Used as fallback if last_scan_commit is not provided or is no longer on the branch.
     bool newest_first = 5;                        // Optional, if true, newest commits first. Defaults to false (chronological order).
+    repeated string include_paths = 6;            // Optional, paths/globs to include in diffs
+    repeated string exclude_paths = 7;            // Optional, paths/globs to exclude from diffs
 }
 
 message CommitDiffsResponse {

--- a/go/internal/gitter/pb/repository/repository.proto
+++ b/go/internal/gitter/pb/repository/repository.proto
@@ -4,6 +4,8 @@ package gitter;
 
 option go_package = "./repository";
 
+import "google/protobuf/timestamp.proto";
+
 message CommitDetail {
     bytes hash = 1;
     bytes patch_id = 2;
@@ -87,4 +89,28 @@ message FileContentRequest {
 
 message FileContentResponse {
     bytes content = 1;
+}
+
+message CommitDiff {
+    string commit = 1;
+    google.protobuf.Timestamp timestamp = 2;
+    string message = 3;
+    string patch = 4;
+    repeated FileChange files_changed = 5;
+}
+
+message CommitDiffsRequest {
+    string url = 1;
+    string branch = 2;                            // Optional, defaults to remote default branch (origin/HEAD)
+    string last_scan_commit = 3;                  // Optional, SHA of last scanned commit, preferred over last_scan_time when provided
+    google.protobuf.Timestamp last_scan_time = 4; // Optional, timestamp of last scan. Used as fallback if last_scan_commit is not provided or is no longer on the branch.
+    bool newest_first = 5;                        // Optional, if true, newest commits first. Defaults to false (chronological order).
+}
+
+message CommitDiffsResponse {
+    string url = 1;
+    string branch = 2;
+    string head_commit = 3;
+    int32 num_commits = 4;
+    repeated CommitDiff commits = 5;
 }


### PR DESCRIPTION
Adds `/commit-diffs` endpoint to return structured commit data (SHA, timestamp, message, diff patches, and modified files) relative to a target branch and last sync point.

The last-sync reference can be a commit SHA or timestamp. 
When both are provided, the commit hash is prioritized, with the timestamp acting as a fallback if the hash is invalid (e.g., from a git commit --amend or rebase).