### PR TITLE
fix(deploy): apt install `google-cloud-cli`

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
     apt-get install -y \
     wget \
     google-cloud-cli-firestore-emulator \
-    google-cloud-sdk-datastore-emulator \
+    google-cloud-cli-datastore-emulator \
     openjdk-21-jre  # Needed for Datastore emulator.
 
 # TODO(michaelkedar): remove datastore emulator after firestore changes are merged.

--- a/docker/deployment/Dockerfile
+++ b/docker/deployment/Dockerfile
@@ -3,6 +3,6 @@ FROM ubuntu:26.04@sha256:2260313b31c8c011cd2eebe728008efac1b3982be73eb71348ea264
 RUN apt-get update && \
     apt-get install -y curl jq
 
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
-    apt-get update && apt-get install -y google-cloud-sdk
+    apt-get update && apt-get install -y google-cloud-cli

--- a/docker/worker-base/Dockerfile
+++ b/docker/worker-base/Dockerfile
@@ -62,9 +62,9 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /
 RUN sed -i 's/^.*ulimit.*$/true/g' /etc/init.d/docker
 
 # Install gcloud
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
-    apt-get update && apt-get install -y google-cloud-sdk
+    apt-get update && apt-get install -y google-cloud-cli
 
 # Install gVisor.
 RUN curl -fsSL https://gvisor.dev/archive.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/gvisor.gpg && \


### PR DESCRIPTION
Apparently, `google-cloud-sdk` has been deprecated for a while in favour of `google-cloud-cli` and only just now has stopped building 🤷. I'm not even sure if google-cloud is still actually needed in these Dockerfiles, but I don't want to dig into OSS-Fuzz stuff too much right now.

Also, use changed apt repo URL to HTTPS instead of HTTP because secure.